### PR TITLE
Give nightly setup stages ownership of generated directories

### DIFF
--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -202,7 +202,7 @@ OBSERVABILITY_POLL_INTERVAL_SECONDS=2
 # installs, upgrades, uninstalls, or deletes cluster state in this mode.
 PRODUCT_OBSERVABILITY="${CURIE_E2E_PRODUCT_OBSERVABILITY:-0}"
 MCP_RECEIPT_FIXTURE="$REPO_ROOT/cli/scripts/fixtures/mcp-receipt"
-MCP_RECEIPT_CONNECTOR="mcp-receipt"
+MCP_RECEIPT_CONNECTOR="receipt"
 MCP_RECEIPT_ALIAS=""
 MCP_RECEIPT_IMAGE=""
 LAST_ORDINARY_TRACE_ID=""
@@ -2139,7 +2139,52 @@ YAML
 # already carries the approval gate for the declared write connector.
 prepare_connector_bundle() {
     local dir="$1"
+    local plugin="$dir/.claude-plugin/plugin.json"
+    local hosted_names
     cp "$CONNECTOR_FIXTURE" "$dir/connectors.yaml"
+    # The fixture is a subset of the example's connectors. The scratch
+    # plugin.json still carries gates for connectors the fixture does not
+    # host; leaving those in place makes the owned copy fail
+    # approval_policy.gate_not_namespaced at skill up (#2423). This stage
+    # owns both files on the scratch copy.
+    hosted_names="$(mktemp)"
+    awk '
+        $0 == "connectors:" { inside = 1; next }
+        inside && /^  [a-zA-Z0-9-]+:/ { print substr($1, 1, length($1) - 1) }
+        inside && /^[^[:space:]#]/ { inside = 0 }
+    ' "$dir/connectors.yaml" > "$hosted_names"
+    if ! python3 - "$plugin" "$hosted_names" <<'PY'
+import json, sys
+from pathlib import Path
+
+plugin_path = Path(sys.argv[1])
+hosted = {line.strip() for line in Path(sys.argv[2]).read_text().splitlines() if line.strip()}
+if not plugin_path.is_file():
+    raise SystemExit(0)
+data = json.loads(plugin_path.read_text())
+policy = data.get("approvalPolicy")
+if not isinstance(policy, dict):
+    raise SystemExit(0)
+gates = policy.get("gates")
+if not isinstance(gates, list):
+    raise SystemExit(0)
+kept = []
+for gate in gates:
+    name = gate.get("gate") if isinstance(gate, dict) else None
+    if isinstance(name, str) and name.startswith("mcp__"):
+        parts = name.split("__")
+        if len(parts) >= 3 and parts[1] not in hosted:
+            continue
+    kept.append(gate)
+policy["gates"] = kept
+plugin_path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+    then
+        rm -f "$hosted_names"
+        echo "error: connector fixture setup could not align approval gates in $plugin." >&2
+        exit 1
+    fi
+    rm -f "$hosted_names"
     echo "connector fixture applied to $dir (connectors.yaml)"
 }
 
@@ -2148,19 +2193,34 @@ prepare_connector_bundle() {
 # file can be evidence because the sandbox is destroyed with the turn.
 prepare_mcp_receipt_bundle() {
     local dir="$1"
-    local destination="$dir/connectors/mcp-receipt"
+    local destination="$dir/connectors/$MCP_RECEIPT_CONNECTOR"
+    # This stage owns $destination and the `$MCP_RECEIPT_CONNECTOR` block in
+    # connectors.yaml. A rerun or a second stage that finds either already
+    # present must refuse: appending a duplicate or copying over an existing
+    # tree is the collision that made the default live lane boot an invalid
+    # bundle (#2423).
+    if [[ -e "$destination" ]]; then
+        echo "error: MCP receipt setup refusing to recreate $destination: already exists." >&2
+        echo "fix: give this setup stage its own scratch copy, or remove the owned directory before rerunning." >&2
+        exit 1
+    fi
+    if [[ -f "$dir/connectors.yaml" ]] && grep -qE "^  ${MCP_RECEIPT_CONNECTOR}:" "$dir/connectors.yaml"; then
+        echo "error: MCP receipt setup refusing to recreate connector '$MCP_RECEIPT_CONNECTOR' in $dir/connectors.yaml: already exists." >&2
+        echo "fix: give this setup stage its own scratch copy, or remove the owned connector before rerunning." >&2
+        exit 1
+    fi
     mkdir -p "$destination"
     cp "$MCP_RECEIPT_FIXTURE/Dockerfile" "$MCP_RECEIPT_FIXTURE/server.py" "$destination/"
     if [[ ! -f "$dir/connectors.yaml" ]]; then
         printf '%s\n' 'connectors:' > "$dir/connectors.yaml"
     fi
-    cat >> "$dir/connectors.yaml" <<'YAML'
-  mcp-receipt:
+    cat >> "$dir/connectors.yaml" <<YAML
+  ${MCP_RECEIPT_CONNECTOR}:
     build:
-      context: connectors/mcp-receipt
+      context: connectors/${MCP_RECEIPT_CONNECTOR}
       platforms: [linux/amd64, linux/arm64]
 YAML
-    echo "MCP receipt fixture applied to $dir (fixtures/mcp-receipt)"
+    echo "MCP receipt fixture applied to $dir (fixtures/mcp-receipt as $MCP_RECEIPT_CONNECTOR)"
 }
 
 # One build before the first rung, so every rung consumes the same lock and the

--- a/cli/scripts/e2e.sh
+++ b/cli/scripts/e2e.sh
@@ -316,16 +316,45 @@ if TRY_KEEP_COLLISION_OUTPUT="$(
         CURIE_CONFIG_DIR="$TRY_KEEP_CONFIG_DIR" \
         "$BIN" try --keep </dev/null 2>&1
 )"; then
-    printf '%s\n' "$TRY_KEEP_COLLISION_OUTPUT"
+    printf '%s\n' "$TRY_KEEP_COLLISION_OUTPUT" | sed 's/^/  /'
     echo "error: curie try --keep overwrote an existing curie-demo project." >&2
     exit 1
 fi
-printf '%s\n' "$TRY_KEEP_COLLISION_OUTPUT"
+printf '%s\n' "$TRY_KEEP_COLLISION_OUTPUT" | sed 's/^/  /'
 if [[ "$(sha256sum "$TRY_KEEP_MANIFEST" | awk '{print $1}')" != "$TRY_KEEP_MANIFEST_SHA256" ]]; then
     echo "error: refused curie try --keep altered the existing plugin manifest." >&2
     exit 1
 fi
 echo "confirmed: a second --keep refuses and preserves the graduated plugin manifest"
+
+echo
+echo "=== curie try --keep (refuse an unowned nonempty directory) ==="
+TRY_UNOWNED_ROOT="$WORKDIR/try-unowned"
+TRY_UNOWNED_CONFIG_DIR="$TRY_UNOWNED_ROOT/config"
+TRY_UNOWNED_PROJECT="$TRY_UNOWNED_ROOT/curie-demo"
+mkdir -p "$TRY_UNOWNED_CONFIG_DIR" "$TRY_UNOWNED_PROJECT"
+printf '%s\n' "user notes" > "$TRY_UNOWNED_PROJECT/notes.txt"
+TRY_UNOWNED_SHA256="$(sha256sum "$TRY_UNOWNED_PROJECT/notes.txt" | awk '{print $1}')"
+if TRY_UNOWNED_OUTPUT="$(
+    cd "$TRY_UNOWNED_ROOT"
+    env "${TRY_ENV_UNSET[@]}" \
+        CURIE_CONFIG_DIR="$TRY_UNOWNED_CONFIG_DIR" \
+        "$BIN" try --keep </dev/null 2>&1
+)"; then
+    printf '%s\n' "$TRY_UNOWNED_OUTPUT" | sed 's/^/  /'
+    echo "error: curie try --keep wrote into an unowned nonempty directory." >&2
+    exit 1
+fi
+printf '%s\n' "$TRY_UNOWNED_OUTPUT" | sed 's/^/  /'
+if [[ "$(sha256sum "$TRY_UNOWNED_PROJECT/notes.txt" | awk '{print $1}')" != "$TRY_UNOWNED_SHA256" ]]; then
+    echo "error: refused curie try --keep altered the user's file." >&2
+    exit 1
+fi
+if [[ -e "$TRY_UNOWNED_PROJECT/.claude-plugin/plugin.json" ]]; then
+    echo "error: refused curie try --keep created a plugin manifest in the unowned directory." >&2
+    exit 1
+fi
+echo "confirmed: try --keep refuses an unowned nonempty directory and leaves user files untouched"
 
 echo
 echo "=== Resolve the bundle under test ==="

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -23,7 +23,8 @@ use crate::evals::{
 use crate::render::{boxed_summary, status_str, TurnPart, TurnPrinter};
 use crate::runner::RunnerClient;
 use crate::scaffold::{
-    derive_plugin_name, read_declared_secrets, read_manifest, scaffold, scaffold_from_spec,
+    derive_plugin_name, read_declared_secrets, read_manifest, refuse_unowned_nonempty_dir,
+    scaffold, scaffold_from_spec,
 };
 use crate::state::{self, RunnerState};
 
@@ -442,6 +443,10 @@ pub async fn try_first_run(keep: bool, image: String) -> Result<()> {
     } else {
         std::env::temp_dir().join(format!("curie-try-{}", uuid::Uuid::new_v4()))
     };
+
+    if keep {
+        refuse_unowned_nonempty_dir(&dir)?;
+    }
 
     if let Err(err) = scaffold(&dir, DEMO_NAME) {
         if !keep && dir.exists() {

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -230,6 +230,33 @@ pub fn scaffold(dir: &Path, name: &str) -> Result<Vec<PathBuf>> {
     write_bundle(dir, files)
 }
 
+/// Refuse to create a generated demo directory over an existing nonempty tree.
+///
+/// `write_bundle` still refuses named scaffold targets so `init --adopt` can
+/// write alongside surviving files. `curie try --keep` is not adopt: a second
+/// stage or rerun must not recreate `./curie-demo` over a previous generated
+/// bundle or a user's files (#2423). Missing and empty directories are owned
+/// by this stage and may be filled.
+pub(crate) fn refuse_unowned_nonempty_dir(dir: &Path) -> Result<()> {
+    if !dir.exists() {
+        return Ok(());
+    }
+    if !dir.is_dir() {
+        bail!("refusing to recreate {}: not a directory", dir.display());
+    }
+    let empty = std::fs::read_dir(dir)
+        .with_context(|| format!("reading {}", dir.display()))?
+        .next()
+        .is_none();
+    if !empty {
+        bail!(
+            "refusing to recreate {}: directory exists and is not empty",
+            dir.display()
+        );
+    }
+    Ok(())
+}
+
 /// Write a bundle's files with the shared collision-refusal discipline: refuse
 /// if ANY target (or a stray root `plugin.json`) already exists, leaving every
 /// existing file untouched and creating nothing on collision. Both the weather
@@ -691,6 +718,28 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         scaffold(dir.path(), "deal-desk").unwrap();
         assert!(scaffold(dir.path(), "deal-desk").is_err());
+    }
+
+    #[test]
+    fn refuse_unowned_nonempty_dir_allows_missing_and_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("curie-demo");
+        refuse_unowned_nonempty_dir(&missing).unwrap();
+        std::fs::create_dir(&missing).unwrap();
+        refuse_unowned_nonempty_dir(&missing).unwrap();
+    }
+
+    #[test]
+    fn refuse_unowned_nonempty_dir_rejects_user_files_without_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let demo = dir.path().join("curie-demo");
+        std::fs::create_dir(&demo).unwrap();
+        let notes = demo.join("notes.txt");
+        std::fs::write(&notes, "user notes\n").unwrap();
+        let err = refuse_unowned_nonempty_dir(&demo).unwrap_err().to_string();
+        assert!(err.contains("not empty"), "{err}");
+        assert_eq!(std::fs::read_to_string(&notes).unwrap(), "user notes\n");
+        assert!(!demo.join(".claude-plugin/plugin.json").exists());
     }
 
     #[test]

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -71,6 +71,130 @@ fn ladder_function(name: &str) -> String {
     format!("{marker}{body}\n}}\n")
 }
 
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .canonicalize()
+        .expect("canonicalize repo root")
+}
+
+fn sh_single_quote(path: &Path) -> String {
+    format!("'{}'", path.display().to_string().replace('\'', "'\"'\"'"))
+}
+
+fn ladder_quoted_assignment(name: &str) -> String {
+    let prefix = format!("{name}=\"");
+    let source = ladder();
+    let (_, tail) = source
+        .split_once(&prefix)
+        .unwrap_or_else(|| panic!("ladder must assign {name}"));
+    let (value, _) = tail
+        .split_once('"')
+        .unwrap_or_else(|| panic!("ladder assignment {name} must be a quoted string"));
+    value.to_string()
+}
+
+fn copy_example_bundle(name: &str, dest: &Path) {
+    fs::create_dir_all(dest).expect("create scratch bundle directory");
+    let src = repo_root().join("examples").join(name);
+    let status = Command::new("cp")
+        .arg("-a")
+        .arg(format!("{}/.", src.display()))
+        .arg(dest)
+        .status()
+        .expect("copy example bundle");
+    assert!(
+        status.success(),
+        "copying examples/{name} into {} must succeed",
+        dest.display()
+    );
+}
+
+fn run_ladder_setup_function(function_name: &str, bundle: &Path) -> Output {
+    let repo = repo_root();
+    let function = ladder_function(function_name);
+    let script = format!(
+        "set -euo pipefail\n\
+         REPO_ROOT={repo}\n\
+         CONNECTOR_FIXTURE=\"$REPO_ROOT/cli/scripts/fixtures/sre-bot-connectors-enabled.yaml\"\n\
+         MCP_RECEIPT_FIXTURE=\"$REPO_ROOT/cli/scripts/fixtures/mcp-receipt\"\n\
+         MCP_RECEIPT_CONNECTOR={connector}\n\
+         {function}\n\
+         {function_name} {bundle}\n",
+        repo = sh_single_quote(&repo),
+        connector = sh_single_quote(Path::new(&ladder_quoted_assignment(
+            "MCP_RECEIPT_CONNECTOR"
+        ))),
+        function = function,
+        function_name = function_name,
+        bundle = sh_single_quote(bundle),
+    );
+    Command::new("bash")
+        .arg("-c")
+        .arg(script)
+        .output()
+        .unwrap_or_else(|error| panic!("run {function_name}: {error}"))
+}
+
+fn validate_bundle_json(dir: &Path) -> serde_json::Value {
+    let validation = Command::new("uv")
+        .current_dir(repo_root())
+        .args([
+            "run",
+            "--frozen",
+            "python",
+            "-c",
+            "import sys\n\
+             from plugin_format import validate_bundle\n\
+             print(validate_bundle(sys.argv[1]).model_dump_json())\n",
+        ])
+        .arg(dir)
+        .output()
+        .expect("run plugin_format.validate_bundle");
+    let stdout = String::from_utf8_lossy(&validation.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&validation.stderr).to_string();
+    assert!(
+        validation.status.success(),
+        "the bundle validator must run: stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let reported = stdout
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or_else(|| panic!("the validator must report a result: stderr:\n{stderr}"));
+    serde_json::from_str(reported)
+        .unwrap_or_else(|error| panic!("validator output must be JSON ({error}): {reported}"))
+}
+
+fn connector_name_forges_mcp_join(name: &str) -> bool {
+    name.starts_with("mcp-") || name.contains("-mcp-")
+}
+
+/// Setup stages run before the ladder's one `curie build`. `build:` connectors
+/// are therefore allowed to report `connectors.lock_missing` here; the live
+/// boot failures were `connectors.ambiguous_name` and
+/// `approval_policy.gate_not_namespaced`, which must not survive setup.
+fn assert_setup_bundle_has_no_boot_blockers(result: &serde_json::Value) {
+    let errors = result["errors"]
+        .as_array()
+        .expect("validator errors must be an array");
+    let codes: Vec<&str> = errors
+        .iter()
+        .map(|error| error["code"].as_str().expect("error code"))
+        .collect();
+    assert!(
+        !codes.iter().any(|code| *code == "connectors.ambiguous_name"
+            || *code == "approval_policy.gate_not_namespaced"),
+        "setup must not leave a bundle that skill up refuses to boot: {result}"
+    );
+    assert!(
+        codes
+            .iter()
+            .all(|code| *code == "connectors.lock_missing"),
+        "the only remaining validator errors before the ladder build must be lock_missing: {result}"
+    );
+}
+
 fn ladder_python_heredoc(function_name: &str) -> String {
     let function = ladder_function(function_name);
     let (_, tail) = function
@@ -1638,10 +1762,10 @@ case "$*" in
     "try --keep")
         # Graduation keeps the standard plugin shape, then the normal skill
         # commands below operate on this directory exactly as they do for a
-        # user-created project. A second graduation must refuse before writing
-        # the retained manifest.
-        if [ -e curie-demo/.claude-plugin/plugin.json ]; then
-            echo "error: curie-demo already exists" >&2
+        # user-created project. A nonempty directory -- a previous generated
+        # bundle or unowned user files -- must refuse before writing (#2423).
+        if [ -e curie-demo ] && [ -n "$(find curie-demo -mindepth 1 -print -quit 2>/dev/null)" ]; then
+            echo "error: refusing to recreate curie-demo: directory exists and is not empty" >&2
             exit 1
         fi
         mkdir -p curie-demo/.claude-plugin
@@ -2695,6 +2819,128 @@ fn skill_up_failure_surfaces_diagnostic_preserves_exit_and_cleans_up() {
             .any(|command| command == "rm -f curie-e2e-runner"),
         "the failure must still invoke cleanup for the owned runner; invocations:\n{docker_invocations}"
     );
+}
+
+/// #2423: the hosted MCP receipt setup must not inject a connector name that
+/// `connectors.ambiguous_name` refuses. The live default skill/local lane
+/// applies this function to a scratch weather copy; a forging name makes
+/// `skill up` unhealthy before any turn evidence.
+#[test]
+fn mcp_receipt_setup_owns_a_legal_connector_name() {
+    let name = ladder_quoted_assignment("MCP_RECEIPT_CONNECTOR");
+    assert!(
+        !connector_name_forges_mcp_join(&name),
+        "MCP_RECEIPT_CONNECTOR={name:?} forges a second -mcp- in the derived object name; \
+         rename it so it does not start with mcp- or contain -mcp-"
+    );
+    let function = ladder_function("prepare_mcp_receipt_bundle");
+    assert!(
+        function.contains("MCP_RECEIPT_CONNECTOR")
+            && !function.contains("connectors/mcp-receipt")
+            && !function.contains("  mcp-receipt:"),
+        "prepare_mcp_receipt_bundle must own $MCP_RECEIPT_CONNECTOR rather than hard-coding mcp-receipt"
+    );
+}
+
+/// #2423: applying the MCP receipt setup to the actual weather scratch copy
+/// must leave a bundle the real validator accepts. A second apply on the same
+/// owned directory must refuse rather than append a duplicate connector.
+#[test]
+fn mcp_receipt_setup_leaves_a_valid_owned_weather_bundle_and_refuses_a_rerun() {
+    if Command::new("uv").arg("--version").output().is_err() {
+        eprintln!(
+            "skipping mcp_receipt_setup_leaves_a_valid_owned_weather_bundle_and_refuses_a_rerun: uv is not on PATH"
+        );
+        return;
+    }
+
+    let harness = tempfile::tempdir().expect("create weather scratch directory");
+    let bundle = harness.path().join("bundle");
+    copy_example_bundle("weather", &bundle);
+
+    let first = run_ladder_setup_function("prepare_mcp_receipt_bundle", &bundle);
+    let first_out = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&first.stdout),
+        String::from_utf8_lossy(&first.stderr)
+    );
+    assert!(
+        first.status.success(),
+        "the MCP receipt setup must own the weather scratch copy: {first_out}"
+    );
+
+    let result = validate_bundle_json(&bundle);
+    assert_setup_bundle_has_no_boot_blockers(&result);
+
+    let second = run_ladder_setup_function("prepare_mcp_receipt_bundle", &bundle);
+    let second_out = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&second.stdout),
+        String::from_utf8_lossy(&second.stderr)
+    );
+    assert_ne!(
+        second.status.code(),
+        Some(0),
+        "a second MCP receipt setup on the same directory must refuse rather than recreate: {second_out}"
+    );
+    assert!(
+        second_out.contains("refusing") || second_out.contains("already exists"),
+        "the rerun refusal must name the collision: {second_out}"
+    );
+}
+
+/// #2423: the connector-fixture setup overwrites connectors.yaml on the
+/// sre-bot scratch copy. It must also own the matching approval gates so the
+/// scratch bundle stays valid; dangling k8s-scale / self-upgrade gates are
+/// the live connector-lane boot failure.
+#[test]
+fn connector_fixture_setup_owns_consistent_approval_gates() {
+    if Command::new("uv").arg("--version").output().is_err() {
+        eprintln!(
+            "skipping connector_fixture_setup_owns_consistent_approval_gates: uv is not on PATH"
+        );
+        return;
+    }
+
+    let harness = tempfile::tempdir().expect("create sre-bot scratch directory");
+    let bundle = harness.path().join("bundle");
+    copy_example_bundle("sre-bot", &bundle);
+
+    let output = run_ladder_setup_function("prepare_connector_bundle", &bundle);
+    let transcript = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.status.success(),
+        "the connector fixture setup must own the sre-bot scratch copy: {transcript}"
+    );
+
+    let plugin: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(bundle.join(".claude-plugin/plugin.json"))
+            .expect("read scratch plugin.json"),
+    )
+    .expect("scratch plugin.json must be JSON");
+    let gates: Vec<String> = plugin["approvalPolicy"]["gates"]
+        .as_array()
+        .expect("approvalPolicy.gates")
+        .iter()
+        .map(|gate| gate["gate"].as_str().expect("gate name").to_string())
+        .collect();
+    assert!(
+        gates.iter().any(|gate| gate.contains("k8s-write")),
+        "the fixture still hosts k8s-write, so its gate must remain: {gates:?}"
+    );
+    assert!(
+        gates
+            .iter()
+            .all(|gate| !gate.contains("k8s-scale") && !gate.contains("self-upgrade")),
+        "gates for connectors the fixture does not host must be dropped from the owned scratch copy: {gates:?}"
+    );
+
+    let result = validate_bundle_json(&bundle);
+    assert_setup_bundle_has_no_boot_blockers(&result);
 }
 
 /// NEGATIVE CONTROL: bundle identity. The cluster rung's deploy receipt reports


