### PR TITLE
Move bundle archive validation off the API event loop

### DIFF
--- a/apps/api/src/curie_api/deploy.py
+++ b/apps/api/src/curie_api/deploy.py
@@ -213,7 +213,8 @@ async def revalidate_stored_bundle(
     settings = settings or get_settings()
     data = await store.get(version.bundle_ref)
     try:
-        plugin_format.check_archive_bounds(
+        await run_in_threadpool(
+            plugin_format.check_archive_bounds,
             data,
             max_uncompressed_bytes=settings.bundle_max_uncompressed_bytes,
             max_compression_ratio=settings.bundle_max_compression_ratio,

--- a/apps/api/src/curie_api/gitflow.py
+++ b/apps/api/src/curie_api/gitflow.py
@@ -575,7 +575,9 @@ async def process_push(
                 repo_full_name=trusted_repo_full_name,
                 ref=ref,
             )
-            extension, content_type = deploy.validate_archive(archive, settings)
+            extension, content_type = await run_in_threadpool(
+                deploy.validate_archive, archive, settings
+            )
             targets = await run_in_threadpool(_read_targets, archive, settings)
     except InvalidRepoFullName as exc:
         return WebhookResult(

--- a/apps/api/src/curie_api/routers/bundles.py
+++ b/apps/api/src/curie_api/routers/bundles.py
@@ -8,6 +8,7 @@ bytes so a runner can pull a bundle by version.
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Response, UploadFile, status
+from starlette.concurrency import run_in_threadpool
 
 from .. import bundles, crud, deploy
 from ..auth import require_api_key
@@ -111,7 +112,7 @@ async def upload_bundle(
         )
 
     try:
-        extension, content_type = deploy.validate_archive(data)
+        extension, content_type = await run_in_threadpool(deploy.validate_archive, data)
     except bundles.UnsupportedArchive as exc:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc)) from exc
     except deploy.BundleInvalid as exc:

--- a/apps/api/tests/test_bundle_validate_offloop.py
+++ b/apps/api/tests/test_bundle_validate_offloop.py
@@ -1,0 +1,286 @@
+"""A large bundle upload must not stall GET /health on the uvicorn worker.
+
+``deploy.validate_archive`` extracts the archive to a temp dir and runs
+``plugin_format.validate_bundle``. Called directly from the async upload
+handler, that work blocked the event loop, so every other request on the
+worker waited. This drives a real one-worker uvicorn with an archive that
+takes at least 200 ms to validate, polls GET /health concurrently, and
+requires health p99 during validation to stay under 50 ms.
+
+Health samples are restricted to requests that overlap the validation
+window. p99 of the whole PUT would be dominated by body-transfer and
+object-store samples, which already run off the loop, and would hide the
+stall this test exists to catch.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import socket
+import tarfile
+import threading
+import time
+from collections.abc import Iterator
+from typing import Any
+
+import httpx
+import pytest
+import uvicorn
+from curie_api import deploy
+from curie_api.main import create_app
+
+MANIFEST = '{"name": "demo-plugin", "version": "0.1.0"}'
+_MIN_VALIDATE_S = 0.200
+_HEALTH_P99_S = 0.050
+_PROBE_THREADS = 4
+_PROBE_INTERVAL_S = 0.005
+_MAX_PAD_BYTES = 150 * 1024 * 1024
+_MAX_MEMBERS = 8000
+
+
+def _skill(name: str) -> bytes:
+    return f"---\nname: {name}\ndescription: does {name} things\n---\n\n# {name}\n".encode()
+
+
+def _tar_plain(files: dict[str, bytes], top: str = "demo-plugin") -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:") as tf:
+        for rel, content in files.items():
+            info = tarfile.TarInfo(f"{top}/{rel}")
+            info.size = len(content)
+            tf.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def _archive(n_extra: int, pad_bytes: int) -> bytes:
+    files: dict[str, bytes] = {
+        ".claude-plugin/plugin.json": MANIFEST.encode(),
+        "skills/alpha/SKILL.md": _skill("alpha"),
+    }
+    for i in range(n_extra):
+        files[f"assets/p{i}.txt"] = f"{i}\n".encode()
+    if pad_bytes:
+        chunk = os.urandom(1024)
+        files["assets/pad.bin"] = (chunk * ((pad_bytes // 1024) + 1))[:pad_bytes]
+    return _tar_plain(files)
+
+
+def _slow_archive() -> tuple[bytes, float]:
+    """Grow an archive until ``validate_archive`` takes at least 200 ms."""
+
+    n_extra = 4000
+    pad_bytes = 0
+    last_elapsed = 0.0
+    archive = b""
+    while True:
+        archive = _archive(n_extra, pad_bytes)
+        started = time.perf_counter()
+        deploy.validate_archive(archive)
+        last_elapsed = time.perf_counter() - started
+        if last_elapsed >= _MIN_VALIDATE_S:
+            return archive, last_elapsed
+        if n_extra < _MAX_MEMBERS:
+            n_extra = min(_MAX_MEMBERS, n_extra * 2)
+            continue
+        if pad_bytes == 0:
+            pad_bytes = 16 * 1024 * 1024
+            continue
+        if pad_bytes < _MAX_PAD_BYTES:
+            pad_bytes = min(_MAX_PAD_BYTES, pad_bytes * 2)
+            continue
+        raise AssertionError(
+            f"could not build an archive that takes {_MIN_VALIDATE_S:.3f}s to "
+            f"validate (last {last_elapsed:.3f}s, members={n_extra}, pad={pad_bytes})"
+        )
+
+
+def _percentile(samples: list[float], p: float) -> float:
+    if not samples:
+        raise AssertionError("no health samples overlapped validation")
+    ordered = sorted(samples)
+    rank = max(1, min(len(ordered), int((p / 100) * len(ordered) + 0.999999)))
+    return ordered[rank - 1]
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class _UvicornThread(threading.Thread):
+    def __init__(self, app: Any, host: str, port: int) -> None:
+        super().__init__(name="curie-api-offloop", daemon=True)
+        self.server = uvicorn.Server(
+            uvicorn.Config(
+                app,
+                host=host,
+                port=port,
+                log_level="warning",
+                access_log=False,
+                lifespan="on",
+            )
+        )
+
+    def run(self) -> None:
+        self.server.run()
+
+    def stop(self) -> None:
+        self.server.should_exit = True
+
+
+@pytest.fixture
+def live_api(_disposable_db: Any, monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
+    """A one-worker uvicorn serving ``create_app`` on a free loopback port."""
+
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+    host = "127.0.0.1"
+    port = _free_port()
+    thread = _UvicornThread(create_app(), host, port)
+    thread.start()
+    deadline = time.time() + 30
+    url = f"http://{host}:{port}"
+    last_exc: Exception | None = None
+    while time.time() < deadline:
+        if thread.server.started:
+            try:
+                response = httpx.get(f"{url}/health", timeout=1.0)
+                if response.status_code == 200:
+                    break
+            except httpx.HTTPError as exc:
+                last_exc = exc
+        time.sleep(0.05)
+    else:
+        thread.stop()
+        thread.join(timeout=5)
+        raise RuntimeError(f"uvicorn did not become healthy: {last_exc}")
+    try:
+        yield url
+    finally:
+        thread.stop()
+        thread.join(timeout=15)
+
+
+def _create_version(http: httpx.Client, headers: dict[str, str]) -> tuple[str, str]:
+    agent = http.post(
+        "/agents",
+        json={
+            "name": "archive-offloop-agent",
+            "channel": {"kind": "slack", "address": "C0EXAMPLE1"},
+        },
+        headers=headers,
+    )
+    assert agent.status_code == 201, agent.text
+    version = http.post(
+        f"/agents/{agent.json()['id']}/versions",
+        json={"version_label": "v1", "created_by": "bconn"},
+        headers=headers,
+    )
+    assert version.status_code == 201, version.text
+    return agent.json()["id"], version.json()["id"]
+
+
+def test_health_p99_stays_under_50ms_during_a_slow_bundle_upload(
+    live_api: str,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive, validate_s = _slow_archive()
+    assert validate_s >= _MIN_VALIDATE_S
+
+    window = {"start": 0.0, "end": 0.0}
+    real_validate = deploy.validate_archive
+
+    def _timed_validate(*args: Any, **kwargs: Any) -> tuple[str, str]:
+        window["start"] = time.perf_counter()
+        try:
+            return real_validate(*args, **kwargs)
+        finally:
+            window["end"] = time.perf_counter()
+
+    monkeypatch.setattr(deploy, "validate_archive", _timed_validate)
+
+    samples: list[tuple[float, float]] = []
+    stop = threading.Event()
+    probe_errors: list[str] = []
+    log = logging.getLogger("curie_api")
+    previous_level = log.level
+    log.setLevel(logging.ERROR)
+
+    def _probe() -> None:
+        with httpx.Client(base_url=live_api, timeout=30.0) as probe:
+            try:
+                warmup = probe.get("/health")
+            except httpx.HTTPError as exc:
+                probe_errors.append(str(exc))
+                return
+            if warmup.status_code != 200:
+                probe_errors.append(f"health {warmup.status_code}")
+                return
+            while not stop.is_set():
+                started = time.perf_counter()
+                try:
+                    response = probe.get("/health")
+                except httpx.HTTPError as exc:
+                    probe_errors.append(str(exc))
+                    return
+                finished = time.perf_counter()
+                if response.status_code != 200:
+                    probe_errors.append(f"health {response.status_code}")
+                    return
+                samples.append((started, finished))
+                if stop.wait(_PROBE_INTERVAL_S):
+                    break
+
+    probers = [threading.Thread(target=_probe, daemon=True) for _ in range(_PROBE_THREADS)]
+    headers = auth_headers
+    try:
+        with httpx.Client(base_url=live_api, timeout=180.0) as http:
+            agent_id, version_id = _create_version(http, headers)
+            warmup = http.get("/health")
+            assert warmup.status_code == 200
+            for thread in probers:
+                thread.start()
+            time.sleep(0.05)
+            response = http.put(
+                f"/agents/{agent_id}/versions/{version_id}/bundle",
+                files={"file": ("demo.tar", archive)},
+                headers=headers,
+            )
+    finally:
+        stop.set()
+        for thread in probers:
+            if thread.is_alive() or thread.ident is not None:
+                thread.join(timeout=10)
+        log.setLevel(previous_level)
+
+    assert not probe_errors, probe_errors
+    assert response.status_code == 201, response.text
+    assert window["start"] > 0 and window["end"] >= window["start"]
+    observed_validate_s = window["end"] - window["start"]
+    assert observed_validate_s >= _MIN_VALIDATE_S, (
+        f"upload-path validate_archive took {observed_validate_s * 1000:.1f}ms, "
+        f"need >= {_MIN_VALIDATE_S * 1000:.0f}ms"
+    )
+
+    overlapping = [
+        finished - started
+        for started, finished in samples
+        if started < window["end"] and finished > window["start"]
+    ]
+    p99 = _percentile(overlapping, 99)
+    print(
+        f"HEALTH_P99_MS={p99 * 1000:.2f} VALIDATE_MS={observed_validate_s * 1000:.2f} "
+        f"PRECHECK_VALIDATE_MS={validate_s * 1000:.2f} SAMPLES={len(overlapping)} "
+        f"ARCHIVE_BYTES={len(archive)}",
+        flush=True,
+    )
+    assert p99 < _HEALTH_P99_S, (
+        f"health p99 during validate_archive was {p99 * 1000:.1f}ms "
+        f"(limit {_HEALTH_P99_S * 1000:.0f}ms); validation took "
+        f"{observed_validate_s * 1000:.1f}ms over {len(overlapping)} overlapping samples"
+    )


### PR DESCRIPTION
## Summary

Bundle archive validation (`deploy.validate_archive` extract plus `plugin_format.validate_bundle`, and `plugin_format.check_archive_bounds` on deploy revalidation) ran synchronously inside async API handlers. A large upload, webhook push, or deployment revalidation blocked the uvicorn worker event loop, so `GET /health` and every other request on that worker waited.

This wraps the three call sites with `starlette.concurrency.run_in_threadpool`, matching `clone_and_archive`, `_read_targets`, and `check_routes_from_bytes` in the same modules. Validation semantics, check order, and status mapping (400 / 413 / 422) are unchanged. `validate_archive` itself stays a sync function; only the three async call sites move onto the threadpool.

Found by curie-performance-review-2026-09 at origin/main 39a57886; implemented against origin/main bd1a34f1.

## Related issue

No tracker issue. Performance finding from the 2026-09 review, not a labeled bug close.

## Fix pin verification

Fix pin: apps/api/tests/test_bundle_validate_offloop.py::test_health_p99_stays_under_50ms_during_a_slow_bundle_upload

## Conservative defaults

- Wrapped at the three cited call sites rather than making `validate_archive` async, so tests and any remaining sync caller keep a blocking function.
- Health p99 is computed over samples that overlap the validation window, not the whole PUT. Body transfer and object-store writes already run off the loop and would hide the stall.
- Local compose used remapped host ports (35432 / 36379 / 39000) because the default ports were occupied by another worktree. That remap is not part of this change.

## Measured before / after

Exact command (from the worktree, compose Postgres/Valkey/RustFS up):

```
uv run pytest -s apps/api/tests/test_bundle_validate_offloop.py::test_health_p99_stays_under_50ms_during_a_slow_bundle_upload -q --tb=short
```

Unmodified origin/main bd1a34f1 (src wraps stashed, same test):

```
HEALTH_P99_MS=347.34 VALIDATE_MS=341.06 PRECHECK_VALIDATE_MS=253.62 SAMPLES=4 ARCHIVE_BYTES=4106240
FAILED
AssertionError: health p99 during validate_archive was 347.3ms (limit 50ms); validation took 341.1ms over 4 overlapping samples
```

After wrapping the three call sites:

```
HEALTH_P99_MS=29.55 VALIDATE_MS=585.81 PRECHECK_VALIDATE_MS=271.17 SAMPLES=284 ARCHIVE_BYTES=4106240
PASSED
```

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | required | Compose-backed API wiring: upload_bundle, gitflow process_push, and revalidate_stored_bundle. | live | `uv run pytest -s apps/api/tests/test_bundle_validate_offloop.py::test_health_p99_stays_under_50ms_during_a_slow_bundle_upload -q --tb=short` on candidate worktree against compose Postgres/Valkey/RustFS: HEALTH_P99_MS=29.55, PASSED. Negative: same command against unmodified bd1a34f1: HEALTH_P99_MS=347.34, FAILED. Existing suites: `uv run pytest -q apps/api/tests/test_bundle_validate_offloop.py apps/api/tests/test_bundles.py apps/api/tests/test_bundle_ingestion_bounds.py apps/api/tests/test_bundle_connectors.py apps/api/tests/test_gitflow_integration.py apps/api/tests/test_gitflow_unit.py apps/api/tests/test_gitflow_targets.py apps/api/tests/test_gitflow_redirect.py apps/api/tests/test_gitflow_routing_check.py apps/api/tests/test_approval_route_config_check.py apps/api/tests/test_resolve_deploy_target.py apps/api/tests/test_crud.py apps/api/tests/test_workspace_control_plane.py` -> 271 passed. |
| local-release | n/a | Does not change released binary or image identity, the install path, version pins, or release compose. | | |
| cluster | n/a | Does not reach chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, or init containers. | | |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, or the MCP/workspace/coding-tool path set. | | |
| external integration | n/a | Does not change Slack, git push webhook verification, connector OAuth, or any third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed. (no user-facing behavior change; CPU placement only)
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. (not an ADR; established `run_in_threadpool` pattern)
