### PR TITLE
Install runner registry deps in a layer that survives a source edit

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -48,32 +48,35 @@ RUN npm install -g @modelcontextprotocol/server-github@2025.4.8
 
 WORKDIR /app
 
-# The five source trees the runner needs: the two frozen workspace packages, the
-# shared telemetry implementation and schema, and the runner itself. Copied by path so the image is
-# reproducible from the lockfile above them (root pyproject/uv.lock are the
-# workspace source of truth).
+# Registry dependency layer: the lockfile plus the pin exporter, and nothing
+# else, so this ~322 MB install (claude_agent_sdk dominates) is invalidated
+# only by a lock or exporter change -- never by a runner/src edit.
+# export_dependency_pins.py remains the pin source (#1436 is pin correctness,
+# not layer placement). --no-deps keeps the closure on those exact pins;
+# local workspace projects are installed by path after the source copy so
+# they resolve to the copied trees, not same-named PyPI distributions.
 COPY uv.lock ./uv.lock
+COPY runner/export_dependency_pins.py ./runner/export_dependency_pins.py
+RUN python3 -m venv /app/.venv \
+    && /app/.venv/bin/pip install --no-cache-dir --upgrade pip \
+    && python3 runner/export_dependency_pins.py < uv.lock > /tmp/runner-dependency-pins.txt \
+    && /app/.venv/bin/pip install --no-cache-dir --no-deps -r /tmp/runner-dependency-pins.txt
+
+# The five source trees the runner needs: the two frozen workspace packages,
+# the shared telemetry implementation and schema, and the runner itself.
+# Copied by path so the image is reproducible from the lockfile above them
+# (root pyproject/uv.lock are the workspace source of truth).
 COPY packages/aci-protocol ./packages/aci-protocol
 COPY packages/plugin-format ./packages/plugin-format
 COPY packages/telemetry ./packages/telemetry
 COPY packages/telemetry-schema ./packages/telemetry-schema
 COPY runner ./runner
-
-# One venv. Install every local project without dependencies, then install the
-# full registry dependency closure exported from the tested workspace uv.lock.
-# The local packages are installed by path first so the
-# workspace requirements resolve to the copied trees, not same-named PyPI
-# distributions.
-RUN python3 -m venv /app/.venv \
-    && /app/.venv/bin/pip install --no-cache-dir --upgrade pip \
-    && /app/.venv/bin/pip install --no-cache-dir --no-deps \
+RUN /app/.venv/bin/pip install --no-cache-dir --no-deps \
         ./packages/aci-protocol \
         ./packages/plugin-format \
         ./packages/telemetry \
         ./packages/telemetry-schema \
-    && /app/.venv/bin/pip install --no-cache-dir --no-deps ./runner \
-    && python3 runner/export_dependency_pins.py < uv.lock > /tmp/runner-dependency-pins.txt \
-    && /app/.venv/bin/pip install --no-cache-dir --no-deps -r /tmp/runner-dependency-pins.txt
+    && /app/.venv/bin/pip install --no-cache-dir --no-deps ./runner
 
 # Run as a non-root user. The claude-agent-sdk spawns
 # `claude --dangerously-skip-permissions` (permission_mode=bypassPermissions),

--- a/runner/Dockerfile.dockerignore
+++ b/runner/Dockerfile.dockerignore
@@ -1,0 +1,27 @@
+# Per-Dockerfile ignore (BuildKit honors <dockerfile>.dockerignore over the
+# context-root .dockerignore). The runner image builds from the REPO ROOT to
+# reach the uv workspace, so this trims the root context to what the runner
+# COPY set needs -- uv.lock, the four packages, and runner/ stay; the heavy
+# non-Python trees plus developer checkout debris (.worktrees, .projects,
+# cli/target) are dropped.
+.git
+**/.venv
+**/__pycache__
+**/*.pyc
+**/.mypy_cache
+**/.pytest_cache
+**/.ruff_cache
+**/node_modules
+apps/ui/dist
+apps/ui/test-results
+apps/ui/playwright-report
+cli/target
+docs
+prototypes
+.github
+charts
+*.md
+**/*.md
+**/.env
+.worktrees
+.projects

--- a/runner/tests/test_dockerfile_dependency_pins.py
+++ b/runner/tests/test_dockerfile_dependency_pins.py
@@ -642,8 +642,7 @@ def test_runner_image_installs_the_shared_telemetry_workspace_dependency() -> No
 
     assert "COPY packages/telemetry ./packages/telemetry" in instructions
     assert any(
-        instruction.startswith("RUN python3 -m venv ")
-        and "pip install --no-cache-dir --no-deps" in instruction
+        "pip install --no-cache-dir --no-deps" in instruction
         and "./packages/telemetry" in instruction
         for instruction in instructions
     )

