### PR TITLE
Derive local-release images from the generated compose artifact

### DIFF
--- a/.github/workflows/nightly-graded-ladder.yaml
+++ b/.github/workflows/nightly-graded-ladder.yaml
@@ -247,6 +247,23 @@ jobs:
           load: true
           cache-from: type=gha,scope=ladder-worker
           cache-to: type=gha,mode=max,scope=ladder-worker
+      # Image tags here must cover every ghcr.io/curie-eng/curie-* ref
+      # compose/release_images.py derives from the generated compose artifact
+      # for full+slack (#2424). Do not add images one at a time: the compose
+      # tests fail this job when the derived set grows past these tags.
+      # Dispatcher is required even without --slack because local message
+      # runs a one-shot container from that image (#1915).
+      - name: Build the dispatcher image locally (one-shot local message producer, no registry auth)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/dispatcher/Dockerfile
+          builder: ${{ steps.releasecache.outputs.name }}
+          tags: ghcr.io/curie-eng/curie-dispatcher:latest
+          push: false
+          load: true
+          cache-from: type=gha,scope=ladder-dispatcher
+          cache-to: type=gha,mode=max,scope=ladder-dispatcher
       # Mirrors ci.yaml's e2e-ladder-release step of the same name. The ladder
       # selects compose's `full` profile whenever the bundle carries
       # evals/trajectory.json, which the weather bundle this rung runs does, and

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -246,11 +246,13 @@ trip against `compose.release.yaml` instead -- the file
 `compose/generate_release_compose.py` derives from `compose.dev.yaml` and the
 artifact a release binary's `curie local up` actually runs, one half of the
 `compose.dev.yaml` / generated-release-compose parity seam (AGENTS.md). It
-generates that file fresh each run, preflights that the release-pinned
-`ghcr.io/curie-eng/curie-api` and `-worker-local` images already exist
-locally (failing with a fix hint otherwise, since the generated file has no
-build directive to fall back on and a release binary has no checkout to build
-one from), then runs the same `local up --minimal -f compose.release.yaml` ->
+generates that file fresh each run, then `compose/release_images.py --check`
+derives the required `ghcr.io/curie-eng/curie-*` set from that artifact
+(including the slack-profile dispatcher `local message` needs) and fails with
+the missing identity and a recovery action if any ref is absent locally --
+the generated file has no build directive to fall back on and a release
+binary has no checkout to build one from -- then runs the same
+`local up --minimal -f compose.release.yaml` ->
 `local deploy` -> `local message` (reply asserted) -> `local down -f
 compose.release.yaml` against it. Elsewhere in CI, the `compose` job already
 asserts this generated file parses and renders the right service counts but

--- a/cli/README.md
+++ b/cli/README.md
@@ -800,9 +800,10 @@ A `local-release` rung repeats the local rung's exact round trip against the
 generated `compose.release.yaml` instead -- the artifact a release binary's
 `curie local up` actually runs -- so the CI config-only check on that file
 (`compose/generate_release_compose.py` + `docker compose config`) is not the
-only coverage it gets. It needs the release-pinned
-`ghcr.io/curie-eng/curie-api` and `-worker-local` images already built and
-tagged locally (it preflights and fails with a fix hint otherwise).
+only coverage it gets. It derives the required `ghcr.io/curie-eng/curie-*`
+image set from that artifact (including the dispatcher `local message`
+needs) and preflights that every ref is tagged locally, failing with the
+missing identity and a recovery action otherwise.
 
 Three env knobs configure it:
 

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -69,11 +69,12 @@
 #                            `local-release` is a fourth, separately-named rung
 #                            (the same local round trip against the generated
 #                            compose.release.yaml instead of compose.dev.yaml);
-#                            it is NOT folded into `all` because it needs the
-#                            release-pinned images (ghcr.io/curie-eng/curie-api
-#                            and -worker-local) built and tagged locally first,
-#                            a step `all`'s existing skill/local/cluster rungs
-#                            don't require -- name it explicitly, e.g.
+#                            it is NOT folded into `all` because it needs every
+#                            curie-owned image the generated compose artifact
+#                            names (derived by compose/release_images.py)
+#                            built and tagged locally first, a step `all`'s
+#                            existing skill/local/cluster rungs don't require --
+#                            name it explicitly, e.g.
 #                            CURIE_E2E_TIERS=skill,local,local-release.
 #   CURIE_E2E_LIVE         1 = real model on every named rung, including
 #                            rung 1 (cli/scripts/e2e.sh reads this same var
