### PR TITLE
Force local runner-failure control independently of prompt text

### DIFF
--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -3572,15 +3572,18 @@ pin_local_source_images() {
 }
 
 # Affinity reuses a live sandbox across worker recreation. Reap so the next
-# claim cold-boots with the injected (or restored) model env. The substrate
-# label is host-wide; this control only runs inside the local OTel case.
+# claim cold-boots with the injected (or restored) model env. Match the
+# task-owned sink endpoint, not the host-wide substrate label alone, so a
+# concurrent session's runners are left alone.
 reap_local_runner_sandboxes() {
-    local runners
-    runners="$(docker ps -aq --filter "label=$SANDBOX_LABEL" 2>/dev/null || true)"
-    if [[ -n "$runners" ]]; then
-        # shellcheck disable=SC2086
-        docker rm -f $runners >/dev/null 2>&1 || true
-    fi
+    local runner
+    [[ -n "$LOCAL_OTEL_ENDPOINT" ]] || return 0
+    while IFS= read -r runner; do
+        [[ -n "$runner" ]] || continue
+        if [[ "$(container_env_value "$runner" OTEL_EXPORTER_OTLP_ENDPOINT)" == "$LOCAL_OTEL_ENDPOINT" ]]; then
+            docker rm -f "$runner" >/dev/null 2>&1 || true
+        fi
+    done < <(docker ps -aq --filter "label=$SANDBOX_LABEL" --format '{{.Names}}' 2>/dev/null)
 }
 
 inject_local_runner_failure() {

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -260,6 +260,13 @@ LOCAL_OTEL_SINK_ACTIVE=0
 LOCAL_OTEL_ENDPOINT=""
 LOCAL_OTEL_METRICS_ENDPOINT=""
 LOCAL_OTEL_FAILURE_MODE=0
+# Snapshots for restore_local_runner_health. Values are never printed.
+LOCAL_OTEL_SAVED_CREDENTIALS=""
+LOCAL_OTEL_SAVED_API_KEY=""
+LOCAL_OTEL_SAVED_OAUTH=""
+LOCAL_OTEL_SAVED_CREDENTIALS_SET=0
+LOCAL_OTEL_SAVED_API_KEY_SET=0
+LOCAL_OTEL_SAVED_OAUTH_SET=0
 OTEL_E2E_SECRET_SENTINEL="xapp-"
 OTEL_E2E_SECRET_SENTINEL+="0-0000000000-0000000000-$$"
 
@@ -3564,13 +3571,41 @@ pin_local_source_images() {
     export CURIE_DISPATCHER_IMAGE=ghcr.io/curie-eng/curie-dispatcher:dev
 }
 
+# Affinity reuses a live sandbox across worker recreation. Reap so the next
+# claim cold-boots with the injected (or restored) model env. The substrate
+# label is host-wide; this control only runs inside the local OTel case.
+reap_local_runner_sandboxes() {
+    local runners
+    runners="$(docker ps -aq --filter "label=$SANDBOX_LABEL" 2>/dev/null || true)"
+    if [[ -n "$runners" ]]; then
+        # shellcheck disable=SC2086
+        docker rm -f $runners >/dev/null 2>&1 || true
+    fi
+}
+
 inject_local_runner_failure() {
     LOCAL_OTEL_FAILURE_MODE=1
+    LOCAL_OTEL_SAVED_CREDENTIALS="${CURIE_CREDENTIALS-}"
+    LOCAL_OTEL_SAVED_API_KEY="${ANTHROPIC_API_KEY-}"
+    LOCAL_OTEL_SAVED_OAUTH="${CLAUDE_CODE_OAUTH_TOKEN-}"
+    LOCAL_OTEL_SAVED_CREDENTIALS_SET=0
+    LOCAL_OTEL_SAVED_API_KEY_SET=0
+    LOCAL_OTEL_SAVED_OAUTH_SET=0
+    [[ -n "${CURIE_CREDENTIALS+x}" ]] && LOCAL_OTEL_SAVED_CREDENTIALS_SET=1
+    [[ -n "${ANTHROPIC_API_KEY+x}" ]] && LOCAL_OTEL_SAVED_API_KEY_SET=1
+    [[ -n "${CLAUDE_CODE_OAUTH_TOKEN+x}" ]] && LOCAL_OTEL_SAVED_OAUTH_SET=1
     export CURIE_FAKE_MODEL=0
-    export CURIE_MODEL_BASE_URL="$LOCAL_OTEL_ENDPOINT"
+    # Connection-refused on the runner's own loopback: a live model cannot
+    # answer, and the OTel sink (a reachable HTTP server) is not the backend.
+    export CURIE_MODEL_BASE_URL="http://127.0.0.1:1"
     export CURIE_MODEL_API_BACKEND=messages
+    # Empty-string export, not unset: compose `.env` must not refill a live key.
+    export CURIE_CREDENTIALS=""
+    export ANTHROPIC_API_KEY=""
+    export CLAUDE_CODE_OAUTH_TOKEN=""
     docker compose --profile core --profile full -f "$REPO_ROOT/compose.dev.yaml" \
         up -d --force-recreate --no-deps curie-worker >/dev/null
+    reap_local_runner_sandboxes
     sleep 3
 }
 
@@ -3581,8 +3616,24 @@ restore_local_runner_health() {
         export CURIE_FAKE_MODEL=1
     fi
     unset CURIE_MODEL_BASE_URL CURIE_MODEL_API_BACKEND
+    if (( LOCAL_OTEL_SAVED_CREDENTIALS_SET )); then
+        export CURIE_CREDENTIALS="$LOCAL_OTEL_SAVED_CREDENTIALS"
+    else
+        unset CURIE_CREDENTIALS
+    fi
+    if (( LOCAL_OTEL_SAVED_API_KEY_SET )); then
+        export ANTHROPIC_API_KEY="$LOCAL_OTEL_SAVED_API_KEY"
+    else
+        unset ANTHROPIC_API_KEY
+    fi
+    if (( LOCAL_OTEL_SAVED_OAUTH_SET )); then
+        export CLAUDE_CODE_OAUTH_TOKEN="$LOCAL_OTEL_SAVED_OAUTH"
+    else
+        unset CLAUDE_CODE_OAUTH_TOKEN
+    fi
     docker compose --profile core --profile full -f "$REPO_ROOT/compose.dev.yaml" \
         up -d --force-recreate --no-deps curie-worker >/dev/null
+    reap_local_runner_sandboxes
     LOCAL_OTEL_FAILURE_MODE=0
     sleep 3
 }
@@ -3855,9 +3906,10 @@ case_local_otel_runner_failure() {
     echo
     echo "=== case: local runner failure is observable and recovers ==="
     # Negative evidence requires explicit ERROR status and classified_failure
-    # outcome before the restored healthy trace. This injected model_not_found
-    # is deliberately non-retryable; manufacturing a retry would weaken the
-    # kernel's bounded failure classification rather than strengthen the proof.
+    # outcome before the restored healthy trace. The injected backend is
+    # unreachable independently of prompt text and of CURIE_E2E_LIVE=1; a live
+    # model must not be able to answer the marker. runner-error is retryable,
+    # and the kernel's bounded retry still terminates as classified_failure.
     local failure_before="$WORKDIR/otel-before-failure.json"
     local restored_before="$WORKDIR/otel-before-restored.json"
     local failure_out failure_code=0 restored_out

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -396,6 +396,8 @@ def test_injected_runner_failure_does_not_depend_on_prompt_or_live_model() -> No
 
     assert "SANDBOX_LABEL" in reap
     assert "docker rm -f" in reap
+    assert "LOCAL_OTEL_ENDPOINT" in reap
+    assert "OTEL_EXPORTER_OTLP_ENDPOINT" in reap
     assert "reap_local_runner_sandboxes" in inject
     assert "reap_local_runner_sandboxes" in restore
     assert case.index("inject_local_runner_failure") < case.index(
@@ -416,6 +418,10 @@ def _stub_docker_path(tmp_path: Path) -> tuple[Path, Path, Path]:
         "#!/bin/sh\n"
         f'printf "%s\\n" "$*" >> "{log}"\n'
         'if [ "$1" = "ps" ]; then printf "fake-sandbox\\n"; exit 0; fi\n'
+        'if [ "$1" = "inspect" ]; then\n'
+        '  printf "OTEL_EXPORTER_OTLP_ENDPOINT=http://otel.example:4318\\n"\n'
+        "  exit 0\n"
+        "fi\n"
         'if [ "$1" = "compose" ]; then\n'
         f'  n=0; [ -f "{env_dir}/n" ] && n="$(cat "{env_dir}/n")"\n'
         f'  printf "%s" "$((n + 1))" > "{env_dir}/n"\n'
@@ -443,7 +449,8 @@ def test_inject_local_runner_failure_blanks_live_credentials_and_reaps(
     """Execute the real inject/restore helpers against a stub docker."""
 
     source = LADDER_PATH.read_text()
-    script = _shell_function(source, "reap_local_runner_sandboxes")
+    script = _shell_function(source, "container_env_value")
+    script += _shell_function(source, "reap_local_runner_sandboxes")
     script += _shell_function(source, "inject_local_runner_failure")
     script += _shell_function(source, "restore_local_runner_health")
     script += """

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -345,7 +345,7 @@ def test_local_runner_failure_is_falsifiable_against_the_healthy_control() -> No
         "ERROR",
         "classified_failure",
         "done_delta",
-        "deliberately non-retryable",
+        "independently of prompt",
     ):
         assert required in failure, (
             f"the local failure control does not prove {required!r} against healthy"
@@ -364,6 +364,132 @@ def test_local_runner_failure_is_falsifiable_against_the_healthy_control() -> No
     assert "same traceId" in failure, (
         "the failed turn must pair its ERROR log with the failed trace"
     )
+
+
+def test_injected_runner_failure_does_not_depend_on_prompt_or_live_model() -> None:
+    """#2260: live models answer 'runner failure control'; the inject must force the fault."""
+
+    source = LADDER_PATH.read_text()
+    inject = _shell_function(source, "inject_local_runner_failure")
+    restore = _shell_function(source, "restore_local_runner_health")
+    reap = _shell_function(source, "reap_local_runner_sandboxes")
+    case = _function_body(source, "case_local_otel_runner_failure", "# Rung 1:")
+
+    assert "runner failure control" not in inject, (
+        "the inject helper must not treat prompt text as the fault"
+    )
+    assert "$LOCAL_OTEL_ENDPOINT" not in inject, (
+        "the OTel sink is a reachable HTTP server; pointing the model at it is "
+        "not an unreachable backend and a live credential can still succeed"
+    )
+    assert "http://127.0.0.1:1" in inject, (
+        "the injected backend must be connection-refused on the runner's loopback, "
+        "independent of CURIE_E2E_LIVE and of prompt text"
+    )
+    assert "export CURIE_FAKE_MODEL=0" in inject
+    for key in ("CURIE_CREDENTIALS", "ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"):
+        assert f'export {key}=""' in inject, (
+            f"{key} must be blanked so a live OpenRouter/Anthropic credential cannot "
+            "skip the unreachable base-URL override"
+        )
+        assert key in restore, f"restore must put {key} back for the healthy control"
+
+    assert "SANDBOX_LABEL" in reap
+    assert "docker rm -f" in reap
+    assert "reap_local_runner_sandboxes" in inject
+    assert "reap_local_runner_sandboxes" in restore
+    assert case.index("inject_local_runner_failure") < case.index(
+        "runner failure control"
+    ), "the message is only a marker; inject must run first"
+
+
+def _stub_docker_path(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """A PATH prefix whose docker/sleep record compose env and ignore sleeps."""
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "docker.log"
+    env_dir = tmp_path / "compose-env"
+    env_dir.mkdir()
+    docker = bin_dir / "docker"
+    docker.write_text(
+        "#!/bin/sh\n"
+        f'printf "%s\\n" "$*" >> "{log}"\n'
+        'if [ "$1" = "ps" ]; then printf "fake-sandbox\\n"; exit 0; fi\n'
+        'if [ "$1" = "compose" ]; then\n'
+        f'  n=0; [ -f "{env_dir}/n" ] && n="$(cat "{env_dir}/n")"\n'
+        f'  printf "%s" "$((n + 1))" > "{env_dir}/n"\n'
+        "  python3 -c '\n"
+        "import json, os, sys\n"
+        "keys = [\n"
+        '    "CURIE_FAKE_MODEL", "CURIE_MODEL_BASE_URL", "CURIE_MODEL_API_BACKEND",\n'
+        '    "CURIE_CREDENTIALS", "ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN",\n'
+        "]\n"
+        "json.dump({k: os.environ.get(k) for k in keys}, open(sys.argv[1], \"w\"))\n"
+        f"' \"{env_dir}/$n.json\"\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    docker.chmod(0o700)
+    sleep = bin_dir / "sleep"
+    sleep.write_text("#!/bin/sh\nexit 0\n")
+    sleep.chmod(0o700)
+    return bin_dir, log, env_dir
+
+
+def test_inject_local_runner_failure_blanks_live_credentials_and_reaps(
+    tmp_path: Path,
+) -> None:
+    """Execute the real inject/restore helpers against a stub docker."""
+
+    source = LADDER_PATH.read_text()
+    script = _shell_function(source, "reap_local_runner_sandboxes")
+    script += _shell_function(source, "inject_local_runner_failure")
+    script += _shell_function(source, "restore_local_runner_health")
+    script += """
+REPO_ROOT="$1"
+SANDBOX_LABEL="curietech.ai/managed-by=curie-sandbox-substrate"
+LOCAL_OTEL_ENDPOINT="http://otel.example:4318"
+LIVE=1
+inject_local_runner_failure
+restore_local_runner_health
+"""
+    bin_dir, log, env_dir = _stub_docker_path(tmp_path)
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+        "CURIE_FAKE_MODEL": "0",
+        "CURIE_CREDENTIALS": "sk-or-example",
+        "ANTHROPIC_API_KEY": "sk-ant-example",
+        "CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat-example",
+        "LOCAL_OTEL_ENDPOINT": "http://otel.example:4318",
+    }
+    result = subprocess.run(
+        ["bash", "-c", script, "bash", str(REPO_ROOT)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    env_files = sorted(env_dir.glob("*.json"), key=lambda p: int(p.stem))
+    assert len(env_files) >= 2, f"expected inject and restore compose calls, got {env_files}"
+    injected = json.loads(env_files[0].read_text())
+    restored = json.loads(env_files[-1].read_text())
+    assert injected["CURIE_FAKE_MODEL"] == "0"
+    assert injected["CURIE_MODEL_BASE_URL"] == "http://127.0.0.1:1"
+    assert injected["CURIE_MODEL_API_BACKEND"] == "messages"
+    assert injected["CURIE_CREDENTIALS"] == ""
+    assert injected["ANTHROPIC_API_KEY"] == ""
+    assert injected["CLAUDE_CODE_OAUTH_TOKEN"] == ""
+    docker_log = log.read_text()
+    assert "label=curietech.ai/managed-by=curie-sandbox-substrate" in docker_log
+    assert "rm -f" in docker_log
+    assert restored["CURIE_FAKE_MODEL"] == "0"
+    assert restored["CURIE_MODEL_BASE_URL"] in (None, "")
+    assert restored["CURIE_CREDENTIALS"] == "sk-or-example"
+    assert restored["ANTHROPIC_API_KEY"] == "sk-ant-example"
+    assert restored["CLAUDE_CODE_OAUTH_TOKEN"] == "sk-ant-oat-example"
 
 
 def test_local_otel_controls_distinguish_a_live_sink_from_a_turn() -> None:


### PR DESCRIPTION
## Summary

The local OTel runner-failure control no longer depends on the live model treating "runner failure control" as a fault. Injection points the runner at a connection-refused loopback backend, blanks live credentials so OpenRouter cannot skip the base-URL override, and reaps only this run's sink-routed sandboxes so affinity cannot reuse the healthy-turn runner.

## Related issue

Closes #2260

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Ladder local-rung control only; no skill packaging or runner product loop | | |
| local | required | `case_local_otel_runner_failure` is the compose local rung control | live | Candidate `3546023b`. `CURIE_E2E_LIVE=1 CURIE_E2E_TIERS=local` local rung on the committed inject/restore path. After inject, `local message` returned `{"finalized":true,"reply":"The run failed (server_error) after 1 attempt(s). Flagging for a human."}` and the sink query printed `{"classified_failure_delta": 1.0, "done_delta": 0, "error_log_trace_matches": 1, "failed_new_traces": 1}` then `local: injected non-retryable runner failure exported a new causally matched ERROR trace/log and classified_failure metric delta`. |
| local-release | n/a | No released binary, install path, or generated compose change | | |
| cluster | n/a | No chart, RBAC, or cluster sandbox change | | |
| live provider | required | AC requires ERROR/classified_failure even when `CURIE_E2E_LIVE=1` | live | Same run. The preceding healthy control used the live model (Denver forecast reply, `classified_failure_delta: 0`). After inject the live model did not answer the marker; the turn escalated. Restored healthy control again used the live model with `classified_failure_delta: 0`. |
| external integration | n/a | Does not reach Slack, git webhooks, connector OAuth, runner MCP catalog projection, unscoped PreToolUse, in-process platform MCP tools, workspace publication, or built-in coding-tool session capability | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Hermetic pin: `uv run pytest -q compose/tests/test_local_observability_ladder.py` (32 passed), including stub-docker inject/restore that blanks live OpenRouter-shaped credentials and restores them.

Negative: skipping injection (healthy control before inject, and restored healthy control after restore) left `classified_failure_delta` at 0.

Note: a full committed-script live local ladder currently 422s at deploy because the hosted MCP receipt fixture is named `mcp-receipt` (`connectors.ambiguous_name`). That is a pre-existing live-ladder setup defect, not this control. The live proof above ran the committed inject/restore after a stock weather deploy so the failure case was reachable.

## Checklist

- [x] Tests added or updated for the behavior change
