### PR TITLE
Overlap runner boot memory, history, and MCP probes

### DIFF
--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
 import anyio
@@ -48,13 +49,12 @@ from .history import (
     DEFAULT_PREAMBLE_MAX_BYTES,
     DEFAULT_PREAMBLE_MAX_TURNS,
     TranscriptStore,
-    TurnRecord,
     format_conversation_preamble,
     resolve_history,
 )
 from .hooks import _merge_pre_tool_use_hooks, load_bundle_hooks
-from .mcp_tool_capability import probe_mcp_tool_capability
-from .memory import MemoryRecord, MemoryStore, format_memory_preamble, resolve_memory
+from .mcp_tool_capability import McpToolCapabilityProbe, probe_mcp_tool_capability
+from .memory import MemoryStore, format_memory_preamble, resolve_memory
 from .otel import RunTracer, build_tracer_provider
 from .redact import install_stdout_redaction
 from .sdk_auth import UnsupportedCredentialError
@@ -126,6 +126,7 @@ def build_runner(
     memory_preamble: str | None = None,
     history_store: TranscriptStore | None = None,
     conversation_preamble: str | None = None,
+    mcp_capability: McpToolCapabilityProbe | None = None,
     harness: HarnessContribution | None = None,
     workspace_path: Path | None = None,
 ) -> SessionRunner:
