### PR TITLE
Discard failed Helm revision before gVisor-off cluster up retry

### DIFF
--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -6230,6 +6230,87 @@ async fn run_install_with_gvisor_observer(
     }
 }
 
+/// Whether the aborted gVisor preflight attempt left a Helm release that must
+/// be removed before the `security.gvisor.mode=off` retry.
+///
+/// A history with no `deployed`/`superseded` revision never reached a
+/// known-good install. Retrying with `helm upgrade --install` is then an
+/// *upgrade*, which fires the pre-upgrade drain hook against Secrets the
+/// cancelled revision never rendered (#2347). An empty history (Helm has not
+/// recorded the release yet) is the same case: uninstall is a no-op if the
+/// release is already absent.
+///
+/// A history that already contains a known-good revision is an in-place
+/// upgrade of a real install and must be left intact.
+fn should_discard_failed_gvisor_install(history: &[HelmRevision]) -> bool {
+    !history
+        .iter()
+        .any(|row| is_eligible_rollback_status(&row.status))
+}
+
+/// Remove a never-deployed failed revision left by the aborted first Helm
+/// attempt so the gVisor-off retry is a clean install (#2347).
+async fn discard_failed_gvisor_install_if_never_deployed(
+    cl: &crate::ui::Checklist,
+    common: &CommonOpts,
+) -> Result<()> {
+    let ui = crate::ui::ui();
+    let history_cmd = helm_history_cmd(common);
+    ui.plumbing(&format!("+ {}", history_cmd.display()));
+    let (ok, out, err) = run_capture(&history_cmd).await?;
+    let history = if !ok {
+        if helm_release_is_absent(&err) || helm_release_is_absent(&out) {
+            Vec::new()
+        } else {
+            return Err(crate::exit::CliError::failure(format!(
+                "could not read helm history for release {} in namespace {} before the gVisor retry: {}",
+                common.release,
+                common.namespace,
+                err.trim()
+            ))
+            .with_fix(format!(
+                "inspect `helm history {} -n {}` and rerun `curie cluster up`",
+                common.release, common.namespace
+            ))
+            .into());
+        }
+    } else if out.trim().is_empty() {
+        Vec::new()
+    } else {
+        parse_helm_history(&out)?
+    };
+    if !should_discard_failed_gvisor_install(&history) {
+        return Ok(());
+    }
+
+    let cmds = down_commands(common);
+    let uninstall = &cmds[0];
+    ui.plumbing(&format!("+ {}", uninstall.display()));
+    let step = cl.step("discarding failed Helm revision");
+    let (ok, out, err) = run_capture(uninstall).await?;
+    for line in out.lines().chain(err.lines()) {
+        ui.plumbing(line);
+    }
+    if ok {
+        step.done("removed");
+        Ok(())
+    } else if err.contains("not found") || out.contains("not found") {
+        step.done("already absent");
+        Ok(())
+    } else {
+        step.fail("failed");
+        Err(crate::exit::CliError::failure(format!(
+            "helm uninstall of the failed gVisor preflight revision failed: {}",
+            err.trim()
+        ))
+        .with_fix(format!(
+            "helm uninstall {} -n {} && curie cluster up --set security.gvisor.mode=off",
+            common.release, common.namespace
+        ))
+        .into())
+    }
+}
+
 /// Run one command under a checklist `step` labeled `label`, capturing its
 /// stdio. Echoes the masked command line and replays the captured output as dim
 /// plumbing (both no-ops unless `--debug`, so default runs stay quiet and the
