### PR TITLE
Skip Claim 5 Postgres:5432 when Postgres is BYO

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -272,6 +272,16 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/postgres-fsgroup-assertions.sh
 
+      # Prove Claim 5 drops in-cluster Postgres:5432 when postgres.deploy is
+      # false, names postgres.host:postgres.port on the skip path, and still
+      # probes the in-chart Service while deploy stays true (#2432). Pointing
+      # Claim 5 at RDS would fail helm test: there is no in-cluster ingress
+      # rail on an external host.
+      - name: helm render assertions (BYO postgres security probe)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/security-probe-byo-postgres-assertions.sh
+
       # Keep the chart ClickHouse default and Langfuse pin as one supported
       # pair. ClickHouse 24.8 cannot apply Langfuse 3.225.x migration 39, so
       # the default must stay on 25.12 and AVX-required (#2210).

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -557,6 +557,20 @@ is encrypted but not authenticated; a `verify-full` mode needs a mounted CA
 bundle and is a second step. Leave `sslMode` empty (the default) for the
 in-cluster store: the rendered DSNs stay suffix-free.
 
+Flipping `postgres.deploy` to `false` removes the in-cluster StatefulSet and
+Service. Helm does not delete a StatefulSet PVC, so if
+`postgres.persistence.enabled` was true (the default) the volume
+`data-<release>-postgres-0` stays Bound and billed. A later `helm rollback`
+re-binds that claim by name: that is a free rollback onto the in-cluster data,
+and also a second copy of every credential until you remove it. Once the
+managed database is the source of truth and you no longer want that rollback
+path, delete the leftover volume:
+
+```bash
+kubectl delete pvc -n <namespace> data-<release>-postgres-0
+```
+
+
 Toggles (all default `true`): `langfuse.deploy`, `postgres.deploy`,
 `valkey.deploy`, `clickhouse.deploy`, `rustfs.deploy`, `otelCollector.deploy`.
 Flipping any to `false` removes its resources from the render; consumers

