### PR TITLE
Render a TLS parameter on every Postgres DSN

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -183,6 +183,18 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/valkey-tls-assertions.sh
 
+      # Prove every Postgres DSN carries a TLS parameter when asked, and that
+      # the signal reaches both driver families rather than one of them (#2431).
+      # SQLAlchemy/asyncpg needs ?ssl=require; Prisma needs ?sslmode=no-verify;
+      # the api migrate probe must lift ssl= into the connect kwarg or asyncpg
+      # forwards it as a server setting and the API never leaves init. Also
+      # proves the guard refuses require against the in-chart store, which
+      # serves no TLS listener, and that false/0/prefer are refused by name.
+      - name: helm render assertions (postgres TLS mode)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/postgres-ssl-mode-assertions.sh
+
       # Prove the tenant capacity ceiling actually binds the pods it is meant to.
       # The quota is PriorityClass-scoped, so if its scope is not the name the
       # sandbox pods carry it matches nothing and enforces nothing -- silently,

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -522,7 +522,22 @@ postgres:
   port: 5432
   auth: { username: curie, database: curie }
   existingSecret: my-pg-secret   # must carry key: postgresPassword
+  sslMode: require               # RDS / Cloud SQL / Neon that enforce TLS
 ```
+
+A BYO Postgres that enforces TLS (RDS with `rds.force_ssl=1`, Cloud SQL, Neon)
+also needs `postgres.sslMode: require` alongside `postgres.deploy: false` and
+`postgres.host`. One helper (`curie.postgres.dsnParams`) renders the per-driver
+suffix onto every DSN: `?ssl=require` for the api and worker (SQLAlchemy +
+asyncpg) and `?sslmode=no-verify` for both Langfuse Deployments (Prisma). The
+api migrate init container lifts `ssl=` out of the DSN into the asyncpg connect
+kwarg, because asyncpg's DSN parser would otherwise forward `ssl` as a server
+setting and the API would never leave init. `postgres.sslMode: require` against
+the in-chart Postgres fails the render: that StatefulSet serves no TLS
+listener. Neither suffix verifies the server certificate, so Langfuse traffic
+is encrypted but not authenticated; a `verify-full` mode needs a mounted CA
+bundle and is a second step. Leave `sslMode` empty (the default) for the
+in-cluster store: the rendered DSNs stay suffix-free.
 
 Toggles (all default `true`): `langfuse.deploy`, `postgres.deploy`,
 `valkey.deploy`, `clickhouse.deploy`, `rustfs.deploy`, `otelCollector.deploy`.

--- a/charts/curie/ci/postgres-ssl-mode-assertions.sh
+++ b/charts/curie/ci/postgres-ssl-mode-assertions.sh
@@ -1,0 +1,501 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for Postgres TLS mode on every DSN (#2431).
+#
+# postgres.deploy: false points the chart at a managed Postgres, but every DSN
+# _helpers.tpl composes used to end at the database name. There was no value
+# that asked for TLS, so on a store that enforces it (RDS ships rds.force_ssl=1)
+# the install worked only because each driver's default happened to be
+# "prefer". A parameter-group change or a driver default moving would drop to
+# plaintext or refuse to connect with no render-time signal.
+#
+# The two driver families also disagree on the spelling, which is why an
+# operator cannot fix this from postgres.auth.database:
+#
+#   api, worker (SQLAlchemy + asyncpg)  ->  ?ssl=require
+#   Langfuse web + worker (Prisma)      ->  ?sslmode=no-verify
+#
+# One more consumer: the api migrate init container calls asyncpg.connect() on
+# the DSN directly. asyncpg's DSN parser knows sslmode, not ssl, so an ssl=
+# query arg is forwarded to the server as an unknown setting and the API never
+# leaves init. The probe must lift ssl into the connect kwarg.
+#
+# postgres.sslMode is threaded through ONE helper (curie.postgres.dsnParams)
+# included from both curie.env.postgres and curie.langfuse.env. The bug class
+# this chart has hit twice (#2052, #2327) is "two consumer groups read the
+# same postgres.* field and only one of them was updated".
+#
+# Asserts:
+#
+#   1. default: DATABASE_URL on api, worker, migrate, and both Langfuse
+#      containers has no TLS query parameter, byte-for-byte the pre-change
+#      shape, so an existing install does not change on upgrade.
+#   2. byo-plain (deploy=false + host, sslMode left default): still no TLS
+#      query parameter. This is what makes assertion 3 non-vacuous: without
+#      it, a template that emitted the suffix unconditionally would pass.
+#   3. byo-require (deploy=false + host + sslMode=require): api/worker/migrate
+#      DSNs end in ?ssl=require; both Langfuse DSNs end in ?sslmode=no-verify.
+#      Host still resolves to the BYO host in the SAME render.
+#   4. NEGATIVE CONTROL -- the in-chart guard: helm template
+#      --set postgres.sslMode=require with postgres.deploy left true exits
+#      non-zero and stderr names BOTH postgres.sslMode and postgres.deploy.
+#      The in-chart Postgres StatefulSet serves no TLS listener.
+#   5. NEGATIVE CONTROL -- invalid values: prefer, disable, verify-full, a
+#      quoted "false", and 0 each fail the render and name postgres.sslMode.
+#      Sprig `default` swallows false and 0, so these are read raw.
+#   6. The migrate probe extracted from the byo-require render lifts ssl= out
+#      of the DSN into the asyncpg.connect kwarg as the string "require" (not
+#      True, which asyncpg maps to verify-full), then a fake driver fails
+#      against a closed port with a connection error class.
+#   7. The same extracted probe runs against a closed port with the installed
+#      asyncpg driver (no fake), so a scheme or ssl-kwarg rejection cannot hide
+#      behind the argument stub.
+#
+# Every render goes through --output-dir, never a stdout pipe: piping helm
+# template in this environment silently truncates a large render at exit 0
+# with empty stderr. Structural checks go through PyYAML rather than grep.
+#
+# Runnable locally (from anywhere) and from CI. Fails loudly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$CHART/../.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+render() {
+  local name="$1"
+  shift
+  RENDER_DIR="$TMP/$name"
+  rm -rf "$RENDER_DIR"
+  helm template rel "$CHART" --output-dir "$RENDER_DIR" "$@" >/dev/null \
+    || fail "helm template failed for render '$name'"
+}
+
+BYO_HOST="pg.acme.internal"
+
+echo "=== Rendering (defaults) ==="
+render default
+DEFAULT_DIR="$RENDER_DIR/curie/templates"
+
+echo "=== Rendering (byo-plain: deploy=false + host, sslMode left default) ==="
+render byo-plain \
+  --set postgres.deploy=false \
+  --set-string postgres.host="$BYO_HOST"
+BYO_PLAIN_DIR="$RENDER_DIR/curie/templates"
+
+echo "=== Rendering (byo-require: deploy=false + host + sslMode=require) ==="
+render byo-require \
+  --set postgres.deploy=false \
+  --set-string postgres.host="$BYO_HOST" \
+  --set-string postgres.sslMode=require
+BYO_REQUIRE_DIR="$RENDER_DIR/curie/templates"
+
+DEFAULT_DIR="$DEFAULT_DIR" BYO_PLAIN_DIR="$BYO_PLAIN_DIR" \
+BYO_REQUIRE_DIR="$BYO_REQUIRE_DIR" BYO_HOST="$BYO_HOST" \
+python3 <<'PY'
+import os
+import sys
+
+import yaml
+
+DEFAULT_DIR = os.environ["DEFAULT_DIR"]
+BYO_PLAIN_DIR = os.environ["BYO_PLAIN_DIR"]
+BYO_REQUIRE_DIR = os.environ["BYO_REQUIRE_DIR"]
+BYO_HOST = os.environ["BYO_HOST"]
+
+INCLUSTER_HOST = "rel-curie-postgres"
+USER = "postgres"
+DB = "postgres"
+PASSWORD = "$(POSTGRES_PASSWORD)"
+
+APP_BASE = f"postgresql+asyncpg://{USER}:{PASSWORD}@{{host}}:5432/{DB}"
+LANGFUSE_BASE = f"postgresql://{USER}:{PASSWORD}@{{host}}:5432/{DB}"
+
+failures = []
+_docs_cache = {}
+
+
+def load_docs(path):
+    if path not in _docs_cache:
+        if not os.path.isfile(path):
+            _docs_cache[path] = []
+        else:
+            with open(path) as handle:
+                _docs_cache[path] = [doc for doc in yaml.safe_load_all(handle) if doc]
+    return _docs_cache[path]
+
+
+def find_containers(obj, acc, key="containers"):
+    if isinstance(obj, dict):
+        found = obj.get(key)
+        if isinstance(found, list):
+            acc.extend(found)
+        for value in obj.values():
+            find_containers(value, acc, key)
+    elif isinstance(obj, list):
+        for item in obj:
+            find_containers(item, acc, key)
+
+
+def containers_named(manifest_path, name, *, init=False):
+    acc = []
+    for doc in load_docs(manifest_path):
+        find_containers(doc, acc, "initContainers" if init else "containers")
+    return [container for container in acc if isinstance(container, dict) and container.get("name") == name]
+
+
+def database_url(containers, label):
+    if len(containers) != 1:
+        failures.append(f"found {len(containers)} container(s) matching {label!r}, expected exactly 1")
+        return None
+    entries = [entry for entry in (containers[0].get("env") or []) if entry.get("name") == "DATABASE_URL"]
+    if len(entries) != 1:
+        failures.append(f"{label}: DATABASE_URL rendered {len(entries)} time(s), expected exactly 1")
+        return None
+    value = entries[0].get("value")
+    if not isinstance(value, str) or not value:
+        failures.append(f"{label}: DATABASE_URL is {value!r}, expected a non-empty string")
+        return None
+    return value
+
+
+def check_url(aid, containers, label, expected, ctx):
+    actual = database_url(containers, f"{ctx}:{label}")
+    if actual is None:
+        return
+    if actual != expected:
+        failures.append(
+            f"[{aid}] {ctx}: DATABASE_URL on {label!r} = {actual!r}, expected {expected!r}"
+        )
+
+
+def consumers(templates_dir, host):
+    app = APP_BASE.format(host=host)
+    langfuse = LANGFUSE_BASE.format(host=host)
+    return [
+        ("api", containers_named(f"{templates_dir}/api.yaml", "api"), app),
+        ("worker", containers_named(f"{templates_dir}/worker.yaml", "worker"), app),
+        (
+            "migrate",
+            containers_named(f"{templates_dir}/api.yaml", "migrate", init=True),
+            app,
+        ),
+        (
+            "langfuse-web",
+            containers_named(f"{templates_dir}/langfuse.yaml", "langfuse-web"),
+            langfuse,
+        ),
+        (
+            "langfuse-worker",
+            containers_named(f"{templates_dir}/langfuse.yaml", "langfuse-worker"),
+            langfuse,
+        ),
+    ]
+
+
+# ---- 1: default, no TLS query parameter, in-cluster host. -----------------
+for label, containers, expected in consumers(DEFAULT_DIR, INCLUSTER_HOST):
+    check_url("1", containers, label, expected, "default render")
+_postgres_manifest = f"{DEFAULT_DIR}/postgres.yaml"
+if not (os.path.isfile(_postgres_manifest) and os.path.getsize(_postgres_manifest) > 0):
+    failures.append("[1] default render: templates/postgres.yaml did not render (or is empty)")
+
+# ---- 2: byo-plain, still no TLS query parameter, BYO host. ----------------
+for label, containers, expected in consumers(BYO_PLAIN_DIR, BYO_HOST):
+    check_url("2", containers, label, expected, "byo-plain render")
+
+# ---- 3: byo-require, per-driver suffix, BYO host. -------------------------
+for label, containers, expected in consumers(BYO_REQUIRE_DIR, BYO_HOST):
+    if label in {"api", "worker", "migrate"}:
+        expected = expected + "?ssl=require"
+    else:
+        expected = expected + "?sslmode=no-verify"
+    check_url("3", containers, label, expected, "byo-require render")
+
+if failures:
+    for message in failures:
+        print(f"FAIL {message}", file=sys.stderr)
+    print(f"{len(failures)} python-side assertion(s) failed", file=sys.stderr)
+    sys.exit(1)
+
+print("  [1] default: DATABASE_URL has no TLS query parameter on all five consumers: OK")
+print("  [2] byo-plain: still no TLS query parameter (require is not unconditional): OK")
+print("  [3] byo-require: ?ssl=require on asyncpg, ?sslmode=no-verify on Prisma: OK")
+PY
+
+echo
+echo "=== Rendering (guard: sslMode=require with postgres.deploy left at its default) ==="
+GUARD_OUT="$(helm template rel "$CHART" --set-string postgres.sslMode=require 2>&1)" && {
+  fail "[4] postgres.sslMode=require with postgres.deploy left true rendered successfully; expected a render-time refusal"
+}
+for needle in "postgres.sslMode" "postgres.deploy"; do
+  if ! printf '%s' "$GUARD_OUT" | grep -qF "$needle"; then
+    echo "FAIL: [4] the guard's refusal did not name '$needle'" >&2
+    echo "  actual output:" >&2
+    printf '%s\n' "$GUARD_OUT" | sed 's/^/    /' >&2
+    exit 1
+  fi
+done
+echo "  [4] negative control: sslMode=require + deploy=true is refused at render time, naming both keys: OK"
+
+echo
+echo "=== Rendering (guard: invalid sslMode values) ==="
+refuse_invalid() {
+  local flag="$1"
+  local label="$2"
+  local out
+  out="$(helm template rel "$CHART" \
+    --set postgres.deploy=false \
+    --set-string postgres.host="$BYO_HOST" \
+    $flag 2>&1)" && {
+    fail "[5] $label rendered successfully; expected a render-time refusal naming postgres.sslMode"
+  }
+  if ! printf '%s' "$out" | grep -qF "postgres.sslMode"; then
+    echo "FAIL: [5] $label refusal did not name postgres.sslMode" >&2
+    echo "  actual output:" >&2
+    printf '%s\n' "$out" | sed 's/^/    /' >&2
+    exit 1
+  fi
+}
+
+refuse_invalid "--set-string postgres.sslMode=prefer" "sslMode=prefer"
+refuse_invalid "--set-string postgres.sslMode=disable" "sslMode=disable"
+refuse_invalid "--set-string postgres.sslMode=verify-full" "sslMode=verify-full"
+refuse_invalid "--set-string postgres.sslMode=false" "sslMode=false (quoted)"
+refuse_invalid "--set postgres.sslMode=0" "sslMode=0"
+echo "  [5] negative control: prefer/disable/verify-full/false/0 each refuse and name postgres.sslMode: OK"
+
+echo
+echo "=== Extracted migrate probe against a closed port (byo-require) ==="
+BYO_REQUIRE_DIR="$BYO_REQUIRE_DIR" TMP="$TMP" python3 <<'PY'
+import os
+import pathlib
+import socket
+import subprocess
+import sys
+import textwrap
+
+import yaml
+
+templates_dir = os.environ["BYO_REQUIRE_DIR"]
+tmp = pathlib.Path(os.environ["TMP"])
+
+
+def die(message):
+    print(f"FAIL: [6] {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+docs = [
+    doc
+    for doc in yaml.safe_load_all(pathlib.Path(templates_dir, "api.yaml").read_text())
+    if doc
+]
+migrate = []
+for doc in docs:
+    spec = (
+        (doc.get("spec") or {})
+        .get("template", {})
+        .get("spec", {})
+    )
+    for container in spec.get("initContainers") or []:
+        if container.get("name") == "migrate":
+            migrate.append(container)
+if len(migrate) != 1:
+    die(f"expected exactly one migrate init container, found {len(migrate)}")
+
+process = list(migrate[0].get("command") or []) + list(migrate[0].get("args") or [])
+if len(process) < 3 or process[1] != "-c":
+    die(f"migrate init is not a shell -c script: {process[:3]!r}")
+script = process[2]
+marker = "python -c '"
+start = script.find(marker)
+if start < 0:
+    die("migrate init script has no python -c probe")
+start += len(marker)
+end = script.find("'", start)
+if end < 0:
+    die("migrate init python -c probe is not single-quote terminated")
+probe_src = textwrap.dedent(script[start:end])
+if "urlparse" not in probe_src or "ssl" not in probe_src:
+    die("extracted probe does not lift ssl out of the DSN (no urlparse/ssl split)")
+
+closed = socket.socket()
+closed.bind(("127.0.0.1", 0))
+host, port = closed.getsockname()
+closed.close()
+
+fake = tmp / "fake-asyncpg"
+fake.mkdir()
+(fake / "asyncpg.py").write_text(
+    """\
+import os
+import socket
+from urllib.parse import parse_qs, urlparse
+
+
+class Connection:
+    async def close(self):
+        return None
+
+
+async def connect(database_url, timeout=None, **kwargs):
+    parsed = urlparse(database_url)
+    query = parse_qs(parsed.query)
+    if "ssl" in query:
+        raise RuntimeError("ssl_query_not_lifted")
+    if os.environ.get("EXPECT_SSL_KWARG") == "1":
+        # asyncpg maps ssl=True to verify-full; the chart must pass the
+        # mode string so require encrypts without a CA, matching SQLAlchemy.
+        if kwargs.get("ssl") is True:
+            raise RuntimeError("ssl_kwarg_is_true_not_require")
+        if kwargs.get("ssl") != "require":
+            raise RuntimeError("ssl_kwarg_missing")
+    socket.create_connection(
+        (parsed.hostname, parsed.port or 5432),
+        timeout=timeout if timeout is not None else 2,
+    )
+    return Connection()
+"""
+)
+
+database_url = (
+    f"postgresql+asyncpg://curie:not-a-secret@{host}:{port}/curie?ssl=require"
+)
+result = subprocess.run(
+    [sys.executable, "-c", probe_src],
+    env={
+        **os.environ,
+        "DATABASE_URL": database_url,
+        "EXPECT_SSL_KWARG": "1",
+        "PYTHONPATH": str(fake),
+    },
+    capture_output=True,
+    text=True,
+    timeout=15,
+    check=False,
+)
+output = (result.stdout or "") + (result.stderr or "")
+if result.returncode == 0:
+    die(f"probe succeeded against a closed port: {output!r}")
+if "ssl_query_not_lifted" in output:
+    die("probe forwarded ssl= to the server instead of lifting it to the connect kwarg")
+if "ssl_kwarg_is_true_not_require" in output:
+    die("probe passed ssl=True (asyncpg verify-full) instead of ssl='require'")
+if "ssl_kwarg_missing" in output:
+    die("probe stripped ssl= from the DSN but did not pass ssl='require' to asyncpg.connect")
+if "ConnectionRefusedError" not in output and "OSError" not in output:
+    die(
+        "probe against a closed port must fail with a connection error class, "
+        f"got {output!r}"
+    )
+print(
+    "  [6] extracted migrate probe lifts ssl= to the connect kwarg and fails "
+    "against a closed port with a connection error class: OK"
+)
+PY
+
+echo
+echo "=== Extracted migrate probe with real asyncpg against a closed port ==="
+REAL_PYTHON=""
+if python3 -c 'import asyncpg' >/dev/null 2>&1; then
+  REAL_PYTHON="$(command -v python3)"
+elif command -v uv >/dev/null 2>&1 && (cd "$REPO_ROOT" && uv run python -c 'import asyncpg') >/dev/null 2>&1; then
+  REAL_PYTHON="$(cd "$REPO_ROOT" && uv run python -c 'import sys; print(sys.executable)')"
+else
+  python3 -m venv "$TMP/asyncpg-venv" \
+    || fail "[7] could not create a venv to install asyncpg"
+  "$TMP/asyncpg-venv/bin/pip" install --quiet asyncpg \
+    || fail "[7] could not install asyncpg into a throwaway venv"
+  REAL_PYTHON="$TMP/asyncpg-venv/bin/python"
+fi
+BYO_REQUIRE_DIR="$BYO_REQUIRE_DIR" REAL_PYTHON="$REAL_PYTHON" python3 <<'PY'
+import os
+import pathlib
+import socket
+import subprocess
+import sys
+import textwrap
+
+import yaml
+
+templates_dir = os.environ["BYO_REQUIRE_DIR"]
+
+
+def die(message):
+    print(f"FAIL: [7] {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+docs = [
+    doc
+    for doc in yaml.safe_load_all(pathlib.Path(templates_dir, "api.yaml").read_text())
+    if doc
+]
+migrate = []
+for doc in docs:
+    spec = (doc.get("spec") or {}).get("template", {}).get("spec", {})
+    for container in spec.get("initContainers") or []:
+        if container.get("name") == "migrate":
+            migrate.append(container)
+if len(migrate) != 1:
+    die(f"expected exactly one migrate init container, found {len(migrate)}")
+
+process = list(migrate[0].get("command") or []) + list(migrate[0].get("args") or [])
+script = process[2]
+marker = "python -c '"
+start = script.find(marker) + len(marker)
+end = script.find("'", start)
+probe_src = textwrap.dedent(script[start:end])
+
+closed = socket.socket()
+closed.bind(("127.0.0.1", 0))
+host, port = closed.getsockname()
+closed.close()
+
+database_url = (
+    f"postgresql+asyncpg://curie:not-a-secret@{host}:{port}/curie?ssl=require"
+)
+env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+env["DATABASE_URL"] = database_url
+real_python = os.environ["REAL_PYTHON"]
+result = subprocess.run(
+    [real_python, "-c", probe_src],
+    env=env,
+    capture_output=True,
+    text=True,
+    timeout=15,
+    check=False,
+)
+output = (result.stdout or "") + (result.stderr or "")
+if result.returncode == 0:
+    die(f"real asyncpg probe succeeded against a closed port: {output!r}")
+if "IndentationError" in output or "SyntaxError" in output:
+    die(f"extracted probe is not valid Python: {output!r}")
+if "ClientConfigurationError" in output:
+    die(f"real asyncpg rejected the lifted ssl kwarg: {output!r}")
+if "postgresql+asyncpg" in output and "scheme" in output.lower():
+    die(f"probe did not convert the SQLAlchemy scheme before asyncpg.connect: {output!r}")
+if "ConnectionRefusedError" not in output and "OSError" not in output:
+    die(
+        "real asyncpg against a closed port must fail with a connection error class, "
+        f"got {output!r}"
+    )
+print(
+    "  [7] extracted migrate probe with real asyncpg fails against a closed "
+    "port with a connection error class: OK"
+)
+PY
+
+echo
+echo "PASS: postgres.sslMode renders a TLS parameter on every Postgres DSN"
+echo "      (asyncpg ?ssl=require, Prisma ?sslmode=no-verify), the default and"
+echo "      BYO-plain renders stay suffix-free, invalid values and require+"
+echo "      in-chart deploy are refused by name, and the migrate probe lifts"
+echo "      ssl='require' out of the DSN before asyncpg.connect, including"
+echo "      against a closed port with the real driver."

--- a/charts/curie/files/reserved-env.yaml
+++ b/charts/curie/files/reserved-env.yaml
@@ -66,7 +66,7 @@ worker:
   CURIE_WORKSPACE_SCRATCH_ROOT: worker.workspace.mountPath
   CURIE_WORKSPACE_TOTAL_TIMEOUT_SECONDS: worker.workspace.totalTimeoutSeconds
   CURIE_WORKSPACE_UPLOAD_TIMEOUT_SECONDS: worker.workspace.uploadTimeoutSeconds
-  DATABASE_URL: postgres.host / postgres.port / postgres.auth
+  DATABASE_URL: postgres.host / postgres.port / postgres.auth / postgres.sslMode
   DB_SCHEMA: the chart-managed database schema (remove this override)
   LANGFUSE_HOST: langfuse.host / langfuse.web.service.port
   LANGFUSE_PUBLIC_KEY: langfuse.init.projectPublicKey
@@ -90,7 +90,7 @@ api:
   CURIE_INTERNAL_WORKER_TOKEN: worker.internalWorkerToken
   CURIE_PUBLICATION_PATCH_MAX_BYTES: worker.publication.patchMaxBytes
   CURIE_PUBLICATION_RETENTION_SECONDS: worker.publication.retentionSeconds
-  DATABASE_URL: postgres.host / postgres.port / postgres.auth
+  DATABASE_URL: postgres.host / postgres.port / postgres.auth / postgres.sslMode
   DB_SCHEMA: the chart-managed database schema (remove this override)
   ENVIRONMENT: api.environment
   GITHUB_API_URL: api.githubApiUrl

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -162,6 +162,43 @@ ANTHROPIC_BASE_URL ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_AUTH_TOKE
 {{- end -}}
 {{- end -}}
 
+{{/* Per-driver TLS query suffix for a Postgres DSN (#2431). ONE helper,
+     included from BOTH curie.env.postgres (SQLAlchemy/asyncpg: ?ssl=require)
+     and curie.langfuse.env (Prisma/node-postgres: ?sslmode=no-verify): the
+     two driver families disagree on the spelling, so an operator cannot put
+     a suffix in postgres.auth.database.
+
+     Empty (the default, and a missing key on --reuse-values of a release
+     created before this existed) renders nothing, so an existing in-cluster
+     install is byte-identical on upgrade. "require" is the only other
+     accepted value; everything else, including false and 0, which Sprig
+     default would swallow, fails at render naming postgres.sslMode. The
+     value is read raw for that reason.
+
+     Why the deploy guard. The in-chart Postgres StatefulSet serves no TLS
+     listener, so sslMode=require against it would break every consumer at
+     once behind a healthy-looking manifest. Refuse at render, naming both
+     keys. Neither rendered suffix verifies the server certificate; a
+     verify-full mode needs a mounted CA bundle and is a second step. */}}
+{{- define "curie.postgres.dsnParams" -}}
+{{- $root := required "curie.postgres.dsnParams requires root" .root -}}
+{{- $driver := required "curie.postgres.dsnParams requires driver" .driver -}}
+{{- if not (has $driver (list "asyncpg" "prisma")) -}}
+{{- fail (printf "curie.postgres.dsnParams driver must be asyncpg or prisma, got %q" $driver) -}}
+{{- end -}}
+{{- $mode := index $root.Values.postgres "sslMode" -}}
+{{- $empty := or (not (hasKey $root.Values.postgres "sslMode")) (kindIs "invalid" $mode) (and (kindIs "string" $mode) (eq $mode "")) -}}
+{{- if $empty -}}
+{{- else if eq (toString $mode) "require" -}}
+{{- if $root.Values.postgres.deploy -}}
+{{- fail "postgres.sslMode is require but postgres.deploy is also true: the in-chart Postgres serves no TLS listener, so every consumer would fail to connect. Set postgres.deploy=false and point postgres.host at your external TLS store, or leave postgres.sslMode empty." -}}
+{{- end -}}
+{{- if eq $driver "asyncpg" -}}?ssl=require{{- else -}}?sslmode=no-verify{{- end -}}
+{{- else -}}
+{{- fail (printf "postgres.sslMode must be empty or \"require\", got %q" (printf "%v" $mode)) -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "curie.valkey.host" -}}
 {{- if .Values.valkey.deploy -}}
 {{- printf "%s-valkey" (include "curie.fullname" .) -}}
@@ -868,7 +905,7 @@ http://{{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.
       name: {{ .Values.postgres.existingSecret | default (include "curie.secretName" .) }}
       key: postgresPassword
 - name: DATABASE_URL
-  value: postgresql+asyncpg://{{ .Values.postgres.auth.username }}:$(POSTGRES_PASSWORD)@{{ include "curie.postgres.host" . }}:{{ .Values.postgres.port }}/{{ .Values.postgres.auth.database }}
+  value: postgresql+asyncpg://{{ .Values.postgres.auth.username }}:$(POSTGRES_PASSWORD)@{{ include "curie.postgres.host" . }}:{{ .Values.postgres.port }}/{{ .Values.postgres.auth.database }}{{ include "curie.postgres.dsnParams" (dict "root" . "driver" "asyncpg") }}
 - name: DB_SCHEMA
   value: curie
 {{- end -}}
@@ -1032,7 +1069,7 @@ livenessProbe:
       name: {{ .Values.postgres.existingSecret | default (include "curie.secretName" .) }}
       key: postgresPassword
 - name: DATABASE_URL
-  value: postgresql://{{ .Values.postgres.auth.username }}:$(POSTGRES_PASSWORD)@{{ include "curie.postgres.host" . }}:{{ .Values.postgres.port }}/{{ .Values.postgres.auth.database }}
+  value: postgresql://{{ .Values.postgres.auth.username }}:$(POSTGRES_PASSWORD)@{{ include "curie.postgres.host" . }}:{{ .Values.postgres.port }}/{{ .Values.postgres.auth.database }}{{ include "curie.postgres.dsnParams" (dict "root" . "driver" "prisma") }}
 - name: SALT
   valueFrom:
     secretKeyRef:

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -75,9 +75,15 @@ spec:
               max_attempts=60
               probe_error_class=""
               while [ "$attempt" -le "$max_attempts" ]; do
+                # Lift ssl= out of the DSN into the connect kwarg (#2431).
+                # asyncpg's DSN parser knows sslmode, not ssl, so an ssl=
+                # query arg is forwarded as a server setting. Pass the mode
+                # string through: ssl=True is verify-full; ssl="require"
+                # encrypts without a CA, matching SQLAlchemy's ?ssl=require.
                 if probe_error_class=$(python -c '
               import asyncio
               import os
+              from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
               try:
                   import asyncpg
@@ -86,7 +92,19 @@ spec:
                       database_url = os.environ["DATABASE_URL"].replace(
                           "postgresql+asyncpg://", "postgresql://", 1
                       )
-                      connection = await asyncpg.connect(database_url, timeout=2)
+                      parsed = urlparse(database_url)
+                      query = []
+                      ssl = None
+                      for key, value in parse_qsl(parsed.query, keep_blank_values=True):
+                          if key == "ssl":
+                              ssl = value
+                          else:
+                              query.append((key, value))
+                      database_url = urlunparse(parsed._replace(query=urlencode(query)))
+                      connect_kwargs = {"timeout": 2}
+                      if ssl is not None:
+                          connect_kwargs["ssl"] = ssl
+                      connection = await asyncpg.connect(database_url, **connect_kwargs)
                       await connection.close()
 
                   asyncio.run(probe())

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -337,7 +337,8 @@ langfuse:
 # ---------------------------------------------------------------------------
 # Postgres. Langfuse's transactional store AND the app-state DB (agents,
 # versions, deployments). BYO: deploy=false + host/port/auth (or existingSecret
-# with key postgresPassword).
+# with key postgresPassword), plus sslMode=require for a managed store that
+# enforces TLS.
 # ---------------------------------------------------------------------------
 postgres:
   deploy: true
@@ -356,6 +357,15 @@ postgres:
     password: postgres
     database: postgres
   existingSecret: ""
+  # TLS query parameter on every Postgres DSN (#2431). Empty (the default)
+  # renders no suffix, so an in-cluster install is unchanged on upgrade.
+  # "require" is for a BYO store that enforces TLS: SQLAlchemy/asyncpg gets
+  # ?ssl=require, Prisma/Langfuse gets ?sslmode=no-verify. Neither suffix
+  # verifies the server certificate; verify-full needs a mounted CA bundle
+  # and is a second step. require with deploy=true fails the render: the
+  # in-chart StatefulSet serves no TLS listener. Any other value fails at
+  # render. Read raw: Sprig default would swallow false and 0.
+  sslMode: ""
   # fsGroup that owns the mounted data volume: the gid (and uid) of the
   # `postgres` user INSIDE the pinned image above, read with
   # `docker run --rm --entrypoint id <image> -g postgres`. Asserted against the

--- a/docs/interfaces/relational-db/managed-postgres-swap.md
+++ b/docs/interfaces/relational-db/managed-postgres-swap.md
@@ -28,11 +28,17 @@ and the one validation that proves it.
    DATABASE_URL=postgresql+asyncpg://<user>:<password>@<host>:5432/<database>
    ```
 
