### PR TITLE
Bound namespace byte-cap checks with a SQL upper bound

### DIFF
--- a/apps/api/src/curie_api/routers/state.py
+++ b/apps/api/src/curie_api/routers/state.py
@@ -20,7 +20,7 @@ import uuid
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
-from sqlalchemy import func, select, text
+from sqlalchemy import Text, cast, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud, sandbox_token
@@ -234,21 +234,48 @@ async def _enforce_caps(
             f"{settings.state_max_value_bytes}-byte per-value cap",
         )
 
-    others = await session.scalars(
-        select(WorkflowStateEntry.value).where(
-            WorkflowStateEntry.agent_id == agent_id,
-            WorkflowStateEntry.binding_scope == scope,
-            WorkflowStateEntry.namespace == namespace,
-            WorkflowStateEntry.key != key,
-        )
+    # Cap unit is compact json.dumps (ensure_ascii=True). jsonb::text is not
+    # byte-identical: object whitespace makes it an *upper* bound for ASCII
+    # JSON, but UTF-8 output is shorter than ensure_ascii escapes, so a
+    # multibyte sibling must take the exact fallback. The aggregates return
+    # two scalars; fetching sibling values is only the over-bound path.
+    sibling_filter = (
+        WorkflowStateEntry.agent_id == agent_id,
+        WorkflowStateEntry.binding_scope == scope,
+        WorkflowStateEntry.namespace == namespace,
+        WorkflowStateEntry.key != key,
     )
-    namespace_bytes = value_bytes + sum(_json_size(v) for v in others)
-    if namespace_bytes > settings.state_max_namespace_bytes:
-        raise HTTPException(
-            413,
-            f"namespace {namespace!r} would be {namespace_bytes} bytes, over the "
-            f"{settings.state_max_namespace_bytes}-byte per-namespace cap",
+    sibling_text = (
+        select(cast(WorkflowStateEntry.value, Text).label("json_text"))
+        .where(*sibling_filter)
+        .subquery()
+    )
+    sibling_bound, has_multibyte = (
+        await session.execute(
+            select(
+                func.coalesce(func.sum(func.octet_length(sibling_text.c.json_text)), 0),
+                func.coalesce(
+                    func.bool_or(
+                        func.octet_length(sibling_text.c.json_text)
+                        != func.length(sibling_text.c.json_text)
+                    ),
+                    False,
+                ),
+            )
         )
+    ).one()
+    sibling_bound_bytes = int(sibling_bound or 0)
+    if bool(has_multibyte) or (
+        value_bytes + sibling_bound_bytes > settings.state_max_namespace_bytes
+    ):
+        others = await session.scalars(select(WorkflowStateEntry.value).where(*sibling_filter))
+        namespace_bytes = value_bytes + sum(_json_size(v) for v in others)
+        if namespace_bytes > settings.state_max_namespace_bytes:
+            raise HTTPException(
+                413,
+                f"namespace {namespace!r} would be {namespace_bytes} bytes, over the "
+                f"{settings.state_max_namespace_bytes}-byte per-namespace cap",
+            )
 
     # Per-agent namespace-count cap (#852): refuse only a NEW namespace, and only
     # once the agent is at its limit -- writes to an existing namespace never hit
@@ -273,7 +300,7 @@ async def _enforce_caps(
     #    COMMIT or the ROLLBACK with no explicit unlock and no leak path when
     #    the 403 below propagates. This REQUIRES a transaction to already be
     #    open -- outside one the lock would be released immediately and this
-    #    guard would be vacuous. The byte-cap ``others`` SELECT above runs
+    #    guard would be vacuous. The byte-cap SQL bound SELECT above runs
     #    unconditionally and autobegins it; moving this block above those
     #    queries would silently make the lock meaningless.
     #

--- a/apps/api/tests/test_state.py
+++ b/apps/api/tests/test_state.py
@@ -5,6 +5,8 @@ disposable-DB conftest provisions and migrates a throwaway database per run).
 """
 
 import asyncio
+import json
+import os
 import threading
 import time
 import uuid
@@ -13,8 +15,13 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any
 
 import asyncpg
+import pytest
 from curie_api.config import get_settings
-from curie_api.routers.state import _NAMESPACE_LOCK_CLASS, _namespace_lock_key
+from curie_api.routers.state import (
+    _NAMESPACE_LOCK_CLASS,
+    _json_size,
+    _namespace_lock_key,
+)
 from curie_api.sandbox_token import mint
 from sqlalchemy import make_url
 from sqlalchemy.exc import IntegrityError
@@ -407,6 +414,276 @@ def test_namespace_over_the_per_namespace_cap_is_rejected(
         assert b.status_code == 413, b.text
     finally:
         get_settings.cache_clear()
+
+
+def test_namespace_exactly_at_the_byte_cap_is_accepted(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # Cap check is strict greater-than, so a write that lands exactly on
+    # state_max_namespace_bytes must still succeed. Two 50-byte JSON strings
+    # fill a 100-byte namespace with no slack.
+    from curie_api.config import get_settings
+
+    aid = _agent(client, auth_headers)
+    base = f"/agents/{aid}/state/exact-cap"
+    fifty = "x" * 48
+    assert _json_size(fifty) == 50
+    get_settings().state_max_namespace_bytes = 100
+    try:
+        a = client.put(f"{base}/a", json={"value": fifty}, headers=auth_headers)
+        assert a.status_code == 200, a.text
+        b = client.put(f"{base}/b", json={"value": fifty}, headers=auth_headers)
+        assert b.status_code == 200, b.text
+        assert b.json()["value"] == fifty
+    finally:
+        get_settings.cache_clear()
+
+
+def test_namespace_one_byte_over_the_byte_cap_is_rejected(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # One extra serialized byte past the same 100-byte cap must 413, and the
+    # message text is the load-bearing operator string (do not reword it).
+    from curie_api.config import get_settings
+
+    aid = _agent(client, auth_headers)
+    base = f"/agents/{aid}/state/over-cap"
+    get_settings().state_max_namespace_bytes = 100
+    try:
+        a = client.put(f"{base}/a", json={"value": "x" * 48}, headers=auth_headers)
+        assert a.status_code == 200, a.text
+        b = client.put(f"{base}/b", json={"value": "x" * 49}, headers=auth_headers)
+        assert b.status_code == 413, b.text
+        assert "would be 101 bytes" in b.text
+        assert "100-byte per-namespace cap" in b.text
+    finally:
+        get_settings.cache_clear()
+
+
+def test_sql_text_bound_over_cap_falls_back_to_exact_size(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """JSONB ::text is an upper bound, not the cap unit.
+
+    Postgres renders object whitespace (`{"k": 1}`) that compact json.dumps
+    does not (`{"k":1}`). A namespace of those objects can have
+    sum(octet_length(value::text)) over the cap while the exact Python size
+    is still under it. That write must be accepted; using the SQL bound as
+    the verdict (removing the exact fallback) 413s it.
+    """
+    from curie_api.config import get_settings
+
+    aid = _agent(client, auth_headers)
+    namespace = "sql-bound-slack"
+    base = f"/agents/{aid}/state/{namespace}"
+    obj = {"k": 1}
+    exact_each = _json_size(obj)
+    cap = 50
+    incoming = obj
+    get_settings().state_max_namespace_bytes = cap
+    try:
+        for i in range(6):
+            r = client.put(f"{base}/s{i}", json={"value": obj}, headers=auth_headers)
+            assert r.status_code == 200, r.text
+
+        sibling_exact, sibling_sql = asyncio.run(
+            _namespace_sibling_sizes(namespace, exclude_key="s6")
+        )
+        incoming_size = _json_size(incoming)
+        assert sibling_exact + incoming_size <= cap, (
+            f"exact total {sibling_exact + incoming_size} must be at or under the cap"
+        )
+        assert sibling_sql + incoming_size > cap, (
+            f"SQL text bound {sibling_sql + incoming_size} must exceed the cap so "
+            "this test fails if the exact fallback is removed; each="
+            f"{exact_each} sql_siblings={sibling_sql}"
+        )
+
+        accepted = client.put(f"{base}/s6", json={"value": incoming}, headers=auth_headers)
+        assert accepted.status_code == 200, accepted.text
+        assert accepted.json()["value"] == incoming
+    finally:
+        get_settings.cache_clear()
+
+
+def test_multibyte_sibling_still_uses_exact_json_dumps_bytes(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """Postgres jsonb::text is UTF-8; compact json.dumps is ensure_ascii.
+
+    A sibling of three 'é' characters is 8 bytes as jsonb::text but 20 bytes
+    as json.dumps. Treating the SQL sum as the verdict would accept a follow-on
+    write that is actually over the cap. Exact semantics must still 413.
+    """
+    from curie_api.config import get_settings
+
+    aid = _agent(client, auth_headers)
+    namespace = "unicode-bound"
+    base = f"/agents/{aid}/state/{namespace}"
+    sibling = "é" * 3
+    incoming = "a"
+    cap = 20
+    assert _json_size(sibling) == 20
+    assert _json_size(incoming) == 3
+    get_settings().state_max_namespace_bytes = cap
+    try:
+        first = client.put(f"{base}/u0", json={"value": sibling}, headers=auth_headers)
+        assert first.status_code == 200, first.text
+        sibling_exact, sibling_sql = asyncio.run(
+            _namespace_sibling_sizes(namespace, exclude_key="u1")
+        )
+        assert sibling_exact == 20, sibling_exact
+        assert sibling_sql < cap, sibling_sql
+        assert sibling_sql + _json_size(incoming) <= cap
+        assert sibling_exact + _json_size(incoming) > cap
+        refused = client.put(f"{base}/u1", json={"value": incoming}, headers=auth_headers)
+        assert refused.status_code == 413, refused.text
+        assert "100-byte per-namespace cap" not in refused.text
+        assert "20-byte per-namespace cap" in refused.text
+        assert "would be 23 bytes" in refused.text
+    finally:
+        get_settings.cache_clear()
+
+
+def test_under_namespace_cap_does_not_reserialize_sibling_values(
+    client: Any, auth_headers: dict[str, str], clean_db: None, monkeypatch: Any
+) -> None:
+    # Common-case O(1) wire: when the SQL upper bound of sibling jsonb::text
+    # plus the incoming value is under the namespace cap, _enforce_caps must
+    # not json.dumps the sibling values. Pre-change this is RED because every
+    # write fetches and re-serializes every other key.
+    import curie_api.routers.state as state_mod
+
+    aid = _agent(client, auth_headers)
+    base = f"/agents/{aid}/state/hot-path"
+    for i in range(4):
+        r = client.put(f"{base}/k{i}", json={"value": {"n": i}}, headers=auth_headers)
+        assert r.status_code == 200, r.text
+
+    calls: list[Any] = []
+    original = state_mod._json_size
+
+    def _spy(value: Any) -> int:
+        calls.append(value)
+        return original(value)
+
+    monkeypatch.setattr(state_mod, "_json_size", _spy)
+    incoming = {"n": 4}
+    r = client.put(f"{base}/k4", json={"value": incoming}, headers=auth_headers)
+    assert r.status_code == 200, r.text
+    assert calls == [incoming], calls
+
+
+async def _namespace_sibling_sizes(namespace: str, exclude_key: str) -> tuple[int, int]:
+    """Exact compact-json bytes vs Postgres jsonb::text bytes for siblings."""
+    connection = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        rows = await connection.fetch(
+            """
+            SELECT value
+            FROM curie.workflow_state_entries
+            WHERE namespace = $1 AND key <> $2
+            """,
+            namespace,
+            exclude_key,
+        )
+        sql_bound = await connection.fetchval(
+            """
+            SELECT COALESCE(SUM(octet_length(value::text)), 0)
+            FROM curie.workflow_state_entries
+            WHERE namespace = $1 AND key <> $2
+            """,
+            namespace,
+            exclude_key,
+        )
+    finally:
+        await connection.close()
+    exact = 0
+    for row in rows:
+        raw = row["value"]
+        value = json.loads(raw) if isinstance(raw, (str, bytes, bytearray)) else raw
+        exact += _json_size(value)
+    return exact, int(sql_bound)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("CURIE_STATE_CAP_BENCH"),
+    reason="opt-in namespace-cap microbenchmark; set CURIE_STATE_CAP_BENCH=1",
+)
+def test_namespace_cap_write_p50_and_payload_bytes(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """Record p50 PUT latency and cap-check payload bytes at 16 x 64 KiB.
+
+    Not a CI gate: it prints one STATE_CAP_BENCH JSON line for the PR body.
+    `legacy_sibling_json_bytes` is what the old path transferred (every sibling
+    jsonb::text). `sql_bound_result_bytes` is what the SQL SUM path returns.
+    """
+    aid = _agent(client, auth_headers)
+    namespace = "bench-ns"
+    base = f"/agents/{aid}/state/{namespace}"
+    value_bytes = 64 * 1024
+    payload = "x" * (value_bytes - 2)
+    assert _json_size(payload) == value_bytes
+    n_keys = 16
+    for i in range(n_keys):
+        r = client.put(f"{base}/k{i:02d}", json={"value": payload}, headers=auth_headers)
+        assert r.status_code == 200, r.text
+
+    sibling_json_bytes, bound_result_bytes = asyncio.run(
+        _cap_check_payload_bytes(namespace, exclude_key="k00")
+    )
+    samples: list[float] = []
+    iterations = 30
+    for _ in range(iterations):
+        started = time.perf_counter()
+        r = client.put(f"{base}/k00", json={"value": payload}, headers=auth_headers)
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        assert r.status_code == 200, r.text
+        samples.append(elapsed_ms)
+    samples.sort()
+    p50 = samples[len(samples) // 2]
+    report = {
+        "p50_ms": round(p50, 3),
+        "samples_ms": [round(s, 3) for s in samples],
+        "iterations": iterations,
+        "keys": n_keys,
+        "value_bytes": value_bytes,
+        "legacy_sibling_json_bytes": sibling_json_bytes,
+        "sql_bound_result_bytes": bound_result_bytes,
+    }
+    print(f"STATE_CAP_BENCH {json.dumps(report)}", flush=True)
+    assert sibling_json_bytes >= (n_keys - 1) * value_bytes
+    assert bound_result_bytes > 0
+    assert bound_result_bytes < sibling_json_bytes
+
+
+async def _cap_check_payload_bytes(namespace: str, exclude_key: str) -> tuple[int, int]:
+    connection = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        sibling_json_bytes = await connection.fetchval(
+            """
+            SELECT COALESCE(SUM(octet_length(value::text)), 0)::bigint
+            FROM curie.workflow_state_entries
+            WHERE namespace = $1 AND key <> $2
+            """,
+            namespace,
+            exclude_key,
+        )
+        bound_result_bytes = await connection.fetchval(
+            """
+            SELECT pg_column_size(
+                COALESCE(SUM(octet_length(value::text)), 0)
+            )
+            FROM curie.workflow_state_entries
+            WHERE namespace = $1 AND key <> $2
+            """,
+            namespace,
+            exclude_key,
+        )
+    finally:
+        await connection.close()
+    return int(sibling_json_bytes), int(bound_result_bytes)
 
 
 def test_namespace_count_over_the_per_agent_cap_is_rejected(


### PR DESCRIPTION
## Summary

State writes were paying a full sibling-value fetch on every PUT: `_enforce_caps` selected every other JSONB value in the namespace, the ORM decoded it, and the handler `json.dumps`ed each value again to sum compact-JSON bytes. At a full 1 MiB namespace (16 values of 64 KiB) that is about 1 MiB of Postgres traffic plus event-loop CPU on the per-turn path (runner transcript and memory writes). This change keeps the cap unit as compact `json.dumps` byte length, but first asks Postgres for `sum(octet_length(value::text))` and only loads sibling values when that bound exceeds `state_max_namespace_bytes` or a sibling is non-ASCII (jsonb UTF-8 can be shorter than `ensure_ascii` dumps, so the SQL sum is not a safe exact verdict on its own).

## Related issue

No GitHub issue. Found by the 2026-09 performance review of origin/main 39a57886.

## Fix pin verification

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin or skill packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | required | PUT `/agents/{id}/state/...` and memory writers share `_enforce_caps` on the compose API. | fake | `uv run pytest -q apps/api/tests/test_state.py apps/api/tests/test_memory.py` against compose.dev.yaml (COMPOSE_PROJECT_NAME=curie-perf-api-state-cap) at ed58356d: 61 passed, 1 skipped. Focused cap tests including exact-at-cap 200, one-over 413, SQL-bound-over-exact 200, unicode sibling 413, and no sibling `_json_size` on the under-cap path: 10 passed. |
| local-release | n/a | Does not change released binary identity, install path, version pins, or release compose. | | |
| cluster | n/a | Does not reach chart templates, RBAC, sandbox claims, or init containers. | | |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, or the MCP/workspace/coding-tool path set. | | |
| external integration | n/a | Does not reach Slack, git push webhooks, connector OAuth, or any third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

### Benchmark (16 values of 64 KiB)

Command (from the worktree, compose stack up):

```
CURIE_STATE_CAP_BENCH=1 uv run pytest -q apps/api/tests/test_state.py::test_namespace_cap_write_p50_and_payload_bytes -s
```

Before (origin/main `_enforce_caps` still fetching sibling JSONB):

`STATE_CAP_BENCH {"p50_ms": 16.912, "iterations": 30, "keys": 16, "value_bytes": 65536, "legacy_sibling_json_bytes": 983040, "sql_bound_result_bytes": 8}`

After (ed58356d):

`STATE_CAP_BENCH {"p50_ms": 24.789, "iterations": 30, "keys": 16, "value_bytes": 65536, "legacy_sibling_json_bytes": 983040, "sql_bound_result_bytes": 8}`

The cap-check payload on the wire drops from 983040 sibling JSON bytes to an 8-byte aggregate. Wall-clock p50 of the full PUT at this worst-case fill did not improve: proving the bound still renders `jsonb::text` in Postgres, and the conservative non-ASCII scan (needed so UTF-8 jsonb text cannot accept a write that compact `json.dumps` would reject) walks that same 1 MiB of text. The event loop no longer decodes or re-serializes the sibling values.

### Conservative default

`octet_length(value::text)` is an upper bound of compact `json.dumps` for ASCII JSON (Postgres inserts spaces in objects). It is not an upper bound for non-ASCII: `"é"*3` is 8 bytes as jsonb text and 20 bytes as `json.dumps`. When any sibling has `octet_length <> length`, the handler falls back to the exact Python sum. `test_multibyte_sibling_still_uses_exact_json_dumps_bytes` pins that 413.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed. Observable accept/reject behavior is unchanged; no doc change.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. Not an ADR; same cap semantics, cheaper check.