--- a/charts/curie/ci/security-probe-byo-postgres-assertions.sh
+++ b/charts/curie/ci/security-probe-byo-postgres-assertions.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for issue #2432.
+#
+# Claim 5 of the security probe builds DATATIER_TARGETS only for stores with
+# deploy: true. That is correct for the in-cluster ingress rail (there is no
+# StatefulSet to wrap once postgres.deploy is false), but two things went
+# missing on the BYO path:
+#
+#   1. The in-cluster Postgres:5432 target must not remain on Claim 5, or helm
+#      test reports a 5432 failure against a Service that is no longer there
+#      (or against an RDS endpoint that has no in-cluster deny/allow pair).
+#   2. The probe must still name the operator-configured
+#      postgres.host:postgres.port so the skip is a retarget, not a silent
+#      disappearance of the 5432 check.
+#
+# Claim 5's allowed=reachable / denied=blocked pair cannot be pointed at RDS:
+# there is no in-cluster NetworkPolicy on that host, so the denied pod would
+# stay reachable and helm test would fail a correct BYO install. The skip
+# names the BYO target instead. Rail 1 (runner default-deny egress) is what
+# still blocks a sandbox from opening that port, and Claim 1 already proves
+# that rail.
+#
+# Asserts:
+#
+#   1. default: DATATIER_TARGETS includes the in-chart Service at
+#      postgres.port (5432), and POSTGRES_BYO_TARGET is empty.
+#   2. postgres.port override: DATATIER_TARGETS follows the Service port the
+#      same way assertion 13 pins rustfs.port (#1507), and the default 5432
+#      target is gone.
+#   3. BYO (deploy=false + host): DATATIER_TARGETS contains neither the
+#      in-chart Service nor the RDS host, POSTGRES_BYO_TARGET is
+#      host:port, and the probe script's Claim 5 path names that target on a
+#      SKIP line. A render that still nc's 5432, or that drops the BYO host
+#      without saying so, fails this gate.
+#   4. BYO + custom port: POSTGRES_BYO_TARGET uses postgres.port, not a
+#      hardcoded 5432.
+#   5. NEGATIVE: postgres.deploy left true while postgres.host is set still
+#      probes the in-chart Service. The helper ignores host on the in-chart
+#      branch; a probe that flipped to the BYO host while the StatefulSet is
+#      still deployed would Claim-5-fail (or worse, miss) the in-cluster rail.
+#
+# Runnable locally and from CI. Fails loudly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP="$(mktemp -d)"
+
+cleanup() {
+  [[ -n "${TMP:-}" && -d "$TMP" ]] && rm -rf -- "$TMP"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+render_probe() {
+  local name="$1"
+  shift
+  local out="$TMP/${name}.yaml"
+  helm template curie "$CHART" \
+    --show-only templates/security-probe.yaml \
+    "$@" >"$out"
+  printf '%s\n' "$out"
+}
+
+CHECKER="$TMP/check.py"
+cat > "$CHECKER" <<'PY'
+import pathlib
+import sys
+
+import yaml
+
+
+def die(message):
+    raise SystemExit(message)
+
+
+def load_probe_job(path):
+    docs = [doc for doc in yaml.safe_load_all(pathlib.Path(path).read_text()) if doc]
+    jobs = [doc for doc in docs if doc.get("kind") == "Job"]
+    if len(jobs) != 1:
+        die(f"{path}: expected exactly one Job, found {len(jobs)}")
+    containers = (
+        jobs[0]
+        .get("spec", {})
+        .get("template", {})
+        .get("spec", {})
+        .get("containers", [])
+    )
+    probes = [container for container in containers if container.get("name") == "probe"]
+    if len(probes) != 1:
+        die(f"{path}: expected exactly one probe container, found {len(probes)}")
+    return probes[0]
+
+
+def env_entry(container, name):
+    entries = [
+        entry for entry in container.get("env", []) if entry.get("name") == name
+    ]
+    if len(entries) != 1:
+        die(
+            f"probe env {name!r} appears {len(entries)} times "
+            f"(want exactly one literal value)"
+        )
+    if set(entries[0]) != {"name", "value"}:
+        die(f"probe env {name!r} must be one literal value, got {entries[0]!r}")
+    return entries[0]["value"]
+
+
+def command_script(container):
+    command = container.get("command") or []
+    if not command:
+        die("probe container has no command")
+    return "\n".join(str(part) for part in command)
+
+
+def main():
+    path, mode = sys.argv[1], sys.argv[2]
+    container = load_probe_job(path)
+    targets = env_entry(container, "DATATIER_TARGETS").split()
+    byo = env_entry(container, "POSTGRES_BYO_TARGET")
+    script = command_script(container)
+
+    if mode == "default":
+        if "curie-postgres:5432" not in targets:
+            die(
+                "default DATATIER_TARGETS must include in-chart "
+                f"'curie-postgres:5432'; got {targets!r}"
+            )
+        if byo != "":
+            die(f"default POSTGRES_BYO_TARGET must be empty, got {byo!r}")
+        if "Claim 5 does not probe in-cluster Postgres" not in script:
+            die(
+                "default probe script must still carry the BYO Claim 5 skip "
+                "path, gated on POSTGRES_BYO_TARGET"
+            )
+        print("  ok: default Claim 5 still probes in-chart postgres:5432")
+        return
+
+    if mode == "port-override":
+        if "curie-postgres:15432" not in targets:
+            die(
+                "DATATIER_TARGETS must follow postgres.port=15432 "
+                f"('curie-postgres:15432'); got {targets!r}"
+            )
+        if "curie-postgres:5432" in targets:
+            die(
+                "DATATIER_TARGETS still contains the default 5432 target "
+                f"after postgres.port=15432; got {targets!r}"
+            )
+        if byo != "":
+            die(f"in-chart port override must leave POSTGRES_BYO_TARGET empty, got {byo!r}")
+        print("  ok: Claim 5 follows postgres.port on the in-chart Service")
+        return
+
+    if mode == "byo":
+        expected_byo = "my-rds.example.com:5432"
+        forbidden = (
+            "curie-postgres:5432",
+            "curie-postgres:15432",
+            expected_byo,
+        )
+        leftover = [item for item in targets if item in forbidden or item.startswith("curie-postgres:")]
+        if leftover:
+            die(
+                "BYO DATATIER_TARGETS must not include in-chart Postgres or the "
+                f"RDS host (Claim 5 would nc it and fail helm test); got leftover "
+                f"{leftover!r} in {targets!r}"
+            )
+        if byo != expected_byo:
+            die(
+                f"BYO POSTGRES_BYO_TARGET must be {expected_byo!r} so the skip "
+                f"names the operator host:port; got {byo!r}"
+            )
+        if "Claim 5 does not probe in-cluster Postgres" not in script:
+            die(
+                "probe script must SKIP in-cluster Postgres on the BYO path "
+                "with an explicit Claim 5 skip line"
+            )
+        if "POSTGRES_BYO_TARGET" not in script:
+            die(
+                "probe script must read POSTGRES_BYO_TARGET at runtime so the "
+                "BYO host:port is not a dead env var"
+            )
+        print("  ok: BYO Claim 5 skips in-cluster 5432 and names host:port")
+        return
+
+    if mode == "byo-port":
+        expected_byo = "my-rds.example.com:15432"
+        if byo != expected_byo:
+            die(
+                f"BYO POSTGRES_BYO_TARGET must follow postgres.port "
+                f"({expected_byo!r}); got {byo!r}"
+            )
+        if "my-rds.example.com:5432" == byo:
+            die("BYO target still hardcodes 5432 after postgres.port=15432")
+        leftover = [
+            item
+            for item in targets
+            if item.startswith("curie-postgres:") or item.startswith("my-rds.example.com:")
+        ]
+        if leftover:
+            die(
+                "BYO custom-port DATATIER_TARGETS still contains a Postgres "
+                f"target Claim 5 would nc: {leftover!r} in {targets!r}"
+            )
+        print("  ok: BYO Claim 5 skip target follows postgres.port")
+        return
+
+    if mode == "host-ignored-when-deployed":
+        if "curie-postgres:5432" not in targets:
+            die(
+                "postgres.host set while deploy stays true must still probe "
+                f"the in-chart Service; got DATATIER_TARGETS={targets!r}"
+            )
+        if "my-rds.example.com:5432" in targets or byo == "my-rds.example.com:5432":
+            die(
+                "postgres.host must not retarget Claim 5 while the in-chart "
+                f"StatefulSet is still deployed; DATATIER={targets!r} BYO={byo!r}"
+            )
+        if byo != "":
+            die(
+                "POSTGRES_BYO_TARGET must stay empty while postgres.deploy "
+                f"is true; got {byo!r}"
+            )
+        print("  ok: postgres.host is ignored for Claim 5 while deploy is true")
+        return
+
+    die(f"unknown mode {mode!r}")
+
+
+if __name__ == "__main__":
+    main()
+PY
+
+echo "=== Assertion 1: default in-chart Claim 5 still probes postgres:5432 ==="
+DEFAULT_RENDER="$(render_probe default)"
+python3 "$CHECKER" "$DEFAULT_RENDER" default
+
+echo "=== Assertion 2: Claim 5 follows postgres.port (#2432 / #1507 parity) ==="
+PORT_RENDER="$(render_probe port-override --set postgres.port=15432)"
+python3 "$CHECKER" "$PORT_RENDER" port-override
+
+echo "=== Assertion 3: BYO postgres skips in-cluster 5432 and names host:port ==="
+BYO_RENDER="$(render_probe byo \
+  --set postgres.deploy=false \
+  --set postgres.host=my-rds.example.com)"
+python3 "$CHECKER" "$BYO_RENDER" byo
+
+echo "=== Assertion 4: BYO skip target follows postgres.port ==="
+BYO_PORT_RENDER="$(render_probe byo-port \
+  --set postgres.deploy=false \
+  --set postgres.host=my-rds.example.com \
+  --set postgres.port=15432)"
+python3 "$CHECKER" "$BYO_PORT_RENDER" byo-port
+
+echo "=== Assertion 5: postgres.host is ignored while deploy stays true ==="
+HOST_SET_RENDER="$(render_probe host-set \
+  --set postgres.host=my-rds.example.com)"
+python3 "$CHECKER" "$HOST_SET_RENDER" host-ignored-when-deployed
+
+echo "PASS: security probe skips in-cluster Postgres:5432 on BYO, names postgres.host:postgres.port on the skip path, follows postgres.port in-chart, and does not retarget Claim 5 while the in-chart StatefulSet is still deployed"

--- a/charts/curie/templates/security-probe.yaml
+++ b/charts/curie/templates/security-probe.yaml
@@ -165,11 +165,20 @@ spec:
      must be in that store's allow-list or Claim 5 red-fails a correct rail.
      Claim 5 only asserts the data-tier boundary when the rail that creates it is
      enabled AND the store is in-chart-deployed; BYO stores are external and
-     excluded. Both a disabled rail and all-BYO stores yield an empty list =>
-     Claim 5 skips. */}}
+     excluded from $dt (there is no in-cluster ingress rail to prove). Both a
+     disabled rail and all-BYO stores yield an empty list => Claim 5 skips.
+     When postgres.deploy is false and postgres.host is set, $pgByo carries
+     host:port so Claim 5 can SKIP the in-cluster 5432 check by name rather
+     than dropping it silently (#2432). Do not put that host on $dt: Claim 5's
+     allowed=reachable / denied=blocked pair cannot hold on an external
+     endpoint, and helm test would fail a correct BYO/RDS install. */}}
 {{- $dt := list -}}