@@ -6812,6 +6893,11 @@ async fn run_prepared_up(
                     step.warn("retrying");
                     value_plan.set(GVISOR_MODE_KEY, "off");
                     ClusterUpInference::GvisorOff.render(ui);
+                    if let Err(error) =
+                        discard_failed_gvisor_install_if_never_deployed(&cl, &opts.common).await
+                    {
+                        return Err(convergence::installation_failure(&opts.common, error).await);
+                    }
                     let retry = up_commands_with_plan(&opts, &value_plan)
                         .into_iter()
                         .next()
@@ -7464,10 +7550,14 @@ impl RollbackTarget {
 /// whose status is `deployed` or `superseded`.
 ///
 /// This is the whole fix for #1899. A `cluster up` against a cluster with no
-/// `runsc` RuntimeClass records a FAILED revision before its successful retry,
-/// so the history alternates failed/superseded and the immediately preceding
-/// revision -- the one bare `helm rollback` targets -- is a failed one. Skipping
-/// ineligible statuses is what stops an operator having to know that.
+/// `runsc` RuntimeClass used to record a FAILED revision before its successful
+/// retry, so the history alternated failed/superseded and the immediately
+/// preceding revision -- the one bare `helm rollback` targets -- was a failed
+/// one. Skipping ineligible statuses is what stops an operator having to know
+/// that. Issue #2347 now discards a never-deployed failed revision before that
+/// retry, so a current first-install recovery no longer leaves the pair.
+/// Rollback still has to skip ineligible statuses: a later upgrade can fail,
+/// and releases installed by an older CLI still carry the pair.
 ///
 /// Pure by construction so the decision is unit-testable with no cluster.
 pub fn select_rollback_revision(history: &[HelmRevision]) -> Result<RollbackTarget> {
@@ -9564,6 +9654,46 @@ mod tests {
     /// `chart_fullname_tests::the_default_release_is_a_byte_identical_no_op`.
     fn fullname() -> ReleaseFullname {
         chart_fullname("curie")
+    }
+
+    fn history_row(revision: u32, status: &str) -> HelmRevision {
+        HelmRevision {
+            revision,
+            status: status.to_string(),
+            chart: "curie-0.0.0".to_string(),
+            description: String::new(),
+        }
+    }
+
+    #[test]
+    fn gvisor_retry_discards_a_history_that_never_deployed() {
+        assert!(should_discard_failed_gvisor_install(&[]));
+        assert!(should_discard_failed_gvisor_install(&[history_row(
+            1, "failed"
+        )]));
+        assert!(should_discard_failed_gvisor_install(&[
+            history_row(1, "failed"),
+            history_row(2, "pending-install"),
+        ]));
+        assert!(should_discard_failed_gvisor_install(&[history_row(
+            1,
+            "pending-upgrade"
+        )]));
+    }
+
+    #[test]
+    fn gvisor_retry_keeps_a_history_with_a_known_good_revision() {
+        assert!(!should_discard_failed_gvisor_install(&[history_row(
+            1, "deployed"
+        )]));
+        assert!(!should_discard_failed_gvisor_install(&[
+            history_row(1, "superseded"),
+            history_row(2, "failed"),
+        ]));
+        assert!(!should_discard_failed_gvisor_install(&[
+            history_row(1, "deployed"),
+            history_row(2, "pending-upgrade"),
+        ]));
     }
 
     #[test]

--- a/cli/tests/cluster_up_gvisor_preflight.rs
+++ b/cli/tests/cluster_up_gvisor_preflight.rs
@@ -48,6 +48,8 @@ struct Fixture {
     bin_dir: PathBuf,
     plan_file: PathBuf,
     upgrade_log: PathBuf,
+    uninstall_log: PathBuf,
+    helm_sequence: PathBuf,
     event_log: PathBuf,
     helm_pid: PathBuf,
     helm_termination_log: PathBuf,
@@ -59,6 +61,7 @@ struct Fixture {
     event_mode: String,
     singleton_mode: String,
     credential: String,
+    history_status: String,
 }
 
 impl Fixture {
@@ -73,6 +76,8 @@ impl Fixture {
         )
         .expect("write prepared apply plan");
         let upgrade_log = temp.path().join("upgrades.log");
+        let uninstall_log = temp.path().join("uninstalls.log");
+        let helm_sequence = temp.path().join("helm-sequence.log");
         let event_log = temp.path().join("event-queries.log");
         let helm_pid = temp.path().join("helm.pid");
         let helm_termination_log = temp.path().join("helm-termination.log");
@@ -180,6 +185,7 @@ fi
 
 if [ "$1" = "upgrade" ] && [ "$2" = "--install" ]; then
     printf '%s\n' "$*" >> "$CURIE_TEST_UPGRADE_LOG"
+    printf '%s\n' "$*" >> "$CURIE_TEST_HELM_SEQUENCE"
     printf '%s\n' "$$" > "$CURIE_TEST_HELM_PID"
     gvisor_mode="auto"
     fake_model="true"
@@ -222,6 +228,43 @@ if [ "$1" = "upgrade" ] && [ "$2" = "--install" ]; then
     fi
     sleep 1
     printf '%s\n' 'Release installed'
+    exit 0
+fi
+
+if [ "$1" = "history" ]; then
+    printf '%s\n' "$*" >> "$CURIE_TEST_HELM_SEQUENCE"
+    if [ "$2" != "target-release" ] || [ "$3" != "-n" ] || [ "$4" != "target-namespace" ]; then
+        printf 'unexpected helm history: %s\n' "$*" >&2
+        exit 64
+    fi
+    case "$CURIE_TEST_HISTORY_STATUS" in
+        absent)
+            printf '%s\n' 'Error: release: not found' >&2
+            exit 1
+            ;;
+        deployed)
+            printf '%s\n' '[{"revision":1,"status":"deployed","chart":"curie-0.0.0","description":"Install complete"}]'
+            exit 0
+            ;;
+        superseded)
+            printf '%s\n' '[{"revision":1,"status":"superseded","chart":"curie-0.0.0","description":"Upgrade complete"},{"revision":2,"status":"failed","chart":"curie-0.0.0","description":"Upgrade \"target-release\" failed: context canceled"}]'
+            exit 0
+            ;;
+        *)
+            printf '%s\n' '[{"revision":1,"status":"failed","chart":"curie-0.0.0","description":"Release \"target-release\" failed: context canceled"}]'
+            exit 0
+            ;;
+    esac
+fi
+
+if [ "$1" = "uninstall" ]; then
+    printf '%s\n' "$*" >> "$CURIE_TEST_UNINSTALL_LOG"
+    printf '%s\n' "$*" >> "$CURIE_TEST_HELM_SEQUENCE"
+    if [ "$2" != "target-release" ] || [ "$3" != "-n" ] || [ "$4" != "target-namespace" ]; then
+        printf 'unexpected helm uninstall: %s\n' "$*" >&2
+        exit 64
+    fi
+    printf '%s\n' 'release "target-release" uninstalled'
     exit 0
 fi
 
@@ -391,6 +434,8 @@ exit 64
             bin_dir,
             plan_file,
             upgrade_log,
+            uninstall_log,
+            helm_sequence,
             event_log,
             helm_pid,
             helm_termination_log,
@@ -402,7 +447,13 @@ exit 64
             event_mode: event_mode.to_string(),
             singleton_mode: singleton_mode.to_string(),
             credential: credential.to_string(),
+            history_status: "failed".to_string(),
         }
+    }
+
+    fn with_history_status(mut self, status: &str) -> Self {
+        self.history_status = status.to_string();
+        self
     }
 
     fn run(&self, extra: &[&str]) -> (Output, Duration) {
@@ -454,6 +505,9 @@ exit 64
             .env("TERM", "dumb")
             .env("NO_COLOR", "1")
             .env("CURIE_TEST_UPGRADE_LOG", &self.upgrade_log)
+            .env("CURIE_TEST_UNINSTALL_LOG", &self.uninstall_log)
+            .env("CURIE_TEST_HELM_SEQUENCE", &self.helm_sequence)
+            .env("CURIE_TEST_HISTORY_STATUS", &self.history_status)
             .env("CURIE_TEST_EVENT_LOG", &self.event_log)
             .env("CURIE_TEST_HELM_PID", &self.helm_pid)
             .env(
@@ -488,6 +542,78 @@ exit 64
             .unwrap_or_default()
             .lines()
             .count()
+    }
+
+    fn uninstall_count(&self) -> usize {
+        fs::read_to_string(&self.uninstall_log)
+            .unwrap_or_default()
+            .lines()
+            .count()
+    }
+
+    fn helm_mutations(&self) -> Vec<String> {
+        fs::read_to_string(&self.helm_sequence)
+            .unwrap_or_default()
+            .lines()
+            .filter_map(|line| {
+                let verb = line.split_whitespace().next()?;
+                matches!(verb, "upgrade" | "uninstall").then(|| line.to_string())
+            })
+            .collect()
+    }
+
+    /// Issue #2347: aborting the first Helm attempt leaves a failed revision.
+    /// Recovery must uninstall that never-deployed release before the gVisor-off
+    /// retry so Helm treats the retry as a clean install, not a pre-upgrade.
+    fn assert_failed_revision_discarded_before_retry(&self) {
+        let uninstalls = fs::read_to_string(&self.uninstall_log).unwrap_or_default();
+        assert_eq!(
+            uninstalls.lines().count(),
+            1,
+            "automatic gVisor recovery must uninstall the failed first revision once:\n{uninstalls}"
+        );
+        assert_eq!(
+            uninstalls.trim(),
+            "uninstall target-release -n target-namespace",
+            "the discard must reuse cluster down's helm uninstall argv:\n{uninstalls}"
+        );
+        let mutations = self.helm_mutations();
+        assert_eq!(
+            mutations.len(),
+            3,
+            "recovery must run upgrade, uninstall, upgrade — not a second upgrade against the failed revision:\n{mutations:?}"
+        );
+        assert!(
+            mutations[0].starts_with("upgrade --install"),
+            "the interrupted first attempt must be helm upgrade --install:\n{mutations:?}"
+        );
+        assert_eq!(
+            mutations[1], "uninstall target-release -n target-namespace",
+            "the failed revision must be uninstalled before the retry:\n{mutations:?}"
+        );
+        assert!(
+            mutations[2].starts_with("upgrade --install")
+                && mutations[2].contains("security.gvisor.mode=off"),
+            "the retry must be a clean helm upgrade --install with gVisor off:\n{mutations:?}"
+        );
+        let sequence = fs::read_to_string(&self.helm_sequence).unwrap_or_default();
+        assert!(
+            sequence.lines().any(|line| line.starts_with("history ")
+                && line.contains("target-release")
+                && line.contains("-n target-namespace")
+                && line.contains("-o json")
+                && line.contains("--max")
+                && line.contains("256")),
+            "recovery must read helm history before deciding to discard:\n{sequence}"
+        );
+    }
+
+    fn assert_no_failed_revision_discard(&self) {
+        let uninstalls = fs::read_to_string(&self.uninstall_log).unwrap_or_default();
+        assert!(
+            uninstalls.is_empty(),
+            "this path must not helm uninstall the release:\n{uninstalls}"
+        );
     }
 
     fn assert_event_was_observed_for_rendered_job(&self) {
@@ -703,6 +829,7 @@ fn bare_cluster_up_infers_all_detected_facts_and_retries_once() {
         !shown.contains(OPENROUTER_CREDENTIAL),
         "credential leaked: {shown}"
     );
+    fixture.assert_failed_revision_discarded_before_retry();
     fixture.assert_event_was_observed_for_rendered_job();
     fixture.assert_graceful_helm_interruption();
     fixture.assert_children_stopped();
@@ -725,6 +852,7 @@ fn runtimeclass_document_before_job_still_observes_the_rendered_job() {
         stderr(&output)
     );
     assert_eq!(fixture.upgrade_count(), 1);
+    fixture.assert_no_failed_revision_discard();
     fixture.assert_event_was_observed_for_rendered_job();
     fixture.assert_children_stopped();
 }
@@ -774,6 +902,7 @@ fn fresh_namespace_rejection_is_observed_after_helm_creates_the_namespace() {
             .all(|line| line.contains("-n target-namespace") && !line.contains("--all-namespaces")),
         "fresh namespace retries must retain namespaced permissions:\n{invocations}"
     );
+    fixture.assert_failed_revision_discarded_before_retry();
     fixture.assert_graceful_helm_interruption();
     fixture.assert_children_stopped();
 }