### PR DESCRIPTION
## Summary

Nightly skill/local setup mutated a shared scratch bundle until `skill up` refused to boot it, while GitHub annotated the expected `try --keep` collision as the job error. Each setup stage now owns its generated directory: the hosted MCP receipt connector is named `receipt` so it does not forge `-mcp-`, the connector fixture aligns scratch approval gates with the connectors it actually hosts, and `curie try --keep` refuses a nonempty unowned directory. The named-file overwrite guard and captured skill-up diagnostics stay in place. The shipped weather and sre-bot inputs are preserved; only the ladder's owned scratch copies are rewritten.

## Related issue

Closes #2423

## Fix pin verification

Fix pin: cli/tests/nightly_graded_ladder.rs::mcp_receipt_setup_leaves_a_valid_owned_weather_bundle_and_refuses_a_rerun

## End-to-end verification

Candidate: `87122ce106d6f8ed746d5c06e2aed3703058fca9`

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | required | Nightly skill rung boots the scratch bundle after these setup stages | fake | `CURIE_E2E_TIERS=skill CURIE_E2E_CONNECTOR_BUNDLE=examples/sre-bot bash cli/scripts/e2e-ladder.sh` observed `LADDER PASS (tiers: skill)` with hosted kubernetes/k8s-write/tempo. Independent default: `CURIE_E2E_TIERS=skill bash cli/scripts/e2e-ladder.sh` observed `LADDER PASS (tiers: skill)` and `confirmed: try --keep refuses an unowned nonempty directory`. Receipt path: `skill up --fake-model` after `prepare_mcp_receipt_bundle` on a weather copy observed `waiting for runner: ok`. |
| local | required | Same scratch bundle is deployed by the local rung | fake | Not run. `curie-r2427-src-1229530` already held host ports 25432/26379/29000. Displacing that sibling task-owned compose is out of contract. Skill proofs used the same setup-owned copies the local rung would pack. |
| local-release | n/a | Does not change compose.release.yaml, release image identity, or #2424 provisioning | | |
| cluster | n/a | Does not change chart templates, RBAC, sandbox claims, or init containers | | |
| live provider | required | Default nightly skill/local lane is `CURIE_E2E_LIVE=1` | live | After `prepare_mcp_receipt_bundle` and `curie build --plugin-dir` on a weather copy: `curie skill up --plugin-dir <scratch> --name curie-2423-live-* --port 7258` observed `waiting for runner: ok` and boot panel `Model CURIE_CREDENTIALS`; `curie skill message --url http://localhost:7258 "In one short sentence, say hello."` observed `-- final (done)` and `Hello!`. Task-owned runner removed. |
| external integration | n/a | Does not change Slack, git webhooks, connector OAuth, or product MCP catalog projection / PreToolUse / workspace / coding-tool code | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [ ] No required tier is left unproved; any blocked tier names its blocker in the table.

Local remains blocked by a sibling task-owned compose on the shared host ports. Skill (default and connector) and live-provider receipt boot are recorded above.

## Checklist

- [x] Tests cover the new behavior (setup ownership, legal receipt name, gate alignment, unowned nonempty refusal)
- [x] `cargo test --test nightly_graded_ladder` and scaffold unit tests pass
- [x] `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `bash -n` on the two scripts
- [x] No frozen-interface, schema, or ADR change
- [x] Task-owned runners were removed; the 2427 compose stack was left untouched