+{{- $pgByo := "" -}}
+{{- if and (not .Values.postgres.deploy) .Values.postgres.host -}}
+{{- $pgByo = printf "%s:%v" .Values.postgres.host .Values.postgres.port -}}
+{{- end -}}
 {{- if .Values.security.dataTierNetworkPolicy.enabled -}}
-{{- if .Values.postgres.deploy }}{{- $dt = append $dt (printf "%s:5432" (include "curie.postgres.host" .)) -}}{{- end }}
+{{- if .Values.postgres.deploy }}{{- $dt = append $dt (printf "%s:%v" (include "curie.postgres.host" .) .Values.postgres.port) -}}{{- end }}
 {{- if .Values.rustfs.deploy }}{{- $dt = append $dt (printf "%s:%v" (include "curie.rustfs.host" .) .Values.rustfs.port) -}}{{- end }}
 {{- if .Values.clickhouse.deploy }}{{- $dt = append $dt (printf "%s:8123" (include "curie.clickhouse.host" .)) -}}{{- end }}
 {{- if .Values.valkey.deploy }}{{- $dt = append $dt (printf "%s:6379" (include "curie.valkey.host" .)) -}}{{- end }}
@@ -239,6 +248,11 @@ spec:
             # only a probe label with NO app labels (rail SHOULD block it).
             - name: DATATIER_TARGETS
               value: {{ join " " $dt | quote }}
