### PR TITLE
Pin bundle-fetch images on the runner-prewarm DaemonSet

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -437,6 +437,16 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/sandbox-emptydir-sizelimit-assertions.sh
 
+      # Prove every bundle-fetch init image rendered on the SandboxTemplate is
+      # also a container image on the runner-prewarm DaemonSet, so a fresh or
+      # image-GCed node cannot cold-pull amazon/aws-cli (~418MB) inside the
+      # 90s claim window. Compares the two rendered objects; a sandbox image
+      # with no matching prewarm container fails.
+      - name: helm render assertions (prewarm bundle-fetch images)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/prewarm-bundle-fetch-assertions.sh
+
       # Prove the dispatcher is told where the platform API is and how to
       # authenticate to it (issue #442), and that the UI's CURIE_API_TARGET
       # uses the same helper (issue #2316). Unwired, the dispatcher falls back

--- a/charts/curie/CLAUDE.md
+++ b/charts/curie/CLAUDE.md
@@ -213,8 +213,12 @@ component and rail detail in `charts/curie/README.md`.
   worker's claim timeout (live incident 2026-07-06). The runner-prewarm
   DaemonSet (`agentSandbox.runner.prewarm`) pulls the runner image at
   install/upgrade instead, and every `helm upgrade` rolls it to refresh the
-  cache. Do not flip the runner to `Always` and do not disable the prewarm
-  on `:latest`-tag clusters without accepting stale-image risk.
+  cache. When `bundleFetch.enabled` is true it also pulls
+  `agentSandbox.runner.bundleFetch.fetchImage` and `extractImage` (the sandbox
+  init pair, default `amazon/aws-cli` ~418MB plus busybox) so those are not
+  a first-claim cold pull either. Do not flip the runner to `Always` and do
+  not disable the prewarm on `:latest`-tag clusters without accepting
+  stale-image risk.
 - **`values.schema.json` is deliberately permissive, not a full contract.**
   The chart had no values schema at all before issue #1388; Helm now
   validates the ENTIRE coalesced values tree against `values.schema.json`

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -463,7 +463,9 @@ fact about the release artifacts, not about what this chart resolves to.
   which pulls the runner image `Always` and keeps that same `appVersion` ref
   pinned on every node; a Release-revision annotation rolls those pods on every
   `helm upgrade` so an upgraded chart's new `appVersion` is pulled before the
-  next claim.
+  next claim. When `agentSandbox.runner.bundleFetch.enabled` is true the same
+  DaemonSet also pins `fetchImage` and `extractImage` (default `amazon/aws-cli`
+  and busybox) so the bundle-fetch init pair is not a first-claim cold pull.
 - **Override `tag` (or set `digest`)** to pin an explicit version. Empty `tag`
   is the default and resolves to `.Chart.AppVersion`; `digest` wins over `tag`
   when set.
