### PR TITLE
Split the console landing bundle away from views and jszip

### DIFF
--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -44,10 +44,9 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Compress static text payloads. The single Vite JS bundle is about
-    # 567 kB raw and about 155 kB gzipped, and it is render-blocking for the
-    # SPA, so shrinking it on the wire is worth the CPU. text/html is always
-    # gzipped by nginx and cannot be listed here.
+    # Compress static text payloads. The landing JS chunk is render-blocking
+    # for the SPA, so shrinking it on the wire is worth the CPU. text/html is
+    # always gzipped by nginx and cannot be listed here.
     gzip on;
     gzip_vary on;
     gzip_comp_level 6;

--- a/apps/ui/e2e/code-split-landing.spec.ts
+++ b/apps/ui/e2e/code-split-landing.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Pins the landing Overview split: the initial document must not download the
+// non-landing views or jszip, and navigating to Agents / Observability must
+// then request their deferred chunks. Chunk hashes change per build; identity
+// is "referenced by index.html" vs "requested only after navigation".
+
+const JS_ASSET = /\/assets\/([^/?]+\.js)(?:\?|$)/;
+
+function jsAssetName(url: string): string | null {
+  const match = url.match(JS_ASSET);
+  return match ? match[1] : null;
+}
+
+function jsAssetNames(urls: Iterable<string>): string[] {
+  const names = new Set<string>();
+  for (const url of urls) {
+    const name = jsAssetName(url);
+    if (name) names.add(name);
+  }
+  return [...names].sort();
+}
+
+function htmlJsAssets(html: string): string[] {
+  const names = new Set<string>();
+  for (const match of html.matchAll(/\/assets\/([^"' ]+\.js)/g)) {
+    names.add(match[1]);
+  }
+  return [...names].sort();
+}
+
+async function stubShell(page: Page) {
+  await page.route("**/api/agents**", (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+    }
+    return route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+  });
+  await page.route("**/api/config**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ org_name: "Globex Corporation" }),
+    }),
+  );
+  await page.route("**/api/deployments**", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  await page.route("**/api/langfuse/**", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  await page.route("**/api/observability/**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        start: "2026-06-28",
+        end: "2026-07-05",
+        runs: 0,
+        latency_p95_ms: 0,
+        tokens: 0,
+        cost_usd: 0,
+        error_rate: 0,
+        metric: "runs",
+        granularity: "day",
+        points: [],
+      }),
+    }),
+  );
+  await page.route("**/api/evals/**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        suite: "default",
+        versions: [],
+        cases: [],
+        rows: [],
+        models: [],
+        model_summaries: [],
+      }),
+    }),
+  );
+}
+
+test("landing document requests only the landing chunk; Agents and Observability load theirs on navigate", async ({
+  page,
+}) => {
+  const requestedJs: string[] = [];
+  page.on("request", (req) => {
+    if (jsAssetName(req.url())) requestedJs.push(req.url());
+  });
+
+  await stubShell(page);
+
+  const document = await page.goto("/?api=1");
+  expect(document, "index.html must load").not.toBeNull();
+  const landingHtml = await document!.text();
+  const htmlChunks = htmlJsAssets(landingHtml);
+  expect(htmlChunks.length, `index.html JS refs: ${htmlChunks.join(", ")}`).toBeGreaterThan(0);
+  expect(
+    htmlChunks.filter((name) => /jszip/i.test(name)),
+    `index.html must not reference jszip: ${htmlChunks.join(", ")}`,
+  ).toEqual([]);
+
+  await expect(page.getByText("Welcome to Curie")).toBeVisible();
+  await page.waitForLoadState("networkidle");
+
+  const landingRequested = jsAssetNames(requestedJs);
+  const extraOnLanding = landingRequested.filter((name) => !htmlChunks.includes(name));
+  expect(
+    extraOnLanding,
+    `initial document requested JS beyond the landing HTML refs (html=${htmlChunks.join(", ")}; requested=${landingRequested.join(", ")})`,
+  ).toEqual([]);
+
+  const beforeAgents = requestedJs.length;
+  await page.getByRole("navigation").getByText("Agents", { exact: true }).click();
+  await expect(page.getByText("Create your first agent")).toBeVisible();
+  await page.waitForLoadState("networkidle");
+  const agentsChunks = jsAssetNames(requestedJs.slice(beforeAgents)).filter(
+    (name) => !htmlChunks.includes(name),
+  );
+  expect(
+    agentsChunks.length,
+    `navigating to Agents must request a deferred JS chunk; got [${agentsChunks.join(", ")}] (landing html=${htmlChunks.join(", ")})`,
+  ).toBeGreaterThan(0);
+
+  const beforeObs = requestedJs.length;
+  await page.getByRole("navigation").getByText("Observability", { exact: true }).click();
+  await expect(
+    page.getByText("OpenTelemetry traces, Prometheus-style metrics, and Loki-style logs", {
+      exact: false,
+    }),
+  ).toBeVisible();
+  await page.waitForLoadState("networkidle");
+  const obsChunks = jsAssetNames(requestedJs.slice(beforeObs)).filter(
+    (name) => !htmlChunks.includes(name) && !agentsChunks.includes(name),
+  );
+  expect(
+    obsChunks.length,
+    `navigating to Observability must request a deferred JS chunk; got [${obsChunks.join(", ")}] (agents=${agentsChunks.join(", ")})`,
+  ).toBeGreaterThan(0);
+
+  expect(
+    jsAssetNames(requestedJs).filter((name) => /jszip/i.test(name)),
+    "jszip must stay off the Overview / Agents / Observability path",
+  ).toEqual([]);
+});

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -1,23 +1,41 @@
+import { lazy, Suspense } from "react";
 import { C } from "./tokens";
 import { useStore } from "./state/store";
 import { Sidebar } from "./components/Sidebar";
 import { Topbar, DevBanner } from "./components/Topbar";
 import { ModalHost } from "./components/ModalHost";
 import { Confetti } from "./components/Confetti";
