### PR TITLE
Release eval sandboxes before the next cluster message

### DIFF
--- a/apps/api/tests/test_thread_reset_vector.py
+++ b/apps/api/tests/test_thread_reset_vector.py
@@ -10,7 +10,12 @@ from curie_api.threadreset import THREAD_RESET_INFLIGHT_SET, THREAD_RESET_SET
 _VECTOR = (
     Path(__file__).resolve().parents[3] / "tests" / "vectors" / "thread-reset-set.json"
 )
-_EXPECTED_KEYS = {"comment", "thread_reset_set", "thread_reset_inflight_set"}
+_EXPECTED_KEYS = {
+    "comment",
+    "thread_reset_set",
+    "thread_reset_inflight_set",
+    "thread_key_examples",
+}
 
 
 def test_thread_reset_keys_match_the_frozen_vector() -> None:

--- a/apps/worker/src/curie_worker/eval/stream.py
+++ b/apps/worker/src/curie_worker/eval/stream.py
@@ -631,7 +631,13 @@ class EvalStreamConsumer(StreamConsumer):
             )
         finally:
             if release_key is not None:
-                await asyncio.to_thread(self._substrate.release, release_key)
+                # wait_gone: Kubernetes delete returns before the pod is gone,
+                # and a still-terminating eval sandbox pins ResourceQuota so the
+                # ladder's post-eval cluster message cannot bind inside 45s
+                # (#2259). The wait is here, after the suite and before the
+                # matrix report the CLI polls, so eval returning means quota is
+                # free.
+                await asyncio.to_thread(self._substrate.release, release_key, wait_gone=True)
 
         if run_result is None:
             return await self._report_failed(

--- a/apps/worker/src/curie_worker/sandbox/substrate.py
+++ b/apps/worker/src/curie_worker/sandbox/substrate.py
@@ -390,10 +390,19 @@ class SandboxSubstrate:
 
     # -- release / reap -------------------------------------------------------
 
-    def release(self, thread_key: str) -> bool:
+    def release(self, thread_key: str, *, wait_gone: bool = False) -> bool:
         """End the thread's session: delete the claim (the claim's lifecycle
         deletes its sandbox and pod) and drop the route. True if a route
-        existed."""
+        existed.
+
+        Kubernetes delete of a SandboxClaim returns while the object (and its
+        pod) still exist under a deletionTimestamp. ``wait_gone=True`` polls
+        until ``get_claim`` is None so ResourceQuota is actually free before
+        the caller continues (#2259). A wait that times out is logged, not
+        raised: the delete was issued, and a following claim is no worse off
+        than today's fire-and-forget path. Operator reset-thread keeps the
+        default False so it stays inside the kernel's 5s release cap.
+        """
 
         started = time.monotonic()
         released = False
@@ -407,9 +416,13 @@ class SandboxSubstrate:
             try:
                 record = self._affinity.get(thread_key)
                 if record is not None:
-                    self._k8s.delete_claim(record.handle.claim_name)
-                    self._affinity.delete_if_claim(thread_key, record.handle.claim_name)
+                    claim_name = record.handle.claim_name
+                    sandbox_name = record.handle.sandbox_name
+                    self._k8s.delete_claim(claim_name)
+                    self._affinity.delete_if_claim(thread_key, claim_name)
                     released = True
+                    if wait_gone:
+                        self._await_quota_freed(claim_name, sandbox_name)
             except Exception as exc:
                 error = exc
                 if hasattr(span, "set_status"):
@@ -434,6 +447,33 @@ class SandboxSubstrate:
         if error is not None:
             raise error
         return released
+
+    def _await_quota_freed(self, claim_name: str, sandbox_name: str) -> None:
+        """Poll until the deleted claim AND its sandbox are absent.
+
+        ResourceQuota charges the pod, not the SandboxClaim. A default
+        background delete can hide the CR while the pod is still terminating,
+        which is the #2259 race: eval reports, the CLI starts cluster message,
+        and the new claim waits on quota the dying pod still holds. Timeout
+        logs and returns: the delete was issued, and a stuck finalizer must
+        not turn a successful eval report into a CLI hang.
+        """
+
+        deadline = time.monotonic() + self._config.release_gone_timeout_seconds
+        sleeps = _poll_sleeps(self._config)
+        while time.monotonic() < deadline:
+            claim_gone = self._k8s.get_claim(claim_name) is None
+            sandbox_gone = self._k8s.get_sandbox(sandbox_name) is None
+            if claim_gone and sandbox_gone:
+                return
+            time.sleep(max(0.0, min(next(sleeps), deadline - time.monotonic())))
+        logger.warning(
+            "sandbox claim %s / sandbox %s still present %.1fs after delete; "
+            "quota may stay held until the controller finishes (#2259)",
+            claim_name,
+            sandbox_name,
+            self._config.release_gone_timeout_seconds,
+        )
 
     def reap_orphans(self) -> list[str]:
         """Measure orphan cleanup at the substrate seam for every backend."""

--- a/apps/worker/src/curie_worker/sandbox/types.py
+++ b/apps/worker/src/curie_worker/sandbox/types.py
@@ -204,6 +204,13 @@ class SubstrateConfig:
     poll_backoff_factor: float = 2.0
     key_prefix: str = "curie:sandbox"
     claim_prefix: str = "curie-thread"
+    # How long ``release(..., wait_gone=True)`` waits for the deleted claim AND
+    # its sandbox/pod to disappear. Kubernetes delete of a SandboxClaim returns
+    # while the object (and its pod) still exist; ResourceQuota charges the pod,
+    # so a claim-only wait is not enough (#2259). Operator reset-thread keeps
+    # the default False and is still bounded by the kernel's 5s release cap;
+    # the eval plane waits because a following cluster message has only 45s.
+    release_gone_timeout_seconds: float = 30.0
 
     def claim_name_for(self, thread_key: str, nonce: str) -> str:
         """A DNS-safe, per-generation claim name for a thread.

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -1173,7 +1173,7 @@ class _TokenSubstrate:
     ) -> _FakeHandle:
         return _FakeHandle(base_url="http://sandbox.local:8080", token=self._token)
 
-    def release(self, key: str) -> None:
+    def release(self, key: str, **_: object) -> None:
         self.released.append(key)
 
 
@@ -1347,7 +1347,7 @@ class _ConcurrencyProbeSubstrate:
             self._live -= 1
         return _FakeHandle(base_url="http://sandbox.local:8080", token="t")
 
-    def release(self, _key: str) -> None:  # pragma: no cover - unused here
+    def release(self, _key: str, **_: object) -> None:  # pragma: no cover - unused here
         pass
 
 
@@ -1720,6 +1720,112 @@ def test_eval_claim_with_connector_secrets_targets_the_per_agent_pool(monkeypatc
     asyncio.run(go())
     assert fake_k8s.created_pools == ["curie-agent-acme-a-runner-pool"]
     assert fake_k8s.created_labels[-1][AGENT_LABEL] == "acme-a"
+
+
+@dataclass
+class _DelayedDeleteK8s(_FakeK8s):
+    """Eval-plane sibling of the substrate delayed-delete fake (#2259).
+
+    The claim CR can vanish while the sandbox/pod still exists. ResourceQuota
+    charges the pod, so wait_gone must poll both.
+    """
+
+    claim_gone_after_gets: int = 2
+    sandbox_gone_after_gets: int = 4
+    claim_gets: dict[str, int] = field(default_factory=dict)
+    sandbox_gets: dict[str, int] = field(default_factory=dict)
+    lingering_sandboxes: dict[str, str] = field(default_factory=dict)
+
+    def delete_claim(self, name: str) -> None:
+        claim = self.claims.get(name)
+        if claim is None or name in self.claim_gets:
+            return
+        self.claim_gets[name] = 0
+        self.sandbox_gets[claim.sandbox_name] = 0
+        self.lingering_sandboxes[claim.sandbox_name] = name
+        self.deleted.append(name)
+
+    def get_claim(self, name: str) -> ClaimView | None:
+        if name in self.claim_gets:
+            self.claim_gets[name] += 1
+            if self.claim_gets[name] >= self.claim_gone_after_gets:
+                self.claims.pop(name, None)
+                return None
+        return super().get_claim(name)
+
+    def get_sandbox(self, name: str) -> SandboxView | None:
+        if name in self.sandbox_gets:
+            self.sandbox_gets[name] += 1
+            if self.sandbox_gets[name] >= self.sandbox_gone_after_gets:
+                self.lingering_sandboxes.pop(name, None)
+                return None
+            return SandboxView(
+                name=name, ready=True, service_fqdn="127.0.0.1", operating_mode="Running"
+            )
+        return super().get_sandbox(name)
+
+
+def test_eval_suite_waits_until_the_released_claim_is_gone(monkeypatch) -> None:
+    """#2259: the weather ladder uses the trajectory eval plane, not run_eval_turns.
+
+    Kubernetes delete returns before the pod is gone, so a following cluster
+    message still contends for ResourceQuota unless the eval finally waits.
+    Leaving the claim listed after _run_and_report is the falsifiable negative.
+    """
+    from curie_worker.eval import stream as stream_module
+
+    async def _skip_suite(*_args: object, **_kwargs: object) -> EvalRunResult:
+        return EvalRunResult(version="deadbeef", suite="s", results=[])
+
+    monkeypatch.setattr(stream_module, "run_eval_suite", _skip_suite)
+    fake_k8s = _DelayedDeleteK8s(claim_gone_after_gets=2, sandbox_gone_after_gets=4)
+    sandbox_prefix = f"test:curie:sandbox:{uuid.uuid4().hex}"
+    affinity = AffinityStore(
+        redis.Redis(host=_VH, port=_VP, password=_VPW or None, decode_responses=False),
+        key_prefix=sandbox_prefix,
+    )
+    substrate = SandboxSubstrate(
+        fake_k8s,  # type: ignore[arg-type]
+        affinity,
+        SubstrateConfig(
+            namespace="test-ns",
+            warm_pool="curie-runner-pool",
+            claim_timeout_seconds=3.0,
+            poll_interval_seconds=0.001,
+            poll_interval_max_seconds=0.001,
+            release_gone_timeout_seconds=2.0,
+            key_prefix=sandbox_prefix,
+        ),
+    )
+    consumer = _consumer(
+        WorkerConfig(fake_model=True),
+        bundle_store=_FakeBundleStore(
+            _suite_bundle(
+                EvalSuite(
+                    name="s",
+                    cases=[EvalCase(id="1", input="q", grader=Grader(kind=CONTAINS, expected="a"))],
+                )
+            )
+        ),
+        substrate=substrate,
+        reporter=_FakeReporter(),
+        repo_lookup=_StubRepo(),
+    )
+    item = _item(suite="s", sha="deadbeef", bundle_ref="bundles/x.tgz", target_url=None)
+
+    async def go() -> None:
+        await consumer._run_and_report(item, "test-stream-id")
+
+    asyncio.run(go())
+    assert fake_k8s.deleted, "eval must still issue the claim delete"
+    assert not fake_k8s.claims, (
+        "eval must wait until the deleted SandboxClaim is gone so quota is free "
+        "for the following cluster message"
+    )
+    assert not fake_k8s.lingering_sandboxes, (
+        "eval must wait until the sandbox/pod is gone; ResourceQuota charges "
+        "the pod, not the claim CR"
+    )
 
 
 def test_eval_threads_claim_token_into_run_eval_suite(monkeypatch) -> None:
@@ -2950,7 +3056,7 @@ class _ProvisioningFailureSubstrate:
     def claim(self, _key: str, **_kwargs: object) -> Any:
         raise SandboxError("no capacity for an eval sandbox")
 
-    def release(self, key: str) -> None:  # pragma: no cover - must not be reached
+    def release(self, key: str, **_: object) -> None:  # pragma: no cover - must not be reached
         self.released.append(key)
 
 

--- a/apps/worker/tests/kernel/test_consumer.py
+++ b/apps/worker/tests/kernel/test_consumer.py
@@ -1464,6 +1464,66 @@ def test_next_turn_drains_reset_before_claiming_when_quota_is_full(make_harness)
     asyncio.run(go())
 
 
+def test_sadd_of_bare_eval_conversation_id_does_not_release_scoped_sandbox(
+    make_harness,
+) -> None:
+    """#2259 negative: after ADR-0096 the worker keys sandboxes as
+    quote(kind):quote(channel):quote(conversation_id). SADDing the bare
+    ``eval:`` conversation_id (what cluster eval used to queue) is a no-op
+    drain: lookup misses, the sandbox keeps its ResourceQuota slot.
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="hi", status=DONE)]
+            event = _qevent("eval-case-1", thread="eval:1720000000.000100")
+            await h.kernel.process_event(event)
+            scoped = kernel_module._thread_key_for(event)
+            assert h.substrate.lookup(scoped) is not None
+            assert scoped == "slack:C1:eval%3A1720000000.000100"
+
+            await h.async_redis.sadd(THREAD_RESET_SET, event.conversation_id)
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            nxt = _qevent("follow-up", thread="tNext", event_id="eval-wrong-key")
+            entry_id = await h.async_redis.xadd(h.config.stream, to_stream_fields(nxt))
+            await consumer._sem.acquire()
+            await consumer._handle(entry_id, to_stream_fields(nxt))
+
+            assert h.substrate.lookup(scoped) is not None, (
+                "a THREAD_RESET_SET member that is not the scoped thread key "
+                "must not release the eval sandbox"
+            )
+
+    asyncio.run(go())
+
+
+def test_sadd_of_scoped_eval_isolate_key_releases_the_sandbox(make_harness) -> None:
+    """#2259: the CLI must SADD the same percent-encoded triple the worker
+    claimed, including the ``eval:`` conversation_id whose colon encodes.
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="hi", status=DONE)]
+            event = _qevent("eval-case-1", thread="eval:1720000000.000100")
+            await h.kernel.process_event(event)
+            scoped = kernel_module._thread_key_for(event)
+            assert h.substrate.lookup(scoped) is not None
+
+            await h.async_redis.sadd(THREAD_RESET_SET, scoped)
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            nxt = _qevent("eval-case-2", thread="eval:1720000000.000200", event_id="eval-scoped")
+            entry_id = await h.async_redis.xadd(h.config.stream, to_stream_fields(nxt))
+            await consumer._sem.acquire()
+            await consumer._handle(entry_id, to_stream_fields(nxt))
+
+            assert h.substrate.lookup(scoped) is None
+
+    asyncio.run(go())
+
+
 def test_maintenance_tick_drains_pending_thread_reset_requests(make_harness) -> None:
     """#713: an operator-requested thread reset (the API SADDs the thread_key
     into THREAD_RESET_SET) is picked up and applied by the maintenance tick,

--- a/apps/worker/tests/sandbox/test_substrate.py
+++ b/apps/worker/tests/sandbox/test_substrate.py
@@ -324,6 +324,112 @@ def test_release_deletes_claim_and_route(
     assert not substrate.release("T1")
 
 
+@dataclass
+class _DelayedDeleteClient(FakeSandboxClient):
+    """A Kubernetes delete that returns before quota is free.
+
+    Production ``delete_namespaced_custom_object`` is fire-and-forget. The
+    SandboxClaim can disappear before its sandbox/pod, and ResourceQuota
+    charges the pod. Claim-only wait is the #2259 false pass.
+    """
+
+    claim_gone_after_gets: int = 2
+    sandbox_gone_after_gets: int = 4
+    claim_gets: dict[str, int] = field(default_factory=dict)
+    sandbox_gets: dict[str, int] = field(default_factory=dict)
+
+    def delete_claim(self, name: str) -> None:
+        claim = self.claims.get(name)
+        if claim is None or name in self.claim_gets:
+            return
+        self.claim_gets[name] = 0
+        self.sandbox_gets[claim.sandbox_name] = 0
+        self.deleted.append(name)
+
+    def get_claim(self, name: str) -> ClaimView | None:
+        if name in self.claim_gets:
+            self.claim_gets[name] += 1
+            if self.claim_gets[name] >= self.claim_gone_after_gets:
+                # Drop the CR only. The sandbox/pod can outlive it.
+                self.claims.pop(name, None)
+                return None
+        return super().get_claim(name)
+
+    def get_sandbox(self, name: str) -> SandboxView | None:
+        if name in self.sandbox_gets:
+            self.sandbox_gets[name] += 1
+            if self.sandbox_gets[name] >= self.sandbox_gone_after_gets:
+                self.sandboxes.pop(name, None)
+                return None
+        return super().get_sandbox(name)
+
+
+def test_release_without_wait_gone_returns_while_claim_still_counts(
+    affinity: AffinityStore, config: SubstrateConfig
+) -> None:
+    """#2259 negative: issuing delete is not the same as freeing quota.
+
+    A following claim that races the controller still sees the dying pod.
+    """
+
+    fake_k8s = _DelayedDeleteClient()
+    substrate = SandboxSubstrate(fake_k8s, affinity, config)
+    handle = substrate.claim("T-eval-1")
+    assert substrate.release("T-eval-1")
+    assert handle.claim_name in fake_k8s.claims
+    assert handle.sandbox_name in fake_k8s.sandboxes
+    assert handle.claim_name in fake_k8s.deleted
+
+
+def test_release_wait_gone_blocks_until_claim_and_sandbox_are_absent(
+    affinity: AffinityStore, config: SubstrateConfig
+) -> None:
+    """#2259: eval-owned sandboxes must not pin ResourceQuota after the suite.
+
+    The claim CR can vanish while the pod still counts. ``wait_gone=True``
+    polls both so the next cluster message can bind inside 45s.
+    """
+
+    fake_k8s = _DelayedDeleteClient(claim_gone_after_gets=2, sandbox_gone_after_gets=4)
+    fast = replace(
+        config,
+        poll_interval_seconds=0.001,
+        poll_interval_max_seconds=0.001,
+        release_gone_timeout_seconds=2.0,
+    )
+    substrate = SandboxSubstrate(fake_k8s, affinity, fast)
+    handle = substrate.claim("T-eval-1")
+    assert substrate.release("T-eval-1", wait_gone=True)
+    assert handle.claim_name not in fake_k8s.claims
+    assert handle.sandbox_name not in fake_k8s.sandboxes
+    assert fake_k8s.get_claim(handle.claim_name) is None
+    assert fake_k8s.get_sandbox(handle.sandbox_name) is None
+
+
+def test_release_wait_gone_does_not_return_when_only_the_claim_has_vanished(
+    affinity: AffinityStore, config: SubstrateConfig
+) -> None:
+    """#2259 negative: a claim-only wait would pass while the pod still
+    holds ResourceQuota. The sandbox outlives the CR here.
+    """
+
+    fake_k8s = _DelayedDeleteClient(
+        claim_gone_after_gets=1,
+        sandbox_gone_after_gets=10_000,
+    )
+    fast = replace(
+        config,
+        poll_interval_seconds=0.001,
+        poll_interval_max_seconds=0.001,
+        release_gone_timeout_seconds=0.05,
+    )
+    substrate = SandboxSubstrate(fake_k8s, affinity, fast)
+    handle = substrate.claim("T-eval-1")
+    assert substrate.release("T-eval-1", wait_gone=True)
+    assert handle.claim_name not in fake_k8s.claims
+    assert handle.sandbox_name in fake_k8s.sandboxes
+
+
 def test_reap_orphans_deletes_unrouted_claims(
     substrate: SandboxSubstrate, fake_k8s: FakeSandboxClient, affinity: AffinityStore
 ) -> None:

--- a/apps/worker/tests/test_thread_reset_vector.py
+++ b/apps/worker/tests/test_thread_reset_vector.py
@@ -4,13 +4,19 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from urllib.parse import quote
 
+from aci_protocol import QueuedTurn, ReplyHandle
 from curie_worker.consumer import THREAD_RESET_INFLIGHT_SET, THREAD_RESET_SET
+from curie_worker.kernel import _thread_key_for
 
-_VECTOR = (
-    Path(__file__).resolve().parents[3] / "tests" / "vectors" / "thread-reset-set.json"
-)
-_EXPECTED_KEYS = {"comment", "thread_reset_set", "thread_reset_inflight_set"}
+_VECTOR = Path(__file__).resolve().parents[3] / "tests" / "vectors" / "thread-reset-set.json"
+_EXPECTED_KEYS = {
+    "comment",
+    "thread_reset_set",
+    "thread_reset_inflight_set",
+    "thread_key_examples",
+}
 
 
 def test_thread_reset_keys_match_the_frozen_vector() -> None:
@@ -23,3 +29,25 @@ def test_thread_reset_keys_match_the_frozen_vector() -> None:
     )
     assert parsed["thread_reset_set"] == THREAD_RESET_SET
     assert parsed["thread_reset_inflight_set"] == THREAD_RESET_INFLIGHT_SET
+    examples = parsed["thread_key_examples"]
+    assert examples, "the vector must freeze at least one scoped thread-key example"
+    for example in examples:
+        turn = QueuedTurn(
+            event_id="EvSIM-vector",
+            conversation_id=example["conversation_id"],
+            author="U1",
+            text="ping",
+            reply_handle=ReplyHandle(
+                kind=example["kind"], channel=example["channel"], placeholder="p-1"
+            ),
+            received_at="2026-07-05T00:00:00+00:00",
+        )
+        assert _thread_key_for(turn) == example["thread_key"]
+        assert example["thread_key"] == ":".join(
+            quote(part, safe="")
+            for part in (
+                example["kind"],
+                example["channel"],
+                example["conversation_id"],
+            )
+        )

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -34,7 +34,8 @@ use crate::chat::{
 use crate::evals::{EvalCase, EvalSuite, ExpectedStatus, LoadedEval};
 use crate::ops::{plain, require_on_path, run_capture, OpsCommand};
 use crate::queue::{
-    self, connect, diagnostics, eval_case_turn, queue_thread_reset, synthetic_turn, xadd,
+    self, connect, diagnostics, eval_case_turn, queue_thread_reset, synthetic_turn,
+    thread_key_for_turn, xadd,
 };
 use crate::state::{save_turn, TurnContext, TurnVerb};
 
@@ -3449,8 +3450,11 @@ async fn run_eval_turns(
                     &placeholder_ts,
                     Some(reply_endpoint),
                 );
-                let conversation_id = event.conversation_id.clone();
-                eval_threads.push(conversation_id.clone());
+                // The worker claims under quote(kind):quote(channel):quote(conversation_id),
+                // not the bare eval-prefixed conversation_id. SADD the scoped key
+                // or the drain is a no-op and the sandbox keeps its quota slot (#2259).
+                let thread_key = thread_key_for_turn(&event);
+                eval_threads.push(thread_key.clone());
                 let started = Instant::now();
                 let stream_id = xadd(conn, &opts.stream, &event).await?;
                 let mut observe_update = |_: &str| {};
@@ -3467,7 +3471,7 @@ async fn run_eval_turns(
                 // Release this sample's sandbox on every completed/red/timed-out
                 // path so a three-case suite run twice cannot pin eight
                 // curie-thread-* claims against the default ResourceQuota (#1534).
-                queue_thread_reset(conn, &conversation_id).await?;
+                queue_thread_reset(conn, &thread_key).await?;
                 let elapsed = started.elapsed().as_secs_f64();
                 let output = match &outcome {
                     Outcome::Replied(reply) => reply.clone(),
@@ -3515,8 +3519,8 @@ async fn run_eval_turns(
     let result = run.await;
     // Suite error/cancel: still queue every case we enqueued, including the
     // in-flight one, so an abandoned retry cannot bind a late sandbox.
-    for conversation_id in &eval_threads {
-        let _ = queue_thread_reset(conn, conversation_id).await;
+    for thread_key in &eval_threads {
+        let _ = queue_thread_reset(conn, thread_key).await;
     }
     bar.finish();
     result
@@ -4849,11 +4853,15 @@ mod tests {
             "each eval case must mint through eval_case_turn so the enqueued conversation_id is isolated"
         );
         assert!(
-            src.contains("queue_thread_reset(conn, &conversation_id)"),
-            "each eval case must queue its isolated conversation_id for sandbox release"
+            src.contains("thread_key_for_turn(&event)"),
+            "each eval case must SADD the worker's scoped thread key, not the bare conversation_id"
         );
         assert!(
-            src.contains("for conversation_id in &eval_threads"),
+            src.contains("queue_thread_reset(conn, &thread_key)"),
+            "each eval case must queue its scoped thread key for sandbox release"
+        );
+        assert!(
+            src.contains("for thread_key in &eval_threads"),
             "suite error/cancel must still queue every enqueued eval thread"
         );
     }

--- a/cli/src/queue.rs
+++ b/cli/src/queue.rs
@@ -56,6 +56,42 @@ pub fn is_eval_isolate_thread(thread_key: &str) -> bool {
     thread_key.starts_with(EVAL_ISOLATE_THREAD_PREFIX)
 }
 
+/// RFC 3986 unreserved set, matching Python `urllib.parse.quote(s, safe="")`.
+fn percent_encode_unreserved(s: &str) -> String {
+    let mut out = String::new();
+    for byte in s.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(*byte as char);
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+/// The worker's internal sandbox key for a turn: percent-encoded
+/// `kind:channel:conversation_id`. Frozen with the Python `_thread_key_for`
+/// helper in `tests/vectors/thread-reset-set.json`. A THREAD_RESET_SET member
+/// that is only the conversation_id cannot release the sandbox (#2259).
+pub fn thread_key_for(kind: &str, channel: &str, conversation_id: &str) -> String {
+    [
+        percent_encode_unreserved(kind),
+        percent_encode_unreserved(channel),
+        percent_encode_unreserved(conversation_id),
+    ]
+    .join(":")
+}
+
+/// [`thread_key_for`] from a minted `QueuedTurn`.
+pub fn thread_key_for_turn(turn: &QueuedTurn) -> String {
+    thread_key_for(
+        &turn.reply_handle.kind,
+        &turn.reply_handle.channel,
+        &turn.conversation_id,
+    )
+}
+
 /// Mint the QueuedTurn `run_eval_turns` enqueues: a synthetic turn whose
 /// `conversation_id` carries the isolate prefix so the worker omits ambient
 /// agent memory (#1909). The only production mint for local/cluster eval
@@ -187,9 +223,10 @@ pub async fn xadd(
 /// Queue `thread_key` for a forced sandbox release on the worker's next drain
 /// (`THREAD_RESET_SET`, the same SET `reset-thread` uses). Idempotent.
 ///
-/// `curie local eval` / `curie cluster eval` call this after every case so
+/// `curie local eval` / `curie cluster eval` call this after every text-graded
+/// case with the worker's scoped thread key (`thread_key_for_turn`), so
 /// eval-owned `curie-thread-*` sandboxes do not pin quota until
-/// `routeTtlSeconds` (#1534).
+/// `routeTtlSeconds` (#1534, #2259).
 pub async fn queue_thread_reset(conn: &mut MultiplexedConnection, thread_key: &str) -> Result<()> {
     let _: i32 = redis::cmd("SADD")
         .arg(THREAD_RESET_SET)
@@ -685,11 +722,21 @@ mod tests {
 
     #[derive(serde::Deserialize)]
     #[serde(deny_unknown_fields)]
+    struct ThreadKeyExample {
+        kind: String,
+        channel: String,
+        conversation_id: String,
+        thread_key: String,
+    }
+
+    #[derive(serde::Deserialize)]
+    #[serde(deny_unknown_fields)]
     struct ThreadResetVector {
         #[serde(rename = "comment")]
         _comment: String,
         thread_reset_set: String,
         thread_reset_inflight_set: String,
+        thread_key_examples: Vec<ThreadKeyExample>,
     }
 
     #[test]
@@ -707,6 +754,34 @@ mod tests {
         assert_eq!(
             parsed.thread_reset_inflight_set,
             "curie:thread-reset-inflight"
+        );
+        assert!(
+            !parsed.thread_key_examples.is_empty(),
+            "the vector must freeze at least one scoped thread-key example"
+        );
+        for example in parsed.thread_key_examples {
+            assert_eq!(
+                thread_key_for(&example.kind, &example.channel, &example.conversation_id),
+                example.thread_key,
+                "CLI thread_key_for drifted from tests/vectors/thread-reset-set.json"
+            );
+        }
+    }
+
+    #[test]
+    fn eval_isolate_turn_thread_key_encodes_the_colon() {
+        let turn = eval_case_turn(
+            "slack",
+            "C-SIM-abc",
+            "U1",
+            "ping",
+            "1720000000.000100",
+            "1720000000.000200",
+            None,
+        );
+        assert_eq!(
+            thread_key_for_turn(&turn),
+            "slack:C-SIM-abc:eval%3A1720000000.000100"
         );
     }
 }

--- a/tests/vectors/thread-reset-set.json
+++ b/tests/vectors/thread-reset-set.json
@@ -1,5 +1,19 @@
 {
-  "comment": "Single source of truth for the thread-reset Valkey SET the API, worker, and CLI share. The API SADDs an operator reset (`apps/api/src/curie_api/threadreset.py`), the worker drains it (`apps/worker/src/curie_worker/consumer.py`), and `curie local eval` / `curie cluster eval` SADDs each eval-owned conversation_id onto the same set so the next turn (or the maintenance tick) releases that case's sandbox (#1534). The three lanes cannot share code across Python/Rust, so the literals are frozen here: changing one language without this file fails that language's test. Read by apps/api/tests/test_thread_reset_vector.py, apps/worker/tests/test_thread_reset_vector.py, and the test module in cli/src/queue.rs. Both keys are asserted; an unknown top-level key is rejected so a new key one lane cannot see cannot pass vacuously.",
+  "comment": "Single source of truth for the thread-reset Valkey SET the API, worker, and CLI share. The API SADDs an operator reset (`apps/api/src/curie_api/threadreset.py`), the worker drains it (`apps/worker/src/curie_worker/consumer.py`), and `curie local eval` / `curie cluster eval` SADDs each eval-owned thread key onto the same set so the next turn (or the maintenance tick) releases that case's sandbox (#1534). SET members are the worker's internal thread key (percent-encoded kind:channel:conversation_id, matching `_thread_key_for`), not the bare conversation_id: a colon in an eval-isolate id encodes as %3A (#2259). The three lanes cannot share code across Python/Rust, so the literals are frozen here: changing one language without this file fails that language's test. Read by apps/api/tests/test_thread_reset_vector.py, apps/worker/tests/test_thread_reset_vector.py, and the test module in cli/src/queue.rs. An unknown top-level key is rejected so a new key one lane cannot see cannot pass vacuously.",
   "thread_reset_set": "curie:thread-reset-requests",
-  "thread_reset_inflight_set": "curie:thread-reset-inflight"
+  "thread_reset_inflight_set": "curie:thread-reset-inflight",
+  "thread_key_examples": [
+    {
+      "kind": "slack",
+      "channel": "C1",
+      "conversation_id": "tEval1",
+      "thread_key": "slack:C1:tEval1"
+    },
+    {
+      "kind": "slack",
+      "channel": "C-SIM-abc",
+      "conversation_id": "eval:1720000000.000100",
+      "thread_key": "slack:C-SIM-abc:eval%3A1720000000.000100"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Nightly cluster eval uses the weather bundle's trajectory sidecar, so it runs on the worker eval plane rather than `run_eval_turns`. That plane already deleted the SandboxClaim in `finally`, but Kubernetes delete returns while the pod still exists, and ResourceQuota charges the pod. Two eval suites therefore left runners on the node; the post-eval `cluster message` claimed a new sandbox that was still not Ready at 45s (nightly 34203042133). Independently, text-graded eval SADDed the bare `eval:` conversation_id onto THREAD_RESET_SET, which does not match the worker's percent-encoded `kind:channel:conversation_id` key after ADR-0096.

This change waits until both the claim and its sandbox are gone before the eval plane reports, so the CLI cannot start the next message while quota is still held. Text-graded eval now SADDs the scoped key frozen in `tests/vectors/thread-reset-set.json`.

## Related issue

Closes #2259

## Fix pin verification

Fix pin: apps/worker/tests/eval/test_stream.py::test_eval_suite_waits_until_the_released_claim_is_gone

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach skill packaging, skill eval, or ACI events. | | |
| local | required | Local trajectory eval uses the same worker eval plane. | fake | `uv run pytest -q apps/worker/tests/eval/test_stream.py::test_eval_suite_waits_until_the_released_claim_is_gone` on 1d034df1: pass. Delayed delete leaves the claim listed unless `wait_gone` polls until the sandbox is gone. |
| local-release | n/a | Does not change released binary identity, install path, pins, or release compose. | | |
| cluster | required | The AC is two cluster evals then `cluster message` inside 45s on kind. | live observation of the bug; fake k8s for the fix | Reproduced on nightly run 34203042133 (main `5cdcf11c`, 2026-09-08): first message finalized at 81s; two retention evals passed; post-eval message `finalized=false status=unparseable` at 45s; four `curie-thread-*` pods still present, newest still failing `/healthz`. Fix proven by delayed-delete tests that drop the claim CR first and keep the sandbox until a later poll. A kind ladder of this candidate was not run here (k8scratch is out of contract; this box cannot hold a second full platform). |
| live provider | n/a | Does not reach model routing, credentials, MCP catalog, PreToolUse, platform MCP tools, workspace publication, or coding-tool session capability. The hang is sandbox retention. | | |
| external integration | n/a | Does not reach Slack, git webhooks, connector OAuth, or third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive: `test_release_wait_gone_blocks_until_claim_and_sandbox_are_absent` and `test_eval_suite_waits_until_the_released_claim_is_gone` wait until both objects are gone.

Negative: `test_release_without_wait_gone_returns_while_claim_still_counts` leaves the claim and sandbox listed; `test_sadd_of_bare_eval_conversation_id_does_not_release_scoped_sandbox` leaves the sandbox when the SET member is the bare conversation_id.

Independent Codex review (agent-router 358) required waiting for the pod, not only the claim CR; that is in this commit.

## Checklist

- [x] Tests cover the new behavior
- [x] Docs updated if a public surface changed (n/a)
- [x] No frozen contract change