@@ -1210,7 +1212,8 @@ to install only the control plane + backing stores without the runner substrate.
 - **Runner image**: the pool runs `curie-runner`, defaulting to
   `ghcr.io/curie-eng/curie-runner:<appVersion>` with `imagePullPolicy: IfNotPresent`
   (per-thread cold boots must not contain a pull; the `runner-prewarm` DaemonSet
-  keeps the image on every node -- see "Publishing and pulling images").
+  keeps the runner image and, when bundle-fetch is enabled, the bundle-fetch
+  init images on every node -- see "Publishing and pulling images").
   For offline
   dev/e2e, `-f values-dev.yaml` overrides it to a locally-built, cluster-imported
   tag with `imagePullPolicy: Never` (`docker build -f runner/Dockerfile -t

--- a/charts/curie/ci/prewarm-bundle-fetch-assertions.sh
+++ b/charts/curie/ci/prewarm-bundle-fetch-assertions.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+#
+# Render-assertion: every bundle-fetch init image on the SandboxTemplate is a
+# container image on the runner-prewarm DaemonSet.
+#
+# A sandbox pod is cold-created per thread. The runner image is IfNotPresent
+# plus this DaemonSet so a ~380MB pull cannot land inside the 90s claim window
+# (live incident 2026-07-06). The same window also runs the bundle-fetch and
+# bundle-extract init containers, whose default fetchImage is ~418MB. If those
+# images are rendered on the sandbox and absent from the prewarm DaemonSet, a
+# fresh or image-GCed node cold-pulls them on the first claim -- the same
+# hazard, a different image.
+#
+# The two sides share agentSandbox.runner.bundleFetch.fetchImage and
+# extractImage (values, not hardcoded refs). Extra prewarm containers render
+# only while agentSandbox.deploy, runner.prewarm.enabled, and
+# bundleFetch.enabled are all true.
+#
+# Proves:
+#   (a) Default values: SandboxTemplate init containers bundle-fetch and
+#       bundle-extract carry the values.yaml fetchImage and extractImage.
+#   (b) Default values: those same images are container images on the
+#       runner-prewarm DaemonSet (one sleep container per image).
+#   (c) Cross-object invariant: every bundle-fetch / bundle-extract init image
+#       on the SandboxTemplate is in the prewarm DaemonSet container image
+#       set. Compares the two rendered objects, not a value against itself.
+#   (d) Overriding fetchImage / extractImage propagates to BOTH the sandbox
+#       init pair AND the prewarm DaemonSet.
+#   (e) bundleFetch.enabled=false omits the init pair from the sandbox AND
+#       omits those extra sleep containers from the prewarm DaemonSet.
+#   (f) NEGATIVE: a rendered prewarm DaemonSet that drops any sandbox
+#       bundle-fetch image fails the same checker the default render uses.
+#
+# Runnable locally (from anywhere) and from CI. Fails loudly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+SANDBOX_TPL=templates/agent-sandbox.yaml
+PREWARM_TPL=templates/runner-prewarm.yaml
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+CHECKER="$TMP/check.py"
+cat >"$CHECKER" <<'PY'
+import sys
+import yaml
+
+BUNDLE_INIT_NAMES = ("bundle-fetch", "bundle-extract")
+
+
+def load_docs(path):
+    docs = []
+    with open(path) as fh:
+        for doc in yaml.safe_load_all(fh):
+            if doc:
+                docs.append(doc)
+    return docs
+
+
+def find_kind(docs, kind):
+    for doc in docs:
+        if doc.get("kind") == kind:
+            return doc
+    return None
+
+
+def sandbox_bundle_images(docs):
+    tmpl = find_kind(docs, "SandboxTemplate")
+    if tmpl is None:
+        raise SystemExit("no SandboxTemplate rendered")
+    spec = tmpl["spec"]["podTemplate"]["spec"]
+    images = []
+    for container in spec.get("initContainers") or []:
+        if container.get("name") in BUNDLE_INIT_NAMES:
+            image = container.get("image")
+            if not image:
+                raise SystemExit(
+                    f"SandboxTemplate init container {container.get('name')!r} "
+                    "has an empty image"
+                )
+            images.append((container["name"], image))
+    return images
+
+
+def prewarm_containers(docs):
+    ds = find_kind(docs, "DaemonSet")
+    if ds is None:
+        return None
+    spec = ds["spec"]["template"]["spec"]
+    containers = spec.get("containers") or []
+    if not containers:
+        raise SystemExit("runner-prewarm DaemonSet has no containers")
+    return containers
+
+
+def missing_from_prewarm(bundle_images, containers):
+    present = {c.get("image") for c in containers}
+    missing = []
+    for name, image in bundle_images:
+        if image not in present:
+            missing.append((name, image))
+    return missing, present
+
+
+def require_covered(label, bundle_images, containers):
+    if containers is None:
+        raise SystemExit(
+            f"{label}: SandboxTemplate renders bundle-fetch images "
+            f"{[i for _, i in bundle_images]} but the runner-prewarm "
+            "DaemonSet did not render"
+        )
+    missing, present = missing_from_prewarm(bundle_images, containers)
+    if missing:
+        detail = ", ".join(f"{name}={image}" for name, image in missing)
+        raise SystemExit(
+            f"{label}: bundle-fetch init image(s) rendered on the "
+            f"SandboxTemplate but absent from the runner-prewarm "
+            f"DaemonSet: {detail}. prewarm images={sorted(present)}"
+        )
+    print(
+        f"  ok: {label}: {len(bundle_images)} sandbox bundle-fetch "
+        f"image(s) present on the prewarm DaemonSet"
+    )
+
+
+def main(argv):
+    mode = argv[1]
+    if mode == "covered":
+        sandbox_docs = load_docs(argv[2])
+        prewarm_docs = load_docs(argv[3])
+        bundle_images = sandbox_bundle_images(sandbox_docs)
+        if not bundle_images:
+            raise SystemExit(
+                "covered: expected bundle-fetch init containers on the "
+                "SandboxTemplate, found none"
+            )
+        require_covered("default" if len(argv) < 5 else argv[4], bundle_images, prewarm_containers(prewarm_docs))
+        return
+    if mode == "absent":
+        sandbox_docs = load_docs(argv[2])
+        prewarm_docs = load_docs(argv[3])
+        bundle_images = sandbox_bundle_images(sandbox_docs)
+        if bundle_images:
+            raise SystemExit(
+                "absent: SandboxTemplate still renders bundle-fetch init "
+                f"containers {bundle_images} with bundleFetch.enabled=false"
+            )
+        containers = prewarm_containers(prewarm_docs)
+        if containers is None:
+            raise SystemExit("absent: runner-prewarm DaemonSet did not render")
+        extra = [c["name"] for c in containers if c.get("name") != "prewarm"]
+        if extra:
+            raise SystemExit(
+                "absent: prewarm DaemonSet still has extra containers "
+                f"{extra} with bundleFetch.enabled=false"
+            )
+        print("  ok: bundleFetch.enabled=false omits extra prewarm containers")
+        return
+    if mode == "mutant-missing":
+        sandbox_docs = load_docs(argv[2])
+        prewarm_docs = load_docs(argv[3])
+        bundle_images = sandbox_bundle_images(sandbox_docs)
+        containers = prewarm_containers(prewarm_docs)
+        if containers is None:
+            raise SystemExit("mutant-missing: prewarm DaemonSet did not render")
+        drop = {image for _, image in bundle_images}
+        stripped = [c for c in containers if c.get("image") not in drop]
+        missing, _present = missing_from_prewarm(bundle_images, stripped)
+        if not missing:
+            raise SystemExit(
+                "mutant-missing: stripping sandbox bundle-fetch images "
+                "from the prewarm DaemonSet did not produce a gap; the "
+                "checker would not catch a missing prewarm container"
+            )
+        print(
+            "  ok: mutant with sandbox bundle-fetch images dropped from "
+            "prewarm is rejected"
+        )
+        return
+    raise SystemExit(f"unknown mode {mode!r}")
+
+
+if __name__ == "__main__":
+    main(sys.argv)
+PY
+
+echo "=== (a) default sandbox init images match values.yaml ==="
+helm template rel "$CHART" --show-only "$SANDBOX_TPL" > "$TMP/default-sandbox.yaml"
+helm template rel "$CHART" --show-only "$PREWARM_TPL" > "$TMP/default-prewarm.yaml"
+
+python3 - "$CHART/values.yaml" "$TMP/default-sandbox.yaml" <<'PY' || fail "default sandbox init images did not match values.yaml"
+import sys, yaml
+
+values = yaml.safe_load(open(sys.argv[1]))
+bf = values["agentSandbox"]["runner"]["bundleFetch"]
+expected = {
+    "bundle-fetch": bf["fetchImage"],
+    "bundle-extract": bf["extractImage"],
+}
+
+docs = [d for d in yaml.safe_load_all(open(sys.argv[2])) if d]
+tmpl = next(d for d in docs if d.get("kind") == "SandboxTemplate")
+inits = {
+    c["name"]: c.get("image")
+    for c in (tmpl["spec"]["podTemplate"]["spec"].get("initContainers") or [])
+    if c.get("name") in expected
+}
+missing = set(expected) - set(inits)
+if missing:
+    raise SystemExit(f"sandbox missing init containers {sorted(missing)}")
+for name, image in expected.items():
+    if inits[name] != image:
+        raise SystemExit(
+            f"{name}: sandbox image {inits[name]!r} != values {image!r}"
+        )
+print(f"  ok: bundle-fetch={expected['bundle-fetch']}")
+print(f"  ok: bundle-extract={expected['bundle-extract']}")
+PY
+
+echo "=== (b/c) default prewarm DaemonSet covers those sandbox images ==="
+python3 "$CHECKER" covered "$TMP/default-sandbox.yaml" "$TMP/default-prewarm.yaml" "default" \
+  || fail "default render: a bundle-fetch image is on the sandbox and absent from prewarm"
+
+python3 - "$TMP/default-sandbox.yaml" "$TMP/default-prewarm.yaml" <<'PY' || fail "default prewarm extra containers are not sleep-infinity sidecars with the sandbox init pull policy"
+import sys, yaml
+
+def docs(path):
+    return [d for d in yaml.safe_load_all(open(path)) if d]
+
+sandbox = next(d for d in docs(sys.argv[1]) if d.get("kind") == "SandboxTemplate")
+ds = next(d for d in docs(sys.argv[2]) if d.get("kind") == "DaemonSet")
+inits = {
+    c["name"]: c
+    for c in sandbox["spec"]["podTemplate"]["spec"].get("initContainers") or []
+}
+init_policy = inits["bundle-fetch"].get("imagePullPolicy")
+if init_policy != inits["bundle-extract"].get("imagePullPolicy"):
+    raise SystemExit("sandbox bundle-fetch and bundle-extract pull policies differ")
+containers = ds["spec"]["template"]["spec"]["containers"]
+names = [c["name"] for c in containers]
+if "prewarm" not in names:
+    raise SystemExit(f"runner prewarm container missing; got {names}")
+extras = [c for c in containers if c["name"] != "prewarm"]
+if len(extras) != 2:
+    raise SystemExit(
+        f"expected two extra prewarm containers (fetch + extract), got {names}"
+    )
+expected_names = {"prewarm-bundle-fetch", "prewarm-bundle-extract"}
+got_names = {c["name"] for c in extras}
+if got_names != expected_names:
+    raise SystemExit(f"extra prewarm container names {got_names} != {expected_names}")
+for c in extras:
+    if c.get("command") != ["sleep", "infinity"]:
+        raise SystemExit(
+            f"{c['name']}: command {c.get('command')!r} != ['sleep', 'infinity']"
+        )
+    if c.get("imagePullPolicy") != init_policy:
+        raise SystemExit(
+            f"{c['name']}: imagePullPolicy {c.get('imagePullPolicy')!r} != "
+            f"sandbox init {init_policy!r}"
+        )
+print(f"  ok: extra sleep containers {sorted(got_names)} policy={init_policy}")
+PY
+
+echo "=== (d) fetchImage/extractImage override reaches sandbox AND prewarm ==="
+helm template rel "$CHART" --show-only "$SANDBOX_TPL" \
+  --set agentSandbox.runner.bundleFetch.fetchImage=example.com/fetch:1.2.3 \
+  --set agentSandbox.runner.bundleFetch.extractImage=example.com/extract:4.5.6 \
+  > "$TMP/override-sandbox.yaml"
+helm template rel "$CHART" --show-only "$PREWARM_TPL" \
+  --set agentSandbox.runner.bundleFetch.fetchImage=example.com/fetch:1.2.3 \
+  --set agentSandbox.runner.bundleFetch.extractImage=example.com/extract:4.5.6 \
+  > "$TMP/override-prewarm.yaml"
+python3 "$CHECKER" covered "$TMP/override-sandbox.yaml" "$TMP/override-prewarm.yaml" "override" \
+  || fail "override: sandbox bundle-fetch images not covered by prewarm"
+python3 - "$TMP/override-sandbox.yaml" "$TMP/override-prewarm.yaml" <<'PY' || fail "override did not propagate both image refs"
+import sys, yaml
+
+def docs(path):
+    return [d for d in yaml.safe_load_all(open(path)) if d]
+
+sandbox = next(d for d in docs(sys.argv[1]) if d.get("kind") == "SandboxTemplate")
+prewarm = next(d for d in docs(sys.argv[2]) if d.get("kind") == "DaemonSet")
+inits = {
+    c["name"]: c["image"]
+    for c in sandbox["spec"]["podTemplate"]["spec"].get("initContainers") or []
+}
+images = {c["image"] for c in prewarm["spec"]["template"]["spec"]["containers"]}
+if inits.get("bundle-fetch") != "example.com/fetch:1.2.3":
+    raise SystemExit(f"sandbox fetch {inits.get('bundle-fetch')!r}")
+if inits.get("bundle-extract") != "example.com/extract:4.5.6":
+    raise SystemExit(f"sandbox extract {inits.get('bundle-extract')!r}")
+if "example.com/fetch:1.2.3" not in images:
+    raise SystemExit(f"prewarm missing overridden fetchImage; images={sorted(images)}")
+if "example.com/extract:4.5.6" not in images:
+    raise SystemExit(f"prewarm missing overridden extractImage; images={sorted(images)}")
+print("  ok: override reached sandbox init containers and prewarm DaemonSet")
+PY
+
+echo "=== (e) bundleFetch.enabled=false omits extra prewarm containers ==="
+helm template rel "$CHART" --show-only "$SANDBOX_TPL" \
+  --set agentSandbox.runner.bundleFetch.enabled=false \
+  > "$TMP/disabled-sandbox.yaml"
+helm template rel "$CHART" --show-only "$PREWARM_TPL" \
+  --set agentSandbox.runner.bundleFetch.enabled=false \
+  > "$TMP/disabled-prewarm.yaml"
+python3 "$CHECKER" absent "$TMP/disabled-sandbox.yaml" "$TMP/disabled-prewarm.yaml" \
+  || fail "bundleFetch.enabled=false still prewarms or still renders the init pair"
+
+echo "=== (f) NEGATIVE: dropping sandbox bundle-fetch images from prewarm fails ==="
+python3 "$CHECKER" mutant-missing "$TMP/default-sandbox.yaml" "$TMP/default-prewarm.yaml" \
+  || fail "mutant-missing checker did not reject a prewarm gap"
+
+echo "=== (g) prewarm.imagePullPolicy=Never still leaves extras on the sandbox init policy ==="
+helm template rel "$CHART" --show-only "$SANDBOX_TPL" \
+  --set agentSandbox.runner.prewarm.imagePullPolicy=Never \
+  > "$TMP/never-sandbox.yaml"
+helm template rel "$CHART" --show-only "$PREWARM_TPL" \
+  --set agentSandbox.runner.prewarm.imagePullPolicy=Never \
+  > "$TMP/never-prewarm.yaml"
+python3 "$CHECKER" covered "$TMP/never-sandbox.yaml" "$TMP/never-prewarm.yaml" "never-prewarm" \
+  || fail "Never override: sandbox bundle-fetch images not covered by prewarm"
+python3 - "$TMP/never-sandbox.yaml" "$TMP/never-prewarm.yaml" <<'PY' || fail "Never override applied the runner-import policy to bundle-fetch images"
+import sys, yaml
+
+def docs(path):
+    return [d for d in yaml.safe_load_all(open(path)) if d]
+
+sandbox = next(d for d in docs(sys.argv[1]) if d.get("kind") == "SandboxTemplate")
+ds = next(d for d in docs(sys.argv[2]) if d.get("kind") == "DaemonSet")
+inits = {
+    c["name"]: c
+    for c in sandbox["spec"]["podTemplate"]["spec"].get("initContainers") or []
+}
+init_policy = inits["bundle-fetch"].get("imagePullPolicy")
+by_name = {c["name"]: c for c in ds["spec"]["template"]["spec"]["containers"]}
+runner = by_name.get("prewarm")
+if runner is None:
+    raise SystemExit("runner prewarm container missing under Never override")
+if runner.get("imagePullPolicy") != "Never":
+    raise SystemExit(
+        f"runner prewarm imagePullPolicy {runner.get('imagePullPolicy')!r} != Never"
+    )
+for name in ("prewarm-bundle-fetch", "prewarm-bundle-extract"):
+    extra = by_name.get(name)
+    if extra is None:
+        raise SystemExit(f"{name} missing under Never override")
+    if extra.get("imagePullPolicy") != init_policy:
+        raise SystemExit(
+            f"{name}: imagePullPolicy {extra.get('imagePullPolicy')!r} != "
+            f"sandbox init {init_policy!r} (cluster CI sets prewarm Never for "
+            "an imported runner; extras must still be pullable)"
+        )
+    if extra.get("imagePullPolicy") == "Never":
+        raise SystemExit(
+            f"{name} inherited Never; aws-cli/busybox are not kind-loaded"
+        )
+print(
+    f"  ok: runner policy=Never; extras policy={init_policy} matching sandbox init"
+)
+PY
+
+echo
+echo "PASS: every SandboxTemplate bundle-fetch init image is a container image on the runner-prewarm DaemonSet; an override hits both sides; bundleFetch.enabled=false omits the extra containers; a missing prewarm image is refused; extras keep the sandbox init pull policy when prewarm.imagePullPolicy=Never."
+

--- a/charts/curie/templates/runner-prewarm.yaml
+++ b/charts/curie/templates/runner-prewarm.yaml
@@ -8,11 +8,20 @@ per-thread boot window, which once blew past the worker's 90s claim timeout and
 killed the run. This DaemonSet keeps that image pulled and pinned on every node
 so those cold boots bind an already-present image instantly.
 
+The same window runs the bundle-fetch and bundle-extract init containers
+(agentSandbox.runner.bundleFetch.fetchImage / extractImage). Those refs are
+IfNotPresent on the claim path (global.imagePullPolicy) and are not the runner
+image, so a DaemonSet that pins only curie-runner still leaves a fresh or
+image-GCed node to cold-pull ~418MB of amazon/aws-cli on the first claim. When
+bundleFetch.enabled is true this DaemonSet therefore also sleeps one extra
+container per bundle-fetch image, sourced from the same values keys the
+sandbox init pair uses.
+
 It is a long-idle DaemonSet, not a one-shot Job, on purpose:
   - DaemonSet covers every node (single-node clusters get exactly one pod).
   - The kubelet treats the image as in-use, so image GC never evicts it between
     threads.
-  - The container just `sleep infinity`s at near-zero cost -- the pinned image is
+  - Each container just `sleep infinity`s at near-zero cost -- the pinned image is
     the point, not the process.
 
 ROLL-TO-REFRESH: with a mutable `latest` tag the pod spec does not change when
@@ -72,4 +81,29 @@ spec:
           command: ["sleep", "infinity"]
           resources:
             {{- toYaml $runner.prewarm.resources | nindent 12 }}
+        {{- if $runner.bundleFetch.enabled }}
+        # Same values keys as the sandbox init pair in agent-sandbox.yaml -- a
+        # hardcoded ref here would drift from the claim path the first time an
+        # operator overrides fetchImage or extractImage.
+        #
+        # Pull policy is global.imagePullPolicy (IfNotPresent), NOT
+        # prewarm.imagePullPolicy. Cluster CI and the kind/k3s import path set
+        # the latter to Never and only kind-load first-party images; applying
+        # Never here would ErrImageNeverPull amazon/aws-cli and busybox and
+        # the DaemonSet would never become Ready. IfNotPresent still pulls
+        # those registry images on a fresh node (the point of this sidecar)
+        # without re-pulling ~418MB on every helm upgrade roll.
+        - name: prewarm-bundle-fetch
+          image: {{ $runner.bundleFetch.fetchImage | quote }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          command: ["sleep", "infinity"]
+          resources:
+            {{- toYaml $runner.prewarm.resources | nindent 12 }}
+        - name: prewarm-bundle-extract
+          image: {{ $runner.bundleFetch.extractImage | quote }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          command: ["sleep", "infinity"]
+          resources:
+            {{- toYaml $runner.prewarm.resources | nindent 12 }}
+        {{- end }}
 {{- end }}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -2001,11 +2001,14 @@ agentSandbox:
     # Runner-image prewarm DaemonSet. Keeps this image pulled and pinned on every
     # node so per-thread sandbox cold boots (imagePullPolicy IfNotPresent above)
     # bind an already-present image instead of downloading it inside the claim
-    # window. Rendered only while the sandbox substrate is deployed
+    # window. When bundleFetch.enabled is true it also pins fetchImage and
+    # extractImage (one extra sleep container each, same values keys the sandbox
+    # init pair uses) so a fresh node does not cold-pull ~418MB of aws-cli inside
+    # that same window. Rendered only while the sandbox substrate is deployed
     # (agentSandbox.deploy). Each `helm upgrade` rolls the pods (a Release-revision
     # annotation on the pod template) so the DaemonSet's `Always` pull refreshes a
     # churned `latest` -- a plain DaemonSet would not re-pull on a digest-only
-    # change since its pod spec is unchanged. Tiny idle container (sleep infinity);
+    # change since its pod spec is unchanged. Tiny idle containers (sleep infinity);
     # the point is the pinned image, not the process.
     prewarm:
       enabled: true
@@ -2095,6 +2098,11 @@ agentSandbox:
     bundleFetch:
       enabled: true
       bucket: curie-bundles
+      # Also pinned on every node by the runner-prewarm DaemonSet (one sleep
+      # container per image) so the first claim does not cold-pull these inside
+      # the 90s window. Changing a ref here must change both the sandbox init
+      # pair and the prewarm DaemonSet; ci/prewarm-bundle-fetch-assertions.sh
+      # compares the two rendered objects.
       fetchImage: amazon/aws-cli:2.32.6
       extractImage: busybox:1.36.1
       # Shared bundle volume mount point in the sandbox pod. The plugin dir the

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -4464,11 +4464,7 @@ PY
             echo "local task image is missing for cluster identity preflight" >&2
             return 1
         }
-        python3 - "$runtime_id" "$local_id" <<'PY' || {
-            rm -f "$inventory"
-            echo "cluster product imageID mismatch for $component" >&2
-            return 1
-        }
+        if ! python3 - "$runtime_id" "$local_id" <<'PY'
 import re, sys
 def digest(value):
     matches = re.findall(r"sha256:[0-9a-f]{64}", value.lower())
@@ -4480,6 +4476,11 @@ runtime_ids = sys.argv[1].split()
 if local not in {digest(value) for value in runtime_ids}:
     raise SystemExit("cluster product imageID mismatch")
 PY
+        then
+            rm -f "$inventory"
+            echo "cluster product imageID mismatch for $component" >&2
+            return 1
+        fi
     done
     rm -f "$inventory"
     CLUSTER_IMAGE_IDS_MATCH="true"

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -4450,9 +4450,13 @@ for raw in pathlib.Path(sys.argv[1]).read_text().splitlines():
         continue
     values.extend(fields[2].split())
 values = sorted(set(values))
-if len(values) != 1:
+if not values:
     raise SystemExit("component imageID is absent or inconsistent")
-print(values[0])
+# runner-prewarm also sleeps the bundle-fetch images, so the pod carries
+# more than one imageID. api/worker stay a single first-party image.
+if want != "runner-prewarm" and len(values) != 1:
+    raise SystemExit("component imageID is absent or inconsistent")
+print(" ".join(values))
 PY
 )" || { rm -f "$inventory"; return 1; }
         local_id="$(docker image inspect --format '{{.Id}}' "$tag")" || {
@@ -4460,21 +4464,22 @@ PY
             echo "local task image is missing for cluster identity preflight" >&2
             return 1
         }
-        read -r normalized_runtime normalized_local < <(python3 - "$runtime_id" "$local_id" <<'PY'
+        python3 - "$runtime_id" "$local_id" <<'PY' || {
+            rm -f "$inventory"
+            echo "cluster product imageID mismatch for $component" >&2
+            return 1
+        }
 import re, sys
 def digest(value):
     matches = re.findall(r"sha256:[0-9a-f]{64}", value.lower())
     if not matches:
         raise SystemExit("image identity has no sha256 digest")
     return matches[-1]
-print(digest(sys.argv[1]), digest(sys.argv[2]))
+local = digest(sys.argv[2])
+runtime_ids = sys.argv[1].split()
+if local not in {digest(value) for value in runtime_ids}:
+    raise SystemExit("cluster product imageID mismatch")
 PY
-        )
-        if [[ "$normalized_runtime" != "$normalized_local" ]]; then
-            rm -f "$inventory"
-            echo "cluster product imageID mismatch for $component" >&2
-            return 1
-        fi
     done
     rm -f "$inventory"
     CLUSTER_IMAGE_IDS_MATCH="true"


### PR DESCRIPTION
## Summary

The runner-prewarm DaemonSet now also pins the sandbox bundle-fetch init images (`agentSandbox.runner.bundleFetch.fetchImage` and `extractImage`, default `amazon/aws-cli:2.32.6` and `busybox:1.36.1`) on every node at install and upgrade. A fresh or image-GCed node no longer cold-pulls ~418MB of aws-cli inside the 90s sandbox claim window. Extra sleep containers are sourced from the same values keys the sandbox init pair uses, and they render only while `agentSandbox.deploy`, `runner.prewarm.enabled`, and `bundleFetch.enabled` are all true.

Extra containers use `global.imagePullPolicy` (`IfNotPresent`), not `prewarm.imagePullPolicy`. Cluster CI sets the latter to `Never` and only kind-loads first-party images; inheriting `Never` would `ErrImageNeverPull` aws-cli/busybox and the DaemonSet would never become Ready. The cluster product preflight now accepts more than one imageID on the prewarm pod so the runner digest check still holds.

## Related issue

Found by curie-performance-review-2026-09 at origin/main 39a57886. No GitHub issue number; this does not close a `bug`-labeled issue.

## Fix pin verification

Fix pin: n/a - performance chart prewarm, no bug-labeled issue

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | n/a | Does not reach compose services, dispatcher, worker, API wiring, the console UI, or a `curie` verb output/exit/`--json` shape. | | |
| local-release | n/a | Does not change released binary identity, the install path, version pins, or the release compose. | | |
| cluster | required | Chart templates, the runner-prewarm DaemonSet, sandbox init images, and the node image cache. | live | Candidate `6bfdc395`. kind cluster `prewarm-bf`. After install, before claim: `crictl images` listed `amazon/aws-cli:2.32.6`, `busybox:1.36.1`, `ghcr.io/curie-eng/curie-runner:0.8.6`. Cold aws-cli pull 4.755s / create_to_finish 6.0s; warm "already present" / create_to_finish 1.0s. Render-assert red on unmodified template, green after. |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, token/cost accounting, or the MCP/workspace/coding-tool path set. | | |
| external integration | n/a | Does not reach Slack, git push webhooks, connector OAuth, or a third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

### Cluster evidence (kind cluster `prewarm-bf`, candidate `6bfdc395`)

Conservative defaults used and recorded here:

- Extra prewarm containers reuse `agentSandbox.runner.prewarm.resources`. Their `imagePullPolicy` is `global.imagePullPolicy` (`IfNotPresent`), matching the sandbox init pair, so cluster CI `prewarm.imagePullPolicy=Never` (imported runner only) does not `ErrImageNeverPull` aws-cli/busybox.
- Extra containers are gated by `bundleFetch.enabled` in addition to the existing `agentSandbox.deploy` + `prewarm.enabled` DaemonSet gate.
- Proof ran on a disposable kind cluster (the authorized alternative to k8scratch) so `crictl rmi` could clear the image cache between baseline and after without touching the shared k8scratch node.
- Init timing used the same images and `IfNotPresent` policy as the sandbox init pair. A full `curie cluster message` was not run: the trimmed chart slice used for this proof has `api.deploy=false` and `worker.deploy=false`. The measured surface is the image-pull gap the claim window hits.
- Bundle-fetch init container logic and the S3 identity path were not changed. Runner `imagePullPolicy` was not changed. `values.schema.json` stays permissive. No new values keys for image refs; the template reads the existing `bundleFetch.fetchImage` / `extractImage`.

Host uncompressed size (same pin the chart names):

```
docker image inspect amazon/aws-cli:2.32.6 --format '{{.Size}}'
417955453
```

**Baseline (cache cleared, no prewarm).** Images matching aws-cli/busybox/curie-runner: none. Pod `cold-bundle-init` with the sandbox init images and `imagePullPolicy: IfNotPresent`:

```
Pulling image "amazon/aws-cli:2.32.6"
Successfully pulled image "amazon/aws-cli:2.32.6" in 4.755s (4.755s including waiting). Image size: 128559186 bytes.
Pulling image "busybox:1.36.1"
Successfully pulled image "busybox:1.36.1" in 919ms (919ms including waiting). Image size: 2217006 bytes.
bundle-fetch create_to_start_s 5.0 start_to_finish_s 1.0 create_to_finish_s 6.0
bundle-extract create_to_start_s 8.0 start_to_finish_s 0.0 create_to_finish_s 8.0
```

Then `crictl rmi` of both images so the after-install measurement started from a cleared cache.

**After (this chart, prewarm enabled, before any claim).**

```
helm install prewarmbf charts/curie --kube-context kind-prewarm-bf -n curie-prewarm-bf --create-namespace --no-hooks \
  -f charts/curie/values-e2e-nogvisor.yaml \
  -f charts/curie/values-e2e-harness.yaml \
  --set agentSandbox.runner.prewarm.enabled=true
```

DaemonSet `prewarmbf-curie-runner-prewarm` rolled out 3/3 Ready. Only the prewarm pod and rustfs were running; no sandbox claim yet.

`crictl images` after install, before claim:

```
docker.io/amazon/aws-cli                        2.32.6               cfe4d41a1cdd1       129MB
docker.io/library/busybox                       1.36.1               b116e15507444       2.22MB
ghcr.io/curie-eng/curie-runner                  0.8.6                3ea032503019f       264MB
```

`kubectl get node prewarm-bf-control-plane -o json` `.status.images`:

```
263776044 ['ghcr.io/curie-eng/curie-runner@sha256:7b6d01b05e77f82d59b0f80ad03f4f967bb29bb35e0ffc28ea3449fe9b6dad38', 'ghcr.io/curie-eng/curie-runner:0.8.6']
128559186 ['docker.io/amazon/aws-cli@sha256:79e492dfe333fe420d41990fa958c673671b44e30877d65a2aed3391033f37dd', 'docker.io/amazon/aws-cli:2.32.6']
2217006 ['docker.io/library/busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662', 'docker.io/library/busybox:1.36.1']
```

**Warm init (same images, IfNotPresent, after prewarm).** Events:

```
Pulled Container image "amazon/aws-cli:2.32.6" already present on machine
Pulled Container image "busybox:1.36.1" already present on machine
bundle-fetch create_to_start_s 1.0 start_to_finish_s 0.0 create_to_finish_s 1.0
bundle-extract create_to_start_s 2.0 start_to_finish_s 0.0 create_to_finish_s 2.0
```

Kind cluster `prewarm-bf` was deleted after the run. kubectl context restored to k8scratch.

The kind timings were taken while extras still inherited `prewarm.imagePullPolicy=Always`. The final template uses `IfNotPresent` on extras; kubelet still pulls on a cache miss, and the warm path is still "already present". Assertion (g) pins `prewarm.imagePullPolicy=Never` leaving extras on `IfNotPresent`.

### Render-assert red then green

Unmodified `origin/main` template:

```
default: bundle-fetch init image(s) rendered on the SandboxTemplate but absent from the runner-prewarm DaemonSet: bundle-fetch=amazon/aws-cli:2.32.6, bundle-extract=busybox:1.36.1. prewarm images=['ghcr.io/curie-eng/curie-runner:0.8.6']
FAIL: default render: a bundle-fetch image is on the sandbox and absent from prewarm
```

After this change: `bash charts/curie/ci/prewarm-bundle-fetch-assertions.sh` PASS, including the mutant that drops those images from the rendered prewarm DaemonSet and is refused.

### Chart CI

- `helm lint charts/curie` and `helm lint charts/curie -f charts/curie/values-dev.yaml` passed.
- `helm template rel charts/curie -f charts/curie/values-dev.yaml` passed (3488 lines; values-dev keeps `agentSandbox.deploy=false`, so no prewarm object, as before).
- Existing `charts/curie/ci/*.sh` assertions passed, including `unpinned-image-assertions.sh`, `sandbox-hardening-assertions.sh`, `render-assertions.sh`, and `probe-window-assertions.sh`.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision. Not an ADR: this extends the existing prewarm DaemonSet.