-import { Toast } from "./primitives";
-
-import { Observability } from "./views/Observability";
+import { Notice, Toast } from "./primitives";
 
 import { WiredOverview } from "./views/wired/WiredOverview";
-import { WiredAgents } from "./views/wired/WiredAgents";
-import { WiredAgentDetail } from "./views/wired/WiredAgentDetail";
-import { WiredConnections, WiredSettings } from "./views/wired/WiredStubs";
-import { WiredEvals } from "./views/wired/WiredEvals";
-import { WiredVersions } from "./views/wired/WiredVersions";
+
+const Observability = lazy(() =>
+  import("./views/Observability").then((m) => ({ default: m.Observability })),
+);
+const WiredAgents = lazy(() =>
+  import("./views/wired/WiredAgents").then((m) => ({ default: m.WiredAgents })),
+);
+const WiredAgentDetail = lazy(() =>
+  import("./views/wired/WiredAgentDetail").then((m) => ({ default: m.WiredAgentDetail })),
+);
+const WiredConnections = lazy(() =>
+  import("./views/wired/WiredStubs").then((m) => ({ default: m.WiredConnections })),
+);
+const WiredSettings = lazy(() =>
+  import("./views/wired/WiredStubs").then((m) => ({ default: m.WiredSettings })),
+);
+const WiredEvals = lazy(() =>
+  import("./views/wired/WiredEvals").then((m) => ({ default: m.WiredEvals })),
+);
+const WiredVersions = lazy(() =>
+  import("./views/wired/WiredVersions").then((m) => ({ default: m.WiredVersions })),
+);
 
 // The console is always backed by the live API. Each nav renders its
 // backend-driven view; views that are not wired yet render an honest