@@ -798,6 +927,7 @@ fn nonmatching_failedcreate_does_not_abort_successful_install() {
         !shown.contains("--set security.gvisor.mode=off"),
         "an unrelated event must not produce the gVisor remediation:\n{shown}"
     );
+    fixture.assert_no_failed_revision_discard();
     fixture.assert_event_was_observed_for_rendered_job();
     fixture.assert_children_stopped();
 }
@@ -833,6 +963,7 @@ fn bare_cluster_up_json_keeps_inferences_on_stderr_and_one_success_on_stdout() {
     }
     assert_automatic_gvisor_recovery_narration(&shown);
     assert_eq!(fixture.upgrade_count(), 2);
+    fixture.assert_failed_revision_discarded_before_retry();
     fixture.assert_event_was_observed_for_rendered_job();
     fixture.assert_graceful_helm_interruption();
     fixture.assert_children_stopped();
@@ -874,6 +1005,7 @@ fn explicit_gvisor_mode_contradicting_admission_is_rejected_before_retry() {
             !retrying_install_line(&shown),
             "an explicit contradiction must not narrate a retry:\n{shown}"
         );
+        fixture.assert_no_failed_revision_discard();
         fixture.assert_graceful_helm_interruption();
         fixture.assert_children_stopped();
     }