-   - **RDS / Cloud SQL:** the endpoint host + port; TLS is negotiated by asyncpg.
-     For Cloud SQL prefer the Auth Proxy (a localhost endpoint) so the DSN stays a
-     plain host/port.
-   - **Neon:** use the pooled or direct endpoint host; keep `sslmode=require`
-     semantics by connecting over the provider's TLS endpoint.
+   - **RDS / Cloud SQL:** the endpoint host + port. On the chart path, set
+     `postgres.sslMode: require` (see `charts/curie/README.md`) so every DSN
+     carries a TLS parameter rather than relying on the driver default of
+     `prefer`. For Cloud SQL prefer the Auth Proxy (a localhost endpoint) so the
+     DSN stays a plain host/port.
+   - **Neon:** use the pooled or direct endpoint host, and set
+     `postgres.sslMode: require` on the chart path. That renders `?ssl=require`
+     for the api and worker (SQLAlchemy + asyncpg) and `?sslmode=no-verify` for
+     Langfuse (Prisma). `no-verify` encrypts without authenticating the server
+     certificate; a `verify-full` mode needs a mounted CA bundle and is not
+     this knob.
    - The role must own (or be able to create) the `curie` schema. Migration
      `0001_initial` issues `CREATE SCHEMA IF NOT EXISTS curie`.
 