-// "Coming Soon" stub rather than demo data.
+// "Coming Soon" stub rather than demo data. Overview stays eager so the
+// landing path does not wait on a view chunk; every other view is a
+// separate async chunk behind the single Suspense boundary below.
 function Main() {
   const { state } = useStore();
   if (state.agentDetail) return <WiredAgentDetail />;
@@ -51,7 +69,9 @@ export function App() {
           <Topbar />
           {envDev ? <DevBanner /> : null}
           <div style={{ flex: 1, padding: "28px 36px", maxWidth: 1280, width: "100%", margin: "0 auto" }}>
-            <Main />
+            <Suspense fallback={<Notice>Loading…</Notice>}>
+              <Main />
+            </Suspense>
           </div>
         </div>
       </div>

--- a/apps/ui/src/api/bundle.ts
+++ b/apps/ui/src/api/bundle.ts
@@ -1,5 +1,3 @@
-import JSZip from "jszip";
-
 // Packages the editor's skill.md into a Claude Code plugin bundle, client-side.
 // jszip is the packaging choice: it is the de-facto browser zip library, ships
 // its own types, and produces an archive that apps/api's zip intake accepts
@@ -69,6 +67,7 @@ export function bundleTreeFromFiles(agentName: string, files: BundleFileEntry[])
 }
 
 async function zipTree(tree: Record<string, string>): Promise<Blob> {
+  const { default: JSZip } = await import("jszip");
   const zip = new JSZip();
   for (const [path, content] of Object.entries(tree)) {
     zip.file(path, content);

--- a/apps/ui/src/views/Observability.tsx
+++ b/apps/ui/src/views/Observability.tsx
@@ -1,13 +1,32 @@
+import { lazy } from "react";
 import { SectionTitle, Tabs } from "../primitives";
 import { useStore } from "../state/store";
 import type { ObsTab } from "../state/types";
-import { RealTracesList, RealTraceDetail } from "./obs/RealTraces";
-import { RealMetrics } from "./obs/RealMetrics";
-import { RealLogs } from "./obs/RealLogs";
-import { RealCost } from "./obs/RealCost";
-import { RealMemory } from "./obs/RealMemory";
-import { RealApprovals } from "./obs/RealApprovals";
-import { WiredUsage } from "./wired/WiredStubs";
+
+const RealTracesList = lazy(() =>
+  import("./obs/RealTraces").then((m) => ({ default: m.RealTracesList })),
+);
+const RealTraceDetail = lazy(() =>
+  import("./obs/RealTraces").then((m) => ({ default: m.RealTraceDetail })),
+);
+const RealMetrics = lazy(() =>
+  import("./obs/RealMetrics").then((m) => ({ default: m.RealMetrics })),
+);
+const RealLogs = lazy(() =>
+  import("./obs/RealLogs").then((m) => ({ default: m.RealLogs })),
+);
+const RealCost = lazy(() =>
+  import("./obs/RealCost").then((m) => ({ default: m.RealCost })),
+);
+const RealMemory = lazy(() =>
+  import("./obs/RealMemory").then((m) => ({ default: m.RealMemory })),
+);
+const RealApprovals = lazy(() =>
+  import("./obs/RealApprovals").then((m) => ({ default: m.RealApprovals })),
+);
+const WiredUsage = lazy(() =>
+  import("./wired/WiredStubs").then((m) => ({ default: m.WiredUsage })),
+);
 
 const TABS: [ObsTab, string][] = [
   ["traces", "Traces"],


### PR DESCRIPTION
## Summary

Split the console production bundle so Overview no longer downloads every view and the jszip packager. Non-landing views and observability tabs load through `React.lazy` behind one `Suspense` boundary; `jszip` is dynamically imported inside the bundle builder. Rendered output once a chunk has loaded is unchanged.

## Related issue

Found by curie-performance-review-2026-09 at origin/main 39a57886. No tracker issue to close.

## Fix pin verification

Not a fix pull request and this does not close a bug-labeled issue.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin or skill packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | required | Reaches the console UI: Vite production chunks, React.lazy/Suspense, stackless Playwright, and the UI image build. | fake | Candidate `69d1cbcb`. `cd apps/ui && pnpm e2e`: 41 passed, including `e2e/code-split-landing.spec.ts` (landing HTML refs only the landing JS; Agents then Observability each request a deferred `/assets/*.js`). `pnpm lint`, `pnpm typecheck`, `pnpm test` (161, including CliHint.parity 8/8), and `docker build -f apps/ui/Dockerfile -t curie-ui:perf-lazy-views .` from the worktree all passed. |
| local-release | n/a | Does not change released binary or image identity, the install path, version pins, or release compose. The UI Dockerfile is the same wrapper around the Vite build. | | |
| cluster | n/a | Does not reach chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, or init containers. | | |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, token or cost accounting, or the MCP/workspace/coding-tool path set. | | |
| external integration | n/a | Does not reach Slack, git push webhooks, connector OAuth, or any third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive proof (AC 1-4): `pnpm build` emits a 359.43 kB / 101.12 kB gzip landing `index-*.js` plus deferred view and `jszip.min-*.js` chunks; the Playwright spec watches the production preview and sees Agents/Observability fetch those deferred files; lint/typecheck/test/e2e and the UI image build pass.

Falsifiable negative: the same Playwright spec failed on unsplit `origin/main` with `navigating to Agents must request a deferred JS chunk; got [] (landing html=index-DCAV9LSX.js)`. Second path: vitest `src/api/api.test.ts` still builds a real zip through `buildBundleZip` after the dynamic import.

## Bundle size

Command, both measurements, from the worktree:

```
cd apps/ui && pnpm build
```

Before (origin/main `cc4dd57d`, this worktree before the split):

```
dist/index.html                   0.45 kB │ gzip:   0.28 kB
dist/assets/index-Dy6rUgIu.css    0.82 kB │ gzip:   0.39 kB
dist/assets/index-DCAV9LSX.js   567.34 kB │ gzip: 155.71 kB
```

Vite warned the chunk exceeded 500 kB. The review's 566.93 / 155.50 figures were at 39a57886; main has moved, so this PR remeasured.

After (this branch):

```
dist/index.html                             0.69 kB │ gzip:   0.35 kB
dist/assets/index-Dy6rUgIu.css              0.82 kB │ gzip:   0.39 kB
dist/assets/parity-CJNi9OwQ.js              0.06 kB │ gzip:   0.08 kB
dist/assets/rolldown-runtime-W7wSyTde.js    0.97 kB │ gzip:   0.56 kB
dist/assets/RealMemory-D6mp2cdp.js          1.10 kB │ gzip:   0.65 kB
dist/assets/WiredStubs-CdSs1hF0.js          2.38 kB │ gzip:   0.94 kB
dist/assets/Observability-DKWaJq97.js       2.46 kB │ gzip:   0.93 kB
dist/assets/WiredAgentMemory-C2WaNpF9.js    3.48 kB │ gzip:   1.37 kB
dist/assets/WiredAgents-CEQuhLjD.js         3.94 kB │ gzip:   1.49 kB
dist/assets/RealMetrics-C4-kDSoo.js         4.63 kB │ gzip:   1.70 kB
dist/assets/WiredEvals-D3PcaFN7.js          5.73 kB │ gzip:   2.13 kB
dist/assets/WiredVersions-CYh3QChI.js       6.18 kB │ gzip:   2.18 kB
dist/assets/RealLogs-CTwcX-mc.js            6.34 kB │ gzip:   2.28 kB
dist/assets/client-BFsdmtV0.js              7.39 kB │ gzip:   1.87 kB
dist/assets/RealTraces-BQ9r_2FA.js          7.68 kB │ gzip:   2.53 kB
dist/assets/RealCost-Cfi8fPEo.js            8.42 kB │ gzip:   2.49 kB
dist/assets/RealApprovals-Cc4r8kmb.js      10.43 kB │ gzip:   3.43 kB
dist/assets/primitives-DlBcN2kM.js         18.77 kB │ gzip:   6.46 kB
dist/assets/WiredAgentDetail-10usAZ43.js   30.61 kB │ gzip:   7.91 kB
dist/assets/jszip.min-CkI-MrRj.js          95.82 kB │ gzip:  28.43 kB
dist/assets/index-BovDH2LN.js             359.43 kB │ gzip: 101.12 kB
```

Landing `index-*.js`: 359.43 kB raw / 101.12 kB gzip (target <= 420 / 115).

Initial document JS (script plus modulepreload: index + rolldown-runtime + primitives + client): 386.56 kB raw / 110.01 kB gzip, also under the target. `jszip` is not in that set.

## Conservative defaults

- One Suspense boundary around `Main`, as specified. Sidebar and topbar stay mounted; an Observability tab switch flashes the main pane to the existing `Notice` "Loading…" placeholder while that tab's chunk loads. Once loaded, the view is unchanged.
- Named exports kept; `React.lazy` uses `.then((m) => ({ default: m.X }))` rather than adding default exports.
- Overview stays a static import. `NewAgentModal` stays a static import; only `jszip` is deferred, inside `zipTree`.
- `src/generated/commandManifest.ts` and the manifest generator are not touched.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