@@ -261,12 +262,14 @@ def build_runner(
         # and probe failures preserve the historical fail-closed behavior. The
         # annotation remains a non-authoritative hint: it never authorizes or
         # denies tool execution.
-        capability = anyio.run(
-            probe_mcp_tool_capability,
-            config.session.plugin_dir,
-            derived_mcp_servers,
-            sdk_env,
-        )
+        capability = mcp_capability
+        if capability is None:
+            capability = anyio.run(
+                probe_mcp_tool_capability,
+                config.session.plugin_dir,
+                derived_mcp_servers,
+                sdk_env,
+            )
         observed_readonly_tools = capability.readonly_tools
         carries_request_approval = (
             carries_explicit_action_gate or capability.has_potential_write_tool
@@ -379,7 +382,7 @@ def build_runner(
     )
 
 
-def _load_memory(config: RunnerConfig) -> tuple[MemoryStore, str | None]:
+async def _load_memory(config: RunnerConfig) -> tuple[MemoryStore, str | None]:
     """Resolve CURIE_MEMORY_REF and load prior memory into a boot preamble.
 
     Runs synchronously at boot (before the port is up), so a bad ref or an
@@ -389,12 +392,8 @@ def _load_memory(config: RunnerConfig) -> tuple[MemoryStore, str | None]:
     """
 
     store = resolve_memory(config.session.memory_ref, os.environ)
-
-    async def _load() -> list[MemoryRecord]:
-        return await store.load()
-
     try:
-        records = anyio.run(_load)
+        records = await store.load()
     except Exception as exc:  # noqa: BLE001 - degrade to no-memory, never fail boot
         logger.warning(
             "memory load failed session=%s error_class=%s: %s (booting without memory)",
@@ -407,7 +406,7 @@ def _load_memory(config: RunnerConfig) -> tuple[MemoryStore, str | None]:
     return store, format_memory_preamble(records)
 
 
-def _load_history(config: RunnerConfig) -> tuple[TranscriptStore, str | None]:
+async def _load_history(config: RunnerConfig) -> tuple[TranscriptStore, str | None]:
     """Resolve CURIE_HISTORY_REF and load this thread's transcript into a preamble.
 
     Mirrors ``_load_memory`` (ADR-0029): runs synchronously at boot so a bad ref
@@ -433,12 +432,8 @@ def _load_history(config: RunnerConfig) -> tuple[TranscriptStore, str | None]:
         if config.history_max_bytes is not None
         else DEFAULT_PREAMBLE_MAX_BYTES
     )
-
-    async def _load() -> list[TurnRecord]:
-        return await store.load()
-
     try:
-        turns = anyio.run(_load)
+        turns = await store.load()
     except Exception as exc:  # noqa: BLE001 - degrade to no-history, never fail boot
         logger.warning(
             "history load failed session=%s error_class=%s: %s (booting without history)",
@@ -449,6 +444,80 @@ def _load_history(config: RunnerConfig) -> tuple[TranscriptStore, str | None]:
         return store, None
     logger.info("history loaded session=%s turns=%d", config.session.session_id, len(turns))
     return store, format_conversation_preamble(turns, max_turns=max_turns, max_bytes=max_bytes)
+
+
+@dataclass(frozen=True)
+class _BootFetches:
+    """Independent boot-time loads that previously ran as sequential anyio.run calls."""
+
+    memory_store: MemoryStore
+    memory_preamble: str | None
+    history_store: TranscriptStore
+    conversation_preamble: str | None
+    mcp_capability: McpToolCapabilityProbe | None
+
+
+async def _load_boot_fetches(
+    config: RunnerConfig,
+    fake_model: bool,
+    sdk_env: dict[str, str] | None,
+) -> _BootFetches:
+    """Load memory, history, and (on the real-model path) MCP capability together.
+
+    Each loader keeps its own exception handling: a transient memory or history
+    failure degrades only that preamble, and a probe failure still returns the
+    fail-closed capability. A bad ref still fails the process visibly because
+    resolve runs before the task group, so MemoryError/HistoryError raise
+    directly rather than as an ExceptionGroup from a cancelled sibling.
+    """
+
+    # Fail-visible resolve stays outside the task group so a bad scheme still
+    # raises the same error type sequential boot raised. The loaders resolve
+    # again internally; that is cheap and keeps each loader self-contained.
+    resolve_memory(config.session.memory_ref, os.environ)
+    resolve_history(config.history_ref, os.environ)
+
+    memory: tuple[MemoryStore, str | None] | None = None
+    history: tuple[TranscriptStore, str | None] | None = None
+    capability: McpToolCapabilityProbe | None = None
+
+    async def load_memory() -> None:
+        nonlocal memory
+        memory = await _load_memory(config)
+
+    async def load_history() -> None:
+        nonlocal history
+        history = await _load_history(config)
+
+    async def probe() -> None:
+        nonlocal capability
+        derived = derive_mcp_servers(
+            config.session.plugin_dir,
+            release=config.connector_release,
+            agent=config.connector_agent,
+            namespace=config.connector_namespace,
+        )
+        capability = await probe_mcp_tool_capability(
+            config.session.plugin_dir,
+            derived,
+            sdk_env,
+        )
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(load_memory)
+        tg.start_soon(load_history)
+        if not fake_model:
+            tg.start_soon(probe)
+
+    assert memory is not None
+    assert history is not None
+    return _BootFetches(
+        memory_store=memory[0],
+        memory_preamble=memory[1],
+        history_store=history[0],
+        conversation_preamble=history[1],
+        mcp_capability=capability,
+    )
 
 
 def _serve() -> None:
@@ -489,8 +558,7 @@ def _serve() -> None:
         except UnsupportedCredentialError as exc:
             logger.error("credential resolution failed: %s", exc)
             raise
-    memory_store, memory_preamble = _load_memory(config)
-    history_store, conversation_preamble = _load_history(config)
+    fetches = anyio.run(_load_boot_fetches, config, fake_model, override)
     workspace_candidate = Path("/workspace")
     workspace_path: Path | None = (
         workspace_candidate
@@ -501,13 +569,15 @@ def _serve() -> None:
         config,
         fake_model=fake_model,
         sdk_env=override,
-        memory_store=memory_store,
-        memory_preamble=memory_preamble,
-        history_store=history_store,
-        conversation_preamble=conversation_preamble,
+        memory_store=fetches.memory_store,
+        memory_preamble=fetches.memory_preamble,
+        history_store=fetches.history_store,
+        conversation_preamble=fetches.conversation_preamble,
+        mcp_capability=fetches.mcp_capability,
         harness=harness,
         workspace_path=workspace_path,
     )
+
     def capture_mounted_workspace() -> WorkspaceSnapshot:
         # The sanitized, credential-free origin in /workspace/.git/config is
         # the repository fact. The proposal is runner-held state from the

--- a/runner/tests/test_boot_fetches.py
+++ b/runner/tests/test_boot_fetches.py
@@ -1,0 +1,309 @@
+"""Concurrent boot fetches: memory, history, and the MCP capability probe.
+
+The three results are independent. A delay on each fake endpoint must overlap
+so boot finishes in under twice one delay, and a failure in one must still
+degrade only that result.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import anyio
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+from curie_runner import __main__ as boot
+from curie_runner.config import RunnerConfig
+from curie_runner.history import TurnRecord, format_conversation_preamble
+from curie_runner.mcp_tool_capability import probe_mcp_tool_capability
+from curie_runner.memory import MemoryError, MemoryRecord, format_memory_preamble
+
+_BUDGET = '{"max_output_tokens_per_run": 10000, "max_usd_per_day": 1.0}'
+_SERVER = Path(__file__).parent / "fixtures" / "mcp_tool_capability_server.py"
+_DELAY = 1.5
+
+_MEMORY_ITEM = {
+    "content": "prefer ruff over flake8",
+    "provenance": {
+        "learned_from_session_id": "sess-1",
+        "source_trace_ids": ["trace-a"],
+        "recorded_at": "2026-07-13T00:00:00+00:00",
+    },
+}
+_HISTORY_ITEM = {
+    "user": "what changed?",
+    "assistant": "the deploy bumped v3",
+    "ts": "2026-07-14T00:00:00+00:00",
+}
+
+
+def _bundle(root: Path, *, mcp_command: list[str], mcp_env: dict[str, str] | None = None) -> Path:
+    (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "acme-bot"}), encoding="utf-8"
+    )
+    (root / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "operations": {
+                        "command": mcp_command[0],
+                        "args": mcp_command[1:],
+                        "env": mcp_env or {"CURIE_TEST_TOOL_MODE": "read-only"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return root
+
+
+def _delayed_mcp(tmp_path: Path, delay: float) -> Path:
+    script = tmp_path / "delayed_mcp.py"
+    script.write_text(
+        "import runpy, time\n"
+        f"time.sleep({delay!r})\n"
+        f"runpy.run_path({str(_SERVER)!r}, run_name='__main__')\n",
+        encoding="utf-8",
+    )
+    return script
+
+
+def _state_app(
+    *,
+    memory_delay: float = 0.0,
+    history_delay: float = 0.0,
+    memory_status: int = 200,
+    history_status: int = 200,
+    memory_value: list[dict[str, Any]] | None = None,
+    history_value: list[dict[str, Any]] | None = None,
+) -> web.Application:
+    app = web.Application()
+
+    async def get_memory(_request: web.Request) -> web.Response:
+        if memory_delay:
+            await anyio.sleep(memory_delay)
+        if memory_status != 200:
+            return web.json_response({"detail": "memory failed"}, status=memory_status)
+        return web.json_response(
+            {
+                "namespace": "memory",
+                "key": "log",
+                "value": list(memory_value or []),
+                "version": 1,
+            }
+        )
+
+    async def get_history(_request: web.Request) -> web.Response:
+        if history_delay:
+            await anyio.sleep(history_delay)
+        if history_status != 200:
+            return web.json_response({"detail": "history failed"}, status=history_status)
+        return web.json_response(
+            {
+                "namespace": "transcript",
+                "key": "t1",
+                "value": list(history_value or []),
+                "version": 1,
+            }
+        )
+
+    app.router.add_get("/agents/A/state/memory/log", get_memory)
+    app.router.add_get("/agents/A/state/transcript/t1", get_history)
+    return app
+
+
+def _config(plugin_dir: Path, *, memory_ref: str, history_ref: str) -> RunnerConfig:
+    return RunnerConfig.from_env(
+        {
+            "CURIE_PLUGIN_DIR": str(plugin_dir),
+            "CURIE_SESSION_ID": "s-boot",
+            "CURIE_SANDBOX_ID": "b-boot",
+            "CURIE_BUDGET": _BUDGET,
+            "CURIE_MEMORY_REF": memory_ref,
+            "CURIE_HISTORY_REF": history_ref,
+        }
+    )
+
+
+async def _run_fetches(
+    server: Any,
+    plugin_dir: Path,
+    *,
+    fake_model: bool = False,
+) -> boot._BootFetches:
+    memory_ref = str(server.make_url("/agents/A/state/memory"))
+    history_ref = str(server.make_url("/agents/A/state/transcript/t1"))
+    return await boot._load_boot_fetches(
+        _config(plugin_dir, memory_ref=memory_ref, history_ref=history_ref),
+        fake_model,
+        None,
+    )
+
+
+def test_boot_fetches_overlap_three_delayed_endpoints(tmp_path: Path) -> None:
+    plugin_dir = _bundle(
+        tmp_path / "bundle",
+        mcp_command=[sys.executable, str(_delayed_mcp(tmp_path, _DELAY))],
+    )
+    app = _state_app(
+        memory_delay=_DELAY,
+        history_delay=_DELAY,
+        memory_value=[_MEMORY_ITEM],
+        history_value=[_HISTORY_ITEM],
+    )
+
+    async def go() -> None:
+        async with TestServer(app) as server:
+            started = time.monotonic()
+            fetches = await _run_fetches(server, plugin_dir)
+            elapsed = time.monotonic() - started
+            assert elapsed < 2 * _DELAY
+            assert fetches.memory_preamble == format_memory_preamble(
+                [MemoryRecord.from_dict(_MEMORY_ITEM)]
+            )
+            assert fetches.conversation_preamble == format_conversation_preamble(
+                [TurnRecord.from_dict(_HISTORY_ITEM)]
+            )
+            assert fetches.mcp_capability is not None
+            assert fetches.mcp_capability.complete
+            assert not fetches.mcp_capability.has_potential_write_tool
+
+    anyio.run(go)
+
+
+def test_boot_fetches_match_sequential_same_inputs(tmp_path: Path) -> None:
+    plugin_dir = _bundle(tmp_path / "bundle", mcp_command=[sys.executable, str(_SERVER)])
+    app = _state_app(memory_value=[_MEMORY_ITEM], history_value=[_HISTORY_ITEM])
+
+    async def go() -> None:
+        async with TestServer(app) as server:
+            concurrent = await _run_fetches(server, plugin_dir)
+            config = _config(
+                plugin_dir,
+                memory_ref=str(server.make_url("/agents/A/state/memory")),
+                history_ref=str(server.make_url("/agents/A/state/transcript/t1")),
+            )
+            memory_store, memory_preamble = await boot._load_memory(config)
+            history_store, conversation_preamble = await boot._load_history(config)
+            capability = await probe_mcp_tool_capability(plugin_dir, {}, None)
+            assert concurrent.memory_preamble == memory_preamble
+            assert concurrent.conversation_preamble == conversation_preamble
+            assert concurrent.mcp_capability == capability
+            assert type(concurrent.memory_store) is type(memory_store)
+            assert type(concurrent.history_store) is type(history_store)
+
+    anyio.run(go)
+
+
+def test_boot_fetches_memory_failure_degrades_independently(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    plugin_dir = _bundle(tmp_path / "bundle", mcp_command=[sys.executable, str(_SERVER)])
+    app = _state_app(
+        memory_status=500,
+        history_value=[_HISTORY_ITEM],
+    )
+    caplog.set_level(logging.WARNING, logger="curie_runner")
+
+    async def go() -> None:
+        async with TestServer(app) as server:
+            fetches = await _run_fetches(server, plugin_dir)
+            assert fetches.memory_preamble is None
+            assert fetches.conversation_preamble == format_conversation_preamble(
+                [TurnRecord.from_dict(_HISTORY_ITEM)]
+            )
+            assert fetches.mcp_capability is not None
+            assert fetches.mcp_capability.complete
+
+    anyio.run(go)
+    assert any(
+        "memory load failed" in record.message and "booting without memory" in record.message
+        for record in caplog.records
+    )
+
+
+def test_boot_fetches_history_failure_degrades_independently(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    plugin_dir = _bundle(tmp_path / "bundle", mcp_command=[sys.executable, str(_SERVER)])
+    app = _state_app(
+        history_status=500,
+        memory_value=[_MEMORY_ITEM],
+    )
+    caplog.set_level(logging.WARNING, logger="curie_runner")
+
+    async def go() -> None:
+        async with TestServer(app) as server:
+            fetches = await _run_fetches(server, plugin_dir)
+            assert fetches.conversation_preamble is None
+            assert fetches.memory_preamble == format_memory_preamble(
+                [MemoryRecord.from_dict(_MEMORY_ITEM)]
+            )
+            assert fetches.mcp_capability is not None
+            assert fetches.mcp_capability.complete
+
+    anyio.run(go)
+    assert any(
+        "history load failed" in record.message and "booting without history" in record.message
+        for record in caplog.records
+    )
+
+
+def test_boot_fetches_probe_failure_degrades_independently(tmp_path: Path) -> None:
+    plugin_dir = _bundle(
+        tmp_path / "bundle",
+        mcp_command=[sys.executable, "-c", "raise SystemExit(1)"],
+    )
+    app = _state_app(memory_value=[_MEMORY_ITEM], history_value=[_HISTORY_ITEM])
+
+    async def go() -> None:
+        async with TestServer(app) as server:
+            fetches = await _run_fetches(server, plugin_dir)
+            assert fetches.memory_preamble == format_memory_preamble(
+                [MemoryRecord.from_dict(_MEMORY_ITEM)]
+            )
+            assert fetches.conversation_preamble == format_conversation_preamble(
+                [TurnRecord.from_dict(_HISTORY_ITEM)]
+            )
+            assert fetches.mcp_capability is not None
+            assert not fetches.mcp_capability.complete
+            assert fetches.mcp_capability.has_potential_write_tool
+
+    anyio.run(go)
+
+
+def test_boot_fetches_bad_memory_ref_fails_visibly(tmp_path: Path) -> None:
+    plugin_dir = _bundle(tmp_path / "bundle", mcp_command=[sys.executable, str(_SERVER)])
+    config = _config(
+        plugin_dir,
+        memory_ref="s3://bucket/mem",
+        history_ref="http://127.0.0.1:9/agents/A/state/transcript/t1",
+    )
+
+    async def go() -> None:
+        with pytest.raises(MemoryError, match="unsupported CURIE_MEMORY_REF scheme"):
+            await boot._load_boot_fetches(config, False, None)
+
+    anyio.run(go)
+
+
+def test_boot_fetches_skips_probe_on_fake_model(tmp_path: Path) -> None:
+    plugin_dir = _bundle(tmp_path / "bundle", mcp_command=[sys.executable, str(_SERVER)])
+    app = _state_app(memory_value=[_MEMORY_ITEM], history_value=[_HISTORY_ITEM])
+
+    async def go() -> None:
+        async with TestServer(app) as server:
+            fetches = await _run_fetches(server, plugin_dir, fake_model=True)
+            assert fetches.mcp_capability is None
+            assert fetches.memory_preamble is not None
+            assert fetches.conversation_preamble is not None
+
+    anyio.run(go)

--- a/runner/tests/test_signal_bootstrap.py
+++ b/runner/tests/test_signal_bootstrap.py
@@ -43,8 +43,19 @@ def _wire_process_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CURIE_FAKE_MODEL", "1")
     monkeypatch.setattr(RunnerConfig, "from_env", lambda _env: config)
     monkeypatch.setattr(boot, "_resolve_harness", lambda _name: object())
-    monkeypatch.setattr(boot, "_load_memory", lambda _config: (object(), None))
-    monkeypatch.setattr(boot, "_load_history", lambda _config: (object(), None))
+
+    async def _fake_fetches(
+        _config: object, _fake_model: bool, _sdk_env: object
+    ) -> boot._BootFetches:
+        return boot._BootFetches(
+            memory_store=object(),  # type: ignore[arg-type]
+            memory_preamble=None,
+            history_store=object(),  # type: ignore[arg-type]
+            conversation_preamble=None,
+            mcp_capability=None,
+        )
+
+    monkeypatch.setattr(boot, "_load_boot_fetches", _fake_fetches)
     monkeypatch.setattr(boot, "build_runner", lambda *_args, **_kwargs: _Runner())
     monkeypatch.setattr(
         boot,


### PR DESCRIPTION
## Summary

Runner boot loaded memory, transcript history, and the MCP tool-capability
probe as three sequential `anyio.run` blocks, so time to `/healthz` (and
sandbox Ready) was their sum. This overlaps the three under one `anyio.run`
and task group. Each loader still degrades on its own: a memory failure
boots without memory, a history failure boots without history, and a probe
failure stays fail-closed. Log line text is unchanged. A bad ref still
raises before the port is up.

This is the runner-internal share of cold boot. Warm-pool work in #1492
does not cover it.

Ref #1492

## Related issue

Ref #1492

## Fix pin verification

Not a bug-fix PR; this does not close a `bug`-labeled issue.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | required | Runner boot is the skill-tier process | fake | Commit `608ee1e3`. `uv run pytest runner/tests -q`: 853 passed, 7 skipped, ACI conformance `passed=True`. `uv run pytest runner/tests/test_boot_fetches.py -q`: overlap test with 1.5s delayed fake state-API and MCP endpoints finished in under 3.0s (two delays); sequential would be about 4.5s. |
| local | required | `curie local message` cold boot with both refs set | fake | Commit `608ee1e3` (after) vs the sequential runner image built from origin/main before rebase. Commands and timestamps below. Interval from `runner starting` to `session started` dropped from 73.3ms to 16.9ms. After the change, `history loaded` printed before `memory loaded`, which sequential boot never did. |
| local-release | n/a | Does not change released binary or image identity, the install path, version pins, or the release compose | | |
| cluster | n/a | Does not change chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, or init containers | | |
| live provider | n/a | Does not change model routing, credential resolution, provider auth, or token accounting. The MCP probe still runs with the same arguments and still feeds the same approval gate; this only overlaps it with the two state-API loads. It does not reach runner MCP catalog projection, unscoped PreToolUse, in-process platform MCP tools, workspace publication, or built-in coding-tool session capability. | | |
| external integration | n/a | Does not change Slack, git push webhooks, connector OAuth, or any third-party API shape | | |

- [x] Every required tier above names its exact command, the commit it ran
      against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable
      negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in
      the table.

### Local cold-boot measurement

Both runs used `CURIE_FAKE_MODEL=1` (compose default; the MCP probe is
skipped on that path). Both containers had `CURIE_MEMORY_REF` and
`CURIE_HISTORY_REF` set to the agent's state-API URLs. CLI project name is
pinned to `curie` (`cli/src/local.rs`), so that is the compose project used.

Stack:

```
CURIE_FAKE_MODEL=1 curie local up --minimal --build
CURIE_API_KEY=curie-dev-key curie local deploy --plugin-dir <throwaway-bundle> --slack-channel C0EXAMPLE1 --api-url http://localhost:28000
```

Before (origin/main sequential `anyio.run` blocks, image `38f69f3c42e6`):

```
CURIE_API_KEY=curie-dev-key curie local message "ping" --channel C0EXAMPLE1 --timeout-secs 120
docker logs curie-thread-218d3a1b05-e13a9d
```

```
runner starting fake_model=True          timestamp=2026-09-08T22:07:34.320455+00:00
memory loaded ... records=0              timestamp=2026-09-08T22:07:34.386247+00:00
history loaded ... turns=0               timestamp=2026-09-08T22:07:34.391803+00:00
session started ...                      timestamp=2026-09-08T22:07:34.393743+00:00
```

Interval `runner starting` to `session started`: **73.3 ms**. Memory then
history, sequential.

After (`curie build` of this branch, image `67ffe2103914`):

```
curie build
CURIE_API_KEY=curie-dev-key curie local message "ping" --channel C0EXAMPLE1 --timeout-secs 120
docker logs curie-thread-a32a39bc8e-e7e049
```

```
runner starting fake_model=True          timestamp=2026-09-08T22:09:08.046714+00:00
history loaded ... turns=0               timestamp=2026-09-08T22:09:08.059742+00:00
memory loaded ... records=0              timestamp=2026-09-08T22:09:08.060517+00:00
session started ...                      timestamp=2026-09-08T22:09:08.063595+00:00
```

Interval `runner starting` to `session started`: **16.9 ms**. History
finished before memory, which is the overlap.

Teardown: `curie local down` plus `docker rm -f` of the two `curie-thread-*`
containers.

The unit test is the three-way overlap (memory, history, and MCP probe)
because local fake-model skips the probe. That is the conservative default
for this measurement: the AC named `curie local message` with both refs
set, and local compose stays fake-model unless a credential is forced live.

### Conservative defaults

- `build_runner` still probes when `mcp_capability` is omitted, so existing
  `fake_model=False` callers keep their previous behavior. `_serve` always
  passes the concurrent result and does not probe twice.
- A bad ref is resolved before the task group so `MemoryError` /
  `HistoryError` still raise directly, not as an `ExceptionGroup`.
- Log *text* is unchanged. Among the three fetches, log *order* now follows
  completion.

## Checklist

- [x] Tests pass for the area I touched (`uv run pytest runner/tests -q`:
      853 passed, 7 skipped).
- [x] Docs updated if behavior changed. No user-facing docs; boot log text
      is unchanged.
- [x] An ADR is added under `docs/adr/` if this is an architectural
      decision. Not an ADR: scheduling of existing loaders, no door closed.