### PR DESCRIPTION
## Summary

BYO Postgres (`postgres.deploy: false`) could not ask the chart for TLS: both DSN composers ended at the database name, so every consumer fell back to the driver's `prefer` default. A store that enforces TLS (RDS `rds.force_ssl=1`) connected only by accident.

`postgres.sslMode` is empty (the default, no query suffix, so an in-cluster install is unchanged) or `require`. One helper, `curie.postgres.dsnParams`, renders the per-driver suffix onto every DSN:

- api, worker, and the api migrate init: `?ssl=require` (SQLAlchemy + asyncpg)
- both Langfuse Deployments: `?sslmode=no-verify` (Prisma)

The api migrate probe lifts `ssl=` out of the DSN into the asyncpg connect kwarg as the mode string. Leaving it in the DSN forwards `ssl` as a server setting and the API never leaves init; passing `ssl=True` would ask asyncpg for `verify-full`.

`require` against the in-chart store, and any value other than empty or `require` (including `false` and `0`, which Sprig `default` would swallow), fails the render by name.

Neither suffix verifies the server certificate. Langfuse traffic is encrypted but not authenticated; a `verify-full` mode needs a mounted CA bundle and is a second step.

Adversarial review (agent-router 344, Codex): one blocking finding, the closed-port check used only a fake asyncpg, fixed by also running the extracted probe with the installed driver.