@@ -4229,25 +4230,20 @@ rung_local_release() {
     # ghcr.io/curie-eng/curie-worker-local image, and curie-api/-migrate
     # were already a pull, never a build) -- every curie-owned image it needs
     # must already exist locally under the tag the generator pinned, or `local
-    # up` will try to pull a private GHCR image with no credentials. Check only
-    # the selected profile's images and
-    # only the curie-owned ones: postgres/valkey/rustfs are public and pulled
-    # on demand same as rung_local already assumes.
+    # up` will try to pull a private GHCR image with no credentials. Derive
+    # that set from this artifact (compose/release_images.py), including the
+    # slack profile: `curie local message` runs a one-shot dispatcher
+    # container from the same image with no slack profile (#1915, #2424).
+    # postgres/valkey/rustfs stay public and pulled on demand same as
+    # rung_local. Never pull a missing curie-owned tag.
     local compose_profile="core"
     if [[ -f "$WORKDIR/bundle-release/evals/trajectory.json" ]]; then
         compose_profile="full"
     fi
-    local missing=0 image
-    while IFS= read -r image; do
-        [[ "$image" == ghcr.io/curie-eng/curie-* ]] || continue
-        if ! docker image inspect "$image" >/dev/null 2>&1; then
-            echo "error: image '$image' is required by compose.release.yaml's $compose_profile profile and is not present locally." >&2
-            missing=1
-        fi
-    done < <(docker compose -f "$release_compose" \
-        --profile "$compose_profile" --profile slack config --images)
-    if (( missing )); then
-        echo "fix: build and tag the missing image(s) locally under the tag compose.release.yaml pins (see .github/workflows/ci.yaml's e2e-ladder job for the exact build+tag steps CI uses), then re-run." >&2
+    if ! python3 "$REPO_ROOT/compose/release_images.py" \
+        --compose "$release_compose" \
+        --profiles "$compose_profile,slack" \
+        --check; then
         return 1
     fi
 

--- a/compose/release_images.py
+++ b/compose/release_images.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Derive the curie-owned image set a generated compose.release.yaml requires.
+
+The local-release ladder must provision every ghcr.io/curie-eng/curie-* image
+the generated artifact names for the profiles it starts, not a hand-maintained
+subset. #2005 closed by adding curie-ui; the next night failed on dispatcher.
+This module is the shared consumer: parse the artifact, map each ref to a
+local Dockerfile, and --check presence with `docker image inspect` only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+CURIE_IMAGE_RE = re.compile(
+    r"ghcr\.io/curie-eng/curie-[a-z-]+(?::[\w.-]+|@sha256:[0-9a-f]+)?"
+)
+
+
+class Recipe(NamedTuple):
+    dockerfile: str
+    context: str
+
+
+# Local build recipes for curie-owned compose images. An image the generated
+# artifact requires that is not in this map is a derivation miss: fail it, do
+# not pull a mutable tag, and do not skip the service.
+RECIPES = {
+    "curie-api": Recipe("apps/api/Dockerfile", "."),
+    "curie-worker": Recipe("apps/worker/Dockerfile", "."),
+    "curie-worker-local": Recipe("compose/worker-local.Dockerfile", "compose"),
+    "curie-ui": Recipe("apps/ui/Dockerfile", "."),
+    "curie-dispatcher": Recipe("apps/dispatcher/Dockerfile", "."),
+    "curie-runner": Recipe("runner/Dockerfile", "."),
+}
+
+
+def short_name(ref: str) -> str:
+    name = ref.rsplit("/", 1)[-1]
+    name = name.split("@", 1)[0]
+    return name.split(":", 1)[0]
+
+
+def recipe_for(ref: str) -> Recipe | None:
+    return RECIPES.get(short_name(ref))
+
+
+def _yaml():
+    try:
+        import yaml
+    except ImportError:
+        return None
+    return yaml
+
+
+def required_curie_images(compose_text: str, profiles: set[str]) -> set[str]:
+    """Unique curie-owned image refs for services in any of `profiles`.
+
+    A service with no `profiles` key is always started and is included. This
+    matches `docker compose --profile ... config --images` for the generated
+    release artifact, whose image refs are already literal (T3).
+    """
+    yaml = _yaml()
+    if yaml is None:
+        raise RuntimeError("PyYAML is required to parse compose text in-process")
+    doc = yaml.safe_load(compose_text)
+    services = doc.get("services") or {}
+    images: set[str] = set()
+    for svc in services.values():
+        if not isinstance(svc, dict):
+            continue
+        svc_profiles = svc.get("profiles")
+        if svc_profiles and not set(svc_profiles) & profiles:
+            continue
+        image = svc.get("image")
+        if isinstance(image, str) and image.startswith("ghcr.io/curie-eng/curie-"):
+            images.add(image)
+    return images
+
+
+_DOCKER_TAG_DEST_RE = re.compile(r"docker\s+tag\s+\S+\s+(\S+)")
+_DOCKER_BUILD_TAG_RE = re.compile(r"docker\s+build\b[^\n]*?-t\s+(\S+)")
+
+
+def job_curie_image_tags(job: dict) -> set[str]:
+    """Image refs a GitHub Actions job builds or retags locally.
+
+    Counts build-push-action `tags:` and `docker tag`/`docker build -t`
+    destinations only. A `docker pull` or `docker image inspect` of the same
+    ref is not provisioning: that is how a mutable-tag pull would still pass
+    a substring scan (#2424).
+    """
+    tags: set[str] = set()
+    for step in job.get("steps") or []:
+        if not isinstance(step, dict):
+            continue
+        uses = str(step.get("uses") or "")
+        with_ = step.get("with") or {}
+        raw = with_.get("tags")
+        if isinstance(raw, str) and "build-push-action" in uses:
+            tags.update(CURIE_IMAGE_RE.findall(raw))
+        run = step.get("run")
+        if not isinstance(run, str):
+            continue
+        for dest in _DOCKER_TAG_DEST_RE.findall(run):
+            if CURIE_IMAGE_RE.fullmatch(dest):
+                tags.add(dest)
+        for dest in _DOCKER_BUILD_TAG_RE.findall(run):
+            if CURIE_IMAGE_RE.fullmatch(dest):
+                tags.add(dest)
+    return tags
+
+
+def _docker_bin() -> str:
+    return os.environ.get("CURIE_RELEASE_IMAGES_DOCKER") or "docker"
+
+
+def compose_cli_images(compose_path: Path, profiles: set[str]) -> set[str]:
+    """curie-owned refs `docker compose config --images` reports for `profiles`."""
+    cmd = [_docker_bin(), "compose", "-f", str(compose_path)]
+    for profile in sorted(profiles):
+        cmd.extend(["--profile", profile])
+    cmd.extend(["config", "--images"])
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        raise SystemExit(result.returncode or 1)
+    return {
+        line.strip()
+        for line in result.stdout.splitlines()
+        if line.strip().startswith("ghcr.io/curie-eng/curie-")
+    }
+
+
+def required_from_artifact(compose_path: Path, profiles: set[str]) -> set[str]:
+    """Prefer parsing the artifact text; fall back to compose config --images.
+
+    The ladder jobs do not install PyYAML. docker compose is already the
+    local-release preflight's docker dependency, so it is the runtime source
+    of truth when yaml is absent.
+    """
+    if _yaml() is not None:
+        return required_curie_images(compose_path.read_text(), profiles)
+    return compose_cli_images(compose_path, profiles)
+
+
+def image_present(ref: str) -> bool:
+    result = subprocess.run(
+        [_docker_bin(), "image", "inspect", ref],
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def check(compose_path: Path, profiles: set[str]) -> int:
+    required = required_from_artifact(compose_path, profiles)
+    profile_label = ",".join(sorted(profiles))
+    errors: list[str] = []
+    for ref in sorted(required):
+        if recipe_for(ref) is None:
+            errors.append(
+                f"error: image '{ref}' is required by compose.release.yaml's "
+                f"{profile_label} profiles and has no local build recipe.\n"
+                "fix: add a Dockerfile mapping for this image in "
+                "compose/release_images.py and a matching build+tag step in "
+                "the local-release ladder jobs, then re-run."
+            )
+            continue
+        if not image_present(ref):
+            errors.append(
+                f"error: image '{ref}' is required by compose.release.yaml's "
+                f"{profile_label} profiles and is not present locally.\n"
+                "fix: build and tag the missing image(s) locally under the tag "
+                "compose.release.yaml pins (see .github/workflows/ci.yaml's "
+                "e2e-ladder-release job for the exact build+tag steps CI uses), "
+                "then re-run."
+            )
+    for err in errors:
+        print(err, file=sys.stderr)
+    return 1 if errors else 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Derive and check curie-owned images from compose.release.yaml."
+    )
+    parser.add_argument("--compose", required=True, help="path to generated compose.release.yaml")
+    parser.add_argument(
+        "--profiles",
+        required=True,
+        help="comma-separated compose profiles (e.g. full,slack)",
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help="fail if a required image is missing locally or has no recipe",
+    )
+    mode.add_argument("--list", action="store_true", help="print required image refs")
+    args = parser.parse_args()
+    profiles = {part.strip() for part in args.profiles.split(",") if part.strip()}
+    compose_path = Path(args.compose)
+    if args.list:
+        for ref in sorted(required_from_artifact(compose_path, profiles)):
+            print(ref)
+        return
+    raise SystemExit(check(compose_path, profiles))
+
+
+if __name__ == "__main__":
+    main()

--- a/compose/tests/test_release_images.py
+++ b/compose/tests/test_release_images.py
@@ -1,0 +1,310 @@
+"""#2424: local-release image set is derived from the generated compose artifact.
+
+The local-release rung and its CI/nightly jobs must provision every
+ghcr.io/curie-eng/curie-* image the generated compose.release.yaml requires
+for the profiles it actually starts (plus slack, because local message runs a
+one-shot dispatcher). Adding images one at a time is how #2005 closed and the
+next night failed on dispatcher.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GENERATE_SCRIPT = REPO_ROOT / "compose" / "generate_release_compose.py"
+RELEASE_IMAGES_SCRIPT = REPO_ROOT / "compose" / "release_images.py"
+DEV_PATH = REPO_ROOT / "compose.dev.yaml"
+OTEL_PATH = REPO_ROOT / "otel" / "collector-config.yaml"
+NIGHTLY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "nightly-graded-ladder.yaml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yaml"
+LADDER_SCRIPT = REPO_ROOT / "cli" / "scripts" / "e2e-ladder.sh"
+
+
+def load_release_images():
+    spec = importlib.util.spec_from_file_location("release_images", RELEASE_IMAGES_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_generate():
+    spec = importlib.util.spec_from_file_location("generate_release_compose", GENERATE_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.generate
+
+
+def generated_compose(version: str = "latest") -> str:
+    return load_generate()(DEV_PATH.read_text(), OTEL_PATH.read_text(), version=version)
+
+
+def write_compose(tmp_path: Path, text: str | None = None) -> Path:
+    path = tmp_path / "compose.release.yaml"
+    path.write_text(text if text is not None else generated_compose())
+    return path
+
+
+def run_release_images(
+    *args: str, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    merged = os.environ.copy()
+    if env:
+        merged.update(env)
+    return subprocess.run(
+        [sys.executable, str(RELEASE_IMAGES_SCRIPT), *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env=merged,
+    )
+
+
+def job_by_name(workflow_path: Path, job_name: str) -> dict:
+    workflow = yaml.safe_load(workflow_path.read_text())
+    job = workflow["jobs"][job_name]
+    assert isinstance(job, dict)
+    return job
+
+
+def test_runtime_module_does_not_import_yaml_at_load() -> None:
+    for line in RELEASE_IMAGES_SCRIPT.read_text().splitlines():
+        if line.startswith("import yaml") or line.startswith("from yaml"):
+            raise AssertionError(
+                "compose/release_images.py must lazy-import yaml; "
+                "the local-release ladder jobs do not install PyYAML"
+            )
+
+
+def test_required_from_artifact_falls_back_to_compose_cli(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    if shutil.which("docker") is None:
+        pytest.skip("docker is required for compose config --images")
+    images = load_release_images()
+    monkeypatch.setattr(images, "_yaml", lambda: None)
+    compose_path = write_compose(tmp_path)
+    try:
+        derived = images.required_from_artifact(compose_path, {"full", "slack"})
+    except SystemExit as exc:
+        pytest.skip(f"docker compose config failed: {exc}")
+    assert "ghcr.io/curie-eng/curie-dispatcher:latest" in derived
+    assert "ghcr.io/curie-eng/curie-ui:latest" in derived
+
+
+def test_full_slack_derives_the_generated_compose_curie_images() -> None:
+    images = load_release_images()
+    required = images.required_curie_images(generated_compose(), {"full", "slack"})
+    assert required == {
+        "ghcr.io/curie-eng/curie-api:latest",
+        "ghcr.io/curie-eng/curie-dispatcher:latest",
+        "ghcr.io/curie-eng/curie-ui:latest",
+        "ghcr.io/curie-eng/curie-worker-local:latest",
+    }
+
+
+def test_core_profile_omits_ui_and_keeps_dispatcher_via_slack() -> None:
+    images = load_release_images()
+    required = images.required_curie_images(generated_compose(), {"core", "slack"})
+    assert "ghcr.io/curie-eng/curie-ui:latest" not in required
+    assert "ghcr.io/curie-eng/curie-dispatcher:latest" in required
+    assert "ghcr.io/curie-eng/curie-api:latest" in required
+    assert "ghcr.io/curie-eng/curie-worker-local:latest" in required
+
+
+def test_every_derived_image_has_a_local_build_recipe() -> None:
+    images = load_release_images()
+    required = images.required_curie_images(generated_compose(), {"full", "slack"})
+    missing = [ref for ref in sorted(required) if images.recipe_for(ref) is None]
+    assert missing == [], f"generated compose requires images with no local recipe: {missing}"
+
+
+@pytest.mark.skipif(
+    shutil.which("docker") is None, reason="docker is required for compose config --images"
+)
+def test_derivation_matches_docker_compose_config_images(tmp_path: Path) -> None:
+    compose_path = write_compose(tmp_path)
+    rendered = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "-f",
+            str(compose_path),
+            "--profile",
+            "full",
+            "--profile",
+            "slack",
+            "config",
+            "--images",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if rendered.returncode != 0:
+        pytest.skip(f"docker compose config failed: {rendered.stderr.strip()}")
+    compose_set = {
+        line.strip()
+        for line in rendered.stdout.splitlines()
+        if line.strip().startswith("ghcr.io/curie-eng/curie-")
+    }
+    images = load_release_images()
+    derived = images.required_curie_images(compose_path.read_text(), {"full", "slack"})
+    assert derived == compose_set
+
+
+def test_check_reports_a_missing_identity_and_recovery_without_pulling(
+    tmp_path: Path,
+) -> None:
+    compose_path = write_compose(tmp_path)
+    missing = "ghcr.io/curie-eng/curie-dispatcher:latest"
+    docker_log = tmp_path / "docker.log"
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    stub = stub_dir / "docker"
+    stub.write_text(
+        "\n".join(
+            [
+                "#!/bin/sh",
+                f'echo "$@" >> "{docker_log}"',
+                'if [ "$1" = "pull" ]; then',
+                '  echo "unexpected docker pull $*" >&2',
+                "  exit 99",
+                "fi",
+                'if [ "$1" = "image" ] && [ "$2" = "inspect" ]; then',
+                '  image="$3"',
+                '  [ "$image" = "--format" ] && image="$5"',
+                f'  if [ "$image" = "{missing}" ]; then',
+                "    exit 1",
+                "  fi",
+                "  exit 0",
+                "fi",
+                "exit 0",
+                "",
+            ]
+        )
+    )
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
+
+    env = {
+        "PATH": f"{stub_dir}:{os.environ.get('PATH', '')}",
+        "CURIE_RELEASE_IMAGES_DOCKER": str(stub),
+    }
+    result = run_release_images(
+        "--compose",
+        str(compose_path),
+        "--profiles",
+        "full,slack",
+        "--check",
+        env=env,
+    )
+    assert result.returncode != 0, result.stdout + result.stderr
+    combined = result.stdout + result.stderr
+    assert missing in combined
+    assert "is required by compose.release.yaml" in combined
+    assert "fix:" in combined.lower()
+    log = docker_log.read_text() if docker_log.exists() else ""
+    assert "pull" not in log.split()
+    assert "pull" not in combined.lower()
+
+
+def test_unknown_recipe_fails_with_identity_even_when_the_image_is_present(
+    tmp_path: Path,
+) -> None:
+    extra = "ghcr.io/curie-eng/curie-missing:latest"
+    doc = yaml.safe_load(generated_compose())
+    doc["services"]["curie-missing"] = {
+        "image": extra,
+        "profiles": ["full"],
+    }
+    compose_path = write_compose(tmp_path, yaml.safe_dump(doc))
+    result = run_release_images(
+        "--compose",
+        str(compose_path),
+        "--profiles",
+        "full,slack",
+        "--check",
+    )
+    assert result.returncode != 0, result.stdout + result.stderr
+    combined = result.stdout + result.stderr
+    assert extra in combined
+    assert "no local build recipe" in combined
+    assert "fix:" in combined.lower()
+
+
+def test_job_tags_ignore_pull_and_inspect() -> None:
+    images = load_release_images()
+    pulled = {
+        "steps": [
+            {
+                "run": "docker pull ghcr.io/curie-eng/curie-dispatcher:latest\n"
+                "docker image inspect ghcr.io/curie-eng/curie-ui:latest"
+            }
+        ]
+    }
+    assert images.job_curie_image_tags(pulled) == set()
+    tagged = {
+        "steps": [
+            {
+                "uses": "docker/build-push-action@v7",
+                "with": {"tags": "ghcr.io/curie-eng/curie-dispatcher:latest"},
+            },
+            {
+                "run": "docker tag ghcr.io/curie-eng/curie-api:ci-local "
+                "ghcr.io/curie-eng/curie-api:latest\n"
+                "docker build --build-arg BASE_TAG=ci-local "
+                "-t ghcr.io/curie-eng/curie-worker-local:latest "
+                "-f compose/worker-local.Dockerfile compose"
+            },
+        ]
+    }
+    assert images.job_curie_image_tags(tagged) == {
+        "ghcr.io/curie-eng/curie-dispatcher:latest",
+        "ghcr.io/curie-eng/curie-api:latest",
+        "ghcr.io/curie-eng/curie-worker-local:latest",
+    }
+
+
+@pytest.mark.parametrize(
+    ("workflow_path", "job_name"),
+    [
+        (NIGHTLY_WORKFLOW, "ladder-local-release"),
+        (CI_WORKFLOW, "e2e-ladder-release"),
+    ],
+)
+def test_local_release_job_tags_every_generated_compose_image(
+    workflow_path: Path, job_name: str
+) -> None:
+    images = load_release_images()
+    required = images.required_curie_images(generated_compose(), {"full", "slack"})
+    provisioned = images.job_curie_image_tags(job_by_name(workflow_path, job_name))
+    missing = sorted(required - provisioned)
+    assert missing == [], (
+        f"{workflow_path.name} job {job_name} does not tag the generated "
+        f"compose.release.yaml identities {missing}; derive the set from the "
+        "artifact instead of adding images one at a time"
+    )
+
+
+def test_ladder_local_release_rung_calls_the_shared_checker() -> None:
+    text = LADDER_SCRIPT.read_text()
+    start = text.index("rung_local_release() {")
+    end = text.index('assert_bundle_identity "local-release"', start)
+    body = text[start:end]
+    assert "compose/release_images.py" in body
+    assert "--check" in body
+    assert "docker pull" not in body
+    assert "curie-dispatcher:latest" not in body


### PR DESCRIPTION
## Summary

The nightly local-release job failed because `ghcr.io/curie-eng/curie-dispatcher:latest` is required by the generated compose full+slack image set and was never built. #2005 closed by adding `curie-ui` by hand; the next missing image was dispatcher. This change derives the required set from the generated `compose.release.yaml` artifact and binds the nightly/CI jobs to that set.

`compose/release_images.py --check` is the shared consumer: it lists curie-owned refs for the profiles the local-release rung actually uses (including slack, because `local message` runs a one-shot dispatcher with no slack profile), inspects those exact identities, and fails with the missing ref plus a recovery action. It never pulls. A workflow coverage test fails if a local-release job's build-push-action tags or `docker tag`/`docker build -t` destinations do not cover the derived set; a `docker pull` of the same ref does not count as provisioning.

The nightly `ladder-local-release` job now builds and loads the dispatcher image the same way CI's `e2e-ladder-release` already did, so the candidate identities exist before startup.

## Related issue

Closes #2424
Ref #2245

## Fix pin verification

Fix pin: n/a - compose/tests is not an accepted selector path; the consumer test cannot be named by the gate, and #2424 is not bug-labeled

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin packaging, runner turn loop, ACI events, or skill eval/check. | | |
| local | n/a | compose.dev.yaml local up/message is unchanged. | | |
| local-release | required | Generated compose.release.yaml image derivation, bind, and ladder consumer. | fake | See below. |
| cluster | n/a | No chart, RBAC, sandbox, or init-container change. | | |
| live provider | n/a | Does not reach model routing, credentials, MCP catalog projection, unscoped PreToolUse, in-process platform MCP, workspace publication, or built-in coding-tool session capability. | | |
| external integration | n/a | No Slack, git webhook, or connector OAuth change. | | |

Run at commit `8bda1f69266d1a44106cb7e82b586d336b0be47f`.

**Positive.** Required images derived from the generated artifact were present; the real local-release ladder executed its declared checks:

```
CURIE_BIN=.../release/curie CURIE_E2E_TIERS=local-release CURIE_E2E_LIVE=0 bash cli/scripts/e2e-ladder.sh
```

Observed:

```
########## rung: local-release (compose, generated release artifact) ##########
=== generate compose.release.yaml from compose.dev.yaml ===
starting dev stack: ok (24.2s)
local-release: turn finalized with a reply (plumbing asserted, content deliberately not graded)
local-release: suite parity asserted (name and count only, no ids) -- the tier's own loader reported: grade 1 case(s) from suite "weather" against the local tier
no curie containers running
LADDER PASS (tiers: local-release)
```

Shipped: this PR only. Deployed: not to the permanent soak. Live-observed: fake-model local-release on this candidate; not a graded live-model nightly.

**Negative.** One required identity omitted (dispatcher retagged to `ghcr.io/curie-eng/curie-dispatcher:missing-2424-probe` in a copy of the generated artifact). `--check` using real `docker image inspect`:

```
error: image 'ghcr.io/curie-eng/curie-dispatcher:missing-2424-probe' is required by compose.release.yaml's full,slack profiles and is not present locally.
fix: build and tag the missing image(s) locally under the tag compose.release.yaml pins (see .github/workflows/ci.yaml's e2e-ladder-release job for the exact build+tag steps CI uses), then re-run.
```

Exit 1, no pull. A second path: a stub `docker` that would record a pull is never asked to pull, and a `docker pull` of a required ref does not satisfy the workflow coverage test.

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Checklist

- [x] Tests pass for the area I touched (`uv run pytest compose/tests/test_release_images.py compose/tests/test_generate_release_compose.py`, `uv run ruff check compose/release_images.py compose/tests/test_release_images.py`, `cargo test --test nightly_graded_ladder`).
- [x] Docs updated if behavior changed. The local-release preflight description now names derivation from the generated artifact instead of a two-image list.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. Not one: the consumer already listed compose images; this makes that list the source of provisioned identities.

