### PR TITLE
fix: isolate upgrade drain authority across reinstalls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2118,9 +2118,11 @@ jobs:
           echo "Released-upgrade rung rejected the nil-unsafe placement mutant as expected"
           kubectl patch secret curie-negative-secrets -n curie-negative --type merge \
             -p '{"stringData":{"approvalChatAttesterSecret":""}}'
+          # Candidate hooks must run the candidate worker command surface.
           helm upgrade curie-negative "$mutant" -n curie-negative \
             --reset-then-reuse-values \
             --set api.approvalChatAttesterSecret=null \
+            --set worker.image.repository=curie-worker --set worker.image.tag=upgrade-candidate --set worker.image.digest= --set worker.image.pullPolicy=Never \
             --timeout 15m
           if "$RUNNER_TEMP/verify-managed-attester.sh" curie-negative curie-negative; then
             echo "nil-unsafe negative control unexpectedly passed the released-upgrade assertion" >&2

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -616,6 +616,15 @@ jobs:
         # Keep runtime checks separate from the flat chart-check render inventory.
         working-directory: charts/curie
         run: bash ci/runtime/reserved-env-upgrade-runtime.sh
+      - name: Installation identity Secret lifecycle
+        env:
+          KUBECONFIG: ${{ runner.temp }}/curie-upgrade-drain-kubeconfig
+          CURIE_UPGRADE_DRAIN_KIND_CONTEXT: kind-curie-reserved-env
+        run: |
+          set -euo pipefail
+          trap 'rm -f -- "$KUBECONFIG"' EXIT
+          install -m 600 /home/runner/.kube/config "$KUBECONFIG"
+          bash charts/curie/ci/runtime/upgrade-drain-installation-runtime.sh
       - name: Remove owned cluster
         if: always()
         run: kind delete cluster --name curie-reserved-env

--- a/apps/worker/src/curie_worker/config.py
+++ b/apps/worker/src/curie_worker/config.py
@@ -777,6 +777,25 @@ class WorkerConfig(BaseSettings):
     upgrade_quiesce_ttl_s: float = Field(
         default=1200.0, gt=0, validation_alias="CURIE_UPGRADE_QUIESCE_TTL_S"
     )
+    # The Helm installation that owns upgrade pause authority (#2374). A blank
+    # value is deliberate standalone and Compose compatibility: those surfaces
+    # have no Helm installation boundary and keep using the legacy key. Cluster
+    # workers receive a nonblank value from the chart managed Secret.
+    installation_id: str = Field(
+        default="", validation_alias="CURIE_INSTALLATION_ID"
+    )
+    # Hook revisions fence delayed drain and release Jobs numerically. Ordinary
+    # worker processes only read marker state, so this hook-only value may be
+    # absent there. An explicitly supplied revision must be positive.
+    upgrade_revision: int | None = Field(
+        default=None, gt=0, validation_alias="CURIE_UPGRADE_REVISION"
+    )
+    # True only for the first upgrade from a chart that predates installation
+    # IDs. That hook atomically bridges the scoped marker to the legacy key so
+    # old and new worker replicas pause together during the transition.
+    upgrade_legacy_quiesce: Bool = Field(
+        default=False, validation_alias="CURIE_UPGRADE_LEGACY_QUIESCE"
+    )
 
     # The platform's voluntary termination grace, injected by the chart from
     # the SAME value it renders onto the Pod's ``terminationGracePeriodSeconds``
@@ -1157,11 +1176,18 @@ class WorkerConfig(BaseSettings):
         return f"{self.key_prefix}:completions:pending"
 
     def upgrade_quiesce_key(self) -> str:
-        # The fleet-wide "stop taking new work" flag the pre-upgrade gate sets
-        # (issue #2010). One key for the whole release, not one per replica: the
-        # gate runs as a Job that knows nothing about how many replicas exist,
-        # and every consumer reads the same flag. Always written with a TTL --
-        # see ``upgrade_quiesce_ttl_s`` for why it must never be permanent.
+        # One authoritative "stop taking new work" marker per Helm installation
+        # (#2374), shared by every replica in that installation. Standalone and
+        # Compose deliberately have a blank installation ID and retain the
+        # legacy release-wide key. Every marker is written with a finite TTL.
+        legacy_key = self.upgrade_legacy_quiesce_key()
+        if not self.installation_id:
+            return legacy_key
+        return f"{legacy_key}:{self.installation_id}"
+
+    def upgrade_legacy_quiesce_key(self) -> str:
+        """The pre-#2374 global key used only by standalone or the bridge."""
+
         return f"{self.key_prefix}:upgrade:quiesce"
 
     def lock_key(self, thread_key: str) -> str:

--- a/apps/worker/src/curie_worker/stream_consumer.py
+++ b/apps/worker/src/curie_worker/stream_consumer.py
@@ -1516,6 +1516,11 @@ class StreamConsumer:
     async def _prompt_reclaim_once(self) -> int:
         """Observe capable peers and promptly recover only proven-dead owners."""
 
+        if await self._claims_paused():
+            # A prompt transfer is a new claim just as surely as XREADGROUP is.
+            # Return before liveness observation, pending selection, arbitration,
+            # or XCLAIM so a drain cannot charge or move a peer's delivery.
+            return 0
         return await self._reclaim_dead_consumers()
 
     async def _prompt_reclaim_loop(self) -> None:
@@ -1550,6 +1555,11 @@ class StreamConsumer:
         than on the faster prompt cadence so it inherits the upgrade-drain gate
         and can reuse the ``over_cap`` set this tick already produced.
         """
+        if await self._claims_paused():
+            # Runs already skips this entire maintenance tick at its outer loop.
+            # Keep the shared entrypoint guarded too so eval and direct callers
+            # return before cap scans, dead-letter writes, or any transfer.
+            return 0
         selected: list[StreamEntry] = []
         async with self._reclaim_lock:
             over_cap = await self._dead_letter_over_cap()

--- a/apps/worker/src/curie_worker/upgrade_drain.py
+++ b/apps/worker/src/curie_worker/upgrade_drain.py
@@ -20,10 +20,10 @@ does not complete.
 This module closes the gap ahead of the roll rather than behind it, with the two
 outcomes the issue asks for and nothing in between:
 
-1. **Drain.** Set a fleet-wide quiesce flag so no replica takes new work, then
-   wait for every delivery that currently holds a live ownership lease to reach
-   its terminal outcome. When they all do, the upgrade proceeds and each of
-   those turns completed exactly once.
+1. **Drain.** Set an installation-scoped quiesce marker so no replica in that
+   installation takes new work, then wait for every delivery that currently
+   holds a live ownership lease to reach its terminal outcome. When they all
+   do, the upgrade proceeds and each of those turns completed exactly once.
 2. **Refuse.** If unsafe work is still in flight when the wait expires, the gate
    fails, `helm upgrade` fails with it, and NOTHING is rolled. The turn keeps
    running on the workers that are already there.
@@ -44,8 +44,8 @@ liveness reads for one page go out in a single pipeline. ``markers.py`` states
 the rule this follows: the maintenance path must not ``SCAN`` a production
 Valkey, and this runs against exactly the release an operator is upgrading.
 
-**A refusal must not wedge the fleet.** The quiesce flag is always written with
-a TTL, and :func:`main` clears it explicitly when the drain is refused. A
+**A refusal must not wedge the fleet.** The quiesce marker is always written
+with a TTL, and :func:`main` clears it explicitly when the drain is refused. A
 postponed upgrade leaves the cluster exactly as it found it -- still serving,
 still claiming -- which is what makes "refuse" an acceptable normal-path answer
 rather than an outage.
@@ -55,10 +55,13 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import logging
 import sys
 import time
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Literal, TypedDict
 
 from redis.asyncio import Redis
 from redis.exceptions import ResponseError
@@ -77,6 +80,76 @@ _PEL_SCAN_PAGE = 256
 # operator reading a refusal needs to know WHICH lane is still busy, and a bare
 # entry id is ambiguous across the runs and eval groups.
 _DELIVERY_SEP = "/"
+
+# One atomic write owns every marker applicable to this hook invocation. KEYS
+# contains the installation scoped key first and, only during the first mixed
+# version upgrade, the legacy key second. ARGV is revision, candidate JSON, and
+# TTL milliseconds. A same revision retry refreshes the TTL while retaining the
+# first marker byte for byte, including its original ``since`` value. A lower
+# numeric revision changes nothing.
+_WRITE_OWNED_MARKER_LUA = """
+local function marker_revision(raw)
+  local ok, marker = pcall(cjson.decode, raw)
+  if not ok or type(marker) ~= 'table' then return nil end
+  local revision = marker['revision']
+  if type(revision) ~= 'number' then return nil end
+  if revision < 0 or revision ~= math.floor(revision) then return nil end
+  return revision
+end
+
+local requested = tonumber(ARGV[1])
+local marker = ARGV[2]
+local retained = nil
+
+for _, key in ipairs(KEYS) do
+  local raw = redis.call('GET', key)
+  if raw then
+    local current = marker_revision(raw)
+    if current and current > requested then return 0 end
+    if current and current == requested and not retained then retained = raw end
+  end
+end
+
+if retained then marker = retained end
+for _, key in ipairs(KEYS) do
+  redis.call('SET', key, marker, 'PX', tonumber(ARGV[3]))
+end
+return 1
+"""
+
+# Compare every applicable key before deleting any of them. A delayed release
+# must never clear one half of a newer mixed version marker. The bare ``1`` is
+# recognized only as the unversioned standalone predecessor (revision zero), so
+# a local release can still recover a marker written by the previous version.
+_CLEAR_OWNED_MARKER_LUA = """
+local function marker_revision(raw, requested)
+  if raw == '1' and requested == 0 then return 0 end
+  local ok, marker = pcall(cjson.decode, raw)
+  if not ok or type(marker) ~= 'table' then return nil end
+  local revision = marker['revision']
+  if type(revision) ~= 'number' then return nil end
+  if revision < 0 or revision ~= math.floor(revision) then return nil end
+  return revision
+end
+
+local requested = tonumber(ARGV[1])
+for _, key in ipairs(KEYS) do
+  local raw = redis.call('GET', key)
+  if raw then
+    local current = marker_revision(raw, requested)
+    if current == nil or current ~= requested then return 0 end
+  end
+end
+return redis.call('DEL', unpack(KEYS))
+"""
+
+
+class ClaimStatus(TypedDict):
+    """Safe status shape emitted to the operator-side observer."""
+
+    state: Literal["claims_enabled", "quiescing", "unknown"]
+    since: str | None
+    revision: int | None
 
 
 @dataclass(frozen=True)
@@ -108,6 +181,20 @@ class UpgradeDrainGate:
 
     # -- the quiesce flag -----------------------------------------------------
 
+    def _revision(self) -> int:
+        # Ordinary worker processes do not receive a hook revision. Revision
+        # zero is reserved for explicit standalone legacy mode and can never
+        # supersede a positive Helm revision.
+        return self._config.upgrade_revision or 0
+
+    def _marker_keys(self) -> tuple[str, ...]:
+        authoritative = self._config.upgrade_quiesce_key()
+        if self._config.installation_id and self._config.upgrade_legacy_quiesce:
+            # Scoped first so a same revision retry repairs a legacy key that an
+            # old hook rewrote while retaining the authoritative marker's time.
+            return (authoritative, self._config.upgrade_legacy_quiesce_key())
+        return (authoritative,)
+
     async def request_quiesce(self, *, ttl_s: float | None = None) -> None:
         """Ask every replica to stop taking new work.
 
@@ -116,17 +203,77 @@ class UpgradeDrainGate:
         stopped answering and looks perfectly healthy while doing it.
         """
         ttl = self._config.upgrade_quiesce_ttl_s if ttl_s is None else ttl_s
-        await self._redis.set(
-            self._config.upgrade_quiesce_key(), "1", ex=max(1, int(ttl))
+        revision = self._revision()
+        marker = json.dumps(
+            {
+                "since": datetime.now(UTC).isoformat(),
+                "revision": revision,
+            },
+            separators=(",", ":"),
+        )
+        keys = self._marker_keys()
+        await self._redis.eval(
+            _WRITE_OWNED_MARKER_LUA,
+            len(keys),
+            *keys,
+            str(revision),
+            marker,
+            max(1, int(ttl * 1000)),
         )
 
     async def clear_quiesce(self) -> None:
-        """Let the fleet claim again. Idempotent."""
-        await self._redis.delete(self._config.upgrade_quiesce_key())
+        """Clear only markers owned by this revision. Idempotent."""
+
+        keys = self._marker_keys()
+        await self._redis.eval(
+            _CLEAR_OWNED_MARKER_LUA,
+            len(keys),
+            *keys,
+            str(self._revision()),
+        )
 
     async def is_quiescing(self) -> bool:
         """Is a drain in progress? The read every consumer makes before a claim."""
         return bool(await self._redis.exists(self._config.upgrade_quiesce_key()))
+
+    async def claim_status(self) -> ClaimStatus:
+        """Read the safe claim state without exposing marker identity or bytes."""
+
+        try:
+            raw = await self._redis.get(self._config.upgrade_quiesce_key())
+        except Exception:
+            # Status is diagnostic. An unreadable authority is unknown, never
+            # permission to claim and never an exception containing a key or
+            # credential copied onto stdout.
+            logger.warning("worker claim state is unknown: marker read failed")
+            return {"state": "unknown", "since": None, "revision": None}
+        if raw is None:
+            return {"state": "claims_enabled", "since": None, "revision": None}
+        try:
+            marker = json.loads(raw)
+            if not isinstance(marker, dict):
+                raise ValueError("marker is not an object")
+            since = marker.get("since")
+            revision = marker.get("revision")
+            if not isinstance(since, str):
+                raise ValueError("marker since is not a string")
+            parsed_since = datetime.fromisoformat(since)
+            if (
+                parsed_since.tzinfo is None
+                or parsed_since.utcoffset() != timedelta(0)
+            ):
+                raise ValueError("marker since is not UTC")
+            if (
+                not isinstance(revision, int)
+                or isinstance(revision, bool)
+                or revision < 0
+            ):
+                raise ValueError("marker revision is not an integer")
+        except (OverflowError, TypeError, ValueError):
+            # Existence is pause authority. Bad metadata is intentionally not
+            # echoed because its contents are untrusted diagnostic input.
+            return {"state": "quiescing", "since": None, "revision": None}
+        return {"state": "quiescing", "since": since, "revision": revision}
 
     # -- what is still in flight ----------------------------------------------
 
@@ -248,6 +395,14 @@ def _client(config: WorkerConfig) -> Redis:
     return Redis(**config.valkey_client_kwargs())
 
 
+async def _read_claim_status(config: WorkerConfig) -> ClaimStatus:
+    redis = _client(config)
+    try:
+        return await UpgradeDrainGate(redis, config).claim_status()
+    finally:
+        await redis.aclose()
+
+
 async def run_gate(config: WorkerConfig, *, mode: str) -> int:
     """The chart hook's body, factored out so tests drive it without a process.
 
@@ -259,7 +414,10 @@ async def run_gate(config: WorkerConfig, *, mode: str) -> int:
     try:
         if mode == "release":
             await UpgradeDrainGate(redis, config).clear_quiesce()
-            logger.info("upgrade quiesce cleared; the fleet is claiming again")
+            logger.info(
+                "upgrade quiesce release processing completed; run with --mode status "
+                "to confirm the current claim state"
+            )
             return 0
         gate = UpgradeDrainGate(redis, config)
         outcome = await gate.await_drained()
@@ -288,6 +446,15 @@ async def run_gate(config: WorkerConfig, *, mode: str) -> int:
         await redis.aclose()
 
 
+def _observed_arg(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    raise argparse.ArgumentTypeError("expected true or false")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="curie-worker-upgrade-drain",
@@ -295,13 +462,53 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--mode",
-        choices=("drain", "release"),
+        choices=("drain", "release", "status"),
         default="drain",
-        help="drain: pre-upgrade gate. release: post-upgrade quiesce clear.",
+        help=(
+            "drain: pre-upgrade gate. release: post-upgrade quiesce clear. "
+            "status: read worker claim state."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="write the status result as exactly one JSON object",
+    )
+    parser.add_argument(
+        "--installation-id-observed",
+        type=_observed_arg,
+        default=True,
+        metavar="true|false",
+        help="whether Helm observed the live installation identity",
     )
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
-    return asyncio.run(run_gate(WorkerConfig(), mode=args.mode))
+    if args.mode != "status" and not args.installation_id_observed:
+        # This render-time bit is hook-only. Refuse before WorkerConfig builds a
+        # Redis client, so an unobserved upgrade cannot mutate either marker or
+        # pretend a failed lookup was an installation identity.
+        logger.error(
+            "refusing %s: installation ID was not observed during the upgrade "
+            "render; no Valkey client was created and no marker was mutated",
+            args.mode,
+        )
+        return 1
+
+    config = WorkerConfig()
+    if args.mode == "status":
+        status = asyncio.run(_read_claim_status(config))
+        if args.json:
+            sys.stdout.write(json.dumps(status, separators=(",", ":")) + "\n")
+        elif status["state"] == "quiescing" and status["revision"] is not None:
+            logger.info(
+                "worker claims are quiescing since %s for upgrade revision %d",
+                status["since"],
+                status["revision"],
+            )
+        else:
+            logger.info("worker claim state: %s", status["state"])
+        return 0
+    return asyncio.run(run_gate(config, mode=args.mode))
 
 
 if __name__ == "__main__":  # pragma: no cover - process entry point

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -319,6 +319,13 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         "CURIE_UPGRADE_DRAIN_TIMEOUT_S",
         "CURIE_UPGRADE_DRAIN_POLL_INTERVAL_S",
         "CURIE_UPGRADE_QUIESCE_TTL_S",
+        # Installation-scoped upgrade authority (#2374), read only by the
+        # WORKER process and its worker-image hook entrypoint. These identify
+        # which release owns a marker, fence hook revisions, and enable the
+        # one-upgrade legacy bridge; none is injected into a runner sandbox.
+        "CURIE_INSTALLATION_ID",
+        "CURIE_UPGRADE_REVISION",
+        "CURIE_UPGRADE_LEGACY_QUIESCE",
     }
 )
 

--- a/apps/worker/tests/kernel/test_upgrade_drain.py
+++ b/apps/worker/tests/kernel/test_upgrade_drain.py
@@ -44,6 +44,8 @@ import asyncio
 import contextlib
 import time
 import uuid