## Related issue

Closes #2431

## Fix pin verification

Fix pin: charts/curie/ci/postgres-ssl-mode-assertions.sh

Verified locally with `cli/scripts/verify-fix-pin.sh b2de21998db71debfa8344fdfd3bb5158749795b charts/curie/ci/postgres-ssl-mode-assertions.sh`: the script fails on the pre-fix tree at assertion 3 (DSNs have no TLS suffix where `?ssl=require` / `?sslmode=no-verify` are expected) and passes on this commit (`PINNED`).

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | chart-only change; no runner or skill surface | | |
| local | n/a | compose does not consume `postgres.sslMode` | | |
| local-release | n/a | no released binary or image identity change | | |
| cluster | required | chart templates render the Postgres DSNs and the api migrate probe | fake | `bash charts/curie/ci/postgres-ssl-mode-assertions.sh` on b2de2199: assertions 1-7 PASS, including real asyncpg against a closed port. Negative: `--set postgres.sslMode=require` with `deploy` left true is refused by name; `prefer`/`disable`/`verify-full`/`false`/`0` each refuse and name `postgres.sslMode`. |
| live provider | n/a | no model provider involved | | |
| external integration | n/a | no Slack, git webhook, or third-party API shape | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Sibling checks on this branch: `helm lint charts/curie` (0 failed); `charts/curie/ci/render-assertions.sh` (migrate readiness still passes, including the fake-asyncpg timeout signature); `charts/curie/ci/reserved-env-assertions.sh` (OK); `cargo test --test chart_check helm_ci_and_the_chart_ci_directory_cannot_diverge` (ok).

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