@@ -896,6 +1028,7 @@ fn failed_helm_revision_does_not_replace_explicit_gvisor_usage_recovery() {
         .unwrap()
         .contains("remove the explicit"));
     assert_eq!(fixture.upgrade_count(), 1);
+    fixture.assert_no_failed_revision_discard();
     fixture.assert_children_stopped();
 }
 
@@ -930,6 +1063,7 @@ fn prepared_apply_keeps_the_exact_gvisor_rejection_fail_closed() {
         "prepared apply must not narrate automatic recovery:\n{shown}"
     );
     assert_eq!(fixture.upgrade_count(), 1, "prepared apply must not retry");
+    fixture.assert_no_failed_revision_discard();
     fixture.assert_graceful_helm_interruption();
     fixture.assert_children_stopped();
 }
@@ -946,6 +1080,7 @@ fn fake_model_auto_and_mode_off_skip_the_event_observer() {
             stderr(&output)
         );
         assert_eq!(fixture.upgrade_count(), 1);
+        fixture.assert_no_failed_revision_discard();
         fixture.assert_no_event_watch();
     }
 }
@@ -961,8 +1096,88 @@ fn unavailable_event_watch_preserves_the_helm_result() {
         stderr(&output)
     );
     assert_eq!(fixture.upgrade_count(), 1);