+from dataclasses import replace
+from typing import Any, cast
 
 from aci_protocol import (
     Final,
@@ -55,9 +57,12 @@ from aci_protocol import (
     TurnSource,
 )
 from curie_dispatcher.queue import to_stream_fields
+from curie_worker.config import WorkerConfig
 from curie_worker.consumer import Consumer
+from curie_worker.consumer_liveness import ConsumerLivenessStore
 from curie_worker.delivery_lease import DeliveryLeaseStore
-from curie_worker.upgrade_drain import UpgradeDrainGate
+from curie_worker.eval import EvalStreamConsumer
+from curie_worker.upgrade_drain import UpgradeDrainGate, run_gate
 
 DONE = SessionStatus.DONE
 
@@ -113,6 +118,48 @@ async def _stop(task: asyncio.Task[None], consumer: Consumer | None = None) -> N
     task.cancel()
     with contextlib.suppress(asyncio.CancelledError, Exception):
         await task
+
+
+async def _pending_row(
+    h, *, stream: str, group: str, entry_id: str
+) -> dict[str, Any]:  # noqa: ANN001
+    rows = await h.async_redis.xpending_range(
+        stream,
+        group,
+        min=entry_id,
+        max=entry_id,
+        count=1,
+    )
+    assert len(rows) == 1
+    return rows[0]
+
+
+def _recording_eval_consumer(
+    h,  # noqa: ANN001
+    config: WorkerConfig,
+    gate: UpgradeDrainGate,
+    seen: list[tuple[str, dict[str, str]]],
+    *,
+    leases: DeliveryLeaseStore | None = None,
+) -> EvalStreamConsumer:
+    """An actual eval consumer with only its external execution collaborators inert."""
+    consumer = EvalStreamConsumer(
+        redis=h.async_redis,
+        config=config,
+        bundle_store=cast(Any, object()),
+        substrate=cast(Any, object()),
+        reporter=cast(Any, object()),
+        recorder=cast(Any, object()),
+        repo_lookup=cast(Any, object()),
+        leases=leases,
+        drain=gate,
+    )
+
+    async def record(entry_id: str, fields: dict[str, str]) -> None:
+        seen.append((entry_id, dict(fields)))
+
+    consumer._delivery = replace(consumer._delivery, handler=record)
+    return consumer
 
 
 async def _kill_replica(task: asyncio.Task[None], consumer: Consumer) -> None:
@@ -318,6 +365,566 @@ def test_the_pre_upgrade_gate_refuses_the_roll_and_the_turn_completes_once(make_
 
 
 # --- new claims are suppressed for the whole drain ----------------------------
+
+
+def test_a_leftover_install_flag_cannot_pause_a_fresh_install(
+    make_harness,
+) -> None:  # noqa: ANN001
+    """The #2374 fix pin: quiesce authority belongs to one installation.
+
+    The queued turn first proves that its own installation's marker pauses the
+    real consumer gate.  That consumer is then stopped before markers are
+    switched, avoiding a claim in the clear/set gap.  A fresh consumer for the
+    same installation must claim and reply while only the removed
+    installation's marker remains.
+
+    ``installation_id`` is supplied as ordinary config input.  The pre-fix
+    ``WorkerConfig`` ignores it, so this test still collects and reaches the
+    behavioral failure: both gates address the one global key and the reply
+    never arrives.
+    """
+    thread = "drain-fresh-install-1"
+    event_id = uuid.uuid4().hex
+
+    async def go() -> None:
+        knobs = {**_KNOBS, "upgrade_quiesce_ttl_s": 30.0}
+        async with make_harness(
+            **knobs,
+            installation_id="install-fresh",
+            upgrade_revision=10,
+            upgrade_legacy_quiesce=False,
+        ) as h:
+            h.runner.default_script = [Final(text="handled by fresh install", status=DONE)]
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            fresh_gate = UpgradeDrainGate(h.async_redis, h.config)
+            current = Consumer(
+                redis=h.async_redis,
+                kernel=h.kernel,
+                config=h.config,
+                leases=store,
+                drain=fresh_gate,
+            )
+            await current.ensure_group()
+            await fresh_gate.request_quiesce()
+            current_task = asyncio.create_task(current.run())
+            replacement_task: asyncio.Task[None] | None = None
+            old_gate: UpgradeDrainGate | None = None
+            try:
+                await h.async_redis.xadd(
+                    h.config.stream,
+                    to_stream_fields(
+                        _qevent("queued for fresh install", thread=thread, event_id=event_id)
+                    ),
+                )
+                await asyncio.sleep(1.0)
+                assert h.runner.opened == [], (
+                    "the current installation's marker did not pause its queued turn"
+                )
+
+                await _stop(current_task, current)
+                await fresh_gate.clear_quiesce()
+
+                old_config = WorkerConfig.model_validate(
+                    {
+                        **h.config.model_dump(),
+                        "consumer_name": "worker-removed",
+                        "installation_id": "install-removed",
+                        "upgrade_revision": 9,
+                        "upgrade_legacy_quiesce": False,
+                    }
+                )
+                fresh_replacement_config = WorkerConfig.model_validate(
+                    {
+                        **h.config.model_dump(),
+                        "consumer_name": "worker-fresh-replacement",
+                        "installation_id": "install-fresh",
+                        "upgrade_revision": 10,
+                        "upgrade_legacy_quiesce": False,
+                    }
+                )
+                old_gate = UpgradeDrainGate(h.async_redis, old_config)
+                await old_gate.request_quiesce()
+
+                replacement = Consumer(
+                    redis=h.async_redis,
+                    kernel=h.kernel,
+                    config=fresh_replacement_config,
+                    leases=store,
+                    drain=UpgradeDrainGate(h.async_redis, fresh_replacement_config),
+                )
+                replacement_task = asyncio.create_task(replacement.run())
+                await _wait_until(
+                    lambda: h.sink.last_text == "handled by fresh install",
+                    timeout=5.0,
+                )
+                assert h.runner.opened == ["queued for fresh install"]
+                assert h.sink.last_text == "handled by fresh install"
+            finally:
+                if replacement_task is not None:
+                    await _stop(replacement_task, replacement)
+                elif not current_task.done():
+                    await _stop(current_task, current)
+                if old_gate is not None:
+                    await old_gate.clear_quiesce()
+                await fresh_gate.clear_quiesce()
+
+    asyncio.run(go())
+
+
+def test_current_marker_pauses_eval_new_reads_until_owned_release(
+    make_harness,
+) -> None:  # noqa: ANN001
+    """The eval sibling reaches the same shared new-read gate as runs."""
+
+    from aci_protocol import EvalJob
+
+    async def go() -> None:
+        async with make_harness(
+            **_KNOBS,
+            installation_id="install-current",
+            upgrade_revision=10,
+            upgrade_legacy_quiesce=False,
+        ) as h:
+            eval_config = WorkerConfig.model_validate(
+                {
+                    **h.config.model_dump(),
+                    "eval_stream": f"{h.config.stream}:evals",
+                    "eval_consumer_group": f"{h.config.consumer_group}-evals",
+                    "eval_consumer_name": "eval-current",
+                    "installation_id": "install-current",
+                    "upgrade_revision": 10,
+                    "upgrade_legacy_quiesce": False,
+                }
+            )
+            gate = UpgradeDrainGate(h.async_redis, eval_config)
+            seen: list[tuple[str, dict[str, str]]] = []
+            consumer = _recording_eval_consumer(h, eval_config, gate, seen)
+            job = EvalJob(
+                agent_id=uuid.uuid4(),
+                version_id=uuid.uuid4(),
+                sha="deadbeef",
+                suite="smoke",
+                bundle_ref="bundles/acme-eval.tgz",
+                requested_at="2026-09-08T00:00:00+00:00",
+            )
+            payload = job.model_dump_json()
+            hold = asyncio.Event()
+
+            async def record_parsed_job(item: EvalJob, claimed_id: str) -> Any:
+                assert item == job
+                seen.append((claimed_id, {"payload": item.model_dump_json()}))
+                await hold.wait()
+
+            consumer._run_and_report = record_parsed_job  # type: ignore[method-assign,assignment]
+            await consumer.ensure_group()
+            await gate.request_quiesce()
+            task = asyncio.create_task(consumer._read_loop())
+            entry_id = await h.async_redis.xadd(
+                eval_config.eval_stream, {"payload": payload}
+            )
+            try:
+                await asyncio.sleep(0.6)
+                assert seen == []
+                assert (
+                    await h.async_redis.xpending(
+                        eval_config.eval_stream, eval_config.eval_consumer_group
+                    )
+                )["pending"] == 0, "the eval row entered a PEL while claims were paused"
+
+                await gate.clear_quiesce()
+                await _wait_until(lambda: len(seen) == 1, timeout=5.0)
+                assert seen == [(entry_id, {"payload": payload})]
+                row = await _pending_row(
+                    h,
+                    stream=eval_config.eval_stream,
+                    group=eval_config.eval_consumer_group,
+                    entry_id=entry_id,
+                )
+                assert row["consumer"] == "eval-current"
+                assert int(row["times_delivered"]) == 1
+            finally:
+                await _stop(task)
+                inflight = list(consumer._inflight)
+                for handler in inflight:
+                    handler.cancel()
+                for handler in inflight:
+                    with contextlib.suppress(asyncio.CancelledError, Exception):
+                        await handler
+                await gate.clear_quiesce()
+                await h.async_redis.delete(
+                    eval_config.eval_stream,
+                    eval_config.eval_dead_letter_stream_name(),
+                )
+
+    asyncio.run(go())
+
+
+def test_current_marker_pauses_runs_prompt_reclaim_without_charging_delivery(
+    make_harness,
+) -> None:  # noqa: ANN001
+    """A capable peer transfer is selection, so it stops before the PEL moves."""
+
+    async def go() -> None:
+        knobs = {
+            **_KNOBS,
+            "reclaim_min_idle_ms": 5000,
+            "dead_consumer_idle_ms": 0,
+            "consumer_heartbeat_ttl_ms": 30,
+            "consumer_capability_ttl_ms": 6000,
+            "upgrade_quiesce_ttl_s": 30.0,
+        }
+        async with make_harness(
+            **knobs,
+            installation_id="install-current",
+            upgrade_revision=10,
+            upgrade_legacy_quiesce=False,
+        ) as h:
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="reclaimed")]
+            h.runner.tail = [Final(text="prompt handled", status=DONE)]
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            gate = UpgradeDrainGate(h.async_redis, h.config)
+            consumer_config = h.config.model_copy(
+                update={"consumer_name": "runs-replacement"}
+            )
+            consumer = Consumer(
+                redis=h.async_redis,
+                kernel=h.kernel,
+                config=consumer_config,
+                leases=store,
+                drain=gate,
+            )
+            await consumer.ensure_group()
+            entry_id = await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(
+                    _qevent(
+                        "prompt recovery",
+                        thread="drain-prompt-runs",
+                        event_id=uuid.uuid4().hex,
+                    )
+                ),
+            )
+            assert await h.async_redis.xreadgroup(
+                h.config.consumer_group,
+                "runs-departed",
+                {h.config.stream: ">"},
+                count=1,
+            )
+            liveness = ConsumerLivenessStore(h.async_redis)
+            await liveness.publish(
+                stream=h.config.stream,
+                group=h.config.consumer_group,
+                consumer="runs-departed",
+                heartbeat_ttl_ms=1,
+                capability_ttl_ms=h.config.consumer_capability_ttl_ms,
+            )
+            await asyncio.sleep(0.02)
+            await gate.request_quiesce()
+            try:
+                assert await consumer._prompt_reclaim_once() == 0
+                await asyncio.sleep(
+                    h.config.consumer_heartbeat_ttl_ms / 1000 + 0.02
+                )
+                assert await consumer._prompt_reclaim_once() == 0
+                paused = await _pending_row(
+                    h,
+                    stream=h.config.stream,
+                    group=h.config.consumer_group,
+                    entry_id=entry_id,
+                )
+                assert paused["consumer"] == "runs-departed"
+                assert int(paused["times_delivered"]) == 1
+                assert h.runner.opened == []
+
+                await gate.clear_quiesce()
+                assert await consumer._prompt_reclaim_once() == 0
+                await asyncio.sleep(
+                    h.config.consumer_heartbeat_ttl_ms / 1000 + 0.02
+                )
+                assert await consumer._prompt_reclaim_once() == 1
+                await _wait_until(lambda: h.runner.turn_active, timeout=5.0)
+                transferred = await _pending_row(
+                    h,
+                    stream=h.config.stream,
+                    group=h.config.consumer_group,
+                    entry_id=entry_id,
+                )
+                assert transferred["consumer"] == "runs-replacement"
+                assert int(transferred["times_delivered"]) == 2
+                assert h.runner.opened == ["prompt recovery"]
+            finally:
+                hold.set()
+                if consumer._inflight:
+                    await asyncio.gather(*list(consumer._inflight))
+                await gate.clear_quiesce()
+
+    asyncio.run(go())
+
+
+def test_current_marker_pauses_eval_prompt_reclaim_until_owned_release(
+    make_harness,
+) -> None:  # noqa: ANN001
+    async def go() -> None:
+        knobs = {
+            **_KNOBS,
+            "reclaim_min_idle_ms": 5000,
+            "dead_consumer_idle_ms": 0,
+            "consumer_heartbeat_ttl_ms": 30,
+            "consumer_capability_ttl_ms": 6000,
+            "upgrade_quiesce_ttl_s": 30.0,
+        }
+        async with make_harness(
+            **knobs,
+            installation_id="install-current",
+            upgrade_revision=10,
+            upgrade_legacy_quiesce=False,
+        ) as h:
+            eval_config = WorkerConfig.model_validate(
+                {
+                    **h.config.model_dump(),
+                    "eval_stream": f"{h.config.stream}:evals",
+                    "eval_consumer_group": f"{h.config.consumer_group}-evals",
+                    "eval_consumer_name": "eval-replacement",
+                    "installation_id": "install-current",
+                    "upgrade_revision": 10,
+                    "upgrade_legacy_quiesce": False,
+                }
+            )
+            gate = UpgradeDrainGate(h.async_redis, eval_config)
+            seen: list[tuple[str, dict[str, str]]] = []
+            consumer = _recording_eval_consumer(h, eval_config, gate, seen)
+            await consumer.ensure_group()
+            entry_id = await h.async_redis.xadd(
+                eval_config.eval_stream, {"payload": "prompt-eval"}
+            )
+            assert await h.async_redis.xreadgroup(
+                eval_config.eval_consumer_group,
+                "eval-departed",
+                {eval_config.eval_stream: ">"},
+                count=1,
+            )
+            liveness = ConsumerLivenessStore(h.async_redis)
+            await liveness.publish(
+                stream=eval_config.eval_stream,
+                group=eval_config.eval_consumer_group,
+                consumer="eval-departed",
+                heartbeat_ttl_ms=1,
+                capability_ttl_ms=eval_config.consumer_capability_ttl_ms,
+            )
+            await asyncio.sleep(0.02)
+            await gate.request_quiesce()
+            try:
+                assert await consumer._prompt_reclaim_once() == 0
+                await asyncio.sleep(
+                    eval_config.consumer_heartbeat_ttl_ms / 1000 + 0.02
+                )
+                assert await consumer._prompt_reclaim_once() == 0
+                paused = await _pending_row(
+                    h,
+                    stream=eval_config.eval_stream,
+                    group=eval_config.eval_consumer_group,
+                    entry_id=entry_id,
+                )
+                assert paused["consumer"] == "eval-departed"
+                assert int(paused["times_delivered"]) == 1
+                assert seen == []
+
+                await gate.clear_quiesce()
+                assert await consumer._prompt_reclaim_once() == 0
+                await asyncio.sleep(
+                    eval_config.consumer_heartbeat_ttl_ms / 1000 + 0.02
+                )
+                assert await consumer._prompt_reclaim_once() == 1
+                assert seen == [(entry_id, {"payload": "prompt-eval"})]
+                transferred = await _pending_row(
+                    h,
+                    stream=eval_config.eval_stream,
+                    group=eval_config.eval_consumer_group,
+                    entry_id=entry_id,
+                )
+                assert transferred["consumer"] == "eval-replacement"
+                assert int(transferred["times_delivered"]) == 2
+            finally:
+                await gate.clear_quiesce()
+                await h.async_redis.delete(
+                    eval_config.eval_stream,
+                    eval_config.eval_dead_letter_stream_name(),
+                )
+
+    asyncio.run(go())
+
+
+def test_current_marker_pauses_eval_heavy_reclaim_before_pending_selection(
+    make_harness,
+) -> None:  # noqa: ANN001
+    async def go() -> None:
+        knobs = {
+            **_KNOBS,
+            "reclaim_min_idle_ms": 50,
+            "upgrade_quiesce_ttl_s": 30.0,
+        }
+        async with make_harness(
+            **knobs,
+            installation_id="install-current",
+            upgrade_revision=10,
+            upgrade_legacy_quiesce=False,
+        ) as h:
+            eval_config = WorkerConfig.model_validate(
+                {
+                    **h.config.model_dump(),
+                    "eval_stream": f"{h.config.stream}:evals",
+                    "eval_consumer_group": f"{h.config.consumer_group}-evals",
+                    "eval_consumer_name": "eval-heavy-replacement",
+                    "installation_id": "install-current",
+                    "upgrade_revision": 10,
+                    "upgrade_legacy_quiesce": False,
+                }
+            )
+            gate = UpgradeDrainGate(h.async_redis, eval_config)
+            seen: list[tuple[str, dict[str, str]]] = []
+            consumer = _recording_eval_consumer(h, eval_config, gate, seen)
+            await consumer.ensure_group()
+            entry_id = await h.async_redis.xadd(
+                eval_config.eval_stream, {"payload": "heavy-eval"}
+            )
+            assert await h.async_redis.xreadgroup(
+                eval_config.eval_consumer_group,
+                "eval-old-owner",
+                {eval_config.eval_stream: ">"},
+                count=1,
+            )
+            await asyncio.sleep(eval_config.reclaim_min_idle_ms / 1000 + 0.05)
+            await gate.request_quiesce()
+            try:
+                assert await consumer._reclaim_once() == 0
+                paused = await _pending_row(
+                    h,
+                    stream=eval_config.eval_stream,
+                    group=eval_config.eval_consumer_group,
+                    entry_id=entry_id,
+                )
+                assert paused["consumer"] == "eval-old-owner"
+                assert int(paused["times_delivered"]) == 1
+                assert seen == []
+
+                await gate.clear_quiesce()
+                assert await consumer._reclaim_once() == 1
+                assert seen == [(entry_id, {"payload": "heavy-eval"})]
+                transferred = await _pending_row(
+                    h,
+                    stream=eval_config.eval_stream,
+                    group=eval_config.eval_consumer_group,
+                    entry_id=entry_id,
+                )
+                assert transferred["consumer"] == "eval-heavy-replacement"
+                assert int(transferred["times_delivered"]) == 2
+            finally:
+                await gate.clear_quiesce()
+                await h.async_redis.delete(
+                    eval_config.eval_stream,
+                    eval_config.eval_dead_letter_stream_name(),
+                )
+
+    asyncio.run(go())
+
+
+def test_mixed_version_refusal_allows_a_pre_fix_consumer_to_claim_again(
+    make_harness,
+) -> None:  # noqa: ANN001
+    """Clearing the bridge on refusal restores an old replica's real read path."""
+
+    async def go() -> None:
+        knobs = {
+            **_KNOBS,
+            "upgrade_drain_timeout_s": 0.2,
+            "upgrade_quiesce_ttl_s": 30.0,
+        }
+        async with make_harness(**knobs) as h:
+            current_config = WorkerConfig.model_validate(
+                {
+                    **h.config.model_dump(),
+                    "eval_stream": f"{h.config.stream}:evals",
+                    "eval_consumer_group": f"{h.config.consumer_group}-evals",
+                    "installation_id": "install-adopted",
+                    "upgrade_revision": 9,
+                    "upgrade_legacy_quiesce": True,
+                }
+            )
+            legacy_config = WorkerConfig.model_validate(
+                {
+                    **current_config.model_dump(),
+                    "consumer_name": "worker-pre-fix",
+                    "installation_id": "",
+                    "upgrade_revision": None,
+                    "upgrade_legacy_quiesce": False,
+                }
+            )
+            store = DeliveryLeaseStore(h.async_redis, current_config)
+            legacy_gate = UpgradeDrainGate(h.async_redis, legacy_config)
+            consumer = Consumer(
+                redis=h.async_redis,
+                kernel=h.kernel,
+                config=legacy_config,
+                leases=store,
+                drain=legacy_gate,
+            )
+            h.runner.default_script = [Final(text="pre-fix worker resumed", status=DONE)]
+            await consumer.ensure_group()
+
+            busy_id = await h.async_redis.xadd(
+                current_config.stream,
+                to_stream_fields(
+                    _qevent(
+                        "already in flight",
+                        thread="drain-bridge-busy",
+                        event_id=uuid.uuid4().hex,
+                    )
+                ),
+            )
+            assert await h.async_redis.xreadgroup(
+                current_config.consumer_group,
+                "worker-busy",
+                {current_config.stream: ">"},
+                count=1,
+            )
+            await store.acquire(
+                current_config.stream,
+                current_config.consumer_group,
+                busy_id,
+                consumer="worker-busy",
+            )
+            await h.async_redis.xadd(
+                current_config.stream,
+                to_stream_fields(
+                    _qevent(
+                        "claim after refusal",
+                        thread="drain-bridge-ready",
+                        event_id=uuid.uuid4().hex,
+                    )
+                ),
+            )
+
+            task: asyncio.Task[None] | None = None
+            try:
+                assert await run_gate(current_config, mode="drain") == 1
+                assert await legacy_gate.is_quiescing() is False
+
+                task = asyncio.create_task(consumer.run())
+                await _wait_until(
+                    lambda: h.sink.last_text == "pre-fix worker resumed",
+                    timeout=5.0,
+                )
+                assert h.runner.opened == ["claim after refusal"]
+            finally:
+                if task is not None:
+                    await _stop(task, consumer)
+                await UpgradeDrainGate(h.async_redis, current_config).clear_quiesce()
+                await legacy_gate.clear_quiesce()
+                await h.async_redis.delete(current_config.eval_stream)
+
+    asyncio.run(go())
 
 
 def test_a_quiesced_consumer_claims_nothing_and_resumes_when_released(make_harness) -> None:  # noqa: ANN001