+            # BYO Postgres (#2432): empty on the in-chart path. When set, Claim 5
+            # skips in-cluster :5432 and names this host:port rather than nc'ing
+            # it (no in-cluster deny/allow pair exists for an external store).
+            - name: POSTGRES_BYO_TARGET
+              value: {{ $pgByo | quote }}
             - name: DT_ALLOWED_POD
               value: {{ include "curie.fullname" . }}-dt-probe-allowed
             - name: DT_DENIED_POD
@@ -457,6 +471,9 @@ spec:
               # with no app labels is blocked (the isolation the rail enforces).
               echo ""
               echo "== Claim 5: data-tier ingress isolation (default-deny + scoped-allow) =="
+              if [ -n "$POSTGRES_BYO_TARGET" ]; then
+                echo "SKIP: postgres.deploy is false; Claim 5 does not probe in-cluster Postgres. BYO ${POSTGRES_BYO_TARGET} is outside the cluster and has no data-tier ingress rail."
+              fi
               if [ -z "$DATATIER_TARGETS" ]; then
                 echo "SKIP: data-tier NetworkPolicy rail disabled or no in-chart store deployed"
               else


### PR DESCRIPTION
## Summary

When `postgres.deploy` is false, Claim 5 of the security probe no longer treats in-cluster Postgres:5432 as a data-tier target, so `helm test` cannot fail that check against a missing Service or an RDS host with no in-cluster ingress rail. The probe publishes `postgres.host:postgres.port` as `POSTGRES_BYO_TARGET` and SKIP-names that endpoint instead of nc'ing it. The in-chart path still probes the Service, now at `postgres.port`. The chart README documents that Helm leaves `data-<release>-postgres-0` Bound after the flip, and how to delete it.

Claim 5 is not pointed at the BYO host on purpose: its allowed=reachable / denied=blocked pair cannot hold on RDS, and putting the host on `DATATIER_TARGETS` would fail a correct BYO install. Rail 1 (runner default-deny egress) is unchanged. DSN rendering is untouched.