+    fixture.assert_no_failed_revision_discard();
     assert!(
         !fixture.watch_pid.exists(),
         "a failed Event snapshot must not spawn the watch process"
     );
+}
+
+/// Issue #2347: the gVisor observer aborts attempt 1, Helm records a failed
+/// revision, and a naive `helm upgrade --install` retry is an upgrade whose
+/// pre-upgrade drain hook waits on a Secret that revision never rendered.
+#[test]
+fn gvisor_retry_uninstalls_a_failed_first_revision_before_reinstall() {
+    let fixture = Fixture::new("matching", "foreign", OPENROUTER_CREDENTIAL);
+    let (output, elapsed) = fixture.run(&[]);
+    let shown = stderr(&output);
+
+    assert!(
+        output.status.success(),
+        "recovery must still converge after discarding the failed revision\nstdout:\n{}\nstderr:\n{shown}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+    assert!(elapsed < Duration::from_secs(3), "{elapsed:?}\n{shown}");
+    assert_automatic_gvisor_recovery_narration(&shown);
+    assert_eq!(fixture.upgrade_count(), 2);
+    assert_eq!(fixture.uninstall_count(), 1);
+    fixture.assert_failed_revision_discarded_before_retry();
+    fixture.assert_graceful_helm_interruption();
+    fixture.assert_children_stopped();
+}
+
+/// Negative for #2347: a history that already has a known-good revision is an
+/// in-place upgrade. Discarding it would delete a working release.
+#[test]
+fn gvisor_retry_preserves_a_known_good_release() {
+    for status in ["deployed", "superseded"] {
+        let fixture =
+            Fixture::new("matching", "foreign", OPENROUTER_CREDENTIAL).with_history_status(status);
+        let (output, elapsed) = fixture.run(&[]);
+        let shown = stderr(&output);
+
+        assert!(
+            output.status.success(),
+            "{status} history must still recover with gVisor off\nstdout:\n{}\nstderr:\n{shown}",
+            String::from_utf8_lossy(&output.stdout),
+        );
+        assert!(elapsed < Duration::from_secs(3), "{status}: {elapsed:?}");
+        assert_automatic_gvisor_recovery_narration(&shown);
+        assert_eq!(fixture.upgrade_count(), 2, "{status}");
+        fixture.assert_no_failed_revision_discard();
+        let mutations = fixture.helm_mutations();
+        assert_eq!(
+            mutations.len(),
+            2,
+            "{status}: must retry as a second upgrade, not uninstall a known-good release:\n{mutations:?}"
+        );
+        assert!(
+            mutations
+                .iter()
+                .all(|line| line.starts_with("upgrade --install")),
+            "{status}: {mutations:?}"
+        );
+        fixture.assert_graceful_helm_interruption();
+        fixture.assert_children_stopped();
+    }
+}
+
+/// An interrupted attempt that never recorded a Helm release is already a
+/// clean install target; uninstall must tolerate "not found".
+#[test]
+fn gvisor_retry_tolerates_an_absent_release_history() {
+    let fixture =
+        Fixture::new("matching", "foreign", OPENROUTER_CREDENTIAL).with_history_status("absent");
+    let (output, elapsed) = fixture.run(&[]);
+    let shown = stderr(&output);
+
+    assert!(
+        output.status.success(),
+        "an absent history must still recover\nstdout:\n{}\nstderr:\n{shown}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+    assert!(elapsed < Duration::from_secs(3), "{elapsed:?}\n{shown}");
+    assert_automatic_gvisor_recovery_narration(&shown);
+    fixture.assert_failed_revision_discarded_before_retry();
+    fixture.assert_children_stopped();
 }


### PR DESCRIPTION
## Summary

A first `curie cluster up` on a cluster with no `gvisor` RuntimeClass aborted the in-flight Helm install, left a failed revision, and retried with `helm upgrade --install`. Helm treated that retry as an upgrade, fired the pre-upgrade drain hook, and the hook hung on `<release>-secrets` because revision 1 never rendered it. Every later `cluster up` repeated the same timeout.

This change reads Helm history after the gVisor admission abort. If the release never reached a deployed or superseded revision, it uninstalls that failed record before the `security.gvisor.mode=off` retry so Helm does a clean install. A history that already has a known-good revision is left intact.

## Related issue

Closes #2347

## Fix pin verification

Fix pin: cli/tests/cluster_up_gvisor_preflight.rs::gvisor_retry_uninstalls_a_failed_first_revision_before_reinstall

`curie dev verify-fix-pin 6d83cc6117a6781cb31b3b235af86fd6f92a4f84 cli/tests/cluster_up_gvisor_preflight.rs::gvisor_retry_uninstalls_a_failed_first_revision_before_reinstall` printed `PINNED` (forward pass, reverse fail).

## End-to-end verification

Candidate: `6d83cc6117a6781cb31b3b235af86fd6f92a4f84`.

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin packaging, runner turn loop, ACI events, skill eval, or skill check change. | — | — |
| local | n/a | No compose, dispatcher, worker, API, boot-env, or console change. `cluster up --json` schema is unchanged. | — | — |
| local-release | n/a | No released binary identity, install path, version pin, or release compose change. | — | — |
| cluster | required | `cluster up` Helm retry after gVisor RuntimeClass rejection is the defect surface. | live Kubernetes on disposable namespaces | Candidate binary `curie cluster up --dev --no-expose` against k8scratch (no `gvisor` RuntimeClass), unique namespace/release `curie-2347`. Observed: `installing release curie-2347: retrying (1.5s)`, `helm history`, `helm uninstall`, `discarding failed Helm revision: ok (0.5s)`, `Release "curie-2347" does not exist. Installing it now.`, `installing release curie-2347: ok (28.4s)`, `helm history` revision 1 `deployed` / `Install complete`, no upgrade-drain pods. Negative: `helm upgrade --install` of a failed-only release in `curie-2347-neg` failed `pre-upgrade hooks`; drain pod `CreateContainerConfigError: secret "curie-2347-neg-secrets" not found`. Task namespaces torn down; soak `curie` namespace untouched. |
| live provider | n/a | No model routing, credential resolution, provider auth, token/cost accounting, or MCP/workspace/coding-tool path. | — | — |
| external integration | n/a | No Slack, git webhook, connector OAuth, or third-party API shape change. | — | — |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Checklist

- [x] Tests pass for the area I touched (`cd cli && cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test --test cluster_up_gvisor_preflight --test cluster_rollback`).
- [x] Docs updated if behavior changed. n/a: operator-visible `cluster up` JSON is unchanged; recovery still infers `security.gvisor.mode=off`.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. n/a: correction of the existing gVisor retry, not a new decision.