--- a/apps/worker/tests/test_config.py
+++ b/apps/worker/tests/test_config.py
@@ -1210,3 +1210,76 @@ def test_the_turn_not_started_text_is_operator_overridable(
 
     monkeypatch.setenv("CURIE_TURN_NOT_STARTED_TEXT", "Sorry, please resend that.")
     assert WorkerConfig().turn_not_started_text == "Sorry, please resend that."
+
+
+# --- Installation-scoped upgrade drain authority (#2374) --------------------
+
+
+def test_upgrade_drain_identity_defaults_preserve_standalone_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compose and a bare worker have no Helm installation boundary.
+
+    Blank identity remains the deliberate legacy-key mode, while the hook-only
+    revision and compatibility inputs default away so ``--mode status`` can
+    construct its config in every worker process.
+    """
+    _clear_all_config_env(monkeypatch)
+
+    config = WorkerConfig(key_prefix="curie:worker")
+
+    assert config.installation_id == ""
+    assert config.upgrade_revision is None
+    assert config.upgrade_legacy_quiesce is False
+    assert config.upgrade_quiesce_key() == "curie:worker:upgrade:quiesce"
+
+
+def test_upgrade_drain_identity_reads_only_its_three_curie_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("INSTALLATION_ID", "stray-install")
+    monkeypatch.setenv("UPGRADE_REVISION", "99")
+    monkeypatch.setenv("UPGRADE_LEGACY_QUIESCE", "false")
+    monkeypatch.setenv("CURIE_INSTALLATION_ID", "install-env")
+    monkeypatch.setenv("CURIE_UPGRADE_REVISION", "10")
+    monkeypatch.setenv("CURIE_UPGRADE_LEGACY_QUIESCE", "true")
+
+    config = WorkerConfig(key_prefix="curie:worker")
+
+    assert config.installation_id == "install-env"
+    assert config.upgrade_revision == 10
+    assert config.upgrade_legacy_quiesce is True
+    assert (
+        config.upgrade_quiesce_key()
+        == "curie:worker:upgrade:quiesce:install-env"
+    )
+
+
+@pytest.mark.parametrize("revision", ["nine", "9.5", "0", "-1"])
+def test_upgrade_revision_must_be_a_positive_decimal_integer(
+    monkeypatch: pytest.MonkeyPatch,
+    revision: str,
+) -> None:
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("CURIE_UPGRADE_REVISION", revision)
+
+    with pytest.raises(ValidationError, match="CURIE_UPGRADE_REVISION"):
+        WorkerConfig()
+
+
+def test_deliberately_blank_installation_id_keeps_the_legacy_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_all_config_env(monkeypatch)
+
+    config = WorkerConfig(
+        key_prefix="test:standalone",
+        installation_id="",
+        upgrade_revision=9,
+        upgrade_legacy_quiesce=False,
+    )
+
+    assert config.installation_id == ""
+    assert config.upgrade_revision == 9
+    assert config.upgrade_quiesce_key() == "test:standalone:upgrade:quiesce"

--- a/apps/worker/tests/test_upgrade_drain.py
+++ b/apps/worker/tests/test_upgrade_drain.py
@@ -29,8 +29,14 @@ import ast
 import asyncio
 import contextlib
 import importlib
+import json
+import os
 import re
+import socket
+import subprocess
+import sys
 from collections.abc import AsyncIterator
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -122,6 +128,81 @@ async def _pending(client: AsyncRedis, config: WorkerConfig, consumer: str) -> s
     return str(entry_id)
 
 
+def _legacy_quiesce_key(config: WorkerConfig) -> str:
+    """The pre-#2374 key, named explicitly for mixed-version assertions."""
+    return f"{config.key_prefix}:upgrade:quiesce"
+
+
+def _scoped_quiesce_key(config: WorkerConfig, installation_id: str) -> str:
+    return f"{config.key_prefix}:upgrade:quiesce:{installation_id}"
+
+
+def _module_env(config: WorkerConfig) -> dict[str, str]:
+    """Only public connection/config values needed by the hook subprocess."""
+    installation_id = str(getattr(config, "installation_id", "install-status"))
+    revision = getattr(config, "upgrade_revision", 10)
+    legacy = bool(getattr(config, "upgrade_legacy_quiesce", False))
+    return {
+        **os.environ,
+        "VALKEY_HOST": config.valkey_host,
+        "VALKEY_PORT": str(config.valkey_port),
+        "VALKEY_PASSWORD": config.valkey_password,
+        "VALKEY_DB": str(config.valkey_db),
+        "VALKEY_TLS": "true" if config.valkey_tls else "false",
+        "KEY_PREFIX": config.key_prefix,
+        "CURIE_STREAM": config.stream,
+        "CURIE_CONSUMER_GROUP": config.consumer_group,
+        "CURIE_EVAL_STREAM": config.eval_stream,
+        "CURIE_EVAL_CONSUMER_GROUP": config.eval_consumer_group,
+        "CURIE_INSTALLATION_ID": installation_id,
+        "CURIE_UPGRADE_REVISION": "" if revision is None else str(revision),
+        "CURIE_UPGRADE_LEGACY_QUIESCE": "true" if legacy else "false",
+        "CURIE_UPGRADE_DRAIN_TIMEOUT_S": str(config.upgrade_drain_timeout_s),
+        "CURIE_UPGRADE_DRAIN_POLL_INTERVAL_S": str(
+            config.upgrade_drain_poll_interval_s
+        ),
+        "CURIE_UPGRADE_QUIESCE_TTL_S": str(config.upgrade_quiesce_ttl_s),
+    }
+
+
+def _configure_module_env(
+    monkeypatch: pytest.MonkeyPatch, config: WorkerConfig
+) -> None:
+    for name, value in _module_env(config).items():
+        if name in {
+            "VALKEY_HOST",
+            "VALKEY_PORT",
+            "VALKEY_PASSWORD",
+            "VALKEY_DB",
+            "VALKEY_TLS",
+            "KEY_PREFIX",
+            "CURIE_STREAM",
+            "CURIE_CONSUMER_GROUP",
+            "CURIE_EVAL_STREAM",
+            "CURIE_EVAL_CONSUMER_GROUP",
+            "CURIE_INSTALLATION_ID",
+            "CURIE_UPGRADE_REVISION",
+            "CURIE_UPGRADE_LEGACY_QUIESCE",
+            "CURIE_UPGRADE_DRAIN_TIMEOUT_S",
+            "CURIE_UPGRADE_DRAIN_POLL_INTERVAL_S",
+            "CURIE_UPGRADE_QUIESCE_TTL_S",
+        }:
+            monkeypatch.setenv(name, value)
+
+
+def _status_json(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    config: WorkerConfig,
+) -> tuple[dict[str, object], str]:
+    _configure_module_env(monkeypatch, config)
+    assert main(["--mode", "status", "--json"]) == 0
+    captured = capsys.readouterr()
+    lines = captured.out.splitlines()
+    assert len(lines) == 1, f"status must write one JSON object, got {lines!r}"
+    return json.loads(lines[0]), captured.err
+
+
 # --- the quiesce flag ---------------------------------------------------------
 
 
@@ -171,6 +252,397 @@ def test_clear_quiesce_is_idempotent(names) -> None:  # noqa: ANN001
             assert await gate.is_quiescing() is False
 
     asyncio.run(go())
+
+
+def test_scoped_marker_isolates_installations_and_has_a_finite_ttl(
+    names,
+) -> None:  # noqa: ANN001
+    """A leftover hook can pause only the installation whose ID it carries."""
+
+    async def go() -> None:
+        first = _config(
+            names,
+            installation_id="install-first",
+            upgrade_revision=9,
+            upgrade_legacy_quiesce=False,
+        )
+        second = _config(
+            names,
+            installation_id="install-second",
+            upgrade_revision=9,
+            upgrade_legacy_quiesce=False,
+        )
+        client: AsyncRedis = AsyncRedis(
+            host=_VALKEY_HOST,
+            port=_VALKEY_PORT,
+            password=_VALKEY_PW or None,
+            decode_responses=True,
+        )
+        first_key = _scoped_quiesce_key(first, "install-first")
+        second_key = _scoped_quiesce_key(second, "install-second")
+        legacy_key = _legacy_quiesce_key(first)
+        try:
+            await client.delete(first_key, second_key, legacy_key)
+            await UpgradeDrainGate(client, first).request_quiesce()
+
+            assert await UpgradeDrainGate(client, first).is_quiescing() is True
+            assert await UpgradeDrainGate(client, second).is_quiescing() is False
+            assert await client.exists(first_key)
+            assert not await client.exists(second_key)
+            assert not await client.exists(legacy_key), (
+                "a current install touched the global compatibility key"
+            )
+            ttl_ms = await client.pttl(first_key)
+            assert 0 < ttl_ms <= int(_QUIESCE_TTL_S * 1000)
+        finally:
+            await client.delete(first_key, second_key, legacy_key)
+            await client.aclose()
+
+    asyncio.run(go())
+
+
+def test_marker_json_fences_numeric_revisions_and_retains_same_revision_since(
+    names,
+) -> None:  # noqa: ANN001
+    """Revision 10 outranks 9; retries by one owner preserve authorship time."""
+
+    async def go() -> None:
+        revision_9 = _config(
+            names,
+            installation_id="install-fenced",
+            upgrade_revision=9,
+            upgrade_legacy_quiesce=False,
+        )
+        revision_10 = _config(
+            names,
+            installation_id="install-fenced",
+            upgrade_revision=10,
+            upgrade_legacy_quiesce=False,
+        )
+        client: AsyncRedis = AsyncRedis(
+            host=_VALKEY_HOST,
+            port=_VALKEY_PORT,
+            password=_VALKEY_PW or None,
+            decode_responses=True,
+        )
+        key = _scoped_quiesce_key(revision_9, "install-fenced")
+        gate_9 = UpgradeDrainGate(client, revision_9)
+        gate_10 = UpgradeDrainGate(client, revision_10)
+        try:
+            await client.delete(key, _legacy_quiesce_key(revision_9))
+            await gate_9.request_quiesce()
+            first_raw = await client.get(key)
+            assert first_raw is not None
+            first = json.loads(first_raw)
+            assert first["revision"] == 9
+            assert isinstance(first["revision"], int)
+            parsed_since = datetime.fromisoformat(first["since"])
+            assert parsed_since.tzinfo is not None
+
+            await asyncio.sleep(0.02)
+            await gate_9.request_quiesce()
+            assert await client.get(key) == first_raw, (
+                "a same-revision retry rewrote the original since timestamp"
+            )
+
+            await gate_10.request_quiesce()
+            revision_10_raw = await client.get(key)
+            assert revision_10_raw is not None
+            assert json.loads(revision_10_raw)["revision"] == 10
+
+            await gate_9.request_quiesce()
+            assert await client.get(key) == revision_10_raw, (
+                "numeric revision 9 replaced the newer revision 10 marker"
+            )
+            await gate_9.clear_quiesce()
+            assert await client.get(key) == revision_10_raw, (
+                "a delayed revision 9 release cleared revision 10"
+            )
+            await gate_10.clear_quiesce()
+            assert not await client.exists(key)
+        finally:
+            await client.delete(key, _legacy_quiesce_key(revision_9))
+            await client.aclose()
+
+    asyncio.run(go())
+
+
+def test_current_marker_never_reads_writes_or_clears_the_global_key(
+    names,
+) -> None:  # noqa: ANN001
+    async def go() -> None:
+        config = _config(
+            names,
+            installation_id="install-current",
+            upgrade_revision=10,
+            upgrade_legacy_quiesce=False,
+        )
+        client: AsyncRedis = AsyncRedis(
+            host=_VALKEY_HOST,
+            port=_VALKEY_PORT,
+            password=_VALKEY_PW or None,
+            decode_responses=True,
+        )
+        gate = UpgradeDrainGate(client, config)
+        legacy_key = _legacy_quiesce_key(config)
+        scoped_key = _scoped_quiesce_key(config, "install-current")
+        legacy_value = json.dumps(
+            {"since": "2026-09-08T00:00:00+00:00", "revision": 77},
+            separators=(",", ":"),
+        )
+        try:
+            await client.delete(legacy_key, scoped_key)
+            await client.set(legacy_key, legacy_value, ex=30)
+
+            assert await gate.is_quiescing() is False
+            await gate.request_quiesce()
+            assert await client.get(legacy_key) == legacy_value
+            assert await client.exists(scoped_key)
+            await gate.clear_quiesce()
+            assert await client.get(legacy_key) == legacy_value
+            assert not await client.exists(scoped_key)
+        finally:
+            await client.delete(legacy_key, scoped_key)
+            await client.aclose()
+
+    asyncio.run(go())
+
+
+def test_first_mixed_version_upgrade_atomically_writes_and_clears_both_keys(
+    names,
+) -> None:  # noqa: ANN001
+    async def go() -> None:
+        config = _config(
+            names,
+            installation_id="install-adopted",
+            upgrade_revision=9,
+            upgrade_legacy_quiesce=True,
+        )
+        client: AsyncRedis = AsyncRedis(
+            host=_VALKEY_HOST,
+            port=_VALKEY_PORT,
+            password=_VALKEY_PW or None,
+            decode_responses=True,
+        )
+        gate = UpgradeDrainGate(client, config)
+        legacy_key = _legacy_quiesce_key(config)
+        scoped_key = _scoped_quiesce_key(config, "install-adopted")
+        try:
+            await client.delete(legacy_key, scoped_key)
+            await gate.request_quiesce()
+            legacy_raw, scoped_raw = await client.mget(legacy_key, scoped_key)
+            assert legacy_raw is not None
+            assert scoped_raw is not None
+            assert scoped_raw == legacy_raw, (
+                "the compatibility bridge did not author one marker on both keys"
+            )
+            assert json.loads(scoped_raw)["revision"] == 9
+            assert await client.ttl(legacy_key) > 0
+            assert await client.ttl(scoped_key) > 0
+
+            await gate.clear_quiesce()
+            assert await client.mget(legacy_key, scoped_key) == [None, None]
+        finally:
+            await client.delete(legacy_key, scoped_key)
+            await client.aclose()
+
+    asyncio.run(go())
+
+
+def test_refused_mixed_version_upgrade_clears_both_owned_markers(
+    names,
+) -> None:  # noqa: ANN001
+    """A pre-fix worker sees claims enabled again when the new hook refuses."""
+
+    async def go() -> None:
+        config = _config(
+            names,
+            installation_id="install-adopted",
+            upgrade_revision=9,
+            upgrade_legacy_quiesce=True,
+        )
+        legacy_config = _config(names, installation_id="")
+        client: AsyncRedis = AsyncRedis(
+            host=_VALKEY_HOST,
+            port=_VALKEY_PORT,
+            password=_VALKEY_PW or None,
+            decode_responses=True,
+        )
+        legacy_key = _legacy_quiesce_key(config)
+        scoped_key = _scoped_quiesce_key(config, "install-adopted")
+        try:
+            await client.delete(legacy_key, scoped_key)
+            entry_id = await _pending(client, config, "replica-pre-fix")
+            store = DeliveryLeaseStore(client, config)
+            await store.acquire(
+                config.stream,
+                config.consumer_group,
+                entry_id,
+                consumer="replica-pre-fix",
+            )
+
+            assert await run_gate(config, mode="drain") == 1
+            assert await client.mget(legacy_key, scoped_key) == [None, None]
+            assert await UpgradeDrainGate(client, legacy_config).is_quiescing() is False
+        finally:
+            await client.delete(legacy_key, scoped_key)
+            await client.aclose()
+
+    asyncio.run(go())
+
+
+def test_status_writes_one_safe_json_object_for_absent_owned_and_malformed_markers(
+    names,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:  # noqa: ANN001
+    """Existence is pause authority even when marker metadata is unreadable."""
+
+    config = _config(
+        names,
+        installation_id="install-status",
+        upgrade_revision=10,
+        upgrade_legacy_quiesce=False,
+    )
+    key = _scoped_quiesce_key(config, "install-status")
+
+    async def arrange(value: str | None) -> None:
+        client: AsyncRedis = AsyncRedis(
+            host=_VALKEY_HOST,
+            port=_VALKEY_PORT,
+            password=_VALKEY_PW or None,
+            decode_responses=True,
+        )
+        try:
+            await client.delete(key, _legacy_quiesce_key(config))
+            if value is None:
+                return
+            if value == "owned":
+                await UpgradeDrainGate(client, config).request_quiesce()
+            else:
+                await client.set(key, value, ex=30)
+                assert await UpgradeDrainGate(client, config).is_quiescing() is True
+        finally:
+            await client.aclose()
+
+    try:
+        asyncio.run(arrange(None))
+        status, stderr = _status_json(monkeypatch, capsys, config)
+        assert status == {
+            "state": "claims_enabled",
+            "since": None,
+            "revision": None,
+        }
+        assert "install-status" not in stderr
+
+        asyncio.run(arrange("owned"))
+        status, stderr = _status_json(monkeypatch, capsys, config)
+        assert status["state"] == "quiescing"
+        assert status["revision"] == 10
+        assert isinstance(status["since"], str)
+        since = status["since"]
+        assert isinstance(since, str)
+        assert datetime.fromisoformat(since).tzinfo is not None
+        assert "install-status" not in json.dumps(status)
+        assert "install-status" not in stderr
+
+        asyncio.run(arrange("not-json"))
+        status, stderr = _status_json(monkeypatch, capsys, config)
+        assert status == {"state": "quiescing", "since": None, "revision": None}
+        assert "install-status" not in stderr
+    finally:
+        async def cleanup() -> None:
+            client: AsyncRedis = AsyncRedis(
+                host=_VALKEY_HOST,
+                port=_VALKEY_PORT,
+                password=_VALKEY_PW or None,
+                decode_responses=True,
+            )
+            try:
+                await client.delete(key, _legacy_quiesce_key(config))
+            finally:
+                await client.aclose()
+
+        asyncio.run(cleanup())
+
+
+def test_status_reports_unknown_when_the_marker_cannot_be_read(
+    names,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:  # noqa: ANN001
+    config = _config(
+        names,
+        installation_id="install-status",
+        upgrade_revision=10,
+        upgrade_legacy_quiesce=False,
+    )
+    with socket.socket() as unreachable:
+        unreachable.bind(("127.0.0.1", 0))
+        port = int(unreachable.getsockname()[1])
+        unreadable = config.model_copy(
+            update={"valkey_host": "127.0.0.1", "valkey_port": port}
+        )
+        status, stderr = _status_json(monkeypatch, capsys, unreadable)
+
+    assert status == {"state": "unknown", "since": None, "revision": None}
+    assert "install-status" not in stderr
+    if _VALKEY_PW:
+        assert _VALKEY_PW not in stderr
+
+
+@pytest.mark.parametrize("mode", ["drain", "release"])
+def test_unobserved_installation_refuses_mutating_modes_before_connecting(
+    names,
+    mode: str,
+) -> None:  # noqa: ANN001
+    """Client-only upgrade lookup failure must not mutate either hook path.
+
+    The bound-but-not-listening port makes Valkey deliberately unreachable. A
+    return code of 1 plus the authored refusal proves the identity guard ran;
+    argparse's pre-fix unknown-option exit is 2 and cannot satisfy this test.
+    """
+    config = _config(
+        names,
+        installation_id="install-unobserved",
+        upgrade_revision=10,
+        upgrade_legacy_quiesce=True,
+    )
+    with socket.socket() as unreachable:
+        unreachable.bind(("127.0.0.1", 0))
+        env = _module_env(
+            config.model_copy(
+                update={
+                    "valkey_host": "127.0.0.1",
+                    "valkey_port": int(unreachable.getsockname()[1]),
+                }
+            )
+        )
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "curie_worker.upgrade_drain",
+                "--mode",
+                mode,
+                "--installation-id-observed=false",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env=env,
+        )
+
+    assert completed.returncode == 1
+    assert completed.stdout == ""
+    assert "installation ID was not observed" in completed.stderr
+    assert "refus" in completed.stderr.lower()
+    assert "usage:" not in completed.stderr.lower()
+    assert "connection" not in completed.stderr.lower()
+    assert "traceback" not in completed.stderr.lower()
+    if _VALKEY_PW:
+        assert _VALKEY_PW not in completed.stderr
 
 
 # --- what counts as unsafe in-flight work ------------------------------------
@@ -476,7 +948,7 @@ def test_the_chart_hooks_invoke_a_module_and_modes_this_package_actually_has() -
     ]
     assert commands, f"no container command found in {_CHART_HOOK}"
     for command in commands:
-        interpreter, dash_m, module, mode_flag, mode = command
+        interpreter, dash_m, module, mode_flag, mode, *_hook_args = command
         assert (interpreter, dash_m, mode_flag) == ("python", "-m", "--mode"), command
         importlib.import_module(module)
         # The mode reaches argparse, whose `choices` is the real contract; an

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -85,6 +85,22 @@ it after the upgrade even when Helm fails. The commands below use
 `--reuse-values` only for same chart configuration changes, not a chart version
 upgrade.
 
+**Upgrade drain and claim state.** Before each upgrade, a hook pauses new worker
+claims and waits for accepted deliveries to finish. The chart stores an
+installation identity in its managed Secret and reuses it across upgrades. A
+reinstall mints a new identity, so a late hook from the removed installation
+cannot pause the fresh workers.
+
+`curie cluster status` and `curie doctor` report the current claim state. While
+claims are paused, `curie cluster message` reports `waiting for upgrade revision
+<revision> since <timestamp>`; if safe marker metadata is unavailable, it uses
+the platform-authored `waiting for upgrade; marker metadata unavailable` reason
+instead of echoing marker data. A post-upgrade release clears only its own
+revision. If a newer revision is already active, the older release leaves that
+marker in place, so a successful release Job means release processing completed;
+confirm the actual claim state with `curie cluster status`. The marker TTL is a
+last-resort expiry, not a promise of prompt convergence for a current pause.
+
 **Step 2 -- connect Slack + a real model.** When you have Slack tokens and a
 model credential, upgrade in place (the exact command is also printed in
 `NOTES.txt` after step 1):

--- a/charts/curie/ci/reserved-env-assertions.sh
+++ b/charts/curie/ci/reserved-env-assertions.sh
@@ -77,6 +77,25 @@ with tempfile.TemporaryDirectory() as tmp:
     ]:
         result, _ = render(chart, "--set", f"{workload}.extraEnv[0].name={name}", "--set-string", f"{workload}.extraEnv[0].value=conflict", ok=False)
         assert result.returncode != 0 and replacement in result.stderr, result.stderr
+    # Upgrade lifecycle inputs belong to Helm even when a particular worker
+    # process does not consume every field. Reserving all three prevents a
+    # retained worker.extraEnv value from rebinding a fresh installation to an
+    # old drain key, revision, or mixed-version compatibility mode (#2374).
+    for name in (
+        "CURIE_INSTALLATION_ID",
+        "CURIE_UPGRADE_REVISION",
+        "CURIE_UPGRADE_LEGACY_QUIESCE",
+    ):
+        result, _ = render(
+            chart,
+            "--set",
+            f"worker.extraEnv[0].name={name}",
+            "--set-string",
+            "worker.extraEnv[0].value=conflict",
+            ok=False,
+        )
+        assert result.returncode != 0, f"accepted reserved worker.extraEnv {name}"
+        assert "worker.extraEnv" in result.stderr and name in result.stderr, result.stderr
     for workload in workloads:
         result, _ = render(chart, "--set", f"{workload}.extraEnv[0].name=ACME_EXTENSION", "--set-string", f"{workload}.extraEnv[0].value=same", "--set", f"{workload}.extraEnv[1].name=ACME_EXTENSION", "--set-string", f"{workload}.extraEnv[1].value=same", ok=False)
         assert result.returncode != 0 and "repeats environment variable ACME_EXTENSION" in result.stderr, result.stderr

--- a/charts/curie/ci/runtime/upgrade-drain-installation-runtime.sh
+++ b/charts/curie/ci/runtime/upgrade-drain-installation-runtime.sh
@@ -1,0 +1,468 @@
+#!/usr/bin/env bash
+# Exercise the installation-identity lifecycle against a task-owned kind cluster.
+# Every workload replica is zero and every Helm operation uses --no-hooks: this
+# script proves Secret lookup/reuse and retained-Secret adoption only. It never
+# runs a product image and cannot prove the candidate drain command's guard.
+set -euo pipefail
+
+: "${KUBECONFIG:?set a private kubeconfig for the owned kind cluster}"
+: "${CURIE_UPGRADE_DRAIN_KIND_CONTEXT:?set the explicit task-owned kind context}"
+
+context="$CURIE_UPGRADE_DRAIN_KIND_CONTEXT"
+[[ "$context" == kind-* ]] || {
+  echo "CURIE_UPGRADE_DRAIN_KIND_CONTEXT must name an owned kind-* context" >&2
+  exit 2
+}
+[[ "$(kubectl config get-contexts "$context" -o name)" == "$context" ]] || {
+  echo "the requested owned kind context is not present in KUBECONFIG" >&2
+  exit 2
+}
+
+CHART="$(cd "$(dirname "$0")/../.." && pwd)"
+TMP="$(mktemp -d)"
+namespace="acme-upgrade-drain-${RANDOM}-${RANDOM}"
+release="acme"
+secret_name="acme-curie-secrets"
+created=false
+
+cleanup() {
+  local rc=$? cleanup_failed=false
+  trap - EXIT
+  set +e
+  if [[ "$created" == true ]]; then
+    helm uninstall "$release" \
+      --kube-context "$context" \
+      --namespace "$namespace" \
+      --no-hooks >/dev/null 2>&1 || true
+    kubectl --context "$context" delete namespace "$namespace" \
+      --wait=true --timeout=90s >/dev/null 2>&1 || true
+    if kubectl --context "$context" get namespace "$namespace" >/dev/null 2>&1; then
+      echo "FAIL: task-owned namespace still exists after cleanup" >&2
+      cleanup_failed=true
+    fi
+  fi
+  rm -rf "$TMP"
+  if [[ "$cleanup_failed" == true && "$rc" -eq 0 ]]; then
+    rc=1
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+if kubectl --context "$context" get namespace "$namespace" >/dev/null 2>&1; then
+  fail "random task namespace already exists"
+fi
+kubectl --context "$context" create namespace "$namespace" >/dev/null
+created=true
+
+umask 077
+cat > "$TMP/values.yaml" <<'YAML'
+security:
+  allowDevDefaults: false
+  checkDefaultCredentials: false
+  gvisor:
+    enabled: false
+  networkPolicy:
+    enabled: false
+preflights:
+  avxCheck:
+    enabled: false
+  networkPolicyProbe:
+    enabled: false
+  controllerReady:
+    enabled: false
+postgres:
+  deploy: false
+  host: postgres.example.com
+valkey:
+  deploy: false
+  host: valkey.example.com
+clickhouse:
+  deploy: false
+  host: clickhouse.example.com
+rustfs:
+  deploy: false
+  host: object-store.example.com
+  egress:
+    - cidr: 192.0.2.0/24
+      port: 443
+langfuse:
+  deploy: false
+  host: traces.example.com
+  modelPricing:
+    enabled: false
+otelCollector:
+  deploy: false
+  telemetryDisabled: true
+api:
+  deploy: false
+dispatcher:
+  deploy: false
+mailAdapter:
+  deploy: false
+worker:
+  deploy: true
+  replicas: 0
+  serviceAccount:
+    create: false
+  publication:
+    enabled: false
+  upgradeDrain:
+    enabled: true
+ui:
+  deploy: false
+inference:
+  deploy: false
+grafanaConnector:
+  deploy: false
+agentSandbox:
+  deploy: false
+  controller:
+    deploy: false
+priorityClasses:
+  platform:
+    create: false
+    name: ""
+  sandbox:
+    create: false
+    name: ""
+YAML
+
+install_chart() {
+  local label="$1"
+  shift
+  if ! helm install "$release" "$CHART" \
+    --kube-context "$context" \
+    --namespace "$namespace" \
+    --skip-crds \
+    --no-hooks \
+    -f "$TMP/values.yaml" \
+    "$@" > "$TMP/${label}.log" 2>&1; then
+    fail "$label Helm install failed; output withheld because it may contain Secret data"
+  fi
+}
+
+upgrade_chart() {
+  local label="$1"
+  shift
+  if ! helm upgrade "$release" "$CHART" \
+    --kube-context "$context" \
+    --namespace "$namespace" \
+    --skip-crds \
+    --no-hooks \
+    -f "$TMP/values.yaml" \
+    "$@" > "$TMP/${label}.log" 2>&1; then
+    fail "$label Helm upgrade failed; output withheld because it may contain Secret data"
+  fi
+}
+
+snapshot_secret() {
+  local destination="$1"
+  kubectl --context "$context" get secret "$secret_name" \
+    --namespace "$namespace" -o json > "$destination"
+}
+
+snapshot_hooks() {
+  local destination="$1"
+  helm get hooks "$release" \
+    --kube-context "$context" \
+    --namespace "$namespace" > "$destination"
+}
+
+assert_no_product_pods() {
+  local count
+  count="$(
+    kubectl --context "$context" get pods --namespace "$namespace" -o json |
+      python3 -c 'import json,sys; print(len(json.load(sys.stdin)["items"]))'
+  )"
+  [[ "$count" == 0 ]] || fail "identity-only fixture created a Pod"
+}
+
+assert_secret_transition() {
+  local before="$1" after="$2" mode="$3"
+  python3 - "$before" "$after" "$mode" <<'PY'
+import base64
+import json
+import sys
+
+before_path, after_path, mode = sys.argv[1:4]
+before = json.load(open(before_path))
+after = json.load(open(after_path))
+credential_keys = ("valkeyPassword", "postgresPassword", "apiKey")
+
+
+def decoded(secret, key):
+    encoded = (secret.get("data") or {}).get(key)
+    assert isinstance(encoded, str) and encoded, f"managed Secret is missing {key}"
+    value = base64.b64decode(encoded, validate=True).decode()
+    assert value.strip(), f"managed Secret has blank {key}"
+    return value
+
+
+for key in credential_keys:
+    assert before["data"][key] == after["data"][key], (
+        f"generated {key} changed across the identity lifecycle"
+    )
+
+before_id = decoded(before, "installationId")
+after_id = decoded(after, "installationId")
+assert before["metadata"]["uid"] == after["metadata"]["uid"], (
+    "managed Secret object was replaced instead of updated"
+)
+
+if mode == "uid-fallback":
+    assert after_id == before["metadata"]["uid"], (
+        "first legacy upgrade did not adopt the live Secret UID"
+    )
+elif mode == "reuse":
+    assert after_id == before_id, "subsequent upgrade changed installation identity"
+elif mode == "fresh-install":
+    assert after_id != before_id, "fresh install reused the prior installation identity"
+    assert after_id != after["metadata"]["uid"], (
+        "fresh install used the retained Secret UID instead of a new identity"
+    )
+else:
+    raise AssertionError(f"unknown transition mode {mode}")
+PY
+}
+
+assert_stored_hook_identity() {
+  local secret_json="$1" hooks_yaml="$2" expected_legacy="$3" expected_observed="$4"
+  python3 - "$secret_json" "$hooks_yaml" "$expected_legacy" "$expected_observed" <<'PY'
+import base64
+import json
+import sys
+
+import yaml
+
+secret_path, hooks_path, expected_legacy, expected_observed = sys.argv[1:5]
+secret = json.load(open(secret_path))
+installation_id = base64.b64decode(
+    secret["data"]["installationId"], validate=True
+).decode()
+assert installation_id.strip(), "stored installation identity is blank"
+
+components = {"upgrade-drain": "drain", "upgrade-drain-release": "release"}
+jobs = {}
+for doc in yaml.safe_load_all(open(hooks_path)):
+    if not doc or doc.get("kind") != "Job":
+        continue
+    component = ((doc.get("metadata") or {}).get("labels") or {}).get(
+        "app.kubernetes.io/component"
+    )
+    if component in components:
+        assert component not in jobs, f"duplicate stored hook {component}"
+        jobs[component] = doc
+assert set(jobs) == set(components), "release does not store both upgrade-drain hooks"
+
+identities = []
+revisions = []
+legacy_values = []
+for component, mode in components.items():
+    containers = jobs[component]["spec"]["template"]["spec"]["containers"]
+    assert len(containers) == 1, f"{component} has more than one container"
+    container = containers[0]
+    assert container["command"] == [
+        "python",
+        "-m",
+        "curie_worker.upgrade_drain",
+        "--mode",
+        mode,
+        f"--installation-id-observed={expected_observed}",
+    ], f"{component} stored the wrong observed-identity argument"
+    env = {entry["name"]: entry for entry in container.get("env") or []}
+    identity = env["CURIE_INSTALLATION_ID"]
+    revision = env["CURIE_UPGRADE_REVISION"]
+    legacy = env["CURIE_UPGRADE_LEGACY_QUIESCE"]
+    assert set(identity) == {"name", "value"}, (
+        f"{component} identity is not a stored literal"
+    )
+    assert set(revision) == {"name", "value"}, (
+        f"{component} revision is not a stored literal"
+    )
+    assert set(legacy) == {"name", "value"}, (
+        f"{component} legacy bit is not a stored literal"
+    )
+    assert isinstance(revision["value"], str) and revision["value"].isdecimal(), (
+        f"{component} revision is not a decimal integer string"
+    )
+    assert int(revision["value"]) > 0, f"{component} revision is not positive"
+    identities.append(identity["value"])
+    revisions.append(revision["value"])
+    legacy_values.append(legacy["value"])
+
+assert identities == [installation_id, installation_id], (
+    "stored hook identities do not match the decoded managed Secret value"
+)
+assert len(set(revisions)) == 1, "stored hooks disagree on Helm revision"
+assert legacy_values == [expected_legacy, expected_legacy], (
+    "stored hooks disagree on legacy compatibility"
+)
+PY
+}
+
+# Helm's lookup contract says client-side template rendering returns an empty
+# value while a server-connected install/upgrade can read the live Secret:
+# https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-lookup-function
+install_chart initial
+assert_no_product_pods
+snapshot_secret "$TMP/initial-secret.json"
+snapshot_hooks "$TMP/initial-hooks.yaml"
+python3 - "$TMP/initial-secret.json" <<'PY'
+import base64
+import json
+import sys
+
+secret = json.load(open(sys.argv[1]))
+encoded = secret.get("data", {}).get("installationId")
+assert isinstance(encoded, str) and encoded, "fresh install omitted installationId"
+installation_id = base64.b64decode(encoded, validate=True).decode()
+assert installation_id.strip(), "fresh install rendered a blank installationId"
+assert installation_id != secret["metadata"]["uid"], (
+    "fresh install used the Secret UID instead of a new identity"
+)
+for key in ("valkeyPassword", "postgresPassword", "apiKey"):
+    assert secret["data"].get(key), f"fresh install omitted generated {key}"
+PY
+assert_stored_hook_identity "$TMP/initial-secret.json" "$TMP/initial-hooks.yaml" false true
+
+# A pre-fix Secret has no installationId. The first fix-bearing upgrade must
+# use the UID already visible to Helm, while preserving generated credentials.
+kubectl --context "$context" patch secret "$secret_name" \
+  --namespace "$namespace" --type=json \
+  -p='[{"op":"remove","path":"/data/installationId"}]' >/dev/null
+upgrade_chart legacy-upgrade
+assert_no_product_pods
+snapshot_secret "$TMP/legacy-upgrade-secret.json"
+snapshot_hooks "$TMP/legacy-upgrade-hooks.yaml"
+assert_secret_transition \
+  "$TMP/initial-secret.json" "$TMP/legacy-upgrade-secret.json" uid-fallback
+assert_stored_hook_identity \
+  "$TMP/legacy-upgrade-secret.json" "$TMP/legacy-upgrade-hooks.yaml" true true
+
+# Once installationId exists, every later upgrade decodes and reuses it. The
+# compatibility bridge is then off in both stored hooks.
+upgrade_chart subsequent-upgrade
+assert_no_product_pods
+snapshot_secret "$TMP/subsequent-secret.json"
+snapshot_hooks "$TMP/subsequent-hooks.yaml"
+assert_secret_transition \
+  "$TMP/legacy-upgrade-secret.json" "$TMP/subsequent-secret.json" reuse
+assert_stored_hook_identity \
+  "$TMP/subsequent-secret.json" "$TMP/subsequent-hooks.yaml" false true
+
+# A live annotation is insufficient: Helm uninstall filters the stored release
+# manifest before kube.Client.rdelete deletes the remaining objects. Record the
+# task-only keep policy through a post-renderer on a zero-replica/no-hooks
+# upgrade, then verify it is in the stored manifest.
+# Sources:
+# https://raw.githubusercontent.com/helm/helm/v3.17.3/pkg/action/uninstall.go
+# https://raw.githubusercontent.com/helm/helm/v3.17.3/pkg/kube/client.go
+cat > "$TMP/keep-secret.py" <<'PY'
+#!/usr/bin/env python3
+import os
+import sys
+
+import yaml
+
+target = os.environ["TARGET_SECRET_NAME"]
+documents = list(yaml.safe_load_all(sys.stdin))
+matched = 0
+for document in documents:
+    if not document or document.get("kind") != "Secret":
+        continue
+    metadata = document.setdefault("metadata", {})
+    if metadata.get("name") != target:
+        continue
+    metadata.setdefault("annotations", {})["helm.sh/resource-policy"] = "keep"
+    matched += 1
+assert matched == 1, f"expected one managed Secret named {target}, found {matched}"
+yaml.safe_dump_all(documents, sys.stdout, sort_keys=False)
+PY
+chmod 700 "$TMP/keep-secret.py"
+export TARGET_SECRET_NAME="$secret_name"
+upgrade_chart record-keep --post-renderer "$TMP/keep-secret.py"
+unset TARGET_SECRET_NAME
+assert_no_product_pods
+snapshot_secret "$TMP/keep-secret.json"
+assert_secret_transition "$TMP/subsequent-secret.json" "$TMP/keep-secret.json" reuse
+helm get manifest "$release" \
+  --kube-context "$context" \
+  --namespace "$namespace" > "$TMP/keep-manifest.yaml"
+python3 - "$TMP/keep-manifest.yaml" "$secret_name" <<'PY'
+import sys
+
+import yaml
+
+path, expected_name = sys.argv[1:3]
+secrets = [
+    doc
+    for doc in yaml.safe_load_all(open(path))
+    if doc and doc.get("kind") == "Secret" and doc["metadata"]["name"] == expected_name
+]
+assert len(secrets) == 1, "stored release manifest has no unique managed Secret"
+annotations = secrets[0]["metadata"].get("annotations") or {}
+assert annotations.get("helm.sh/resource-policy") == "keep", (
+    "keep policy was not recorded in the stored release manifest"
+)
+PY
+
+if ! helm uninstall "$release" \
+  --kube-context "$context" \
+  --namespace "$namespace" \
+  --no-hooks > "$TMP/uninstall.log" 2>&1; then
+  fail "Helm uninstall failed; output withheld because it may contain Secret data"
+fi
+snapshot_secret "$TMP/retained-secret.json"
+assert_secret_transition "$TMP/keep-secret.json" "$TMP/retained-secret.json" reuse
+
+# Helm permits same-release adoption when existingResourceConflict and
+# checkOwnership find the Helm managed-by label plus matching release-name and
+# release-namespace annotations. No ownership override is used here:
+# https://raw.githubusercontent.com/helm/helm/v3.16.4/pkg/action/validate.go
+kubectl --context "$context" annotate secret "$secret_name" \
+  --namespace "$namespace" helm.sh/resource-policy- >/dev/null
+snapshot_secret "$TMP/adoptable-secret.json"
+python3 - "$TMP/adoptable-secret.json" "$release" "$namespace" <<'PY'
+import json
+import sys
+
+path, release, namespace = sys.argv[1:4]
+secret = json.load(open(path))
+labels = secret["metadata"].get("labels") or {}
+annotations = secret["metadata"].get("annotations") or {}
+assert labels.get("app.kubernetes.io/managed-by") == "Helm", (
+    "retained Secret lost Helm managed-by ownership"
+)
+assert annotations.get("meta.helm.sh/release-name") == release, (
+    "retained Secret has the wrong Helm release-name owner"
+)
+assert annotations.get("meta.helm.sh/release-namespace") == namespace, (
+    "retained Secret has the wrong Helm release-namespace owner"
+)
+assert "helm.sh/resource-policy" not in annotations, (
+    "temporary keep policy was not removed before reinstall"
+)
+PY
+
+# Reinstall the same name/namespace with ordinary matching-ownership adoption.
+# .Release.IsInstall must still mint a new ID even though lookup sees the
+# retained Secret and its UID; generated credentials remain byte-identical.
+install_chart reinstall
+assert_no_product_pods
+snapshot_secret "$TMP/reinstalled-secret.json"
+snapshot_hooks "$TMP/reinstalled-hooks.yaml"
+assert_secret_transition \
+  "$TMP/adoptable-secret.json" "$TMP/reinstalled-secret.json" fresh-install
+assert_stored_hook_identity \
+  "$TMP/reinstalled-secret.json" "$TMP/reinstalled-hooks.yaml" false true
+
+# The offline observed=false argument is pinned by upgrade-drain-assertions.sh.
+# Executing that Job against the candidate image is driver-owned manual E2E;
+# substituting a registry image here would not prove the candidate guard.
+echo "OK: live UID fallback, decoded ID reuse, hook agreement, generated credential stability, and retained-Secret fresh-install identity reset passed"