--- a/runner/tests/test_dockerfile_registry_layer.py
+++ b/runner/tests/test_dockerfile_registry_layer.py
@@ -1,0 +1,215 @@
+"""The runner image installs the registry dependency closure before copying
+runner source, so an edit under runner/src does not rebuild claude_agent_sdk.
+
+The pin exporter (export_dependency_pins.py) and uv.lock are the only runner
+inputs that may precede that install; they are the pin source, not product
+source. The per-Dockerfile ignore must exist and must not drop a COPY source.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DOCKERFILE = _REPO_ROOT / "runner" / "Dockerfile"
+_DOCKERIGNORE = _REPO_ROOT / "runner" / "Dockerfile.dockerignore"
+_REQUIREMENTS_PATH = "/tmp/runner-dependency-pins.txt"
+_RUNNER_SOURCE_COPY = "COPY runner ./runner"
+_PIN_EXPORTER_COPY = (
+    "COPY runner/export_dependency_pins.py ./runner/export_dependency_pins.py"
+)
+_LOCKFILE_COPY = "COPY uv.lock ./uv.lock"
+
+# Mirror apps/api/Dockerfile.dockerignore plus the trees a repo-root build
+# otherwise walks on a developer checkout.
+_REQUIRED_IGNORE_PATTERNS = (
+    ".git",
+    "**/.venv",
+    "**/__pycache__",
+    "**/*.pyc",
+    "**/.mypy_cache",
+    "**/.pytest_cache",
+    "**/.ruff_cache",
+    "**/node_modules",
+    "apps/ui/dist",
+    "apps/ui/test-results",
+    "apps/ui/playwright-report",
+    "cli/target",
+    "docs",
+    "prototypes",
+    ".github",
+    "charts",
+    "*.md",
+    "**/*.md",
+    "**/.env",
+    ".worktrees",
+    ".projects",
+)
+
+_COPY_SOURCES = (
+    "uv.lock",
+    "packages/aci-protocol",
+    "packages/plugin-format",
+    "packages/telemetry",
+    "packages/telemetry-schema",
+    "runner",
+    "runner/export_dependency_pins.py",
+)
+
+# Patterns that would drop a COPY source wholesale. dockerignore last-match
+# wins; none of these may appear as a (non-negated) pattern.
+_FORBIDDEN_IGNORE_PATTERNS = (
+    "*",
+    "**",
+    "uv.lock",
+    "packages",
+    "packages/",
+    "packages/**",
+    "packages/aci-protocol",
+    "packages/plugin-format",
+    "packages/telemetry",
+    "packages/telemetry-schema",
+    "runner",
+    "runner/",
+    "runner/**",
+    "runner/export_dependency_pins.py",
+)
+
+
+def _logical_instructions(dockerfile_text: str) -> list[str]:
+    instructions: list[str] = []
+    pending: list[str] = []
+    for raw_line in dockerfile_text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        continues = line.endswith("\\")
+        pending.append(line[:-1].rstrip() if continues else line)
+        if not continues:
+            instructions.append(" ".join(pending))
+            pending = []
+    assert not pending, "Dockerfile ends with an unfinished continuation"
+    return instructions
+
+
+def _index_of(instructions: list[str], exact: str) -> int:
+    try:
+        return instructions.index(exact)
+    except ValueError as exc:
+        raise AssertionError(f"missing instruction {exact!r}") from exc
+
+
+def _registry_install_indexes(instructions: list[str]) -> list[int]:
+    return [
+        index
+        for index, instruction in enumerate(instructions)
+        if instruction.startswith("RUN ")
+        and f"-r {_REQUIREMENTS_PATH}" in instruction
+        and "pip install" in instruction
+    ]
+
+
+def _dockerignore_patterns(text: str) -> list[str]:
+    patterns: list[str] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        patterns.append(line)
+    return patterns
+
+
+def test_registry_install_precedes_runner_source_copy() -> None:
+    instructions = _logical_instructions(_DOCKERFILE.read_text(encoding="utf-8"))
+    runner_copy = _index_of(instructions, _RUNNER_SOURCE_COPY)
+    registry_indexes = _registry_install_indexes(instructions)
+    assert len(registry_indexes) == 1, (
+        "Dockerfile must pip-install the generated runner requirements once"
+    )
+    assert registry_indexes[0] < runner_copy, (
+        "registry dependency install must precede COPY runner ./runner so a "
+        "runner source edit does not rebuild the registry closure"
+    )
+
+
+def test_registry_layer_copies_only_lock_and_pin_exporter() -> None:
+    instructions = _logical_instructions(_DOCKERFILE.read_text(encoding="utf-8"))
+    registry_indexes = _registry_install_indexes(instructions)
+    assert len(registry_indexes) == 1
+    registry_index = registry_indexes[0]
+    allowed_copies = {_LOCKFILE_COPY, _PIN_EXPORTER_COPY}
+
+    for instruction in instructions[:registry_index]:
+        first_word = instruction.split(maxsplit=1)[0].upper()
+        if first_word not in ("COPY", "ADD"):
+            continue
+        if instruction.startswith("COPY --from="):
+            continue
+        assert instruction in allowed_copies, (
+            "unexpected source transfer before registry layer: "
+            f"{instruction!r}"
+        )
+
+    assert _index_of(instructions, _LOCKFILE_COPY) < registry_index
+    assert _index_of(instructions, _PIN_EXPORTER_COPY) < registry_index
+
+
+def test_local_package_install_follows_source_copy() -> None:
+    instructions = _logical_instructions(_DOCKERFILE.read_text(encoding="utf-8"))
+    runner_copy = _index_of(instructions, _RUNNER_SOURCE_COPY)
+    local_install_indexes = [
+        index
+        for index, instruction in enumerate(instructions)
+        if instruction.startswith("RUN ")
+        and "pip install --no-cache-dir --no-deps ./runner" in instruction
+    ]
+    assert local_install_indexes, (
+        "Dockerfile must pip-install ./runner with --no-deps after copying it"
+    )
+    assert all(index > runner_copy for index in local_install_indexes)
+
+
+def test_combined_venv_and_registry_install_is_rejected() -> None:
+    """A synthetic pre-change Dockerfile fails the precedes-source check."""
+    prechange = """\
+FROM python:3.13.15-slim
+WORKDIR /app
+COPY uv.lock ./uv.lock
+COPY packages/aci-protocol ./packages/aci-protocol
+COPY runner ./runner
+RUN python3 -m venv /app/.venv \\
+    && /app/.venv/bin/pip install --no-cache-dir --no-deps ./runner \\
+    && python3 runner/export_dependency_pins.py < uv.lock > /tmp/runner-dependency-pins.txt \\
+    && /app/.venv/bin/pip install --no-cache-dir --no-deps -r /tmp/runner-dependency-pins.txt
+"""
+    instructions = _logical_instructions(prechange)
+    runner_copy = _index_of(instructions, _RUNNER_SOURCE_COPY)
+    registry_indexes = _registry_install_indexes(instructions)
+    assert len(registry_indexes) == 1
+    assert registry_indexes[0] > runner_copy
+
+
+def test_dockerignore_exists_with_required_patterns() -> None:
+    assert _DOCKERIGNORE.is_file(), (
+        "runner/Dockerfile.dockerignore must exist so a repo-root build does "
+        "not walk .worktrees, .projects, and cli/target"
+    )
+    patterns = set(_dockerignore_patterns(_DOCKERIGNORE.read_text(encoding="utf-8")))
+    missing = [
+        pattern for pattern in _REQUIRED_IGNORE_PATTERNS if pattern not in patterns
+    ]
+    assert missing == []
+
+
+def test_dockerignore_does_not_exclude_dockerfile_copy_sources() -> None:
+    assert _DOCKERIGNORE.is_file()
+    patterns = _dockerignore_patterns(_DOCKERIGNORE.read_text(encoding="utf-8"))
+    forbidden = [
+        pattern for pattern in patterns if pattern in _FORBIDDEN_IGNORE_PATTERNS
+    ]
+    assert forbidden == []
+    dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
+    for source in _COPY_SOURCES:
+        assert source in dockerfile, (
+            f"COPY source {source!r} is missing from runner/Dockerfile"
+        )


### PR DESCRIPTION
## Summary

Split `runner/Dockerfile` so the registry dependency closure (320 MB, dominated by `claude-agent-sdk`) installs before `COPY runner`, and add `runner/Dockerfile.dockerignore` so a repo-root build no longer walks docs, charts, `.worktrees`, `.projects`, or `cli/target`. A one-line `runner/src` edit now rebuilds about 3.4 MB instead of the 322 MB venv-plus-pip layer. `export_dependency_pins.py` stays the pin source. `pip freeze` inside the old and new images is identical. Image still runs as uid 1000.

Found by curie-performance-review-2026-09 at origin/main 39a57886. No GitHub issue; this is a shared-line cache change, not pin correctness (#1436).

## Related issue

No closing keyword. Distinct from #1436 (pin exporter drift).

## Fix pin verification

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | required | Change rebuilds the runner image that skill up, skill eval, and the skill ladder boot | fake | `CURIE_E2E_TIERS=skill CURIE_E2E_IMAGE=curie-runner-layer-after CURIE_E2E_LIVE=0 CURIE_BIN=<worktree-built curie 0.8.6> curie dev e2e-ladder` against 67fe8fee. Observed: `LADDER PASS (tiers: skill)` and `E2E PASS`. Also `curie skill up --fake-model --plugin-dir examples/weather --name curie-runner-layer-probe --port 17245 --image curie-runner-layer-after`: healthz `{"ok": true}`, `id` is `uid=1000(runner)`. |
| local | n/a | No compose service, dispatcher, worker, API wiring, boot env, console UI, or curie verb --json/exit/output shape changes. `curie build` still runs `docker build -f runner/Dockerfile` from the repo root. | | |
| local-release | n/a | Does not change released binary identity, the install path, version pins, or generated release compose. | | |
| cluster | n/a | Does not change chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, or init containers. Runtime image contents stay the same pinned packages. | | |
| live provider | n/a | Does not change model routing, credential resolution, provider auth, token or cost accounting, or the MCP catalog / PreToolUse / platform MCP / workspace / coding-tool path set. Only Docker layer order and build context ignore. | | |
| external integration | n/a | Does not change Slack, git push webhooks, connector OAuth, or any third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Measurements (worktree at origin/main 5482341c, then this change)

All `docker build --progress=plain -f runner/Dockerfile` from the worktree. Unique tags. Did not build from the primary checkout (35 GB / `.worktrees`).

### Before (origin/main Dockerfile, no dockerignore)

Command: `DOCKER_BUILDKIT=1 docker build --progress=plain -f runner/Dockerfile -t curie-runner-layer-baseline .`

- Timing: `elapsed_seconds 19.73`
- BuildKit: `load .dockerignore` `transferring context: 2B done`; `load build context` `transferring context: 2.73MB 0.0s done`
- `docker history` (relevant layers): `322MB` `RUN python3 -m venv ... pip install ... ./runner ... -r /tmp/runner-dependency-pins.txt` sits after `1.15MB` `COPY runner ./runner`

Then one-line append to `runner/src/curie_runner/server.py`, rebuild `-t curie-runner-layer-baseline-edit`, revert the append.

- Timing: `elapsed_seconds 20.54`
- BuildKit: `load build context` `transferring context: 27.37kB done`
- `COPY runner ./runner` not cached; the `322MB` venv-plus-pip RUN not cached (rebuilt)

### After (this change)

Command: `DOCKER_BUILDKIT=1 docker build --progress=plain -f runner/Dockerfile -t curie-runner-layer-after .`

- Timing: `elapsed_seconds 21.05`
- BuildKit: `load build context` `transferring context: 33.02kB done` (warm session; dockerignore now present)
- `docker history`: `320MB` `RUN python3 -m venv ... -r /tmp/runner-dependency-pins.txt` precedes `1.11MB` `COPY runner ./runner`; local pip install after that copy is `2.32MB`

Then the same one-line append, rebuild `-t curie-runner-layer-after-edit`, revert.

- Timing: `elapsed_seconds 6.85`
- BuildKit: `load build context` `transferring context: 26.63kB done`
- Registry RUN `CACHED`. Rebuilt layers: `COPY runner` 1.11 MB + local pip 2.32 MB + `groupadd` 8.92 kB = **3.44 MB** (under 10 MB)

### dockerignore negative / second path

- 20 MiB blobs in `docs/`, `.worktrees/`, `cli/target/`, and `.projects/` (ignored): `transferring context: 26.61kB done`; registry RUN still `CACHED`
- 20 MiB blob in `runner/` (a COPY source): `transferring context: 20.99MB 0.1s done`
- Worktree `du -sb`: COPY set 4 787 666 bytes; whole tree 35 200 866 bytes (matches the ~35 MB clean checkout). Primary 35 GB checkout was not used as a build context.

### pip freeze (identical)

`docker run --rm --user 0 -e HOME=/tmp --entrypoint /app/.venv/bin/pip <image> freeze` on `curie-runner-layer-baseline` vs `curie-runner-layer-after`: `diff` empty, 58 lines:

```
aci-protocol @ file:///app/packages/aci-protocol
aiohappyeyeballs==2.7.1
aiohttp==3.14.3
aiosignal==1.4.0
annotated-types==0.8.0
anyio==4.14.2
attrs==26.1.0
certifi==2026.7.22
cffi==2.1.1
charset-normalizer==3.5.1
claude-agent-sdk==0.2.147
click==8.5.0
cryptography==50.0.1
curie-runner @ file:///app/runner
curie-telemetry @ file:///app/packages/telemetry
curie-telemetry-schema @ file:///app/packages/telemetry-schema
frozenlist==1.8.0
googleapis-common-protos==1.75.2
grpcio==1.83.0
h11==0.16.0
httpcore2==2.12.0
httpx2==2.12.0
idna==3.19
jsonschema==4.26.0
jsonschema-specifications==2025.9.1
mcp==2.1.1
mcp-types==2.1.1
multidict==6.7.1
opentelemetry-api==1.44.0
opentelemetry-exporter-otlp-proto-common==1.44.0
opentelemetry-exporter-otlp-proto-grpc==1.44.0
opentelemetry-exporter-otlp-proto-http==1.44.0
opentelemetry-proto==1.44.0
opentelemetry-sdk==1.44.0
opentelemetry-semantic-conventions==0.65b0
plugin-format @ file:///app/packages/plugin-format
propcache==0.5.2
protobuf==7.36.0
pycparser==3.0
pydantic==2.13.5
pydantic-settings==2.15.0
pydantic_core==2.46.5
PyJWT==2.13.0
python-dotenv==1.2.3
python-multipart==0.0.32
PyYAML==6.0.3
referencing==0.37.0
requests==2.34.2
rpds-py==2026.6.3
sniffio==1.3.1
sse-starlette==3.4.8
starlette==1.6.0
truststore==0.10.4
typing-inspection==0.4.4
typing_extensions==4.16.0
urllib3==2.7.0
uvicorn==0.52.4
yarl==1.24.5
```

Image `id`: `uid=1000(runner) gid=1000(runner)`.

## COPY set vs ignore list

Dockerfile COPY sources:

- `uv.lock`
- `runner/export_dependency_pins.py`
- `packages/aci-protocol`
- `packages/plugin-format`
- `packages/telemetry`
- `packages/telemetry-schema`
- `runner`

`runner/Dockerfile.dockerignore` (mirrors `apps/api/Dockerfile.dockerignore` plus `.worktrees` and `.projects`; `cli/target` already in the app list):

- `.git`
- `**/.venv`
- `**/__pycache__`
- `**/*.pyc`
- `**/.mypy_cache`
- `**/.pytest_cache`
- `**/.ruff_cache`
- `**/node_modules`
- `apps/ui/dist`
- `apps/ui/test-results`
- `apps/ui/playwright-report`
- `cli/target`
- `docs`
- `prototypes`
- `.github`
- `charts`
- `*.md`
- `**/*.md`
- `**/.env`
- `.worktrees`
- `.projects`

None of those patterns is a COPY source. `*.md` matches the app images and drops markdown from copied trees; runtime Python is unchanged.

## Tests

- `uv run pytest runner/tests/test_dockerfile_registry_layer.py runner/tests/test_dockerfile_dependency_pins.py runner/tests/test_dockerfile_base_pins.py runner/tests/test_dockerfile_dependency_layer.py -q`: 49 passed
- `uv run pytest runner/tests -q`: 851 passed, 7 skipped, 1 failed on this host: `test_run_check_green_bundle_registers_tools` (requires real `claude` on PATH). Failure is ambient project `.mcp.json` leaking Slack/playwright MCP servers plus `green-probe` `MCP error -32000: Connection closed`. Unrelated to this Dockerfile; the test isolates HOME but not the repo-root project MCP config. CI typically skips it when `claude` is absent.

## Conservative defaults

- Local workspace packages still install with `--no-deps` by path, after the source copy, so they resolve to the copied trees rather than PyPI. Order vs the registry install is reversed relative to the previous combined RUN; freeze identity is the proof.
- Did not switch the runner image to `uv sync`.
- Did not add a dockerignore for `compose/worker-local.Dockerfile` (ticket named that as related but distinct).
- Context numbers are from a git worktree (~35 MB, `.git` is a pointer file), not the 35 GB primary checkout.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision.