## Related issue

Closes #2432

## Fix pin verification

Fix pin: charts/curie/ci/security-probe-byo-postgres-assertions.sh

Verified locally with `curie dev verify-fix-pin` equivalent:

`bash cli/scripts/verify-fix-pin.sh HEAD charts/curie/ci/security-probe-byo-postgres-assertions.sh` -> PINNED (reversed product files fail with `probe env 'POSTGRES_BYO_TARGET' appears 0 times`).

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | n/a | Does not reach compose services, dispatcher, worker, API wiring, console UI, or a curie verb. | | |
| local-release | n/a | Does not change released binary or image identity, the install path, version pins, or release compose. | | |
| cluster | required | Changes the Helm security-probe Job env and Claim 5 skip path. Task forbids cluster writes, so proof is helm template / chart ci, not helm test on a live cluster. | fake | `bash charts/curie/ci/security-probe-byo-postgres-assertions.sh` at bd7a5364: `ok: BYO Claim 5 skips in-cluster 5432 and names host:port`. `helm lint charts/curie` pass. `helm template` with `postgres.deploy=false` / `postgres.host=my-rds.example.com` sets `POSTGRES_BYO_TARGET=my-rds.example.com:5432` and leaves postgres off `DATATIER_TARGETS`. Sibling `charts/curie/ci/render-assertions.sh` pass including assertion 13. |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, or token/cost accounting. | | |
| external integration | n/a | Does not reach Slack, git push webhooks, connector OAuth, or a third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive / negative per AC:

- Probe skip on BYO: BYO render has no `curie-postgres:*` and no RDS host on `DATATIER_TARGETS`, and names `my-rds.example.com:5432` on `POSTGRES_BYO_TARGET`. Negative: default render still includes `curie-postgres:5432`; `postgres.host` set while `deploy` stays true still probes the in-chart Service.
- README PVC: paragraph under the managed-Postgres example names `data-<release>-postgres-0` and `kubectl delete pvc`. Second path: the StatefulSet `volumeClaimTemplates` name remains `data` on `{{ fullname }}-postgres`.

## Out of scope

- Other BYO stores (valkey, clickhouse, rustfs) are not added to this skip path. rustfs is the opposite case: the runner must reach it via `rustfs.egress`.
- DSN TLS mode (#2431 / #2460) is not changed.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.

## Done check

- [x] Failing tests were written and seen to fail before any implementation code: first run of the new script failed with `probe env 'POSTGRES_BYO_TARGET' appears 0 times`.
- [n/a] Test writer and implementer in separate contexts: quick path, same session in order (test file, then production).
- [x] Code review passed: `.projects/plans/task-2432-byo-postgres-security-probe.findings.code.md` (0 findings). Independent agent-router review 345 (codex gpt-6-astra) also reported no blocking findings.
- [x] Scope review passed: `.projects/plans/task-2432-byo-postgres-security-probe.findings.scope.md`. Every hunk maps to AC1, AC2, the rustfs.port mechanical parity, or the explicit out-of-scope note above.
- [n/a] No broadened return type or changed contract callers.
- [x] Sibling paths: rustfs/clickhouse/valkey Claim 5 targets unchanged; rustfs.port pin in render-assertions assertion 13 still passes. Other BYO stores called out above.
- [x] Guard: BYO render was executed and Claim 5 does not receive a Postgres target to nc. Default render still includes `curie-postgres:5432`.
- [x] Security review passed: `.projects/plans/task-2432-byo-postgres-security-probe.findings.security.md` (0 findings). Skip avoids a claimed-but-absent RDS ingress rail.
- [x] Real affected surface: helm template of the security-probe Job, not a live `helm test` (no cluster writes).
- [x] Six tiers classified in the table above.
- [x] Required cluster tier has an evidence record at bd7a5364.
- [x] Each AC has positive proof plus a negative or second path, above.
- [x] Does not undo prior intent: Claim 5 already excluded BYO stores from `$dt` (comment from 2026-09-03); this names the skip instead of dropping 5432 silently.
- [x] Affected suite: new script pass, render-assertions.sh pass, helm lint pass, verify-fix-pin PINNED.
- [n/a] Issue is not labeled P0, release-blocker, or sre-bot-e2e-demo.