--- a/charts/curie/ci/upgrade-drain-assertions.sh
+++ b/charts/curie/ci/upgrade-drain-assertions.sh
@@ -27,6 +27,14 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
 helm template t "$CHART" > "$TMP/default.yaml"
+helm template t "$CHART" > "$TMP/fresh-second.yaml"
+helm template t "$CHART" --is-upgrade > "$TMP/client-upgrade.yaml"
+helm template t "$CHART" \
+  --set-string postgres.existingSecret=acme-postgres-credentials \
+  --set-string valkey.existingSecret=acme-valkey-credentials \
+  --set-string agentSandbox.runner.credentialsExistingSecret=acme-model-credentials \
+  --set-string worker.adapterCredentialsExistingSecret=acme-adapter-credentials \
+  > "$TMP/byo-credentials.yaml"
 helm template t "$CHART" --set worker.upgradeDrain.enabled=false > "$TMP/disabled.yaml"
 helm template t "$CHART" --set worker.deploy=false > "$TMP/no-worker.yaml"
 
@@ -193,8 +201,15 @@ if not failures:
         )
         check(
             container.get("command")
-            == ["python", "-m", "curie_worker.upgrade_drain", "--mode", mode],
-            f"{component} command is {container.get('command')!r}",
+            == [
+                "python",
+                "-m",
+                "curie_worker.upgrade_drain",
+                "--mode",
+                mode,
+                "--installation-id-observed=true",
+            ],
+            f"{component} command does not pass the observed installation identity",
         )
         env = {e["name"]: e for e in container.get("env", []) if isinstance(e, dict)}
         for required in ("VALKEY_HOST", "VALKEY_PORT", "VALKEY_PASSWORD"):
@@ -278,4 +293,192 @@ if failures:
     raise SystemExit(1)
 
 print("OK: upgrade drain gate render assertions passed")
+PY
+
+# The installation identity is one render-scoped value shared by the managed
+# Secret, the long-running worker and both lifecycle hooks. Keep these checks in
+# the real Helm consumer: independently calling a random helper from each
+# template would look plausible in source and still split the release across
+# three different Valkey keys.
+python3 - \
+  "$TMP/default.yaml" \
+  "$TMP/fresh-second.yaml" \
+  "$TMP/client-upgrade.yaml" \
+  "$TMP/byo-credentials.yaml" <<'PY'
+import pathlib
+import sys
+
+import yaml
+
+default_path, fresh_second_path, client_upgrade_path, byo_path = map(
+    pathlib.Path, sys.argv[1:5]
+)
+
+DRAIN = "upgrade-drain"
+RELEASE = "upgrade-drain-release"
+
+
+def load(path):
+    return [doc for doc in yaml.safe_load_all(path.read_text()) if doc]
+
+
+def one(docs, *, kind, component=None):
+    matches = []
+    for doc in docs:
+        if doc.get("kind") != kind:
+            continue
+        labels = (doc.get("metadata") or {}).get("labels") or {}
+        if component is not None and labels.get("app.kubernetes.io/component") != component:
+            continue
+        matches.append(doc)
+    assert len(matches) == 1, (
+        f"expected one {kind} for component {component!r}, found {len(matches)}"
+    )
+    return matches[0]
+
+
+def managed_secret(docs):
+    secrets = [
+        doc
+        for doc in docs
+        if doc.get("kind") == "Secret"
+        and ((doc.get("metadata") or {}).get("labels") or {}).get(
+            "app.kubernetes.io/instance"
+        )
+        == "t"
+    ]
+    assert len(secrets) == 1, f"expected one release-managed Secret, found {len(secrets)}"
+    secret = secrets[0]
+    installation_id = (secret.get("stringData") or {}).get("installationId")
+    assert isinstance(installation_id, str) and installation_id.strip(), (
+        "managed Secret has no nonblank stringData.installationId"
+    )
+    return secret, installation_id
+
+
+def container_env(doc):
+    containers = ((doc.get("spec") or {}).get("template") or {}).get("spec", {}).get(
+        "containers"
+    ) or []
+    assert len(containers) == 1, "expected exactly one container"
+    return containers[0], containers[0].get("env") or []
+
+
+def unique_env(env, name):
+    entries = [entry for entry in env if entry.get("name") == name]
+    assert len(entries) == 1, f"expected exactly one {name} entry, found {len(entries)}"
+    return entries[0]
+
+
+def assert_identity_render(docs, *, observed, legacy):
+    secret, installation_id = managed_secret(docs)
+    managed_name = secret["metadata"]["name"]
+
+    worker = one(docs, kind="Deployment", component="worker")
+    _, worker_env = container_env(worker)
+    worker_identity = unique_env(worker_env, "CURIE_INSTALLATION_ID")
+    ref = (worker_identity.get("valueFrom") or {}).get("secretKeyRef") or {}
+    assert ref.get("name") == managed_name, (
+        "worker installation identity does not reference the release-managed Secret"
+    )
+    assert ref.get("key") == "installationId", (
+        "worker installation identity does not reference the installationId key"
+    )
+    assert ref.get("optional", False) is False, (
+        "worker installation identity Secret reference is optional"
+    )
+    assert "value" not in worker_identity, "worker installation identity was inlined"
+
+    revisions = []
+    identities = []
+    legacy_values = []
+    for component, mode in ((DRAIN, "drain"), (RELEASE, "release")):
+        hook = one(docs, kind="Job", component=component)
+        container, env = container_env(hook)
+        assert container.get("command") == [
+            "python",
+            "-m",
+            "curie_worker.upgrade_drain",
+            "--mode",
+            mode,
+            f"--installation-id-observed={str(observed).lower()}",
+        ], f"{component} does not carry the expected observed-identity argument"
+
+        identity = unique_env(env, "CURIE_INSTALLATION_ID")
+        revision = unique_env(env, "CURIE_UPGRADE_REVISION")
+        legacy_entry = unique_env(env, "CURIE_UPGRADE_LEGACY_QUIESCE")
+        assert set(identity) == {"name", "value"}, (
+            f"{component} installation identity is not a render-time literal"
+        )
+        assert set(revision) == {"name", "value"}, (
+            f"{component} upgrade revision is not a render-time literal"
+        )
+        assert set(legacy_entry) == {"name", "value"}, (
+            f"{component} legacy compatibility bit is not a render-time literal"
+        )
+        assert isinstance(revision["value"], str) and revision["value"].isdecimal(), (
+            f"{component} upgrade revision is not a decimal integer string"
+        )
+        assert int(revision["value"]) > 0, f"{component} upgrade revision is not positive"
+        identities.append(identity["value"])
+        revisions.append(revision["value"])
+        legacy_values.append(legacy_entry["value"])
+
+    assert identities == [installation_id, installation_id], (
+        "managed Secret and hook installation identities do not match within one render"
+    )
+    assert len(set(revisions)) == 1, "drain and release hooks carry different revisions"
+    assert legacy_values == [legacy, legacy], (
+        "drain and release hooks disagree on legacy compatibility"
+    )
+    return installation_id, managed_name, worker_env
+
+
+default_docs = load(default_path)
+first_id, _, _ = assert_identity_render(default_docs, observed=True, legacy="false")
+second_id, _, _ = assert_identity_render(
+    load(fresh_second_path), observed=True, legacy="false"
+)
+assert first_id != second_id, "two fresh installs reused one installation identity"
+
+# `helm template --is-upgrade` has no live lookup result. It must remain a valid
+# client-side render while marking the hook as unobserved so an executing drain
+# can refuse before touching Valkey or allowing a rollout.
+assert_identity_render(load(client_upgrade_path), observed=False, legacy="true")
+
+# A store/model/adapter credential may come from an operator-owned Secret, but
+# the installation identity always belongs to this release's managed Secret.
+_, managed_name, byo_worker_env = assert_identity_render(
+    load(byo_path), observed=True, legacy="false"
+)
+expected_credential_refs = {
+    "POSTGRES_PASSWORD": "acme-postgres-credentials",
+    "VALKEY_PASSWORD": "acme-valkey-credentials",
+    "CURIE_CREDENTIALS": "acme-model-credentials",
+    "CURIE_ADAPTER_CREDENTIALS": "acme-adapter-credentials",
+    "CURIE_API_KEY": managed_name,
+}
+for env_name, expected_secret in expected_credential_refs.items():
+    entry = unique_env(byo_worker_env, env_name)
+    actual_secret = (
+        ((entry.get("valueFrom") or {}).get("secretKeyRef") or {}).get("name")
+    )
+    assert actual_secret == expected_secret, (
+        f"{env_name} did not use its expected credential Secret"
+    )
+installation_ref = (
+    (
+        unique_env(byo_worker_env, "CURIE_INSTALLATION_ID").get("valueFrom") or {}
+    ).get("secretKeyRef")
+    or {}
+)
+assert installation_ref.get("name") == managed_name, (
+    "a BYO credential Secret substituted for the managed installation identity"
+)
+
+print(
+    "OK: one memoized installation identity reaches the managed Secret, worker and "
+    "both hooks; fresh installs rotate it; client-only upgrades are marked unobserved; "
+    "BYO credential Secrets cannot replace it"
+)
 PY

--- a/charts/curie/files/reserved-env.yaml
+++ b/charts/curie/files/reserved-env.yaml
@@ -16,6 +16,7 @@ worker:
   CURIE_FAKE_MODEL: agentSandbox.runner.fakeModel
   CURIE_HEARTBEAT_FILE: the chart-managed heartbeat path (remove this override)
   CURIE_INTERNAL_WORKER_TOKEN: worker.internalWorkerToken
+  CURIE_INSTALLATION_ID: the release-managed installation identity (remove this override)
   CURIE_NAMESPACE: the release namespace (Helm --namespace)
   CURIE_PUBLICATION_CPU_LIMIT: worker.publication.resources.limits.cpu
   CURIE_PUBLICATION_CPU_REQUEST: worker.publication.resources.requests.cpu
@@ -52,6 +53,8 @@ worker:
   CURIE_STATUS_TEXT: worker.statusText
   CURIE_SUSPENDED_ROUTE_TTL_SECONDS: worker.suspendedRouteTtlSeconds
   CURIE_TERMINATION_GRACE_PERIOD_S: worker.terminationGracePeriodSeconds
+  CURIE_UPGRADE_LEGACY_QUIESCE: the Helm-managed mixed-version upgrade mode (remove this override)
+  CURIE_UPGRADE_REVISION: the Helm release revision (remove this override)
   CURIE_WARM_POOL: worker.warmPool
   CURIE_WORKSPACE_ARCHIVE_TIMEOUT_SECONDS: worker.workspace.archiveTimeoutSeconds
   CURIE_WORKSPACE_BUCKET: worker.workspace.bucket

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -781,6 +781,72 @@ http://{{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.
 {{- include "curie.otel.validate" . -}}
 {{- end -}}
 
+{{/*
+Resolve the installation identity once for the whole render. The full managed
+Secret is memoized separately from its data so callers can reuse generated
+credentials without losing access to the Secret UID used by the legacy-upgrade
+bridge.
+
+Fresh installs always mint a new identity, including adoption of a retained
+Secret. Upgrades reuse the stored identity; the first upgrade from a chart that
+predates installationId adopts the live Secret UID and enables the one-release
+legacy bridge. A client-only upgrade has no lookup result, so it receives one
+memoized placeholder and marks the identity unobserved for the hook to refuse
+before contacting Valkey.
+*/}}
+{{- define "curie.installationIdentity.init" -}}
+{{- if not (hasKey . "_curieManagedSecret") -}}
+{{- $managedSecret := lookup "v1" "Secret" .Release.Namespace (include "curie.secretName" .) | default dict -}}
+{{- $_ := set . "_curieManagedSecret" $managedSecret -}}
+{{- $managedSecretData := get $managedSecret "data" | default dict -}}
+{{- $installationId := "" -}}
+{{- $observed := true -}}
+{{- $legacy := false -}}
+{{- if .Release.IsInstall -}}
+{{- $installationId = randAlphaNum 32 -}}
+{{- else if .Release.IsUpgrade -}}
+{{- $encodedId := get $managedSecretData "installationId" | default "" -}}
+{{- $decodedId := "" -}}
+{{- if ne (trim (toString $encodedId)) "" -}}
+{{- $decodedId = $encodedId | b64dec -}}
+{{- end -}}
+{{- if ne (trim $decodedId) "" -}}
+{{- $installationId = $decodedId -}}
+{{- else -}}
+{{- $legacy = true -}}
+{{- $metadata := get $managedSecret "metadata" | default dict -}}
+{{- $secretUid := get $metadata "uid" | default "" -}}
+{{- if ne (trim (toString $secretUid)) "" -}}
+{{- $installationId = toString $secretUid -}}
+{{- else -}}
+{{- $installationId = randAlphaNum 32 -}}
+{{- $observed = false -}}
+{{- end -}}
+{{- end -}}
+{{- else -}}
+{{- $installationId = randAlphaNum 32 -}}
+{{- end -}}
+{{- $_ = set . "_curieInstallationId" $installationId -}}
+{{- $_ = set . "_curieInstallationIdObserved" $observed -}}
+{{- $_ = set . "_curieUpgradeLegacyQuiesce" $legacy -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "curie.installationId" -}}
+{{- include "curie.installationIdentity.init" . -}}
+{{- get . "_curieInstallationId" -}}
+{{- end -}}
+
+{{- define "curie.installationIdObserved" -}}
+{{- include "curie.installationIdentity.init" . -}}
+{{- get . "_curieInstallationIdObserved" | toString -}}
+{{- end -}}
+
+{{- define "curie.upgradeLegacyQuiesce" -}}
+{{- include "curie.installationIdentity.init" . -}}
+{{- get . "_curieUpgradeLegacyQuiesce" | toString -}}
+{{- end -}}
+
 {{/* ---- Auto-generated per-release chart credential (issue #195) ----
      Resolve one chart-owned secret value, generating a strong random per release
      for a sealed install instead of shipping the published dev default. Call with

--- a/charts/curie/templates/secrets.yaml
+++ b/charts/curie/templates/secrets.yaml
@@ -42,9 +42,11 @@ so the guard runs on every install/upgrade/template.
 {{- if eq (toString .Values.api.approvalChatAttesterSecret) (toString .Values.api.apiKey) }}
 {{- fail "api.approvalChatAttesterSecret and api.apiKey must differ. Set the Slack approval attestation credential independently; neither value is printed because both are live credentials." }}
 {{- end }}
-{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "curie.secretName" .)).data | default dict -}}
-{{- $langfuseInitProjectSecretKey := include "curie.managedSecret" (dict "root" . "key" "langfuseInitProjectSecretKey" "value" .Values.langfuse.init.projectSecretKey "default" "sk-lf-curie-dev" "hex" false "existingData" $existingSecret) -}}
-{{- $langfuseInitUserPassword := include "curie.managedSecret" (dict "root" . "key" "langfuseInitUserPassword" "value" .Values.langfuse.init.userPassword "default" "curie-dev-password" "hex" false "existingData" $existingSecret) -}}
+{{- include "curie.installationIdentity.init" . -}}
+{{- $existingSecret := get . "_curieManagedSecret" | default dict -}}
+{{- $existingSecretData := $existingSecret.data | default dict -}}
+{{- $langfuseInitProjectSecretKey := include "curie.managedSecret" (dict "root" . "key" "langfuseInitProjectSecretKey" "value" .Values.langfuse.init.projectSecretKey "default" "sk-lf-curie-dev" "hex" false "existingData" $existingSecretData) -}}
+{{- $langfuseInitUserPassword := include "curie.managedSecret" (dict "root" . "key" "langfuseInitUserPassword" "value" .Values.langfuse.init.userPassword "default" "curie-dev-password" "hex" false "existingData" $existingSecretData) -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -53,15 +55,16 @@ metadata:
     {{- include "curie.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  installationId: {{ include "curie.installationId" . | quote }}
   # Backing-store credentials (fallback when a store sets no existingSecret).
-  postgresPassword: {{ include "curie.managedSecret" (dict "root" . "key" "postgresPassword" "value" .Values.postgres.auth.password "default" "postgres" "hex" false "existingData" $existingSecret) | quote }}
-  valkeyPassword: {{ include "curie.managedSecret" (dict "root" . "key" "valkeyPassword" "value" .Values.valkey.password "default" "valkeypass" "hex" false "existingData" $existingSecret) | quote }}
-  clickhousePassword: {{ include "curie.managedSecret" (dict "root" . "key" "clickhousePassword" "value" .Values.clickhouse.auth.password "default" "clickhouse" "hex" false "existingData" $existingSecret) | quote }}
-  rustfsSecretKey: {{ include "curie.managedSecret" (dict "root" . "key" "rustfsSecretKey" "value" .Values.rustfs.auth.secretKey "default" "rustfssecret" "hex" false "existingData" $existingSecret) | quote }}
+  postgresPassword: {{ include "curie.managedSecret" (dict "root" . "key" "postgresPassword" "value" .Values.postgres.auth.password "default" "postgres" "hex" false "existingData" $existingSecretData) | quote }}
+  valkeyPassword: {{ include "curie.managedSecret" (dict "root" . "key" "valkeyPassword" "value" .Values.valkey.password "default" "valkeypass" "hex" false "existingData" $existingSecretData) | quote }}
+  clickhousePassword: {{ include "curie.managedSecret" (dict "root" . "key" "clickhousePassword" "value" .Values.clickhouse.auth.password "default" "clickhouse" "hex" false "existingData" $existingSecretData) | quote }}
+  rustfsSecretKey: {{ include "curie.managedSecret" (dict "root" . "key" "rustfsSecretKey" "value" .Values.rustfs.auth.secretKey "default" "rustfssecret" "hex" false "existingData" $existingSecretData) | quote }}
   # Langfuse app secrets.
-  langfuseSalt: {{ include "curie.managedSecret" (dict "root" . "key" "langfuseSalt" "value" .Values.langfuse.salt "default" "dev-salt-change-me" "hex" false "existingData" $existingSecret) | quote }}
-  langfuseEncryptionKey: {{ include "curie.managedSecret" (dict "root" . "key" "langfuseEncryptionKey" "value" .Values.langfuse.encryptionKey "default" "0000000000000000000000000000000000000000000000000000000000000000" "hex" true "existingData" $existingSecret) | quote }}
-  langfuseNextauthSecret: {{ include "curie.managedSecret" (dict "root" . "key" "langfuseNextauthSecret" "value" .Values.langfuse.nextauthSecret "default" "dev-nextauth-secret-change-me" "hex" false "existingData" $existingSecret) | quote }}
+  langfuseSalt: {{ include "curie.managedSecret" (dict "root" . "key" "langfuseSalt" "value" .Values.langfuse.salt "default" "dev-salt-change-me" "hex" false "existingData" $existingSecretData) | quote }}
+  langfuseEncryptionKey: {{ include "curie.managedSecret" (dict "root" . "key" "langfuseEncryptionKey" "value" .Values.langfuse.encryptionKey "default" "0000000000000000000000000000000000000000000000000000000000000000" "hex" true "existingData" $existingSecretData) | quote }}
+  langfuseNextauthSecret: {{ include "curie.managedSecret" (dict "root" . "key" "langfuseNextauthSecret" "value" .Values.langfuse.nextauthSecret "default" "dev-nextauth-secret-change-me" "hex" false "existingData" $existingSecretData) | quote }}
   # Init project secret key, read by the model-pricing seed Job as basic-auth
   # password against the Langfuse public API.
   langfuseInitProjectSecretKey: {{ $langfuseInitProjectSecretKey | quote }}
@@ -99,14 +102,14 @@ stringData:
   # when worker.adapterCredentialsExistingSecret is set instead (issue #1759).
   adapterCredentials: {{ include "curie.adapterCredentials" . | quote }}
   # First-party app credentials.
-  apiKey: {{ include "curie.managedSecret" (dict "root" . "key" "apiKey" "value" .Values.api.apiKey "default" "curie-dev-key" "hex" false "existingData" $existingSecret) | quote }}
+  apiKey: {{ include "curie.managedSecret" (dict "root" . "key" "apiKey" "value" .Values.api.apiKey "default" "curie-dev-key" "hex" false "existingData" $existingSecretData) | quote }}
   # Dedicated Slack click attestation trust domain. This is deliberately not
   # apiKey: only the dispatcher producer and API verifier receive it.
-  approvalChatAttesterSecret: {{ include "curie.managedSecret" (dict "root" . "key" "approvalChatAttesterSecret" "value" .Values.api.approvalChatAttesterSecret "default" "curie-dev-approval-chat-attester" "hex" false "existingData" $existingSecret) | quote }}
+  approvalChatAttesterSecret: {{ include "curie.managedSecret" (dict "root" . "key" "approvalChatAttesterSecret" "value" .Values.api.approvalChatAttesterSecret "default" "curie-dev-approval-chat-attester" "hex" false "existingData" $existingSecretData) | quote }}
   # Distinct from apiKey: possessing the operator/CLI key must never redeem the
   # repository credential. Generated and retained independently on sealed installs.
-  internalWorkerToken: {{ include "curie.managedSecret" (dict "root" . "key" "internalWorkerToken" "value" .Values.worker.internalWorkerToken "default" "curie-dev-worker-token" "hex" false "existingData" $existingSecret) | quote }}
-  githubWebhookSecret: {{ include "curie.managedSecret" (dict "root" . "key" "githubWebhookSecret" "value" .Values.api.githubWebhookSecret "default" "dev-webhook-secret" "hex" false "existingData" $existingSecret) | quote }}
+  internalWorkerToken: {{ include "curie.managedSecret" (dict "root" . "key" "internalWorkerToken" "value" .Values.worker.internalWorkerToken "default" "curie-dev-worker-token" "hex" false "existingData" $existingSecretData) | quote }}
+  githubWebhookSecret: {{ include "curie.managedSecret" (dict "root" . "key" "githubWebhookSecret" "value" .Values.api.githubWebhookSecret "default" "dev-webhook-secret" "hex" false "existingData" $existingSecretData) | quote }}
   {{/* NOT curie.managedSecret: that helper generates a random when the value
        matches its default, which is right for a credential the install must
        have. This one is optional -- empty means "no GitHub credential", and

--- a/charts/curie/templates/worker-upgrade-drain.yaml
+++ b/charts/curie/templates/worker-upgrade-drain.yaml
@@ -45,6 +45,10 @@ clears it on the next attempt.
      derived rather than refused. */}}
 {{- $drainTimeout := include "curie.worker.upgradeDrain.timeout" . }}
 {{- $quiesceTtl := include "curie.worker.upgradeDrain.quiesceTtl" . }}
+{{- $installationId := include "curie.installationId" . }}
+{{- $installationIdObserved := include "curie.installationIdObserved" . }}
+{{- $upgradeLegacyQuiesce := include "curie.upgradeLegacyQuiesce" . }}
+{{- $upgradeRevision := .Release.Revision | toString }}
 {{- $image := include "curie.image" (dict "repository" .Values.worker.image.repository "tag" .Values.worker.image.tag "digest" .Values.worker.image.digest "defaultTag" .Chart.AppVersion) }}
 apiVersion: batch/v1
 kind: Job
@@ -100,7 +104,7 @@ spec:
           {{- with .Values.worker.containerSecurityContext }}
           {{- include "curie.containerSecurityContext" . | nindent 10 }}
           {{- end }}
-          command: ["python", "-m", "curie_worker.upgrade_drain", "--mode", "drain"]
+          command: ["python", "-m", "curie_worker.upgrade_drain", "--mode", "drain", "--installation-id-observed={{ $installationIdObserved }}"]
           env:
             {{- include "curie.env.valkey" . | nindent 12 }}
             # Valkey is the ONLY wiring the gate needs. Stream, group and key
@@ -115,6 +119,12 @@ spec:
               value: {{ .Values.worker.upgradeDrain.pollIntervalSeconds | quote }}
             - name: CURIE_UPGRADE_QUIESCE_TTL_S
               value: {{ $quiesceTtl | quote }}
+            - name: CURIE_INSTALLATION_ID
+              value: {{ $installationId | quote }}
+            - name: CURIE_UPGRADE_REVISION
+              value: {{ $upgradeRevision | quote }}
+            - name: CURIE_UPGRADE_LEGACY_QUIESCE
+              value: {{ $upgradeLegacyQuiesce | quote }}
           resources:
             {{- toYaml .Values.worker.upgradeDrain.resources | nindent 12 }}
 ---
@@ -167,7 +177,7 @@ spec:
           {{- with .Values.worker.containerSecurityContext }}
           {{- include "curie.containerSecurityContext" . | nindent 10 }}
           {{- end }}
-          command: ["python", "-m", "curie_worker.upgrade_drain", "--mode", "release"]
+          command: ["python", "-m", "curie_worker.upgrade_drain", "--mode", "release", "--installation-id-observed={{ $installationIdObserved }}"]
           env:
             {{- include "curie.env.valkey" . | nindent 12 }}
             # Present so the release Job builds the SAME WorkerConfig the gate
@@ -178,6 +188,12 @@ spec:
               value: {{ $drainTimeout | quote }}
             - name: CURIE_UPGRADE_QUIESCE_TTL_S
               value: {{ $quiesceTtl | quote }}
+            - name: CURIE_INSTALLATION_ID
+              value: {{ $installationId | quote }}
+            - name: CURIE_UPGRADE_REVISION
+              value: {{ $upgradeRevision | quote }}
+            - name: CURIE_UPGRADE_LEGACY_QUIESCE
+              value: {{ $upgradeLegacyQuiesce | quote }}
           resources:
             {{- toYaml .Values.worker.upgradeDrain.resources | nindent 12 }}
 {{- end }}

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -301,6 +301,15 @@ spec:
             # name is knowable only here.
             - name: CURIE_RELEASE
               value: {{ .Release.Name | quote }}
+            # Stable identity for this Helm installation's claim gate. It is
+            # always owned by the release-managed Secret, independently of any
+            # BYO store or provider credential Secret.
+            - name: CURIE_INSTALLATION_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "curie.secretName" . }}
+                  key: installationId
+                  optional: false
 {{- if .Values.worker.connectorReconciler.enabled }}
             # Connector reconciler (ADR-0090, #1184). It reuses CURIE_NAMESPACE
             # and CURIE_RELEASE above deliberately: the runner dials a connector

--- a/cli/src/doctor.rs
+++ b/cli/src/doctor.rs
@@ -650,8 +650,18 @@ fn webhook_recovery(f: &Facts, namespace: &str, release: &str) -> String {
     command
 }
 
-/// Judge the gathered facts. Pure.
+/// Judge caller-supplied facts without adding an observation the caller did
+/// not make. The real doctor path uses [`evaluate_with_worker_claims`] after
+/// its release-scoped observer completes.
 pub fn evaluate(f: &Facts) -> Vec<Check> {
+    evaluate_with_worker_claims(f, None)
+}
+
+/// Judge the gathered facts, including the optional claim observation. Pure.
+fn evaluate_with_worker_claims(
+    f: &Facts,
+    worker_claims: Option<&crate::worker_claims::ClaimsState>,
+) -> Vec<Check> {
     let mut out = Vec::new();
 
     out.push(match (&f.model_credential, &f.model_credential_source) {
@@ -876,6 +886,46 @@ pub fn evaluate(f: &Facts) -> Vec<Check> {
             out.push(skipped(id, title, reason));
         }
         return out;
+    }
+
+    if let Some(worker_claims) = worker_claims {
+        out.push(match worker_claims {
+            crate::worker_claims::ClaimsState::ClaimsEnabled => {
+                ok("worker-claims", "Worker claims", "claims enabled")
+            }
+            crate::worker_claims::ClaimsState::Quiescing { revision, .. } => {
+                let detail = worker_claims
+                    .wait_reason()
+                    .expect("a quiescing claim state has a wait reason");
+                missing(
+                    "worker-claims",
+                    "Worker claims",
+                    detail,
+                    format!(
+                        "wait for upgrade revision {revision} to finish, then re-run `curie doctor \
+                         --namespace {namespace} --release {release}` and `{}`",
+                        targeted("status", namespace, release)
+                    ),
+                )
+            }
+            crate::worker_claims::ClaimsState::QuiescingMetadataUnavailable => missing(
+                "worker-claims",
+                "Worker claims",
+                worker_claims
+                    .wait_reason()
+                    .expect("a metadata-free quiescing state has a wait reason"),
+                format!(
+                    "wait for the current upgrade to finish, then re-run `curie doctor \
+                     --namespace {namespace} --release {release}` and `{}`",
+                    targeted("status", namespace, release)
+                ),
+            ),
+            crate::worker_claims::ClaimsState::Unknown => skipped(
+                "worker-claims",
+                "Worker claims",
+                "worker claim state unknown",
+            ),
+        });
     }
 
     if f.mail_channels.is_empty() {
@@ -4294,6 +4344,17 @@ fn is_plain_https(entry: &serde_json::Value) -> bool {
 /// Gather the facts. Every probe is read-only and failure-tolerant: a missing
 /// tool or an unreachable cluster is a fact to report, never an error to raise.
 pub async fn gather(namespace: &str, release: &str, api: Option<(&str, &str)>) -> Facts {
+    gather_with_worker_claims(namespace, release, api).await.0
+}
+
+/// Gather the existing public facts plus the release-scoped claim observation
+/// used only by the assembled doctor report. Keeping the observation beside
+/// the facts avoids widening `Facts`, which is a public fixture surface.
+async fn gather_with_worker_claims(
+    namespace: &str,
+    release: &str,
+    api: Option<(&str, &str)>,
+) -> (Facts, Option<crate::worker_claims::ClaimsState>) {
     // Four independent probes, issued as ONE stage: none reads another's
     // output, and every one of them is a subprocess plus a round trip that
     // doctor used to pay for in series. The RESULTS are consumed below in
@@ -4379,7 +4440,7 @@ pub async fn gather(namespace: &str, release: &str, api: Option<(&str, &str)>) -
 
     let (ok, ctx, _) = context_probe;
     if !ok || ctx.trim().is_empty() {
-        return f;
+        return (f, None);
     }
     f.kube_context = Some(ctx.trim().to_string());
 
@@ -4401,7 +4462,7 @@ pub async fn gather(namespace: &str, release: &str, api: Option<(&str, &str)>) -
     let (listed, stdout, _) = release_listing;
     f.release = classify_release_probe(helm_present, listed, &stdout, release);
     if !matches!(f.release, ReleaseProbe::Installed { .. }) {
-        return f;
+        return (f, None);
     }
 
     let common = crate::ops::CommonOpts {
@@ -4409,7 +4470,8 @@ pub async fn gather(namespace: &str, release: &str, api: Option<(&str, &str)>) -
         release: release.to_string(),
         dry_run: false,
     };
-    // Two SEPARATE reads, deliberately, issued CONCURRENTLY.
+    // Two SEPARATE reads and the worker selection, deliberately issued
+    // CONCURRENTLY.
     //
     // Separate: `fetch_release_values` reports only what the operator supplied,
     // so an operator who never set a model has nothing to read there and the
@@ -4418,30 +4480,25 @@ pub async fn gather(namespace: &str, release: &str, api: Option<(&str, &str)>) -
     // slack_configured, api.ingress.* or clone_credential onto computed values
     // would silently change three unrelated checks.
     //
-    // Concurrent: neither consumes the other's output and both depend only on
-    // `common`, so awaiting them in turn made every cluster run pay two helm
-    // spawns and two API-server round trips back to back for nothing. Each
-    // result keeps its own failure-tolerant handling below.
-    let (computed, values) = tokio::join!(
+    // Concurrent: none consumes another's output and all depend only on the
+    // confirmed release, so awaiting them in turn would add avoidable cluster
+    // round trips. Each result keeps its own failure-tolerant handling below.
+    let (computed, values, worker_claim_probe) = tokio::join!(
         crate::ops::fetch_release_computed_values(&common),
         crate::ops::fetch_release_values(&common),
+        crate::worker_claims::select_cluster(namespace, release),
     );
 
     // Failed values reads must not claim that the mail adapter is disabled.
     f.mail_channels = vec![crate::mail_channel::unavailable(namespace, release)];
+    let mut mail_enabled = false;
     if let Ok(Some(computed)) = computed {
         f.mail_channels.clear();
-        if helm_truthy(
+        mail_enabled = helm_truthy(
             computed
                 .get("mailAdapter")
                 .and_then(|value| value.get("deploy")),
-        ) {
-            f.mail_channels = crate::mail_channel::observe(namespace, release).await;
-            if f.mail_channels.is_empty() {
-                f.mail_channels
-                    .push(crate::mail_channel::unavailable(namespace, release));
-            }
-        }
+        );
         // The key travels with the id: the chart reads one of two, and a fix
         // naming the other one is a command that changes nothing.
         if let Some((model, key)) = runner_model_from_values(&computed) {
@@ -4453,6 +4510,7 @@ pub async fn gather(namespace: &str, release: &str, api: Option<(&str, &str)>) -
         f.model_release_fake = release_fake_model(&computed);
     }
 
+    let mut api_values_needing_nodeport = None;
     if let Ok(Some(values)) = values {
         // Presence only, both of them: socket mode needs the pair, and reading
         // one while reporting both is what made a half-wired release read as Ok.
@@ -4465,15 +4523,47 @@ pub async fn gather(namespace: &str, release: &str, api: Option<(&str, &str)>) -
         // decision itself still lives in exactly one place; deciding it here
         // too, to skip the read, is how a helper stays right while the report
         // goes wrong.
-        f.api_exposure = match api_exposure_from_values(&values, None) {
-            Some(exposure) => Some(exposure),
-            None => api_exposure_from_values(&values, api_nodeport(namespace, release).await),
-        };
+        f.api_exposure = api_exposure_from_values(&values, None);
         f.clone_credential = clone_credential_from_values(&values);
         (f.sandbox_egress_cidrs, f.sandbox_egress_is_reproducible) =
             sandbox_egress_from_values(&values);
+        if f.api_exposure.is_none() {
+            api_values_needing_nodeport = Some(values);
+        }
     }
-    f
+
+    // These reads consume the preceding stage: mail observation needs the
+    // computed deploy gate, NodePort discovery needs the supplied ingress
+    // values, and worker exec needs the selected pod. Run them together so no
+    // independent subprocess waits behind another.
+    let needs_api_nodeport = api_values_needing_nodeport.is_some();
+    let (mail_channels, nodeport, worker_claims) = tokio::join!(
+        async {
+            if !mail_enabled {
+                return None;
+            }
+            let mut reports = crate::mail_channel::observe(namespace, release).await;
+            if reports.is_empty() {
+                reports.push(crate::mail_channel::unavailable(namespace, release));
+            }
+            Some(reports)
+        },
+        async {
+            if needs_api_nodeport {
+                api_nodeport(namespace, release).await
+            } else {
+                None
+            }
+        },
+        worker_claim_probe.observe(),
+    );
+    if let Some(reports) = mail_channels {
+        f.mail_channels = reports;
+    }
+    if let Some(values) = api_values_needing_nodeport.as_ref() {
+        f.api_exposure = api_exposure_from_values(values, nodeport);
+    }
+    (f, Some(worker_claims.state))
 }
 
 /// The kubectl read behind `api_nodeport`, extracted pure so the Service NAME
@@ -4635,7 +4725,8 @@ pub async fn doctor(
     let api = resolved
         .as_ref()
         .map(|(url, key)| (url.as_str(), key.as_str()));
-    let checks = evaluate(&gather(namespace, release, api).await);
+    let (facts, worker_claims) = gather_with_worker_claims(namespace, release, api).await;
+    let checks = evaluate_with_worker_claims(&facts, worker_claims.as_ref());
     let summary = summary(&checks);
     DoctorOutput { checks, summary }
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -50,6 +50,7 @@ pub mod slack;
 pub mod spec;
 pub mod state;
 pub mod ui;
+pub(crate) mod worker_claims;
 
 pub use retired::retired_hint;
 

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -1267,8 +1267,14 @@ pub async fn status(o: LocalOpts) -> Result<LocalStatusOutput> {
         }));
     }
     require_on_path("docker")?;
-    // `docker compose ps` output is itself the payload table.
-    let (ok, out, err) = run_capture(&cmd).await?;
+    // The service table and claim gate are independent read-only probes. Keep
+    // the additive diagnosis on stderr so LocalStatusOutput remains unchanged.
+    let (status_read, claim_state) = tokio::join!(
+        run_capture(&cmd),
+        crate::worker_claims::observe_local(&o.file),
+    );
+    let (ok, out, err) = status_read?;
+    ui.note(&claim_state.status_diagnosis());
     if !ok {
         for line in err.lines() {
             ui.plumbing(line);

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -1180,6 +1180,47 @@ async fn bounded_diagnostics(
         })
 }
 
+/// Observe the claim gate for the same tier the message targets. The local
+/// message surface has no compose-file flag, so it follows the fixed local
+/// lifecycle file and project used by `curie local up`.
+async fn observe_message_claims(
+    opts: &MessageOpts,
+    verb: TurnVerb,
+) -> crate::worker_claims::ClaimsState {
+    match verb {
+        TurnVerb::Local => {
+            crate::worker_claims::observe_local(crate::local::DEFAULT_COMPOSE_FILE).await
+        }
+        TurnVerb::Cluster => {
+            crate::worker_claims::observe_cluster(&opts.namespace, &opts.release)
+                .await
+                .state
+        }
+    }
+}
+
+/// A known marker is useful before the first reply poll: print it on stderr and
+/// attach it to the active checklist step without exposing any subprocess text.
+fn report_initial_claim_wait(
+    ui: &crate::ui::Ui,
+    step: &crate::ui::Step,
+    state: &crate::worker_claims::ClaimsState,
+) {
+    if let Some(reason) = state.wait_reason() {
+        ui.note(&reason);
+        step.tick_detail(&reason);
+    }
+}
+
+/// Keep the existing diagnostics slot and prepend only the authored current
+/// marker reason. No claim reason leaves the old diagnostics byte shape alone.
+fn diagnostics_with_claim_wait(diagnostics: String, reason: Option<&str>) -> String {
+    match reason {
+        Some(reason) => format!("  {reason}\n{diagnostics}"),
+        None => diagnostics,
+    }
+}
+
 const COMPOSE_CONFIG_FILES_LABEL: &str = "com.docker.compose.project.config_files";
 const COMPOSE_DISPATCHER_SERVICE: &str = "curie-dispatcher";
 const DISPATCHER_ENQUEUE_MODULE: &str = "curie_dispatcher.enqueue_once";
@@ -1738,6 +1779,8 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
 
     let cl = ui.checklist();
     let step = cl.step("waiting for worker reply");
+    let initial_claims = observe_message_claims(&opts, TurnVerb::Local).await;
+    report_initial_claim_wait(ui, &step, &initial_claims);
     let wait_started = Instant::now();
     let outcome = {
         let mut observe_update = |text: &str| {
@@ -1851,12 +1894,20 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
             // next `local message` can bind successfully right away regardless of
             // how long anything after this line takes (#751).
             drop(stub);
+            let latest_claims = observe_message_claims(&opts, TurnVerb::Local).await;
+            let latest_reason = latest_claims.wait_reason();
             // Gather diagnostics only on the human path; under `--json` the
             // timeout object carries no diagnostics, so skip the extra Valkey read.
             let diag = if ui.json() {
+                if let Some(reason) = latest_reason.as_deref() {
+                    ui.note(reason);
+                }
                 None
             } else {
-                Some(bounded_diagnostics(&mut conn, &opts.stream, &stream_id).await)
+                Some(diagnostics_with_claim_wait(
+                    bounded_diagnostics(&mut conn, &opts.stream, &stream_id).await,
+                    latest_reason.as_deref(),
+                ))
             };
             ui.emit(&MessageOutcomeOutput::TimedOut {
                 diagnostics: diag,
@@ -2977,6 +3028,8 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
 
     let cl = ui.checklist();
     let step = cl.step("waiting for worker reply");
+    let initial_claims = observe_message_claims(&opts, TurnVerb::Cluster).await;
+    report_initial_claim_wait(ui, &step, &initial_claims);
     let wait_started = Instant::now();
     let observed = {
         let mut observe_update = |text: &str| {
@@ -3070,12 +3123,20 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
         }
         Outcome::TimedOut => {
             step.fail(&format!("timed out after {}s", opts.timeout_secs));
+            let latest_claims = observe_message_claims(&opts, TurnVerb::Cluster).await;
+            let latest_reason = latest_claims.wait_reason();
             // Gather diagnostics only on the human path; under `--json` the
             // timeout object carries no diagnostics, so skip the extra Valkey read.
             let diag = if ui.json() {
+                if let Some(reason) = latest_reason.as_deref() {
+                    ui.note(reason);
+                }
                 None
             } else {
-                Some(bounded_diagnostics(&mut conn, &opts.stream, &stream_id).await)
+                Some(diagnostics_with_claim_wait(
+                    bounded_diagnostics(&mut conn, &opts.stream, &stream_id).await,
+                    latest_reason.as_deref(),
+                ))
             };
             ui.emit(&MessageOutcomeOutput::TimedOut {
                 diagnostics: diag,

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -7008,22 +7008,20 @@ pub async fn status(opts: CommonOpts) -> Result<ClusterStatusOutput> {
     require_on_path("helm")?;
     require_on_path("kubectl")?;
 
-    // Five independent reads, issued as ONE stage.
+    // Seven independent top-level probes, issued as ONE stage.
     //
     // Safe because none of them consumes another's output: the helm status
-    // line, the pod list, the convergence observation, the release's rendered
-    // fullname and the node host each depend only on `opts`. Awaiting them in
-    // turn made an operator wait through five round trips to a cluster that
-    // could have answered all five at once, and the report is assembled below
-    // in exactly the order it was before -- concurrency here changes when the
-    // answers arrive, never which answer wins.
+    // line, pod list, convergence observation, rendered fullname, node host,
+    // computed-values gate and worker selection each depend only on `opts`.
+    // The report is assembled below in its established order -- concurrency
+    // here changes when the answers arrive, never which answer wins.
     //
     // `?` is applied to the helm result FIRST and the pod result second, so the
     // error an unreachable cluster surfaces is the same one it surfaced when
     // these ran in sequence.
     let helm_status = helm_status_cmd(&opts);
     let pods = pods_cmd(&opts);
-    let (helm, pods_read, observed, fullname, host, computed) = tokio::join!(
+    let (helm, pods_read, observed, fullname, host, computed, worker_claim_probe) = tokio::join!(
         run_capture(&helm_status),
         run_capture(&pods),
         convergence::observe(&opts),
@@ -7040,6 +7038,7 @@ pub async fn status(opts: CommonOpts) -> Result<ClusterStatusOutput> {
             VALUES_READ_FOR_GATE_TIMEOUT,
             fetch_release_computed_values(&opts),
         ),
+        crate::worker_claims::select_cluster(&opts.namespace, &opts.release),
     );
     let computed = computed.unwrap_or_else(|_| {
         Err(crate::exit::CliError::failure("timed out reading computed Helm values").into())
@@ -7127,8 +7126,9 @@ pub async fn status(opts: CommonOpts) -> Result<ClusterStatusOutput> {
     // The same target-manifest check gates up/apply and this read surface.
     // Keep the existing JSON schema: diagnoses use its unhealthy string list.
     // Consumed here, in the position it was awaited in before, so the
-    // `unhealthy` list keeps its order: pod-summary entries, then the
-    // convergence verdict, then the listing failure.
+    // `unhealthy` list keeps its existing order: pod-summary entries, then the
+    // convergence verdict, then the listing failure. The claim diagnosis is
+    // appended after those existing entries.
     match observed {
         Ok(observation) => unhealthy.extend(observation.issues),
         Err(error) => unhealthy.push(format!("convergence could not be verified: {error}")),
@@ -7139,14 +7139,34 @@ pub async fn status(opts: CommonOpts) -> Result<ClusterStatusOutput> {
 
     // (c) URL discovery. The release's rendered fullname and the node host were
     // resolved in the stage above -- both are live-branch only, and `--dry-run`
-    // returned before reaching any of it. The two Service reads DO consume the
-    // fullname, so they wait for that stage and then fan out against each other
-    // rather than queueing up one behind the other.
-    let (ui_url, langfuse_url) = tokio::join!(
+    // returned before reaching any of it. The two Service reads and the worker
+    // exec consume results from that stage, so all three fan out here rather
+    // than queueing behind each other.
+    let (ui_url, langfuse_url, worker_claims) = tokio::join!(
         resolve_service_url(&opts, &fullname, "ui", "UI", &host, true),
         resolve_service_url(&opts, &fullname, "langfuse-web", "Langfuse", &host, false),
+        worker_claim_probe.observe(),
     );
     let urls = vec![ui_url, langfuse_url];
+
+    match &worker_claims.state {
+        crate::worker_claims::ClaimsState::ClaimsEnabled => {
+            if let Some(row) = worker_claims
+                .worker_pod
+                .as_deref()
+                .and_then(|pod| pods.iter_mut().find(|row| row.name == pod))
+            {
+                row.status.push_str("; claims enabled");
+            }
+        }
+        crate::worker_claims::ClaimsState::Quiescing { .. }
+        | crate::worker_claims::ClaimsState::QuiescingMetadataUnavailable => {
+            unhealthy.push(worker_claims.state.status_diagnosis());
+        }
+        crate::worker_claims::ClaimsState::Unknown => {
+            warnings.push(worker_claims.state.status_diagnosis());
+        }
+    }
 
     let output = ClusterStatusOutput::Status(Box::new(ClusterStatus {
         namespace: opts.namespace.clone(),
@@ -8286,7 +8306,7 @@ pub enum SlackApiBase {
 /// `nameOverride`/`fullnameOverride` move it again. Guessing the name is the
 /// defect `release_secret_name` already avoids by selecting on labels, and this
 /// selects the same way for the same reason.
-fn worker_deployment_selector(release: &str) -> String {
+pub(crate) fn worker_deployment_selector(release: &str) -> String {
     component_selector(release, "worker")
 }
 

--- a/cli/src/worker_claims.rs
+++ b/cli/src/worker_claims.rs
@@ -1,0 +1,300 @@
+//! Bounded, read-only observation of the worker claim gate.
+//!
+//! The worker owns the marker and its wire shape. The CLI executes the worker's
+//! status mode in the selected runtime, accepts only that narrow schema, and
+//! turns every selection, process, timeout, or parse failure into `Unknown`.
+//! External command output is never carried into an operator report.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+use serde_json::Value;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime, UtcOffset};
+use tokio::time::Instant;
+
+use crate::ops::{plain, run_capture, OpsCommand};
+
+const OBSERVATION_TIMEOUT: Duration = Duration::from_secs(10);
+const COMPOSE_PROJECT: &str = "curie";
+const COMPOSE_WORKER_SERVICE: &str = "curie-worker";
+
+const STATUS_ARGS: [&str; 6] = [
+    "python",
+    "-m",
+    "curie_worker.upgrade_drain",
+    "--mode",
+    "status",
+    "--json",
+];
+
+/// The only claim-gate states an operator surface may act on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ClaimsState {
+    ClaimsEnabled,
+    Quiescing { since: String, revision: u64 },
+    QuiescingMetadataUnavailable,
+    Unknown,
+}
+
+impl ClaimsState {
+    /// Authored reason shared by doctor and message. Unknown state has no
+    /// proven marker to report.
+    pub(crate) fn wait_reason(&self) -> Option<String> {
+        match self {
+            Self::Quiescing { since, revision } => Some(format!(
+                "waiting for upgrade revision {revision} since {since}"
+            )),
+            Self::QuiescingMetadataUnavailable => {
+                Some("waiting for upgrade; marker metadata unavailable".to_string())
+            }
+            Self::ClaimsEnabled | Self::Unknown => None,
+        }
+    }
+
+    /// Read-only diagnosis used by status surfaces.
+    pub(crate) fn status_diagnosis(&self) -> String {
+        match self {
+            Self::ClaimsEnabled => "worker claims enabled".to_string(),
+            Self::Quiescing { .. } => format!(
+                "worker {}",
+                self.wait_reason()
+                    .expect("a quiescing claim state has a wait reason")
+            ),
+            Self::QuiescingMetadataUnavailable => {
+                "worker quiescing for upgrade; marker metadata unavailable".to_string()
+            }
+            Self::Unknown => "worker claim state unknown".to_string(),
+        }
+    }
+}
+
+/// Cluster observation retains the selected pod only so `cluster status` can
+/// annotate the matching existing row. The pod name is never inferred from an
+/// image or resource name pattern.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ClusterObservation {
+    pub(crate) state: ClaimsState,
+    pub(crate) worker_pod: Option<String>,
+}
+
+impl ClusterObservation {
+    fn unknown() -> Self {
+        Self {
+            state: ClaimsState::Unknown,
+            worker_pod: None,
+        }
+    }
+}
+
+/// A selected cluster target carrying the original observation deadline into
+/// the dependent exec stage.
+pub(crate) struct ClusterProbe {
+    namespace: String,
+    worker_pod: Option<String>,
+    deadline: Instant,
+}
+
+impl ClusterProbe {
+    /// Execute the worker reader with only the time left from selection. This
+    /// method is separate so callers can overlap exec with their other
+    /// dependent reads without resetting the observer budget.
+    pub(crate) async fn observe(self) -> ClusterObservation {
+        let Some(pod) = self.worker_pod else {
+            return ClusterObservation::unknown();
+        };
+        let observation = async {
+            let (executed, stdout, _) = run_capture(&cluster_exec_command(&self.namespace, &pod))
+                .await
+                .ok()?;
+            if !executed {
+                return None;
+            }
+            Some(ClusterObservation {
+                state: parse_status(&stdout),
+                worker_pod: Some(pod),
+            })
+        };
+
+        tokio::time::timeout_at(self.deadline, observation)
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_else(ClusterObservation::unknown)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StatusDocument {
+    state: String,
+    since: Value,
+    revision: Value,
+}
+
+fn valid_utc_rfc3339(value: &str) -> bool {
+    // This also prevents a syntactically valid prefix followed by terminal
+    // control data from becoming an authored operator line.
+    if value.len() > 64 || value.chars().any(char::is_control) {
+        return false;
+    }
+    OffsetDateTime::parse(value, &Rfc3339)
+        .map(|timestamp| timestamp.offset() == UtcOffset::UTC)
+        .unwrap_or(false)
+}
+
+fn parse_status(stdout: &str) -> ClaimsState {
+    let Ok(document) = serde_json::from_str::<StatusDocument>(stdout) else {
+        return ClaimsState::Unknown;
+    };
+
+    match document.state.as_str() {
+        "claims_enabled" if document.since.is_null() && document.revision.is_null() => {
+            ClaimsState::ClaimsEnabled
+        }
+        "unknown" if document.since.is_null() && document.revision.is_null() => {
+            ClaimsState::Unknown
+        }
+        "quiescing" if document.since.is_null() && document.revision.is_null() => {
+            ClaimsState::QuiescingMetadataUnavailable
+        }
+        "quiescing" => {
+            let Some(since) = document.since.as_str() else {
+                return ClaimsState::Unknown;
+            };
+            let Some(revision) = document.revision.as_u64().filter(|revision| *revision > 0) else {
+                return ClaimsState::Unknown;
+            };
+            if !valid_utc_rfc3339(since) {
+                return ClaimsState::Unknown;
+            }
+            ClaimsState::Quiescing {
+                since: since.to_string(),
+                revision,
+            }
+        }
+        _ => ClaimsState::Unknown,
+    }
+}
+
+fn running_worker_pod(stdout: &str, release: &str) -> Option<String> {
+    let document = serde_json::from_str::<Value>(stdout).ok()?;
+    let items = document.get("items")?.as_array()?;
+    let mut matches: Vec<String> = items
+        .iter()
+        .filter_map(|pod| {
+            let metadata = pod.get("metadata")?;
+            let labels = metadata.get("labels")?.as_object()?;
+            let correct_release = labels
+                .get("app.kubernetes.io/instance")
+                .and_then(Value::as_str)
+                == Some(release);
+            let worker_component = labels
+                .get("app.kubernetes.io/component")
+                .and_then(Value::as_str)
+                == Some("worker");
+            let running = pod.pointer("/status/phase").and_then(Value::as_str) == Some("Running");
+            let terminating = metadata
+                .get("deletionTimestamp")
+                .is_some_and(|timestamp| !timestamp.is_null());
+            if !correct_release || !worker_component || !running || terminating {
+                return None;
+            }
+            metadata
+                .get("name")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .map(str::to_string)
+        })
+        .collect();
+    matches.sort_unstable();
+    matches.into_iter().next()
+}
+
+fn cluster_selection_command(namespace: &str, release: &str) -> OpsCommand {
+    OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("get"),
+            plain("pods"),
+            plain("-n"),
+            plain(namespace),
+            plain("-l"),
+            plain(crate::ops::worker_deployment_selector(release)),
+            plain("-o"),
+            plain("json"),
+        ],
+    )
+}
+
+fn cluster_exec_command(namespace: &str, pod: &str) -> OpsCommand {
+    let mut args = vec![
+        plain("exec"),
+        plain("-n"),
+        plain(namespace),
+        plain(pod),
+        plain("--"),
+    ];
+    args.extend(STATUS_ARGS.into_iter().map(plain));
+    OpsCommand::new("kubectl", args)
+}
+
+fn local_exec_command(compose_file: &str) -> OpsCommand {
+    let mut args = vec![
+        plain("compose"),
+        plain("-p"),
+        plain(COMPOSE_PROJECT),
+        plain("-f"),
+        plain(compose_file),
+        plain("exec"),
+        plain("-T"),
+        plain(COMPOSE_WORKER_SERVICE),
+    ];
+    args.extend(STATUS_ARGS.into_iter().map(plain));
+    OpsCommand::new("docker", args)
+}
+
+/// Select one Running worker from this exact release. The returned handle owns
+/// the absolute deadline that also bounds its later exec.
+pub(crate) async fn select_cluster(namespace: &str, release: &str) -> ClusterProbe {
+    let deadline = Instant::now() + OBSERVATION_TIMEOUT;
+    let selection = async {
+        let (selected, stdout, _) = run_capture(&cluster_selection_command(namespace, release))
+            .await
+            .ok()?;
+        if !selected {
+            return None;
+        }
+        running_worker_pod(&stdout, release)
+    };
+    let worker_pod = tokio::time::timeout_at(deadline, selection)
+        .await
+        .ok()
+        .flatten();
+    ClusterProbe {
+        namespace: namespace.to_string(),
+        worker_pod,
+        deadline,
+    }
+}
+
+/// Complete a cluster observation without exposing its two stages to callers
+/// that have no independent work to overlap.
+pub(crate) async fn observe_cluster(namespace: &str, release: &str) -> ClusterObservation {
+    select_cluster(namespace, release).await.observe().await
+}
+
+/// Execute status in the fixed local Compose project and worker service. The
+/// entire child lifetime is covered by one deadline.
+pub(crate) async fn observe_local(compose_file: &str) -> ClaimsState {
+    let observation = async {
+        let (executed, stdout, _) = run_capture(&local_exec_command(compose_file)).await.ok()?;
+        executed.then(|| parse_status(&stdout))
+    };
+
+    tokio::time::timeout(OBSERVATION_TIMEOUT, observation)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or(ClaimsState::Unknown)
+}

--- a/cli/tests/chart_check.rs
+++ b/cli/tests/chart_check.rs
@@ -287,11 +287,10 @@ async fn discovery_skips_non_scripts_and_non_executable_files() {
     );
 }
 
-/// The set of scripts helm-ci names, recovered from the workflow rather than
-/// from a second hardcoded list.
-fn helm_ci_referenced_scripts() -> Vec<String> {
-    let workflow = std::fs::read_to_string(repo_root().join(".github/workflows/helm-ci.yaml"))
-        .expect(".github/workflows/helm-ci.yaml is committed");
+/// The direct children of `charts/curie/ci/` named by helm-ci. Runtime scripts
+/// under `ci/runtime/` are cluster checks outside chart-check's shallow render
+/// inventory, so they must not be compared with its root-only discovery.
+fn helm_ci_referenced_root_scripts_in(workflow: &str) -> Vec<String> {
     let needle = format!("{CHART_CI_DIR}/");
     let mut found: Vec<String> = Vec::new();
     for line in workflow.lines() {
@@ -300,9 +299,38 @@ fn helm_ci_referenced_scripts() -> Vec<String> {
         };
         let rest = &line[start + needle.len()..];
         let end = rest.find(".sh").expect("a referenced script ends in .sh");
-        found.push(rest[..end + 3].to_string());
+        let script = &rest[..end + 3];
+        if !script.contains('/') {
+            found.push(script.to_string());
+        }
     }
     found
+}
+
+/// The set of root scripts helm-ci names, recovered from the workflow rather
+/// than from a second hardcoded list.
+fn helm_ci_referenced_scripts() -> Vec<String> {
+    let workflow = std::fs::read_to_string(repo_root().join(".github/workflows/helm-ci.yaml"))
+        .expect(".github/workflows/helm-ci.yaml is committed");
+    helm_ci_referenced_root_scripts_in(&workflow)
+}
+
+#[test]
+fn helm_ci_reference_inventory_excludes_nested_runtime_scripts() {
+    let workflow = r#"
+        run: bash charts/curie/ci/first-render-assertions.sh
+        run: bash charts/curie/ci/runtime/installation-runtime.sh
+        run: bash charts/curie/ci/second-render-assertions.sh
+    "#;
+
+    assert_eq!(
+        helm_ci_referenced_root_scripts_in(workflow),
+        vec![
+            "first-render-assertions.sh".to_string(),
+            "second-render-assertions.sh".to_string(),
+        ],
+        "nested runtime checks run in helm-ci but are outside chart-check's shallow root inventory"
+    );
 }
 
 /// AC5: the verb and helm-ci cannot silently diverge.

--- a/cli/tests/cluster_stub_trust.rs
+++ b/cli/tests/cluster_stub_trust.rs
@@ -17,6 +17,8 @@ use support::{serve, Response};
 const CHANNEL: &str = "C0EXAMPLE1";
 const API_KEY: &str = "fixture-platform-key";
 const RELAY_ADAPTER: &str = "curie-cluster-message";
+const WORKER_CLAIM_SELECTION: &str = "kubectl get pods -n acme-system -l app.kubernetes.io/instance=acme-release,app.kubernetes.io/component=worker -o json";
+const WORKER_CLAIM_EXEC: &str = "kubectl exec -n acme-system worker-stable-a -- python -m curie_worker.upgrade_drain --mode status --json";
 
 fn bin() -> &'static str {
     env!("CARGO_BIN_EXE_curie")
@@ -293,6 +295,29 @@ if "get deployment acme-release-curie-dispatcher" in joined:
         print("deployment.apps/acme-release-curie-dispatcher")
     sys.exit(0)
 
+# The message diagnosis may observe the claim gate through one exact, scoped,
+# read-only worker selection followed by the worker's status-only entry point.
+worker_selector = "app.kubernetes.io/instance=acme-release,app.kubernetes.io/component=worker"
+if args == ["get", "pods", "-n", "acme-system", "-l", worker_selector, "-o", "json"]:
+    print(json.dumps({"items": [{
+        "metadata": {
+            "name": "worker-stable-a",
+            "labels": {
+                "app.kubernetes.io/instance": "acme-release",
+                "app.kubernetes.io/component": "worker",
+            },
+        },
+        "status": {"phase": "Running"},
+    }]}))
+    sys.exit(0)
+
+if args == [
+    "exec", "-n", "acme-system", "worker-stable-a", "--",
+    "python", "-m", "curie_worker.upgrade_drain", "--mode", "status", "--json",
+]:
+    print('{"state":"claims_enabled","since":null,"revision":null}')
+    sys.exit(0)
+
 # Connected mode reads the worker's configured Slack origin. This read is not a
 # rollout/trust read and must remain on the connected branch.
 if "get deployment" in joined and "app.kubernetes.io/component=worker" in joined and "jsonpath=" in joined:
@@ -469,6 +494,7 @@ fn assert_relay_turn<'a>(turn: &'a serde_json::Value, expected_text: &str) -> &'
 }
 
 fn assert_no_worker_rollout(log: &str, state: &serde_json::Value) {
+    assert_only_bounded_worker_claim_reads(log);
     let forbidden: Vec<&str> = log
         .lines()
         .filter(|line| {
@@ -476,7 +502,9 @@ fn assert_no_worker_rollout(log: &str, state: &serde_json::Value) {
                 || (line.contains("patch deployment") && line.contains("worker"))
                 || (line.contains("set env") && line.contains("worker"))
                 || (line.contains("rollout status") && line.contains("worker"))
-                || (line.contains("get pods") && line.contains("component=worker"))
+                || (line.contains("get pods")
+                    && line.contains("component=worker")
+                    && *line != WORKER_CLAIM_SELECTION)
                 || (line.starts_with("helm ") && line.contains("worker"))
         })
         .collect();
@@ -493,13 +521,16 @@ fn assert_no_worker_rollout(log: &str, state: &serde_json::Value) {
 }
 
 fn assert_no_worker_mutation(log: &str, state: &serde_json::Value) {
+    assert_only_bounded_worker_claim_reads(log);
     let forbidden: Vec<&str> = log
         .lines()
         .filter(|line| {
             (line.contains("patch deployment") && line.contains("worker"))
                 || (line.contains("set env") && line.contains("worker"))
                 || (line.contains("rollout status") && line.contains("worker"))
-                || (line.contains("get pods") && line.contains("component=worker"))
+                || (line.contains("get pods")
+                    && line.contains("component=worker")
+                    && *line != WORKER_CLAIM_SELECTION)
                 || (line.starts_with("helm ") && line.contains("worker"))
         })
         .collect();
@@ -511,6 +542,41 @@ fn assert_no_worker_mutation(log: &str, state: &serde_json::Value) {
     assert_eq!(
         state["pods"],
         serde_json::json!(["worker-stable-a", "worker-stable-b"])
+    );
+}
+
+fn assert_only_bounded_worker_claim_reads(log: &str) {
+    let unexpected: Vec<&str> = log
+        .lines()
+        .filter(|line| {
+            (line.contains("get pods")
+                && line.contains("component=worker")
+                && *line != WORKER_CLAIM_SELECTION)
+                || (line.contains("exec")
+                    && line.contains("curie_worker.upgrade_drain")
+                    && *line != WORKER_CLAIM_EXEC)
+        })
+        .collect();
+    assert!(
+        unexpected.is_empty(),
+        "unexpected worker claim observation: {unexpected:#?}\n{log}"
+    );
+
+    let selections = log
+        .lines()
+        .filter(|line| *line == WORKER_CLAIM_SELECTION)
+        .count();
+    let executions = log
+        .lines()
+        .filter(|line| *line == WORKER_CLAIM_EXEC)
+        .count();
+    assert_eq!(
+        executions, selections,
+        "each scoped worker selection must have one status-only exec: {log}"
+    );
+    assert!(
+        selections <= 2,
+        "one message may observe claims only before and after its wait: {log}"
     );
 }
 

--- a/cli/tests/mail_channel_health.rs
+++ b/cli/tests/mail_channel_health.rs
@@ -60,6 +60,12 @@ impl Fixture {
         let script = r#"#!/bin/sh
 case "${0##*/}:$*" in
   kubectl:*--raw*) printf '%s\n' "$*" >> "${0%/*}/proxy-calls"; cat "${0%/*}/status.json"; exit 0 ;;
+  kubectl:"get pods -n mail-test -l app.kubernetes.io/instance=acme,app.kubernetes.io/component=worker -o json")
+    printf '%s\n' '{"items":[{"metadata":{"name":"acme-worker-abc","labels":{"app.kubernetes.io/instance":"acme","app.kubernetes.io/component":"worker"}},"status":{"phase":"Running"}}]}'
+    exit 0 ;;
+  kubectl:"exec -n mail-test acme-worker-abc -- python -m curie_worker.upgrade_drain --mode status --json")
+    printf '%s\n' '{"state":"claims_enabled","since":null,"revision":null}'
+    exit 0 ;;
   kubectl:"get pods"*) cat "${0%/*}/pods.json"; exit 0 ;;
   kubectl:"config current-context") printf '%s\n' 'owned-test'; exit 0 ;;
   kubectl:*"component=api"*) printf '%s\n' 'acme-api'; exit 0 ;;

--- a/cli/tests/probe_fanout.rs
+++ b/cli/tests/probe_fanout.rs
@@ -44,10 +44,12 @@
 //!    curie --all` (issued only because the Secret listing came back empty);
 //! 3. the four `gather` probes -- docker, the kube context, the helm version
 //!    and `helm list -n curie -o json`;
-//! 4. the two `helm get values` reads, computed and operator-supplied;
+//! 4. the two `helm get values` reads, computed and operator-supplied, alongside
+//!    the exact-label worker pod selection;
 //! 5. the api Service NodePort read, which needs the fullname (a cache hit, so
-//!    no second discovery) and only happens because the values carry no
-//!    ingress.
+//!    no second discovery), alongside the worker status exec, which needs the
+//!    selected Running pod. The NodePort read only happens because the values
+//!    carry no ingress.
 //!
 //! Step 2's helm hop is the second rung of `ops::discover_api_key`'s ladder:
 //! the Secret name listing answers empty, so the key is looked for in Helm's
@@ -55,7 +57,8 @@
 //! "its chart Secret API key could not be read". That is what makes the API
 //! leg observable here without an HTTP round trip. Baseline was 13 calls in 12
 //! stages, including the duplicated label-selector read; the joined
-//! implementation is 12 calls in 5.
+//! implementation is 14 calls in 5, including the two-call bounded worker
+//! claim observation.
 //!
 //! # Why the scenario makes no HTTP call
 //!
@@ -134,6 +137,12 @@ RULES = {
                  "app.kubernetes.io/instance=curie", "-o", NAMES)): "",
     # -- cluster status pod health ----------------------------------------
     ("kubectl", ("get", "pods", "-n", "curie", "-o", "json")): '{"items":[]}\n',
+    # -- exact worker claim observation -----------------------------------
+    ("kubectl", ("get", "pods", "-n", "curie", "-l", WORKER_SELECTOR, "-o", "json")):
+        '{"items":[{"metadata":{"name":"curie-worker-current","labels":{"app.kubernetes.io/instance":"curie","app.kubernetes.io/component":"worker"}},"status":{"phase":"Running"}}]}\n',
+    ("kubectl", ("exec", "-n", "curie", "curie-worker-current", "--", "python", "-m",
+                 "curie_worker.upgrade_drain", "--mode", "status", "--json")):
+        '{"state":"claims_enabled","since":null,"revision":null}\n',
     # -- resolve_node_host fallback (defensive; must not fire) -------------
     ("kubectl", ("get", "nodes", "-o", "json")): '{"items":[]}\n',
 
@@ -312,8 +321,8 @@ fn probe_stages(log: &str) -> (usize, usize, Vec<String>, Vec<String>) {
     (intervals.len(), stages, duplicates, unexpected)
 }
 
-/// `expected_calls` pins the documented probe set from the module doc (12 for
-/// `doctor`, 8 for `cluster status`) exactly, so a probe silently added or
+/// `expected_calls` pins the documented probe set from the module doc (14 for
+/// `doctor`, 10 for `cluster status`) exactly, so a probe silently added or
 /// dropped fails here rather than only showing up as a stage-count wobble.
 fn assert_fanout(
     label: &str,
@@ -371,6 +380,46 @@ fn check_golden(name: &str, actual: &[u8]) {
     );
 }
 
+/// Preserve the byte pin for every pre-#2374 doctor field while the new
+/// `worker-claims` check is asserted exhaustively in `worker_claims.rs`. The
+/// golden files are outside this test writer's ownership, so normalize only
+/// that one additive check before comparing the old payload.
+fn check_doctor_json_golden(actual: &[u8]) {
+    let mut value: serde_json::Value = serde_json::from_slice(actual)
+        .unwrap_or_else(|error| panic!("doctor stdout is not JSON ({error})"));
+    let checks = value["checks"].as_array_mut().expect("doctor checks array");
+    let before = checks.len();
+    checks.retain(|check| check["id"] != "worker-claims");
+    assert_eq!(
+        checks.len() + 1,
+        before,
+        "doctor must add exactly one worker-claims check: {}",
+        String::from_utf8_lossy(actual)
+    );
+    let mut normalized = serde_json::to_vec(&value).expect("serialize normalized doctor JSON");
+    normalized.push(b'\n');
+    check_golden("doctor.json", &normalized);
+}
+
+fn check_doctor_human_golden(actual: &[u8]) {
+    let text = String::from_utf8(actual.to_vec()).expect("doctor human output is UTF-8");
+    let mut removed = 0usize;
+    let mut normalized = String::new();
+    for line in text.lines() {
+        if line.to_ascii_lowercase().contains("claims enabled") {
+            removed += 1;
+            continue;
+        }
+        normalized.push_str(line);
+        normalized.push('\n');
+    }
+    assert_eq!(
+        removed, 1,
+        "doctor must render one claims-enabled row: {text}"
+    );
+    check_golden("doctor.txt", normalized.as_bytes());
+}
+
 fn stdout_of(output: &Output) -> String {
     String::from_utf8_lossy(&output.stdout).into_owned()
 }
@@ -380,8 +429,8 @@ fn stderr_of(output: &Output) -> String {
 }
 
 /// `curie doctor` must join its independent docker/kubectl/helm reads and
-/// resolve the release fullname once. 5 stages is the floor for this scenario
-/// (see the module doc); the sequential implementation took 12.
+/// resolve the release fullname once. The new two-call claim observation fits
+/// into the same 5 dependency stages (see the module doc).
 #[test]
 fn doctor_fans_out_independent_probes() {
     let fixture = fixture();
@@ -393,14 +442,14 @@ fn doctor_fans_out_independent_probes() {
         stdout_of(&output),
         stderr_of(&output)
     );
-    assert_fanout("doctor", &fixture, 5, 12, wall_ms);
+    assert_fanout("doctor", &fixture, 5, 14, wall_ms);
 }
 
 /// `curie cluster status` must issue helm status, the pod list, convergence,
-/// the computed values (the `mailAdapter.deploy` gate, #2457), the fullname and
-/// the host as one stage, then the two Service reads (which consume the
-/// fullname) as a second. The sequential implementation took 6. Exit 1 is part
-/// of the contract (see `cluster_status_output_is_golden`).
+/// the computed values (the `mailAdapter.deploy` gate, #2457), the fullname,
+/// host and exact worker selection as one stage, then the two Service reads and
+/// selected-worker status exec as a second. Exit 1 is part of the contract (see
+/// `cluster_status_output_is_golden`).
 #[test]
 fn cluster_status_fans_out_independent_probes() {
     let fixture = fixture();
@@ -412,7 +461,7 @@ fn cluster_status_fans_out_independent_probes() {
         stdout_of(&output),
         stderr_of(&output)
     );
-    assert_fanout("status", &fixture, 2, 8, wall_ms);
+    assert_fanout("status", &fixture, 2, 10, wall_ms);
 }
 
 /// Joining probes must not move a byte of what either surface prints, so both
@@ -428,7 +477,7 @@ fn doctor_output_is_golden() {
         "stderr: {}",
         stderr_of(&json_output)
     );
-    check_golden("doctor.json", &json_output.stdout);
+    check_doctor_json_golden(&json_output.stdout);
     check_golden("doctor.json.stderr", &json_output.stderr);
 
     let human_fixture = fixture();
@@ -439,7 +488,7 @@ fn doctor_output_is_golden() {
         "stderr: {}",
         stderr_of(&human_output)
     );
-    check_golden("doctor.txt", &human_output.stdout);
+    check_doctor_human_golden(&human_output.stdout);
     check_golden("doctor.txt.stderr", &human_output.stderr);
 }
 

--- a/cli/tests/worker_claims.rs
+++ b/cli/tests/worker_claims.rs
@@ -1,0 +1,1087 @@
+//! Issue #2374: operator surfaces must report the worker's claim gate without
+//! guessing from pod health or leaking the status subprocess's output.
+//!
+//! These are public-surface tests.  The real `curie` binary talks to recording
+//! Docker/kubectl/Helm shims, and the message cases use the same tiny
+//! port-forward servers as the existing cluster-message integration fixture.
+//! No test imports the observer module: reverting only the product
+//! implementation still compiles this file and makes the observable assertions
+//! red.
+
+use std::collections::BTreeSet;
+use std::ffi::OsString;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{Duration, Instant};
+
+const NAMESPACE: &str = "acme-claims";
+const RELEASE: &str = "acme-claims";
+const WORKER_POD: &str = "acme-claims-worker-current";
+const OLD_COMPLETED_HOOK: &str = "acme-claims-upgrade-drain-completed";
+const OLD_STUCK_HOOK: &str = "acme-claims-upgrade-drain-stuck";
+const WORKER_SELECTOR: &str =
+    "app.kubernetes.io/instance=acme-claims,app.kubernetes.io/component=worker";
+const SINCE_17: &str = "2026-09-08T12:34:56Z";
+const SINCE_18: &str = "2026-09-08T12:35:57Z";
+const STATUS_WAITING_17: &str = "worker waiting for upgrade revision 17 since 2026-09-08T12:34:56Z";
+const WAITING_17: &str = "waiting for upgrade revision 17 since 2026-09-08T12:34:56Z";
+const WAITING_18: &str = "waiting for upgrade revision 18 since 2026-09-08T12:35:57Z";
+const STATUS_QUIESCING_WITHOUT_METADATA: &str =
+    "worker quiescing for upgrade; marker metadata unavailable";
+const WAITING_WITHOUT_METADATA: &str = "waiting for upgrade; marker metadata unavailable";
+const PRIVATE_SENTINEL: &str = "private-status-output-must-not-escape";
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+fn write_executable(path: &Path, body: &str) {
+    fs::write(path, body).expect("write tool shim");
+    let mut permissions = fs::metadata(path)
+        .expect("read shim metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("make tool shim executable");
+}
+
+fn shim_path(tools: &Path) -> OsString {
+    let mut paths = vec![tools.to_path_buf()];
+    paths.extend(["/usr/bin", "/bin"].iter().map(PathBuf::from));
+    std::env::join_paths(paths).expect("join shim PATH")
+}
+
+fn describe(output: &Output) -> String {
+    format!(
+        "status: {}\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn json_output(output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "stdout is not one JSON object ({error}): {}",
+            describe(output)
+        )
+    })
+}
+
+fn claim_reply(
+    state: &str,
+    since: serde_json::Value,
+    revision: serde_json::Value,
+) -> serde_json::Value {
+    serde_json::json!({
+        "stdout": serde_json::json!({
+            "state": state,
+            "since": since,
+            "revision": revision,
+        }).to_string(),
+        "stderr": "",
+        "exit": 0,
+        "sleep": 0,
+    })
+}
+
+fn claims_enabled() -> serde_json::Value {
+    claim_reply(
+        "claims_enabled",
+        serde_json::Value::Null,
+        serde_json::Value::Null,
+    )
+}
+
+fn quiescing(since: &str, revision: u64) -> serde_json::Value {
+    claim_reply(
+        "quiescing",
+        serde_json::Value::String(since.to_string()),
+        serde_json::json!(revision),
+    )
+}
+
+fn quiescing_without_metadata() -> serde_json::Value {
+    let mut response = claim_reply(
+        "quiescing",
+        serde_json::Value::Null,
+        serde_json::Value::Null,
+    );
+    response["stderr"] = serde_json::json!(PRIVATE_SENTINEL);
+    response
+}
+
+fn unknown() -> serde_json::Value {
+    claim_reply("unknown", serde_json::Value::Null, serde_json::Value::Null)
+}
+
+/// One shim body serves the operator reports and the message fixture.  Every
+/// command is recorded as JSON so assertions do not depend on shell quoting.
+/// The selector intentionally returns two same-image hook pods in addition to
+/// the real worker: a client that selects by image/name, or trusts the shim to
+/// enforce labels, will exec the wrong pod and fail loudly.
+const TOOL_SHIM: &str = r###"#!/usr/bin/env python3
+import fcntl
+import json
+import os
+import shlex
+import socket
+import sys
+import threading
+import time
+from urllib.parse import urlparse
+
+args = sys.argv[1:]
+tool = os.path.basename(sys.argv[0])
+root = os.environ["CURIE_TEST_WORKER_CLAIMS_ROOT"]
+calls_path = os.path.join(root, "calls.log")
+WORKER_SELECTOR = "app.kubernetes.io/instance=acme-claims,app.kubernetes.io/component=worker"
+
+def record(kind, argv=None):
+    row = {
+        "kind": kind,
+        "tool": tool,
+        "argv": args if argv is None else argv,
+        "compose_project": os.environ.get("COMPOSE_PROJECT_NAME"),
+    }
+    with open(calls_path, "a", encoding="utf-8") as log:
+        fcntl.flock(log, fcntl.LOCK_EX)
+        log.write(json.dumps(row, separators=(",", ":")) + "\n")
+        log.flush()
+
+record("command")
+
+def has_sequence(parts):
+    if len(parts) > len(args):
+        return False
+    return any(args[i:i + len(parts)] == parts for i in range(len(args) - len(parts) + 1))
+
+def next_claim():
+    count_path = os.path.join(root, "claim-count")
+    with open(count_path, "r+", encoding="utf-8") as counter:
+        fcntl.flock(counter, fcntl.LOCK_EX)
+        raw = counter.read().strip()
+        index = int(raw or "0")
+        counter.seek(0)
+        counter.write(str(index + 1))
+        counter.truncate()
+    with open(os.path.join(root, "claim-sequence.json"), encoding="utf-8") as source:
+        sequence = json.load(source)
+    reply = sequence[min(index, len(sequence) - 1)]
+    time.sleep(float(reply.get("sleep", 0)))
+    sys.stdout.write(reply.get("stdout", ""))
+    sys.stderr.write(reply.get("stderr", ""))
+    sys.exit(int(reply.get("exit", 0)))
+
+def pod(name, component, phase, ready, image="ghcr.io/curie-eng/curie-worker:test"):
+    return {
+        "metadata": {
+            "name": name,
+            "labels": {
+                "app.kubernetes.io/instance": "acme-claims",
+                "app.kubernetes.io/component": component,
+            },
+        },
+        "spec": {"containers": [{"name": "worker", "image": image}]},
+        "status": {
+            "phase": phase,
+            "containerStatuses": [{
+                "name": "worker",
+                "image": image,
+                "imageID": "docker-pullable://ghcr.io/curie-eng/curie-worker@sha256:" + "a" * 64,
+                "ready": ready,
+                "state": {"running": {}} if ready else {"terminated": {"exitCode": 0, "reason": "Completed"}},
+            }],
+        },
+    }
+
+worker = pod("acme-claims-worker-current", "worker", "Running", True)
+selector_pods = {
+    "items": [
+        pod("acme-claims-upgrade-drain-completed", "upgrade-drain", "Succeeded", False),
+        pod("acme-claims-upgrade-drain-stuck", "upgrade-drain", "Running", True),
+        pod("acme-claims-worker-pending", "worker", "Pending", False),
+        worker,
+    ]
+}
+
+is_claim_exec = "exec" in args and has_sequence([
+    "python", "-m", "curie_worker.upgrade_drain", "--mode", "status", "--json"
+])
+if is_claim_exec:
+    if tool == "kubectl" and "acme-claims-worker-current" not in args:
+        print("claim probe selected a hook or non-running pod", file=sys.stderr)
+        sys.exit(64)
+    if tool == "docker":
+        exact_project = os.environ.get("COMPOSE_PROJECT_NAME") == "curie" or has_sequence(["-p", "curie"])
+        if "curie-worker" not in args or not exact_project:
+            print("claim probe selected the wrong compose project/service", file=sys.stderr)
+            sys.exit(64)
+    record("claim_exec")
+    next_claim()
+
+if tool == "kubectl":
+    joined = " ".join(args)
+    if "port-forward" in args:
+        requested, remote = args[-1].split(":", 1)
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(("127.0.0.1", int(requested)))
+        listener.listen()
+        print("Forwarding from 127.0.0.1:%d -> %s" % (listener.getsockname()[1], remote), flush=True)
+        is_valkey = "valkey" in joined
+
+        def read_resp(stream):
+            prefix = stream.read(1)
+            if not prefix:
+                return None
+            line = stream.readline().rstrip(b"\r\n")
+            if prefix == b"*":
+                return [read_resp(stream) for _ in range(int(line))]
+            if prefix == b"$":
+                length = int(line)
+                if length < 0:
+                    return None
+                value = stream.read(length)
+                stream.read(2)
+                return value
+            if prefix in (b"+", b":"):
+                return line
+            return None
+
+        def bulk(value):
+            value = value.encode("utf-8")
+            return b"$" + str(len(value)).encode() + b"\r\n" + value + b"\r\n"
+
+        def serve_valkey(client):
+            try:
+                stream = client.makefile("rb")
+                while True:
+                    command = read_resp(stream)
+                    if command is None:
+                        return
+                    words = [part.decode("utf-8") if isinstance(part, bytes) else str(part) for part in command]
+                    verb = words[0].upper()
+                    if verb == "PING":
+                        response = b"+PONG\r\n"
+                    elif verb in ("AUTH", "SELECT") or verb == "CLIENT":
+                        response = b"+OK\r\n"
+                    elif verb == "XADD":
+                        response = bulk("101-0")
+                    elif verb == "QUIT":
+                        response = b"+OK\r\n"
+                    else:
+                        response = b"-ERR unsupported fixture command " + verb.encode() + b"\r\n"
+                    client.sendall(response)
+            finally:
+                client.close()
+
+        def serve_http(client):
+            try:
+                stream = client.makefile("rb")
+                request_line = stream.readline().decode("latin1").strip()
+                if not request_line:
+                    return
+                method, raw_path, _ = request_line.split(" ", 2)
+                while True:
+                    line = stream.readline()
+                    if line in (b"\r\n", b"\n", b""):
+                        break
+                parsed = urlparse(raw_path)
+                record("http_get", [method, parsed.path, parsed.query])
+                body = b'{"events":[],"next_cursor":0,"terminal":false}'
+                client.sendall(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: "
+                    + str(len(body)).encode() + b"\r\nConnection: close\r\n\r\n" + body
+                )
+            finally:
+                client.close()
+
+        handler = serve_valkey if is_valkey else serve_http
+        while True:
+            client, _ = listener.accept()
+            threading.Thread(target=handler, args=(client,), daemon=True).start()
+
+    if has_sequence(["config", "current-context"]):
+        print("claims-test-context")
+        sys.exit(0)
+    if has_sequence(["config", "view"]):
+        print("https://127.0.0.1:6443", end="")
+        sys.exit(0)
+    if "get" in args and ("pod" in args or "pods" in args) and any(WORKER_SELECTOR in value for value in args):
+        time.sleep(float(os.environ.get("CURIE_TEST_SELECTOR_SLEEP", "0")))
+        print(json.dumps(selector_pods, separators=(",", ":")))
+        sys.exit(0)
+    if has_sequence(["get", "pods"]) and "-o" in args and "json" in args:
+        print(json.dumps({"items": [worker]}, separators=(",", ":")))
+        sys.exit(0)
+    if "get" in args and "app.kubernetes.io/component=api" in joined:
+        print("acme-claims-curie-api", end="")
+        sys.exit(0)
+    if "get" in args and "secret" in args:
+        print("", end="")
+        sys.exit(0)
+    if "get" in args and "deployment" in args and "dispatcher" in joined:
+        print("", end="")
+        sys.exit(0)
+    if has_sequence(["get", "svc", "acme-claims-curie-ui"]):
+        print('{"spec":{"type":"NodePort","ports":[{"port":80,"nodePort":30080}]}}')
+        sys.exit(0)
+    if has_sequence(["get", "svc", "acme-claims-curie-langfuse-web"]):
+        print('{"spec":{"type":"ClusterIP","ports":[{"port":3000}]}}')
+        sys.exit(0)
+    if "deployments,statefulsets,daemonsets,pods,jobs" in args:
+        print('{"items":[{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"acme-probe","generation":1},"spec":{"replicas":1,"selector":{"matchLabels":{"component":"acme-probe"}},"template":{"spec":{"containers":[{"name":"probe","image":"busybox:1"}]}}},"status":{"observedGeneration":1,"replicas":1,"updatedReplicas":1,"readyReplicas":1}},{"kind":"Pod","metadata":{"name":"acme-probe-pod","labels":{"component":"acme-probe"}},"spec":{"containers":[{"name":"probe","image":"busybox:1"}]},"status":{"phase":"Running","containerStatuses":[{"name":"probe","image":"busybox:1","imageID":"containerd://sha256:example","ready":true,"state":{"running":{}}}]}}]}')
+        sys.exit(0)
+    if has_sequence(["get", "nodes"]):
+        print('{"items":[]}')
+        sys.exit(0)
+    print("unexpected kubectl invocation: " + shlex.join(args), file=sys.stderr)
+    sys.exit(64)
+
+if tool == "helm":
+    if args and args[0] == "version":
+        print("v3.17.3")
+        sys.exit(0)
+    if args and args[0] == "list":
+        print('[{"name":"acme-claims","namespace":"acme-claims","status":"deployed","chart":"curie-0.8.7"}]')
+        sys.exit(0)
+    if args and args[0] == "status":
+        if "json" in args:
+            print('{"version":1,"info":{"status":"deployed"},"hooks":[]}')
+        else:
+            print("NAME: acme-claims\nSTATUS: deployed\nREVISION: 17")
+        sys.exit(0)
+    if has_sequence(["get", "manifest"]):
+        print('{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"acme-probe"},"spec":{"replicas":1,"selector":{"matchLabels":{"component":"acme-probe"}},"template":{"spec":{"containers":[{"name":"probe","image":"busybox:1"}]}}}}')
+        sys.exit(0)
+    if has_sequence(["get", "values"]):
+        print('{"mailAdapter":{"deploy":false},"api":{"ingress":{"enabled":true}}}')
+        sys.exit(0)
+    print("unexpected helm invocation: " + shlex.join(args), file=sys.stderr)
+    sys.exit(64)
+
+if tool == "docker":
+    if args == ["info"]:
+        sys.exit(0)
+    if "compose" in args and "ps" in args:
+        print("NAME IMAGE COMMAND SERVICE CREATED STATUS PORTS")
+        sys.exit(0)
+    print("unexpected docker invocation: " + shlex.join(args), file=sys.stderr)
+    sys.exit(64)
+
+print("unexpected tool: " + tool, file=sys.stderr)
+sys.exit(64)
+"###;
+
+#[derive(Debug)]
+struct Call {
+    kind: String,
+    tool: String,
+    argv: Vec<String>,
+    compose_project: Option<String>,
+}
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    root: PathBuf,
+    tools: PathBuf,
+    home: PathBuf,
+    cwd: PathBuf,
+}
+
+impl Fixture {
+    fn new(sequence: &[serde_json::Value]) -> Self {
+        assert!(!sequence.is_empty(), "claim sequence must not be empty");
+        let temp = tempfile::tempdir().expect("create worker-claims fixture");
+        let root = temp.path().to_path_buf();
+        let tools = root.join("tools");
+        let home = root.join("home");
+        let cwd = root.join("cwd");
+        for path in [&tools, &home, &cwd] {
+            fs::create_dir_all(path).expect("create fixture directory");
+        }
+        for tool in ["docker", "kubectl", "helm"] {
+            write_executable(&tools.join(tool), TOOL_SHIM);
+        }
+        fs::write(root.join("calls.log"), "").expect("create calls log");
+        fs::write(root.join("claim-count"), "0").expect("create claim counter");
+        fs::write(
+            root.join("claim-sequence.json"),
+            serde_json::to_vec(sequence).expect("serialize claim sequence"),
+        )
+        .expect("write claim sequence");
+        Self {
+            _temp: temp,
+            root,
+            tools,
+            home,
+            cwd,
+        }
+    }
+
+    fn command(&self, args: &[&str]) -> Command {
+        let mut command = Command::new(bin());
+        command
+            .args(args)
+            .current_dir(&self.cwd)
+            .env_clear()
+            .env("PATH", shim_path(&self.tools))
+            .env("HOME", &self.home)
+            .env("CURIE_CONFIG_DIR", self.home.join(".config/curie"))
+            .env("CURIE_TEST_WORKER_CLAIMS_ROOT", &self.root)
+            .env("LC_ALL", "C");
+        command
+    }
+
+    fn run(&self, args: &[&str]) -> Output {
+        self.command(args).output().expect("run curie binary")
+    }
+
+    fn calls(&self) -> Vec<Call> {
+        fs::read_to_string(self.root.join("calls.log"))
+            .expect("read calls log")
+            .lines()
+            .map(|line| {
+                let row: serde_json::Value = serde_json::from_str(line).expect("parse call row");
+                Call {
+                    kind: row["kind"].as_str().expect("call kind").to_string(),
+                    tool: row["tool"].as_str().expect("call tool").to_string(),
+                    argv: row["argv"]
+                        .as_array()
+                        .expect("call argv")
+                        .iter()
+                        .map(|value| value.as_str().expect("argv string").to_string())
+                        .collect(),
+                    compose_project: row["compose_project"].as_str().map(str::to_string),
+                }
+            })
+            .collect()
+    }
+
+    fn claim_execs(&self) -> Vec<Call> {
+        self.calls()
+            .into_iter()
+            .filter(|call| call.kind == "claim_exec")
+            .collect()
+    }
+
+    fn message_command(&self) -> Command {
+        let chart = Path::new(env!("CARGO_MANIFEST_DIR")).join("../charts/curie");
+        let mut command = Command::new(bin());
+        command
+            .args([
+                "--color=never",
+                "--json",
+                "cluster",
+                "message",
+                "wait for the worker",
+                "--channel",
+                "C0EXAMPLE1",
+                "--namespace",
+                NAMESPACE,
+                "--release",
+                RELEASE,
+                "--chart",
+            ])
+            .arg(chart)
+            .args([
+                "--listen-host",
+                "127.0.0.1",
+                "--valkey-local-port",
+                "0",
+                "--api-local-port",
+                "0",
+                "--api-key",
+                "cluster-fixture-api-key",
+                "--valkey-password",
+                "fixture-valkey-password",
+                "--stream",
+                "curie:test:worker-claims-2374",
+                "--timeout-secs",
+                "1",
+            ])
+            .current_dir(&self.cwd)
+            .env_clear()
+            .env("PATH", shim_path(&self.tools))
+            .env("HOME", &self.home)
+            .env("CURIE_CONFIG_DIR", self.home.join(".config/curie"))
+            .env("CURIE_TEST_WORKER_CLAIMS_ROOT", &self.root)
+            .env("LC_ALL", "C");
+        command
+    }
+}
+
+fn cluster_status(fixture: &Fixture) -> Output {
+    fixture.run(&[
+        "--color=never",
+        "--json",
+        "cluster",
+        "status",
+        "--namespace",
+        NAMESPACE,
+        "--release",
+        RELEASE,
+    ])
+}
+
+fn doctor(fixture: &Fixture) -> Output {
+    fixture.run(&[
+        "--color=never",
+        "--json",
+        "doctor",
+        "--namespace",
+        NAMESPACE,
+        "--release",
+        RELEASE,
+    ])
+}
+
+fn claim_check(value: &serde_json::Value) -> &serde_json::Value {
+    value["checks"]
+        .as_array()
+        .expect("doctor checks")
+        .iter()
+        .find(|check| check["id"] == "worker-claims")
+        .expect("worker-claims check")
+}
+
+fn assert_existing_cluster_status_shape(value: &serde_json::Value) {
+    let keys: BTreeSet<_> = value
+        .as_object()
+        .expect("cluster status object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    assert_eq!(
+        keys,
+        BTreeSet::from([
+            "healthy",
+            "namespace",
+            "pods",
+            "release_found",
+            "release_state",
+            "revision",
+            "urls",
+            "warnings",
+        ]),
+        "worker claims must use existing cluster-status fields: {value}"
+    );
+}
+
+#[test]
+fn cluster_status_selects_the_running_labeled_worker_and_annotates_claims_enabled() {
+    let fixture = Fixture::new(&[claims_enabled()]);
+    let output = cluster_status(&fixture);
+    assert_eq!(output.status.code(), Some(0), "{}", describe(&output));
+    let value = json_output(&output);
+    assert_existing_cluster_status_shape(&value);
+    assert_eq!(value["healthy"], true, "{value}");
+    let row = value["pods"]["rows"]
+        .as_array()
+        .expect("pod rows")
+        .iter()
+        .find(|row| row["pod"] == WORKER_POD)
+        .expect("worker row");
+    assert!(
+        row["status"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("claims enabled"),
+        "claims-enabled must annotate the existing worker row without a new JSON field: {value}"
+    );
+
+    let calls = fixture.calls();
+    let selector_reads: Vec<_> = calls
+        .iter()
+        .filter(|call| {
+            call.tool == "kubectl"
+                && call.argv.iter().any(|arg| arg == "get")
+                && call.argv.iter().any(|arg| arg == "pods" || arg == "pod")
+                && call.argv.iter().any(|arg| arg == WORKER_SELECTOR)
+        })
+        .collect();
+    assert_eq!(
+        selector_reads.len(),
+        1,
+        "one exact release+component selector read is the only valid cluster selection: {calls:#?}"
+    );
+    let execs = fixture.claim_execs();
+    assert_eq!(execs.len(), 1, "status observes once: {calls:#?}");
+    assert!(execs[0].argv.iter().any(|arg| arg == WORKER_POD));
+    assert!(!execs[0]
+        .argv
+        .iter()
+        .any(|arg| arg == OLD_COMPLETED_HOOK || arg == OLD_STUCK_HOOK));
+    assert!(execs[0].argv.windows(6).any(|args| args
+        == [
+            "python",
+            "-m",
+            "curie_worker.upgrade_drain",
+            "--mode",
+            "status",
+            "--json",
+        ]));
+}
+
+#[test]
+fn current_quiesce_uses_authored_metadata_in_existing_cluster_status_fields() {
+    let fixture = Fixture::new(&[quiescing(SINCE_17, 17)]);
+    let output = cluster_status(&fixture);
+    assert_eq!(output.status.code(), Some(1), "{}", describe(&output));
+    let value = json_output(&output);
+    assert_existing_cluster_status_shape(&value);
+    assert_eq!(value["healthy"], false, "{value}");
+    assert!(
+        value["pods"]["unhealthy"]
+            .as_array()
+            .expect("unhealthy list")
+            .iter()
+            .any(|item| item == STATUS_WAITING_17),
+        "a known current marker must affect the verdict with authored text: {value}"
+    );
+    assert!(value["warnings"].as_array().unwrap().is_empty(), "{value}");
+}
+
+#[test]
+fn unreadable_and_malformed_claim_observations_never_become_claims_enabled_or_echo_output() {
+    let cases = [
+        ("worker-reported unknown", unknown(), false),
+        (
+            "invalid json",
+            serde_json::json!({
+                "stdout": format!("not-json-{PRIVATE_SENTINEL}"),
+                "stderr": "",
+                "exit": 0,
+                "sleep": 0,
+            }),
+            false,
+        ),
+        (
+            "process failure",
+            serde_json::json!({
+                "stdout": "",
+                "stderr": format!("read failed: {PRIVATE_SENTINEL}"),
+                "exit": 19,
+                "sleep": 0,
+            }),
+            false,
+        ),
+        (
+            "existing marker with unavailable metadata remains paused",
+            quiescing_without_metadata(),
+            true,
+        ),
+        (
+            "revision is not a JSON integer",
+            claim_reply(
+                "quiescing",
+                serde_json::json!(SINCE_17),
+                serde_json::json!("17"),
+            ),
+            false,
+        ),
+        (
+            "negative revision is rejected",
+            claim_reply(
+                "quiescing",
+                serde_json::json!(SINCE_17),
+                serde_json::json!(-1),
+            ),
+            false,
+        ),
+        (
+            "floating revision is rejected",
+            claim_reply(
+                "quiescing",
+                serde_json::json!(SINCE_17),
+                serde_json::json!(17.0),
+            ),
+            false,
+        ),
+        (
+            "overflowing revision is rejected",
+            serde_json::json!({
+                "stdout": "{\"state\":\"quiescing\",\"since\":\"2026-09-08T12:34:56Z\",\"revision\":18446744073709551616}",
+                "stderr": "",
+                "exit": 0,
+                "sleep": 0,
+            }),
+            false,
+        ),
+        (
+            "claims enabled cannot carry metadata",
+            claim_reply(
+                "claims_enabled",
+                serde_json::json!(PRIVATE_SENTINEL),
+                serde_json::json!(17),
+            ),
+            false,
+        ),
+        (
+            "extra output field violates the exact internal shape",
+            serde_json::json!({
+                "stdout": format!(
+                    "{{\"state\":\"claims_enabled\",\"since\":null,\"revision\":null,\"raw\":\"{PRIVATE_SENTINEL}\"}}"
+                ),
+                "stderr": "",
+                "exit": 0,
+                "sleep": 0,
+            }),
+            false,
+        ),
+        (
+            "unsafe metadata is rejected",
+            claim_reply(
+                "quiescing",
+                serde_json::json!(format!("{SINCE_17}\n\u{1b}[31m{PRIVATE_SENTINEL}")),
+                serde_json::json!(17),
+            ),
+            false,
+        ),
+    ];
+
+    for (label, response, paused_without_metadata) in cases {
+        let fixture = Fixture::new(&[response]);
+        let output = cluster_status(&fixture);
+        let text = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            !text.contains(PRIVATE_SENTINEL),
+            "{label} echoed raw output: {text}"
+        );
+        assert!(
+            !text.to_ascii_lowercase().contains("claims enabled"),
+            "{label} became the unsafe fail-open result: {text}"
+        );
+        let value = json_output(&output);
+        assert_existing_cluster_status_shape(&value);
+        if paused_without_metadata {
+            assert_eq!(
+                output.status.code(),
+                Some(1),
+                "{label}: {}",
+                describe(&output)
+            );
+            assert_eq!(value["healthy"], false, "{label}: {value}");
+            assert!(value["warnings"].as_array().unwrap().is_empty(), "{value}");
+            let reasons = value["pods"]["unhealthy"]
+                .as_array()
+                .expect("unhealthy reasons");
+            assert!(
+                reasons
+                    .iter()
+                    .any(|reason| reason == STATUS_QUIESCING_WITHOUT_METADATA),
+                "metadata-free quiesce must be a known unhealthy pause: {value}"
+            );
+            let reason = reasons
+                .iter()
+                .filter_map(|reason| reason.as_str())
+                .find(|reason| reason.contains("metadata unavailable"))
+                .expect("authored metadata-free pause reason");
+            assert!(!reason.contains("revision"), "invented revision: {reason}");
+            assert!(!reason.contains("since"), "invented timestamp: {reason}");
+        } else {
+            assert!(
+                value["warnings"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .any(|line| line == "worker claim state unknown"),
+                "{label} must use the authored unknown warning: {value}"
+            );
+        }
+    }
+}
+
+#[test]
+fn the_whole_cluster_selection_and_exec_observation_is_bounded() {
+    for hang in ["selection", "exec"] {
+        let response = serde_json::json!({
+            "stdout": serde_json::json!({
+                "state": "claims_enabled",
+                "since": null,
+                "revision": null,
+            }).to_string(),
+            "stderr": "",
+            "exit": 0,
+            "sleep": if hang == "exec" { 30 } else { 0 },
+        });
+        let fixture = Fixture::new(&[response]);
+        let mut command = fixture.command(&[
+            "--color=never",
+            "--json",
+            "cluster",
+            "status",
+            "--namespace",
+            NAMESPACE,
+            "--release",
+            RELEASE,
+        ]);
+        if hang == "selection" {
+            command.env("CURIE_TEST_SELECTOR_SLEEP", "30");
+        }
+        let started = Instant::now();
+        let output = command.output().expect("run bounded observer case");
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(15),
+            "{hang} was not bounded as one observation; elapsed {elapsed:?}: {}",
+            describe(&output)
+        );
+        let value = json_output(&output);
+        assert!(
+            value["warnings"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|line| line == "worker claim state unknown"),
+            "a bounded timeout is unknown: {value}"
+        );
+    }
+}
+
+#[test]
+fn local_status_keeps_services_json_exact_and_uses_the_fixed_compose_worker() {
+    let expected_stdout: &[u8] =
+        b"{\"services\":[\"NAME IMAGE COMMAND SERVICE CREATED STATUS PORTS\"]}\n";
+    for (label, response, expected_stderr) in [
+        ("known", quiescing(SINCE_17, 17), STATUS_WAITING_17),
+        (
+            "metadata unavailable",
+            quiescing_without_metadata(),
+            STATUS_QUIESCING_WITHOUT_METADATA,
+        ),
+        ("unknown", unknown(), "worker claim state unknown"),
+    ] {
+        let fixture = Fixture::new(&[response]);
+        let output = fixture.run(&[
+            "--color=never",
+            "--json",
+            "local",
+            "status",
+            "-f",
+            "compose.dev.yaml",
+        ]);
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "{label}: {}",
+            describe(&output)
+        );
+        assert_eq!(
+            output.stdout.as_slice(),
+            expected_stdout,
+            "{label}: claim diagnosis must not alter LocalStatusOutput"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains(expected_stderr), "{label}: {stderr}");
+        assert!(!stderr.contains(PRIVATE_SENTINEL), "{label}: {stderr}");
+        let execs = fixture.claim_execs();
+        assert_eq!(execs.len(), 1, "local status observes once: {execs:#?}");
+        let exec = &execs[0];
+        assert_eq!(exec.tool, "docker");
+        assert!(
+            exec.compose_project.as_deref() == Some("curie")
+                || exec.argv.windows(2).any(|args| args == ["-p", "curie"]),
+            "local observation must select compose project curie explicitly: {exec:#?}"
+        );
+        assert!(exec.argv.iter().any(|arg| arg == "compose.dev.yaml"));
+        assert!(exec.argv.iter().any(|arg| arg == "curie-worker"));
+        assert!(
+            !fixture.calls().iter().any(|call| call.tool == "kubectl"),
+            "local status must stay on the exact compose project/service"
+        );
+    }
+}
+
+#[test]
+fn doctor_reports_enabled_missing_and_unknown_with_the_existing_check_shape() {
+    for (response, state, detail) in [
+        (claims_enabled(), "ok", "claims enabled"),
+        (quiescing(SINCE_17, 17), "missing", WAITING_17),
+        (
+            quiescing_without_metadata(),
+            "missing",
+            WAITING_WITHOUT_METADATA,
+        ),
+        (unknown(), "not_applicable", "worker claim state unknown"),
+    ] {
+        let fixture = Fixture::new(&[response]);
+        let output = doctor(&fixture);
+        assert_eq!(output.status.code(), Some(0), "{}", describe(&output));
+        let value = json_output(&output);
+        let check = claim_check(&value);
+        assert_eq!(check["state"], state, "{check}");
+        if state == "not_applicable" {
+            assert!(
+                check["detail"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains("unknown"),
+                "unknown doctor detail must be authored: {check}"
+            );
+        } else {
+            assert_eq!(check["detail"], detail, "{check}");
+        }
+        let keys: BTreeSet<_> = check
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        let expected = if state == "missing" {
+            BTreeSet::from(["detail", "fix", "id", "state", "title"])
+        } else {
+            BTreeSet::from(["detail", "id", "state", "title"])
+        };
+        assert_eq!(
+            keys, expected,
+            "worker claims must use the existing check shape"
+        );
+        if state == "missing" {
+            let fix = check["fix"].as_str().expect("missing check fix");
+            if detail == WAITING_17 {
+                assert!(fix.contains("revision 17"), "{fix}");
+            } else {
+                assert!(
+                    !fix.contains("revision "),
+                    "metadata-free marker invented a revision: {fix}"
+                );
+            }
+            assert!(fix.contains("curie doctor"), "{fix}");
+            assert!(fix.contains("curie cluster status"), "{fix}");
+            assert!(fix.contains("--namespace acme-claims"), "{fix}");
+            assert!(fix.contains("--release acme-claims"), "{fix}");
+            assert_eq!(value["ready"], false, "{value}");
+        }
+        let rendered = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(!rendered.contains(PRIVATE_SENTINEL), "{rendered}");
+    }
+}
+
+fn assert_message_timeout_contract(output: &Output) {
+    assert_eq!(output.status.code(), Some(3), "{}", describe(output));
+    assert_eq!(
+        output.stdout.as_slice(),
+        b"{\"finalized\":false,\"reply\":null,\"timed_out\":true}\n".as_slice(),
+        "message timeout JSON must remain byte-for-byte the existing object"
+    );
+    assert_eq!(
+        json_output(output),
+        serde_json::json!({"reply": null, "finalized": false, "timed_out": true})
+    );
+}
+
+fn assert_two_message_observations_around_the_wait(fixture: &Fixture) {
+    let calls = fixture.calls();
+    let exec_indices: Vec<_> = calls
+        .iter()
+        .enumerate()
+        .filter_map(|(index, call)| (call.kind == "claim_exec").then_some(index))
+        .collect();
+    assert_eq!(
+        exec_indices.len(),
+        2,
+        "message must observe once before waiting and once after timeout, never in the hot poll: {calls:#?}"
+    );
+    let first_http_get = calls
+        .iter()
+        .position(|call| call.kind == "http_get")
+        .expect("timeout fixture must enter the reply wait");
+    assert!(
+        exec_indices[0] < first_http_get,
+        "the initial claim observation must precede the reply wait: {calls:#?}"
+    );
+    assert!(
+        exec_indices[1] > first_http_get,
+        "the only recheck belongs after the timeout: {calls:#?}"
+    );
+    let selection_count = calls
+        .iter()
+        .filter(|call| {
+            call.tool == "kubectl"
+                && call.argv.iter().any(|arg| arg == WORKER_SELECTOR)
+                && call.argv.iter().any(|arg| arg == "pods" || arg == "pod")
+        })
+        .count();
+    assert_eq!(
+        selection_count, 2,
+        "each bounded observation performs one exact worker selection: {calls:#?}"
+    );
+}
+
+#[test]
+fn message_reports_an_initial_marker_immediately_then_drops_it_when_release_finishes() {
+    let fixture = Fixture::new(&[quiescing(SINCE_17, 17), claims_enabled()]);
+    let output = fixture
+        .message_command()
+        .output()
+        .expect("run marker-removed message timeout");
+    assert_message_timeout_contract(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(WAITING_17),
+        "known pre-wait reason was hidden: {stderr}"
+    );
+    assert_eq!(
+        stderr.matches(WAITING_17).count(),
+        1,
+        "the timeout recheck must use its latest claims-enabled answer, not repeat stale metadata: {stderr}"
+    );
+    assert!(
+        !stderr.contains(WAITING_18),
+        "fixture invented a later marker: {stderr}"
+    );
+    assert_two_message_observations_around_the_wait(&fixture);
+}
+
+#[test]
+fn message_timeout_reports_a_marker_introduced_during_the_wait() {
+    let fixture = Fixture::new(&[claims_enabled(), quiescing(SINCE_18, 18)]);
+    let output = fixture
+        .message_command()
+        .output()
+        .expect("run marker-introduced message timeout");
+    assert_message_timeout_contract(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(WAITING_18),
+        "the timeout must report the one latest authored reason: {stderr}"
+    );
+    assert_eq!(stderr.matches(WAITING_18).count(), 1, "{stderr}");
+    assert!(
+        !stderr.contains(WAITING_17),
+        "fixture surfaced stale metadata: {stderr}"
+    );
+    assert_two_message_observations_around_the_wait(&fixture);
+}
+
+#[test]
+fn message_explains_an_initial_metadata_free_pause_without_inventing_details() {
+    let fixture = Fixture::new(&[quiescing_without_metadata(), claims_enabled()]);
+    let output = fixture
+        .message_command()
+        .output()
+        .expect("run metadata-free marker message timeout");
+    assert_message_timeout_contract(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let reasons: Vec<_> = stderr
+        .lines()
+        .filter(|line| line.contains("metadata unavailable"))
+        .collect();
+    assert_eq!(reasons, [WAITING_WITHOUT_METADATA], "{stderr}");
+    assert!(!reasons[0].contains("revision"), "{stderr}");
+    assert!(!reasons[0].contains("since"), "{stderr}");
+    assert!(!stderr.contains(PRIVATE_SENTINEL), "{stderr}");
+    assert_two_message_observations_around_the_wait(&fixture);
+}


### PR DESCRIPTION
A retained upgrade-drain Job could pause a fresh installation for up to 30 minutes while pod health appeared normal. This binds drain authority to the Helm installation and revision, preserves safe mixed-version draining, and reports paused worker claims through status, doctor, and message waiting diagnostics.

Closes #2374

Fix pin: apps/worker/tests/kernel/test_upgrade_drain.py::test_a_leftover_install_flag_cannot_pause_a_fresh_install

## End-to-end verification

| Tier | Required / n/a | Reason | Mode | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No runner loop, ACI, plugin packaging, or skill-eval change | — | — |
| local | required | Worker admission and CLI diagnostics | fake | `CURIE_E2E_TIERS=local curie dev e2e-ladder` — `LADDER PASS (tiers: local)`; candidate abe104c8 |
| local-release | n/a | No released image/binary pin, install path, or release-compose change | — | — |
| cluster | required | Helm hook and installation lifecycle | fake | `CURIE_E2E_TIERS=cluster curie dev e2e-ladder` — `LADDER PASS (tiers: cluster)`; candidate CLI/worker abe104c8; unchanged chart runtime at 713a590f. `curie dev chart-runtime-e2e --force` with an owned unchanged runner image and explicit disposable Calico kubeconfig — `PASS: API Service NodePort and runtime security assertions` |
| live provider | n/a | No model routing, credential resolution, accounting, or named MCP/workspace/coding-tool path | — | — |
| external integration | n/a | No Slack, webhook, OAuth, or third-party API shape change | — | — |

Observed controls on the disposable cluster:

- Actual `cluster down --yes` / `cluster up --dev --fake-model --no-expose`, retaining completed and blocked old Jobs and all three PVCs: new identity, identical PVC UIDs, claims enabled after 26.0 seconds. The blocked old hook subsequently completed; its old scoped/global markers existed while the current marker remained absent. A real worker/sandbox turn finalized in 25.1 seconds.
- Current revision 10 marker: `cluster status --json` exited 1 with `healthy:false` and the revision/since reason although the worker remained Running. `doctor --json` named the same reason. A five-second `cluster message --json` timeout explained the wait both before waiting and after timeout.
- Revision 9 drain/release and a worker restart preserved revision 10 and its original timestamp. Releasing revision 10 restored claims and a real turn finalized.
- The candidate hook command with `--installation-id-observed=false` exited 1 without creating a current marker or changing the workload generation. A mixed-version drain refused after two seconds with a held eval lease, cleared both owned markers, preserved the lease, and the pre-fix worker then completed a turn.
- Two real pending eval deliveries kept their ownership/delivery counts unchanged for 40 seconds while paused (30-second reclaim interval), then resumed 15 seconds after owned release.

The original failing worker image was reproduced before changes. Reinstall and mixed-version controls used worker source 134587c1. Updated local/cluster ladders used CLI/worker abe104c8. On abe104c8, a deliberately malformed current marker produced a known pause with metadata-unavailable diagnostics: status exited 1, doctor marked worker claims missing, and message explained the pause twice around a five-second timeout. CAS cleanup restored claims. Older release 29 preserved current marker 30 while accurately logging release processing; release 30 restored a bound worker/sandbox turn. Product implementation commit `8ac73009d1690b359838e12a9a72ef699683504a` has the identical Git tree (`44de578c`) as reviewed/tested `abe104c8`. The CLI and worker were rebuilt from that commit; the worker image remained byte-identical. Deployed controls on that commit again proved metadata-free pause diagnostics, older-release fencing and accurate logging, matching release, and a completed bound worker/sandbox turn.

The cluster ladder's optional report-only eval matrix reads returned HTTP 500 in the trimmed stack; those are not graded-eval evidence. Its required message, artifact identity, runtime binding, and repeated-eval-then-message checks passed. The separate pending-eval control proves claim admission/reclaim behavior.

- [x] Every required tier names its command, candidate, mode, and observed outcome.
- [x] Each meaningful criterion has positive and negative or independent-path evidence.
- [x] No required tier remains unproved.

## Checks

Python: 5,998 passed, 16 skipped, plus 28 worker tests after the logging correction; Rust: 2,231 passed. Ruff, mypy, import boundaries, docs/wire checks, fmt, clippy, Helm render/runtime checks passed. `curie dev verify-fix-pin 8ac73009 apps/worker/tests/kernel/test_upgrade_drain.py::test_a_leftover_install_flag_cannot_pause_a_fresh_install` returned `PINNED`: fixed selector passed in 1.10s; reversing production changes failed behaviorally in 6.18s.

Agent-router Code (333) and Scope (332) passed. Review corrections preserve a known pause when metadata is missing and avoid claiming that a fenced release resumed workers.

CI correction: the managed-secret mutant upgrade now uses the already-built candidate worker image, matching the normal upgrade. The v0.8.2 image rejects the candidate hook flag (observed exit 2). The exact released install, both mutations, hooks, and all original rejection/blank-value assertions remain intact. The full negative-control step passed on disposable Calico kind, including cleanup. Code review 338 approved and Scope review 335 accepted. The first Code attempt timed out without a verdict; the completed routed retry supplied approval.

Accepted bounds: revision fencing refuses foreign/unversioned marker authority, including an overlapping pre-fix global writer. The observer has one 10-second total deadline; an unreadable/timed-out probe remains explicitly unknown.

Sibling parity is shared by construction: scoped marker helpers serve runs/eval and both reclaim paths; one CLI observer serves status, doctor, and initial/timeout message diagnostics. Local standalone mode retains the legacy key. No frozen contracts or database schemas changed.

- [x] Tests pass for affected areas.
- [x] Existing chart documentation updated.
- [x] No ADR required for correcting the existing drain mechanism.

## Implementation done-check

- [x] Tests were committed failing first (`4344d2b4`); review regression tests were committed failing before their fix (`1ac21666`).
- [x] All source, test and documentation edits came from scoped native workers; the driver owned git and validation.
- [x] Public return types did not broaden (all executor handoffs confirmed); the new internal claim-state case is handled by every consumer.
- [x] Code review: agent-router review 333 passed with file/line AC and prior-intent evidence; both confirmed findings closed.
- [x] Scope review: agent-router review 332 passed; every nontrivial hunk mapped and no passengers.
- [x] Sibling sites from the plan are covered: runs/eval new reads and both shared reclaim paths; cluster/local status, doctor, and initial/timeout message observation; both hooks and managed/BYO Secret lifecycle.
- [x] Guards were executed against violating inputs: stale/foreign revision, old installation, unobserved identity, reserved environment, held eval lease, unsafe/unreadable/missing metadata.
- [x] Consolidation: built-in `/simplify` unavailable; bounded native pass found no justified edits. Empty diff needs no revalidation or consolidation review.
- [x] Security review: n/a; no security scale-up, credentials/auth/permissions unchanged.
- [x] Driver observed each changed user surface through real CLI and deployed worker commands.
- [x] Native E2E observer independently confirmed deployed status/doctor controls.
- [x] Train: stable v0.8.7 issue, branch based on fresh `main`.
- [x] Discovery surface: real disposable cluster reinstall enabled claims in 26 seconds and completed a worker/sandbox turn despite the retained old hook.
- [x] Re-fix gate: n/a; prior #2010 supplies drain-safety intent, not a prior claimed fix of this reinstall symptom.
- [x] Full affected suites and lint/type/docs checks pass as recorded above.

- [x] CI fixture correction: native worker added only the candidate worker image override and comment; Code 338 approved and Scope 335 accepted. YAML/bash checks and the full original negative-control step passed on disposable Calico kind; cleanup verified.
