### PR TITLE
Add a bounded synthetic restore drill for stable-install state

### DIFF
--- a/apps/mail-adapter/tests/test_state_restore.py
+++ b/apps/mail-adapter/tests/test_state_restore.py
@@ -1,0 +1,38 @@
+"""SQLite file-copy restore preserves pending work and dedup receipts.
+
+This is the mail adapter's existing supported restore mechanism (stop the
+writer, copy the file, open the copy before the writer starts). #2427 uses it
+as synthetic delivery-state; it does not add a second store or replay path.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from curie_mail_adapter.state import MailState
+
+
+def test_copied_sqlite_file_keeps_pending_work_and_refuses_duplicate_ids(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source" / "state.sqlite3"
+    target = tmp_path / "target" / "state.sqlite3"
+    target.parent.mkdir()
+    state = MailState(str(source), max_pending=20, max_bytes=8 * 1024 * 1024)
+    assert (
+        state.admit({"message_id": "msg-pending", "thread_id": "thr-pending"}) == "admitted"
+    )
+    assert state.record_terminal("msg-known", "accepted") == "admitted"
+    state.connection.execute("PRAGMA wal_checkpoint(FULL)")
+    state.connection.close()
+
+    shutil.copy2(source, target)
+
+    restored = MailState(str(target), max_pending=20, max_bytes=8 * 1024 * 1024)
+    assert [row["message_id"] for row in restored.pending()] == ["msg-pending"]
+    assert "msg-known" in restored.known_message_ids()
+    assert (
+        restored.admit({"message_id": "msg-pending", "thread_id": "thr-pending"}) == "known"
+    )
+    assert restored.admit({"message_id": "msg-known", "thread_id": "thr-other"}) == "known"

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -5373,6 +5373,37 @@ export const commandManifest = {
           "name": "wire-tolerance"
         },
         {
+          "about": "Bounded synthetic restore drill for #2427: back up postgres, bundles, mail SQLite, and Valkey from a disposable compose install, restore onto a distinct target, and refuse an omitted or corrupt component (`bash cli/scripts/restore-drill.sh`). Not a production backup product and not an RPO/RTO claim",
+          "args": [
+            {
+              "global": false,
+              "help": "Validate an existing backup directory without starting a stack",
+              "id": "check_backup",
+              "long": "check-backup",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "JSON object of separately supplied key names. Required with --check-backup",
+              "id": "supplied_config",
+              "long": "supplied-config",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Omit this required component and expect the completeness guard to refuse",
+              "id": "negative",
+              "long": "negative",
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "restore-drill"
+        },
+        {
           "about": "Set the release version across cli/Cargo.toml + Chart.yaml version/appVersion (and refresh the CLI lockfile) so a release cut can't leave the three out of sync. Does not commit or tag",
           "args": [
             {

--- a/cli/README.md
+++ b/cli/README.md
@@ -727,6 +727,7 @@ release binary has no dev scripts.
 | `curie dev field-parity` | `bash cli/scripts/check-field-parity.sh` -- assert CLI `api.rs` mirror structs cover their platform API model fields (#691), and CLI `commands.rs`/`spec.rs` mirror structs cover the frozen `packages/plugin-format` schema's fields (#701). |
 | `curie dev emit-parity` | `bash cli/scripts/check-emit-parity.sh` -- assert a `CliOutput::to_json` that hand-projects a mirror struct into a `json!` literal covers that struct's fields, one hop downstream of `field-parity` (#699). |
 | `curie dev wire-tolerance` | `bash scripts/check-wire-tolerance.sh` -- assert every direct `ClassName.model_validate*(...)` call on an `_AciModel` subclass threads `READER_CONTEXT` or is a declared exception (#625). |
+| `curie dev restore-drill` | `bash cli/scripts/restore-drill.sh` -- bounded synthetic restore of postgres, bundles, mail SQLite, and Valkey from a disposable compose install onto a distinct target (#2427). `--check-backup` is the completeness guard; `--negative` omits a required component and expects refusal. Not an RPO/RTO claim or a production backup product. |
 
 Use `curie dev verify-fix-pin <CHANGE> <SELECTOR>` from a source checkout to
 verify a fix commit or pull request. `<CHANGE>` accepts a committed change

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -5370,6 +5370,37 @@
           "name": "wire-tolerance"
         },
         {
+          "about": "Bounded synthetic restore drill for #2427: back up postgres, bundles, mail SQLite, and Valkey from a disposable compose install, restore onto a distinct target, and refuse an omitted or corrupt component (`bash cli/scripts/restore-drill.sh`). Not a production backup product and not an RPO/RTO claim",
+          "args": [
+            {
+              "global": false,
+              "help": "Validate an existing backup directory without starting a stack",
+              "id": "check_backup",
+              "long": "check-backup",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "JSON object of separately supplied key names. Required with --check-backup",
+              "id": "supplied_config",
+              "long": "supplied-config",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Omit this required component and expect the completeness guard to refuse",
+              "id": "negative",
+              "long": "negative",
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "restore-drill"
+        },
+        {
           "about": "Set the release version across cli/Cargo.toml + Chart.yaml version/appVersion (and refresh the CLI lockfile) so a release cut can't leave the three out of sync. Does not commit or tag",
           "args": [
             {

--- a/cli/scripts/restore-drill.sh
+++ b/cli/scripts/restore-drill.sh
@@ -1,0 +1,440 @@
+#!/usr/bin/env bash
+# Bounded synthetic stable-install restore drill for #2427.
+#
+# Uses existing export/restore mechanisms (pg_dump, aws s3 sync, SQLite file
+# copy, Valkey RDB). Does not invent Valkey replay, RPO/RTO, or a production
+# backup product. Tears down only the compose project this script created.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INVENTORY="$REPO_ROOT/tools/restore-drill/restore_inventory.py"
+COMPOSE_FILE="$REPO_ROOT/compose.dev.yaml"
+AWS_CLI_IMAGE="amazon/aws-cli:2.32.6"
+CHECK_BACKUP=""
+SUPPLIED_CONFIG=""
+NEGATIVE=""
+WORKDIR=""
+SRC_PROJECT=""
+DST_PROJECT=""
+OWNED_PROJECTS=()
+LOCK_FD=""
+RESTORE_STARTED_AT=""
+RESTORE_ELAPSED=""
+
+usage() {
+    cat >&2 <<'EOF'
+usage: restore-drill.sh [--check-backup DIR --supplied-config FILE] [--negative COMPONENT]
+
+  --check-backup DIR       Validate a backup directory and refuse if incomplete.
+  --supplied-config FILE   JSON object of separately supplied key names to values.
+  --negative COMPONENT     Omit a required component (postgres, bundles,
+                           mail-adapter-state, valkey) and expect refusal.
+
+With no arguments, run the disposable compose drill: seed, backup, destroy the
+task-owned source, restore onto a distinct target, verify, then a fake-model
+round trip. Always runs the negative control against a copy of the backup.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --check-backup)
+            CHECK_BACKUP="$2"
+            shift 2
+            ;;
+        --supplied-config)
+            SUPPLIED_CONFIG="$2"
+            shift 2
+            ;;
+        --negative)
+            NEGATIVE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+inventory() {
+    (cd "$REPO_ROOT" && uv run python "$INVENTORY" "$@")
+}
+
+emit_json() {
+    python3 -c 'import json,sys; json.dump(json.loads(sys.argv[1]), sys.stdout, indent=2, sort_keys=True); print()' "$1"
+}
+
+run_check() {
+    local backup="$1" supplied="$2"
+    inventory check "$backup" --supplied-config "$supplied"
+}
+
+if [[ -n "$CHECK_BACKUP" ]]; then
+    if [[ -z "$SUPPLIED_CONFIG" ]]; then
+        echo "error: --check-backup requires --supplied-config" >&2
+        exit 2
+    fi
+    if [[ -n "$NEGATIVE" ]]; then
+        WORKDIR="$(mktemp -d)"
+        cp -a "$CHECK_BACKUP" "$WORKDIR/backup"
+        inventory omit "$WORKDIR/backup" "$NEGATIVE"
+        if run_check "$WORKDIR/backup" "$SUPPLIED_CONFIG"; then
+            echo "error: negative control expected restore to refuse after omitting $NEGATIVE" >&2
+            rm -rf "$WORKDIR"
+            exit 1
+        fi
+        rm -rf "$WORKDIR"
+        echo "negative control refused omitted component $NEGATIVE" >&2
+        exit 0
+    fi
+    run_check "$CHECK_BACKUP" "$SUPPLIED_CONFIG"
+    exit $?
+fi
+
+port_busy() {
+    local port="$1"
+    python3 - "$port" <<'PY'
+import socket, sys
+port = int(sys.argv[1])
+sock = socket.socket()
+sock.settimeout(0.2)
+try:
+    sock.connect(("127.0.0.1", port))
+except OSError:
+    sys.exit(0)
+else:
+    sock.close()
+    sys.exit(1)
+PY
+}
+
+require_free_ports() {
+    local port
+    for port in 28000 25432 26379 29000; do
+        if ! port_busy "$port"; then
+            echo "error: host port $port is occupied; stop the owner of the existing Curie stack before this drill" >&2
+            echo "fix: this drill uses the compose.dev.yaml host ports and will not touch another install" >&2
+            exit 1
+        fi
+    done
+}
+
+ensure_runner_network() {
+    docker network inspect "$RUNNER_NETWORK" >/dev/null 2>&1 || docker network create "$RUNNER_NETWORK" >/dev/null
+}
+
+write_compose_override() {
+    cat >"$WORKDIR/compose.override.yaml" <<EOF
+networks:
+  curie_runner:
+    name: ${RUNNER_NETWORK}
+services:
+  curie-worker:
+    environment:
+      - CURIE_DOCKER_NETWORK=${RUNNER_NETWORK}
+      - CURIE_FAKE_MODEL=1
+EOF
+}
+
+compose() {
+    local project="$1"
+    shift
+    OTEL_EXPORTER_OTLP_ENDPOINT= docker compose -p "$project" \
+        -f "$COMPOSE_FILE" -f "$WORKDIR/compose.override.yaml" --profile core "$@"
+}
+
+cleanup() {
+    local project
+    if [[ -n "${BUNDLE:-}" && -f "$BUNDLE/.curie/compose.connectors.yaml" ]]; then
+        echo "cleanup: connector compose for the drill bundle" >&2
+        docker compose -f "$BUNDLE/.curie/compose.connectors.yaml" down -v --remove-orphans >/dev/null 2>&1 || true
+    fi
+    for project in "${OWNED_PROJECTS[@]+"${OWNED_PROJECTS[@]}"}"; do
+        echo "cleanup: docker compose -p $project down -v" >&2
+        compose "$project" down -v --remove-orphans >/dev/null 2>&1 || true
+    done
+    if [[ -n "$WORKDIR" && -d "$WORKDIR" ]]; then
+        rm -rf "$WORKDIR" 2>/dev/null || docker run --rm -v "$WORKDIR:/work" busybox rm -rf /work
+    fi
+    if [[ -n "${RUNNER_NETWORK:-}" ]]; then
+        docker network rm "$RUNNER_NETWORK" >/dev/null 2>&1 || true
+    fi
+}
+
+wait_for_api() {
+    local i
+    for i in $(seq 1 90); do
+        if curl -fsS http://localhost:28000/health >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 2
+    done
+    echo "error: API did not become healthy on localhost:28000" >&2
+    return 1
+}
+
+s3_sync() {
+    local project="$1" direction="$2" stage="$3"
+    local network="${project}_default"
+    local from to
+    mkdir -p "$stage"
+    if [[ "$direction" = export ]]; then
+        from="s3://curie-bundles"
+        to="/stage"
+    else
+        from="/stage"
+        to="s3://curie-bundles"
+    fi
+    # The aws-cli image's entrypoint is `aws`, so override it. Credentials stay
+    # in the container environment; this script never prints them.
+    docker run --rm --network "$network" --entrypoint /bin/sh \
+        --user "$(id -u):$(id -g)" \
+        -e HOME=/tmp \
+        -e AWS_ACCESS_KEY_ID=rustfs \
+        -e AWS_SECRET_ACCESS_KEY=rustfssecret \
+        -e AWS_DEFAULT_REGION=us-east-1 \
+        -e AWS_EC2_METADATA_DISABLED=true \
+        -v "$stage:/stage" \
+        "$AWS_CLI_IMAGE" \
+        -ec "aws configure set default.s3.addressing_style path
+aws --endpoint-url http://rustfs:9000 s3 sync '$from' '$to' --only-show-errors"
+}
+
+backup_postgres() {
+    local project="$1" dest="$2"
+    mkdir -p "$(dirname "$dest")"
+    compose "$project" exec -T postgres pg_dump -U postgres -Fc postgres >"$dest"
+}
+
+restore_postgres() {
+    local project="$1" src="$2"
+    compose "$project" exec -T postgres psql -U postgres -c \
+        "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='postgres' AND pid <> pg_backend_pid();" \
+        >/dev/null
+    compose "$project" exec -T postgres pg_restore -U postgres -d postgres --clean --if-exists --no-owner <"$src"
+}
+
+backup_valkey() {
+    local project="$1" dest="$2"
+    mkdir -p "$(dirname "$dest")"
+    compose "$project" exec -T valkey valkey-cli -a valkeypass --no-auth-warning SAVE >/dev/null
+    compose "$project" cp valkey:/data/dump.rdb "$dest"
+}
+
+restore_valkey() {
+    local project="$1" src="$2"
+    compose "$project" stop valkey >/dev/null
+    compose "$project" cp "$src" valkey:/data/dump.rdb
+    compose "$project" start valkey >/dev/null
+}
+
+resolve_bin() {
+    if [[ -n "${CURIE_BIN:-}" && -x "${CURIE_BIN:-}" ]]; then
+        BIN="$(cd "$(dirname "$CURIE_BIN")" && pwd)/$(basename "$CURIE_BIN")"
+        return
+    fi
+    local target
+    target="$(
+        cd "$REPO_ROOT/cli" && cargo metadata --format-version 1 --no-deps --offline \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])'
+    )"
+    (cd "$REPO_ROOT/cli" && cargo build --quiet)
+    BIN="$target/debug/curie"
+    if [[ ! -x "$BIN" ]]; then
+        echo "error: failed to build curie at $BIN" >&2
+        exit 1
+    fi
+}
+
+json_field() {
+    python3 -c 'import json,sys; d=json.loads(sys.stdin.read()); print(d[sys.argv[1]])' "$1"
+}
+
+nested_field() {
+    python3 -c 'import json,sys; d=json.loads(sys.stdin.read())
+keys=sys.argv[1].split(".")
+for k in keys:
+    d=d[k]
+print(d)' "$1"
+}
+
+exec 9>"/tmp/curie-restore-drill.lock"
+if ! flock -n 9; then
+    echo "error: another restore drill is already running" >&2
+    exit 1
+fi
+LOCK_FD=9
+
+trap cleanup EXIT
+
+require_free_ports
+resolve_bin
+WORKDIR="$(mktemp -d /tmp/curie-restore-drill.XXXXXX)"
+chmod 700 "$WORKDIR"
+RUNNER_NETWORK="curie-r2427-runner-$$"
+export CURIE_FAKE_MODEL=1
+ensure_runner_network
+write_compose_override
+BACKUP="$WORKDIR/backup"
+SUPPLIED="$WORKDIR/supplied.json"
+REPORT="$WORKDIR/report.json"
+CANDIDATE="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+SRC_PROJECT="curie-r2427-src-$$"
+DST_PROJECT="curie-r2427-dst-$$"
+
+cat >"$SUPPLIED" <<'EOF'
+{
+  "POSTGRES_PASSWORD": "postgres",
+  "VALKEY_PASSWORD": "valkeypass",
+  "S3_ACCESS_KEY": "rustfs",
+  "S3_SECRET_KEY": "rustfssecret",
+  "API_KEY": "curie-dev-key"
+}
+EOF
+
+echo "=== source install $SRC_PROJECT ===" >&2
+OWNED_PROJECTS+=("$SRC_PROJECT")
+compose "$SRC_PROJECT" up -d --wait --wait-timeout 300 \
+    postgres valkey rustfs rustfs-perms
+compose "$SRC_PROJECT" run --rm rustfs-init
+compose "$SRC_PROJECT" up -d --wait --wait-timeout 300 \
+    curie-migrate curie-api curie-worker
+wait_for_api
+
+echo "=== deploy synthetic agent ===" >&2
+BUNDLE="$WORKDIR/bundle"
+cp -a "$REPO_ROOT/examples/weather" "$BUNDLE"
+rm -f "$BUNDLE/connectors.yaml"
+DEPLOY_JSON="$("$BIN" --json local deploy --plugin-dir "$BUNDLE")"
+printf '%s\n' "$DEPLOY_JSON" >&2
+AGENT_ID="$(printf '%s' "$DEPLOY_JSON" | nested_field agent.id 2>/dev/null || true)"
+if [[ -z "$AGENT_ID" ]]; then
+    AGENT_ID="$(printf '%s' "$DEPLOY_JSON" | json_field agent_id)"
+fi
+AGENT_NAME="$(printf '%s' "$DEPLOY_JSON" | nested_field agent.name 2>/dev/null || true)"
+if [[ -z "$AGENT_NAME" ]]; then
+    AGENT_NAME="$(printf '%s' "$DEPLOY_JSON" | json_field agent_name)"
+fi
+BUNDLE_SHA="$(printf '%s' "$DEPLOY_JSON" | nested_field bundle.sha256 2>/dev/null || true)"
+if [[ -z "$BUNDLE_SHA" ]]; then
+    BUNDLE_SHA="$(printf '%s' "$DEPLOY_JSON" | json_field bundle_sha256)"
+fi
+VERSION_ID="$(printf '%s' "$DEPLOY_JSON" | nested_field version.id)"
+
+echo "=== seed mail adapter sqlite ===" >&2
+inventory seed-mail "$BACKUP/mail-adapter/state.sqlite3" >/dev/null
+
+echo "=== backup supported state ===" >&2
+backup_postgres "$SRC_PROJECT" "$BACKUP/postgres/curie.dump"
+s3_sync "$SRC_PROJECT" export "$BACKUP/bundles"
+backup_valkey "$SRC_PROJECT" "$BACKUP/valkey/dump.rdb"
+inventory write-manifest "$BACKUP" --candidate "$CANDIDATE" >/dev/null
+run_check "$BACKUP" "$SUPPLIED" >/dev/null
+echo "backup accepted" >&2
+
+echo "=== negative control: omit ${NEGATIVE:-bundles} ===" >&2
+cp -a "$BACKUP" "$WORKDIR/backup-negative"
+inventory omit "$WORKDIR/backup-negative" "${NEGATIVE:-bundles}"
+if run_check "$WORKDIR/backup-negative" "$SUPPLIED" >"$WORKDIR/negative.json"; then
+    echo "error: incomplete backup was accepted" >&2
+    exit 1
+fi
+python3 -c 'import json,sys; p=json.load(open(sys.argv[1])); assert p.get("error") and p.get("fix")' "$WORKDIR/negative.json"
+echo "negative control refused omitted ${NEGATIVE:-bundles}" >&2
+
+echo "=== destroy source install ===" >&2
+compose "$SRC_PROJECT" down -v --remove-orphans
+OWNED_PROJECTS=()
+
+echo "=== restore onto distinct target $DST_PROJECT ===" >&2
+RESTORE_STARTED_AT="$(date -u +%s)"
+OWNED_PROJECTS+=("$DST_PROJECT")
+compose "$DST_PROJECT" up -d --wait --wait-timeout 300 \
+    postgres valkey rustfs rustfs-perms
+compose "$DST_PROJECT" run --rm rustfs-init
+restore_postgres "$DST_PROJECT" "$BACKUP/postgres/curie.dump"
+s3_sync "$DST_PROJECT" import "$BACKUP/bundles"
+restore_valkey "$DST_PROJECT" "$BACKUP/valkey/dump.rdb"
+mkdir -p "$WORKDIR/restored-mail"
+cp -a "$BACKUP/mail-adapter/state.sqlite3" "$WORKDIR/restored-mail/state.sqlite3"
+inventory verify-mail "$WORKDIR/restored-mail/state.sqlite3" >/dev/null
+compose "$DST_PROJECT" up -d --wait --wait-timeout 300 curie-migrate curie-api curie-worker
+wait_for_api
+RESTORE_ELAPSED="$(( $(date -u +%s) - RESTORE_STARTED_AT ))"
+
+echo "=== verify records and bundle digest ===" >&2
+VERSIONS_JSON="$("$BIN" --json local versions "$AGENT_NAME")"
+printf '%s\n' "$VERSIONS_JSON" >&2
+python3 - "$VERSIONS_JSON" "$BUNDLE_SHA" "$VERSION_ID" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+want_sha, want_id = sys.argv[2], sys.argv[3]
+versions = payload.get("versions") or []
+match = next((row for row in versions if row.get("id") == want_id), None)
+if match is None:
+    raise SystemExit(f"restored versions do not include {want_id}")
+got = match.get("bundle_sha256")
+if got != want_sha:
+    raise SystemExit(f"bundle digest mismatch: restored {got} expected {want_sha}")
+print(f"restored version {want_id} digest {got}")
+PY
+
+echo "=== post-restore fake-model round trip ===" >&2
+# local message's one-shot dispatcher always joins `curie_default`. Attach this
+# drill's Valkey there so enqueue reaches the restored stream without renaming
+# the task-owned compose project to `curie` (which would `down -v` someone
+# else's retained volumes). Refuse if that network already has other containers.
+valkey_container="$(compose "$DST_PROJECT" ps -q valkey)"
+if docker network inspect curie_default >/dev/null 2>&1; then
+    others="$(docker network inspect curie_default -f '{{len .Containers}}')"
+    if [[ "$others" != "0" ]]; then
+        echo "error: network curie_default already has containers; will not attach this drill's Valkey" >&2
+        echo "fix: stop the owner of project curie, or re-run when host ports 28000/25432 are free" >&2
+        exit 1
+    fi
+else
+    docker network create curie_default >/dev/null
+fi
+docker network connect --alias valkey curie_default "$valkey_container"
+MESSAGE_JSON="$("$BIN" --json local message --channel C0LOCALDEV --timeout-secs 180 "restore drill ping" || true)"
+docker network disconnect curie_default "$valkey_container" >/dev/null 2>&1 || true
+printf '%s\n' "$MESSAGE_JSON" >&2
+python3 -c '
+import json, sys
+payload = json.loads(sys.argv[1])
+if payload.get("finalized") is True and str(payload.get("reply") or "").strip():
+    sys.exit(0)
+raise SystemExit("post-restore round trip did not finalize a reply")
+' "$MESSAGE_JSON"
+
+python3 - "$REPORT" "$CANDIDATE" "$RESTORE_ELAPSED" "$BUNDLE_SHA" "$WORKDIR/negative.json" <<'PY'
+import json, sys
+report_path, candidate, elapsed, digest, negative_path = sys.argv[1:6]
+negative = json.load(open(negative_path))
+json.dump(
+    {
+        "ok": True,
+        "issue": "2427",
+        "candidate": candidate,
+        "recovered_point": {"bundle_sha256": digest, "manifest": "backup/MANIFEST.json"},
+        "elapsed_restore_seconds": int(elapsed),
+        "data_loss": "none within the declared backup set; Valkey stream/PEL replay is not a Curie contract",
+        "valkey_replay_contract": "missing",
+        "rpo_rto_claimed": False,
+        "recurring_production_backup_established": False,
+        "negative_control": negative,
+        "round_trip": {"mode": "fake", "finalized": True},
+    },
+    open(report_path, "w"),
+    indent=2,
+    sort_keys=True,
+)
+PY
+cat "$REPORT"
+echo "restore drill passed in ${RESTORE_ELAPSED}s" >&2

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1060,6 +1060,22 @@ enum DevAction {
     /// #492's forgotten-context bug, `bash scripts/check-wire-tolerance.sh`).
     /// Offline, no credential.
     WireTolerance,
+    /// Bounded synthetic restore drill for #2427: back up postgres, bundles,
+    /// mail SQLite, and Valkey from a disposable compose install, restore onto
+    /// a distinct target, and refuse an omitted or corrupt component
+    /// (`bash cli/scripts/restore-drill.sh`). Not a production backup product
+    /// and not an RPO/RTO claim.
+    RestoreDrill {
+        /// Validate an existing backup directory without starting a stack.
+        #[arg(long)]
+        check_backup: Option<PathBuf>,
+        /// JSON object of separately supplied key names. Required with --check-backup.
+        #[arg(long)]
+        supplied_config: Option<PathBuf>,
+        /// Omit this required component and expect the completeness guard to refuse.
+        #[arg(long)]
+        negative: Option<String>,
+    },
     /// Set the release version across cli/Cargo.toml + Chart.yaml
     /// version/appVersion (and refresh the CLI lockfile) so a release cut can't
     /// leave the three out of sync. Does not commit or tag.
@@ -2975,6 +2991,27 @@ async fn run(command: Option<Command>) -> Result<()> {
             }
             DevAction::WireTolerance => {
                 commands::dev_script("scripts/check-wire-tolerance.sh", &[]).await
+            }
+            DevAction::RestoreDrill {
+                check_backup,
+                supplied_config,
+                negative,
+            } => {
+                let mut args = Vec::new();
+                if let Some(path) = check_backup {
+                    args.push("--check-backup".to_string());
+                    args.push(path.display().to_string());
+                }
+                if let Some(path) = supplied_config {
+                    args.push("--supplied-config".to_string());
+                    args.push(path.display().to_string());
+                }
+                if let Some(component) = negative {
+                    args.push("--negative".to_string());
+                    args.push(component);
+                }
+                let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+                commands::dev_script("cli/scripts/restore-drill.sh", &arg_refs).await
             }
             DevAction::BumpVersion { version, dry_run } => {
                 commands::bump_version(&version, dry_run).await
@@ -5470,6 +5507,40 @@ mod tests {
             cli.command,
             Some(Command::Dev {
                 action: DevAction::ChartRuntimeE2e { force: true }
+            })
+        ));
+        let cli = Cli::try_parse_from(["curie", "dev", "restore-drill"])
+            .expect("dev restore-drill should parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Dev {
+                action: DevAction::RestoreDrill {
+                    check_backup: None,
+                    supplied_config: None,
+                    negative: None,
+                }
+            })
+        ));
+        let cli = Cli::try_parse_from([
+            "curie",
+            "dev",
+            "restore-drill",
+            "--check-backup",
+            "/tmp/backup",
+            "--supplied-config",
+            "/tmp/supplied.json",
+            "--negative",
+            "bundles",
+        ])
+        .expect("dev restore-drill flags should parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Dev {
+                action: DevAction::RestoreDrill {
+                    check_backup: Some(_),
+                    supplied_config: Some(_),
+                    negative: Some(_),
+                }
             })
         ));
     }

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -673,7 +673,14 @@ The PVC is PII-bearing application data: it can hold email addresses, message an
 thread identifiers, recovery text, and delivery receipts, though never the three
 credentials or a platform database credential. Back up with a storage snapshot
 that is consistent for SQLite, or stop the Deployment before copying the file.
-Restore the claim before starting the writer. An older image refuses a newer
+Restore the claim before starting the writer.
+
+A disposable synthetic restore of postgres records, immutable bundle objects,
+that SQLite delivery state, and a Valkey dump is `curie dev restore-drill`
+(#2427). It uses those existing export/restore mechanisms, requires operator
+keys and config to be supplied separately, and refuses an omitted or corrupt
+component before serving. It does not establish a recurring production backup,
+an RPO/RTO target, or Valkey stream replay. An older image refuses a newer
 schema; restore the pre-upgrade snapshot or roll forward rather than
 deleting state to force a rollback. A chart-managed PVC is deleted by Helm
 uninstall, subject to the StorageClass reclaim policy; an `existingClaim` is not

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,7 @@ testpaths = [
     "tools/sdk-lock-gate/tests",
     "tools/p0-closes-ci/tests",
     "tools/ci-release-target-parity/tests",
+    "tools/restore-drill/tests",
 ]
 
 [tool.ruff]
@@ -199,6 +200,7 @@ select = ["E", "F", "I", "UP", "B"]
 # would collapse. The implementation under tools/doclint/src stays fully linted,
 # I001 included; only the frozen tests are exempt from import-block formatting.
 "tools/doclint/tests/**" = ["I001"]
+"tools/restore-drill/tests/**" = ["E402"]
 
 [tool.mypy]
 python_version = "3.13"

--- a/tools/restore-drill/restore_inventory.py
+++ b/tools/restore-drill/restore_inventory.py
@@ -1,0 +1,408 @@
+"""Declared backup inventory for the #2427 synthetic restore drill.
+
+This is not a disaster-recovery product and does not invent Valkey replay,
+RPO, or RTO. It names the existing supported export/restore inputs, refuses an
+incomplete or inconsistent backup, and keeps operator keys out of the backup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "curie-restore-inventory-v1"
+REQUIRED_DATA_COMPONENTS = (
+    "postgres",
+    "bundles",
+    "mail-adapter-state",
+    "valkey",
+)
+COMPONENT_PATHS = {
+    "postgres": "postgres/curie.dump",
+    "bundles": "bundles",
+    "mail-adapter-state": "mail-adapter/state.sqlite3",
+    "valkey": "valkey/dump.rdb",
+}
+SEPARATELY_SUPPLIED = (
+    "POSTGRES_PASSWORD",
+    "VALKEY_PASSWORD",
+    "S3_ACCESS_KEY",
+    "S3_SECRET_KEY",
+    "API_KEY",
+)
+FORBIDDEN_BACKUP_DIRS = ("keys-and-config", "secrets")
+VALKEY_REPLAY_CONTRACT = "missing"
+
+_RECOVERY = {
+    "postgres": (
+        "postgres dump is missing or empty",
+        "Restore postgres/curie.dump taken with this backup, or re-create the "
+        "agent/version/binding records from a known-good source. Do not serve "
+        "an API against an empty database while bundles still exist.",
+    ),
+    "bundles": (
+        "immutable bundle objects are missing or their digest does not match "
+        "the manifest",
+        "Restore the object-store backup taken with this postgres dump "
+        "(aws s3 sync of the bundle bucket), or re-publish the exact bundle "
+        "each active deployment names. Do not serve deployments whose bundle "
+        "bytes are absent.",
+    ),
+    "mail-adapter-state": (
+        "mail adapter SQLite state is missing or empty",
+        "Restore mail-adapter/state.sqlite3 (stop the writer, copy the "
+        "checkpointed file, open the copy before the writer starts). Pending "
+        "work must resume or stay refused as known; do not start on a fresh "
+        "claim and silently drop deliveries.",
+    ),
+    "valkey": (
+        "Valkey dump is missing or empty",
+        "Restore valkey/dump.rdb as a required backup input. Curie does not "
+        "define stream/PEL replay: restored keys match the dump, and in-flight "
+        "work is not claimed to resume beyond Valkey's own RDB reload.",
+    ),
+}
+
+
+class RestoreRefused(Exception):
+    """A backup cannot be applied without serving inconsistent state."""
+
+    def __init__(self, error: str, fix: str) -> None:
+        super().__init__(error)
+        self.error = error
+        self.fix = fix
+
+    def as_payload(self) -> dict[str, str]:
+        return {"error": self.error, "fix": self.fix}
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def hash_path(path: Path) -> str:
+    if path.is_file():
+        return _sha256_bytes(path.read_bytes())
+    if not path.is_dir():
+        raise RestoreRefused(
+            f"required path {path.name} is not a file or directory",
+            "Recreate the backup with the declared component layout.",
+        )
+    digest = hashlib.sha256()
+    files = sorted(child for child in path.rglob("*") if child.is_file())
+    if not files:
+        raise RestoreRefused(
+            _RECOVERY["bundles"][0] if path.name == "bundles" else f"{path.name} is empty",
+            _RECOVERY["bundles"][1]
+            if path.name == "bundles"
+            else "Replace the empty component with the bytes taken at backup time.",
+        )
+    for child in files:
+        relative = child.relative_to(path).as_posix().encode()
+        digest.update(relative)
+        digest.update(b"\0")
+        digest.update(child.read_bytes())
+    return digest.hexdigest()
+
+
+def _component_path(backup_dir: Path, component: str) -> Path:
+    return backup_dir / COMPONENT_PATHS[component]
+
+
+def _refuse(component: str, detail: str | None = None) -> None:
+    error, fix = _RECOVERY[component]
+    if detail:
+        error = f"{error}: {detail}"
+    raise RestoreRefused(error, fix)
+
+
+def write_manifest(
+    backup_dir: Path, *, candidate: str, created_at: str | None = None
+) -> dict[str, Any]:
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    created = created_at or datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    components: dict[str, Any] = {}
+    for component in REQUIRED_DATA_COMPONENTS:
+        path = _component_path(backup_dir, component)
+        if not path.exists():
+            _refuse(component, "file is absent")
+        digest = hash_path(path)
+        components[component] = {
+            "path": COMPONENT_PATHS[component],
+            "sha256": digest,
+            "required": True,
+        }
+    manifest = {
+        "schema": SCHEMA,
+        "issue": "2427",
+        "created_at": created,
+        "candidate": candidate,
+        "components": components,
+        "separately_supplied": list(SEPARATELY_SUPPLIED),
+        "valkey_replay_contract": VALKEY_REPLAY_CONTRACT,
+        "rpo_rto_claimed": False,
+        "recurring_production_backup_established": False,
+    }
+    (backup_dir / "MANIFEST.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    return manifest
+
+
+def _declared_data_files(backup_dir: Path) -> set[Path]:
+    allowed: set[Path] = set()
+    for relative in COMPONENT_PATHS.values():
+        path = backup_dir / relative
+        allowed.add(path)
+        if path.is_dir():
+            allowed.update(child for child in path.rglob("*") if child.is_file())
+    return allowed
+
+
+def _scan_for_secret_values(backup_dir: Path, supplied: Mapping[str, str]) -> None:
+    values = [value for value in supplied.values() if len(value) >= 8]
+    if not values:
+        return
+    data_files = _declared_data_files(backup_dir)
+    for path in backup_dir.rglob("*"):
+        if not path.is_file() or path in data_files:
+            continue
+        try:
+            text = path.read_text(errors="ignore")
+        except OSError:
+            continue
+        for value in values:
+            if value and value in text:
+                raise RestoreRefused(
+                    "backup contains separately supplied secret material",
+                    "Remove operator keys and config from the backup. Supply "
+                    "POSTGRES_PASSWORD, VALKEY_PASSWORD, S3_ACCESS_KEY, "
+                    "S3_SECRET_KEY, and API_KEY at restore time; never copy "
+                    "them into the backup directory.",
+                )
+
+
+def check_backup(backup_dir: Path, supplied_config: Mapping[str, str]) -> dict[str, Any]:
+    manifest_path = backup_dir / "MANIFEST.json"
+    if not manifest_path.is_file():
+        raise RestoreRefused(
+            "MANIFEST.json is missing",
+            "Write the inventory manifest from the backup components before restore.",
+        )
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except json.JSONDecodeError as error:
+        raise RestoreRefused(
+            "MANIFEST.json is not valid JSON",
+            "Replace the manifest with the one written at backup time.",
+        ) from error
+
+    if manifest.get("schema") != SCHEMA:
+        raise RestoreRefused(
+            "backup manifest schema is not curie-restore-inventory-v1",
+            "Use the inventory this drill wrote. Do not serve a backup with an unknown layout.",
+        )
+    if manifest.get("rpo_rto_claimed") is not False:
+        raise RestoreRefused(
+            "backup claims an RPO/RTO target",
+            "This drill records elapsed restore time only. Do not claim an RPO or RTO.",
+        )
+    if manifest.get("valkey_replay_contract") != VALKEY_REPLAY_CONTRACT:
+        raise RestoreRefused(
+            "backup invents a Valkey replay contract",
+            "Valkey dump restore is a required input; stream/PEL replay is missing. "
+            "Keep valkey_replay_contract=missing rather than claiming resume or drop.",
+        )
+    if manifest.get("recurring_production_backup_established") is not False:
+        raise RestoreRefused(
+            "backup claims a recurring production backup",
+            "This drill is a one-shot synthetic restore. Do not treat it as a scheduled backup.",
+        )
+
+    for forbidden in FORBIDDEN_BACKUP_DIRS:
+        if (backup_dir / forbidden).exists():
+            raise RestoreRefused(
+                f"backup contains {forbidden}/; keys and config are separately supplied",
+                "Delete operator key material from the backup and pass it through "
+                "supplied config at restore time.",
+            )
+
+    missing_keys = [name for name in SEPARATELY_SUPPLIED if not supplied_config.get(name)]
+    if missing_keys:
+        raise RestoreRefused(
+            "separately supplied key/config is missing: " + ", ".join(missing_keys),
+            "Provide POSTGRES_PASSWORD, VALKEY_PASSWORD, S3_ACCESS_KEY, "
+            "S3_SECRET_KEY, and API_KEY from outside the backup. They are "
+            "never stored in the backup directory.",
+        )
+
+    declared = manifest.get("components") or {}
+    for component in REQUIRED_DATA_COMPONENTS:
+        path = _component_path(backup_dir, component)
+        if not path.exists():
+            _refuse(component, "file is absent")
+        if path.is_file() and path.stat().st_size == 0:
+            _refuse(component, "file is empty")
+        actual = hash_path(path)
+        expected = (declared.get(component) or {}).get("sha256")
+        if expected is None:
+            _refuse(component, "manifest has no sha256")
+        if actual != expected:
+            _refuse(component, "sha256 does not match the manifest")
+
+    _scan_for_secret_values(backup_dir, supplied_config)
+
+    return {
+        "ok": True,
+        "schema": SCHEMA,
+        "issue": "2427",
+        "candidate": manifest.get("candidate"),
+        "created_at": manifest.get("created_at"),
+        "components": sorted(REQUIRED_DATA_COMPONENTS),
+        "separately_supplied": list(SEPARATELY_SUPPLIED),
+        "valkey_replay_contract": VALKEY_REPLAY_CONTRACT,
+        "rpo_rto_claimed": False,
+        "recurring_production_backup_established": False,
+    }
+
+
+def seed_mail(path: Path) -> dict[str, list[str]]:
+    """Write synthetic pending and known delivery rows using MailState."""
+    from curie_mail_adapter.state import MailState
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        path.unlink()
+    state = MailState(str(path), max_pending=20, max_bytes=8 * 1024 * 1024)
+    admitted = state.admit({"message_id": "msg-pending", "thread_id": "thr-pending"})
+    if admitted != "admitted":
+        raise RestoreRefused(
+            f"mail seed failed to admit pending work: {admitted}",
+            "Recreate the SQLite file with MailState.admit before backup.",
+        )
+    known = state.record_terminal("msg-known", "accepted")
+    if known != "admitted":
+        raise RestoreRefused(
+            f"mail seed failed to record a dedup receipt: {known}",
+            "Recreate the SQLite file with MailState.record_terminal before backup.",
+        )
+    state.connection.execute("PRAGMA wal_checkpoint(FULL)")
+    state.connection.close()
+    return {"pending": ["msg-pending"], "known": ["msg-known", "msg-pending"]}
+
+
+def verify_mail(path: Path) -> dict[str, list[str]]:
+    """Re-open restored SQLite and assert pending/dedup invariants."""
+    from curie_mail_adapter.state import MailState
+
+    if not path.is_file() or path.stat().st_size == 0:
+        _refuse("mail-adapter-state", "restored file is absent or empty")
+    state = MailState(str(path), max_pending=20, max_bytes=8 * 1024 * 1024)
+    pending = [row["message_id"] for row in state.pending()]
+    known = state.known_message_ids()
+    if pending != ["msg-pending"]:
+        raise RestoreRefused(
+            "restored mail pending work does not match the backup",
+            "Restore mail-adapter/state.sqlite3 taken with this backup. Pending "
+            "ids must resume; a fresh SQLite file silently drops them.",
+        )
+    if "msg-known" not in known or "msg-pending" not in known:
+        raise RestoreRefused(
+            "restored mail dedup receipts are missing",
+            "Restore the checkpointed SQLite file so known message ids stay known.",
+        )
+    if state.admit({"message_id": "msg-pending", "thread_id": "thr-pending"}) != "known":
+        raise RestoreRefused(
+            "restored mail pending id was not treated as known",
+            "Dedup must refuse a duplicate id rather than creating a second delivery.",
+        )
+    if state.admit({"message_id": "msg-known", "thread_id": "thr-other"}) != "known":
+        raise RestoreRefused(
+            "restored mail terminal id was not treated as known",
+            "Dedup must refuse a duplicate id rather than creating a second delivery.",
+        )
+    state.connection.close()
+    return {"pending": pending, "known": known}
+
+
+def omit_component(backup_dir: Path, component: str) -> None:
+    """Negative control: remove or empty a required backup component."""
+    if component not in COMPONENT_PATHS:
+        raise RestoreRefused(
+            f"unknown backup component {component}",
+            "Omit one of: " + ", ".join(REQUIRED_DATA_COMPONENTS),
+        )
+    path = _component_path(backup_dir, component)
+    if path.is_file():
+        path.unlink()
+        return
+    if path.is_dir():
+        for child in path.rglob("*"):
+            if child.is_file():
+                child.unlink()
+
+
+def _load_supplied(path: Path | None) -> dict[str, str]:
+    if path is None:
+        return {}
+    payload = json.loads(path.read_text())
+    if not isinstance(payload, dict):
+        raise RestoreRefused(
+            "supplied-config is not a JSON object",
+            "Pass a JSON object of environment names to values. Values are not logged.",
+        )
+    return {str(key): str(value) for key, value in payload.items()}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check or write a Curie restore inventory.")
+    sub = parser.add_subparsers(dest="command", required=True)
+    check = sub.add_parser("check", help="Refuse an incomplete or inconsistent backup")
+    check.add_argument("backup_dir")
+    check.add_argument("--supplied-config", required=True)
+    write = sub.add_parser("write-manifest", help="Write MANIFEST.json from backup components")
+    write.add_argument("backup_dir")
+    write.add_argument("--candidate", default="unknown")
+    seed = sub.add_parser("seed-mail", help="Write synthetic pending and known mail rows")
+    seed.add_argument("state_path")
+    verify = sub.add_parser("verify-mail", help="Assert restored mail pending and dedup")
+    verify.add_argument("state_path")
+    omit = sub.add_parser("omit", help="Remove a required component for the negative control")
+    omit.add_argument("backup_dir")
+    omit.add_argument("component")
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "check":
+            result = check_backup(Path(args.backup_dir), _load_supplied(Path(args.supplied_config)))
+            json.dump(result, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+            return 0
+        if args.command == "write-manifest":
+            manifest = write_manifest(Path(args.backup_dir), candidate=args.candidate)
+            json.dump(manifest, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+            return 0
+        if args.command == "seed-mail":
+            result = seed_mail(Path(args.state_path))
+            json.dump(result, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+            return 0
+        if args.command == "verify-mail":
+            result = verify_mail(Path(args.state_path))
+            json.dump(result, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+            return 0
+        omit_component(Path(args.backup_dir), args.component)
+        return 0
+    except RestoreRefused as error:
+        json.dump(error.as_payload(), sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/restore-drill/tests/conftest.py
+++ b/tools/restore-drill/tests/conftest.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tools/restore-drill/tests/test_restore_inventory.py
+++ b/tools/restore-drill/tests/test_restore_inventory.py
@@ -1,0 +1,202 @@
+"""Completeness guard for the #2427 synthetic restore inventory.
+
+The consumer path is tools/restore-drill/restore_inventory.py (invoked by
+`curie dev restore-drill --check-backup`). A missing or corrupt required
+component must refuse with recovery instructions. Secret values must never be
+accepted inside the backup. Valkey stream replay is not a Curie restore
+contract and must stay reported as missing.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from restore_inventory import (
+    SEPARATELY_SUPPLIED,
+    RestoreRefused,
+    check_backup,
+    write_manifest,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+INVENTORY = REPO_ROOT / "tools" / "restore-drill" / "restore_inventory.py"
+
+
+def _supplied() -> dict[str, str]:
+    return {
+        "POSTGRES_PASSWORD": "pg-secret-example",
+        "VALKEY_PASSWORD": "vk-secret-example",
+        "S3_ACCESS_KEY": "rustfs",
+        "S3_SECRET_KEY": "rustfs-secret-example",
+        "API_KEY": "api-secret-example",
+    }
+
+
+def _write(path: Path, body: bytes | str = b"payload") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(body if isinstance(body, bytes) else body.encode())
+
+
+def _complete_backup(tmp_path: Path) -> Path:
+    backup = tmp_path / "backup"
+    _write(backup / "postgres" / "curie.dump", b"pg-dump-bytes")
+    _write(backup / "bundles" / "acme-bot" / "v1.tar.gz", b"bundle-bytes")
+    _write(backup / "mail-adapter" / "state.sqlite3", b"sqlite-bytes")
+    _write(backup / "valkey" / "dump.rdb", b"rdb-bytes")
+    write_manifest(backup, candidate="abc123")
+    return backup
+
+
+def test_complete_backup_with_separately_supplied_config_is_accepted(tmp_path: Path) -> None:
+    backup = _complete_backup(tmp_path)
+    result = check_backup(backup, _supplied())
+    assert result["ok"] is True
+    assert result["rpo_rto_claimed"] is False
+    assert result["valkey_replay_contract"] == "missing"
+    assert result["separately_supplied"] == list(SEPARATELY_SUPPLIED)
+    manifest = json.loads((backup / "MANIFEST.json").read_text())
+    joined = json.dumps(manifest)
+    for value in _supplied().values():
+        assert value not in joined
+
+
+@pytest.mark.parametrize(
+    "component,needle",
+    [
+        ("postgres", "postgres"),
+        ("bundles", "bundle"),
+        ("mail-adapter-state", "mail"),
+        ("valkey", "valkey"),
+    ],
+)
+def test_omitted_required_component_refuses_and_explains_recovery(
+    tmp_path: Path, component: str, needle: str
+) -> None:
+    backup = _complete_backup(tmp_path)
+    if component == "postgres":
+        (backup / "postgres" / "curie.dump").unlink()
+    elif component == "bundles":
+        for path in (backup / "bundles").rglob("*"):
+            if path.is_file():
+                path.unlink()
+    elif component == "mail-adapter-state":
+        (backup / "mail-adapter" / "state.sqlite3").unlink()
+    else:
+        (backup / "valkey" / "dump.rdb").unlink()
+
+    with pytest.raises(RestoreRefused) as raised:
+        check_backup(backup, _supplied())
+    assert needle in str(raised.value).lower()
+    assert raised.value.fix
+    assert "rpo" not in raised.value.fix.lower()
+    assert "rto" not in raised.value.fix.lower()
+
+
+def test_corrupt_bundle_digest_refuses_before_serving(tmp_path: Path) -> None:
+    backup = _complete_backup(tmp_path)
+    (backup / "bundles" / "acme-bot" / "v1.tar.gz").write_bytes(b"tampered-bytes")
+    with pytest.raises(RestoreRefused) as raised:
+        check_backup(backup, _supplied())
+    assert "digest" in str(raised.value).lower() or "sha256" in str(raised.value).lower()
+    assert "bundle" in str(raised.value).lower()
+    assert raised.value.fix
+
+
+def test_missing_separately_supplied_key_refuses_and_does_not_read_it_from_backup(
+    tmp_path: Path,
+) -> None:
+    backup = _complete_backup(tmp_path)
+    supplied = _supplied()
+    supplied.pop("API_KEY")
+    with pytest.raises(RestoreRefused) as raised:
+        check_backup(backup, supplied)
+    assert "API_KEY" in str(raised.value)
+    assert "separately" in str(raised.value).lower() or "supplied" in str(raised.value).lower()
+    assert "api-secret-example" not in str(raised.value)
+
+
+def test_secret_value_inside_backup_is_refused(tmp_path: Path) -> None:
+    backup = _complete_backup(tmp_path)
+    (backup / "notes.txt").write_text("password=pg-secret-example\n")
+    with pytest.raises(RestoreRefused) as raised:
+        check_backup(backup, _supplied())
+    assert "secret" in str(raised.value).lower()
+    assert "pg-secret-example" not in str(raised.value)
+    assert "pg-secret-example" not in raised.value.fix
+
+
+def test_secret_value_in_manifest_is_refused(tmp_path: Path) -> None:
+    backup = _complete_backup(tmp_path)
+    manifest_path = backup / "MANIFEST.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["operator_note"] = _supplied()["API_KEY"]
+    manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(RestoreRefused) as raised:
+        check_backup(backup, _supplied())
+    assert "secret" in str(raised.value).lower()
+    assert _supplied()["API_KEY"] not in str(raised.value)
+
+
+def test_keys_and_config_directory_in_backup_is_refused(tmp_path: Path) -> None:
+    backup = _complete_backup(tmp_path)
+    _write(backup / "keys-and-config" / "api-key", b"nope")
+    with pytest.raises(RestoreRefused) as raised:
+        check_backup(backup, _supplied())
+    assert "keys-and-config" in str(raised.value) or "separately" in str(raised.value).lower()
+
+
+def test_manifest_may_not_claim_rpo_rto_or_invent_valkey_replay(tmp_path: Path) -> None:
+    backup = _complete_backup(tmp_path)
+    manifest_path = backup / "MANIFEST.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["rpo_rto_claimed"] = True
+    manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(RestoreRefused):
+        check_backup(backup, _supplied())
+
+    write_manifest(backup, candidate="abc123")
+    manifest = json.loads(manifest_path.read_text())
+    manifest["valkey_replay_contract"] = "resume-pending-entries"
+    manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(RestoreRefused) as raised:
+        check_backup(backup, _supplied())
+    assert "missing" in raised.value.fix.lower() or "replay" in str(raised.value).lower()
+
+
+def test_check_backup_cli_is_the_consumer_path_for_the_guard(tmp_path: Path) -> None:
+    import subprocess
+    import sys
+
+    backup = _complete_backup(tmp_path)
+    (backup / "postgres" / "curie.dump").unlink()
+    supplied = tmp_path / "supplied.json"
+    supplied.write_text(json.dumps(_supplied()))
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(INVENTORY),
+            "check",
+            str(backup),
+            "--supplied-config",
+            str(supplied),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode != 0
+    payload = json.loads(completed.stdout)
+    assert payload["error"]
+    assert payload["fix"]
+    assert "postgres" in payload["error"].lower()
+    for value in _supplied().values():
+        assert value not in completed.stdout
+        assert value not in completed.stderr


### PR DESCRIPTION
## Summary

Adds a bounded synthetic restore drill for #2427. A disposable compose install is backed up with existing export paths (pg_dump, aws s3 sync, SQLite file copy, Valkey RDB), destroyed, and restored onto a distinct task-owned target. The completeness guard refuses an omitted or corrupt required component and keeps operator keys out of the backup. This does not invent Valkey stream replay, claim an RPO/RTO, or establish a recurring production backup.

## Related issue

Closes #2427

## Fix pin verification

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not change plugin packaging, the skill-tier runner loop, ACI events, or skill eval/check. | | |
| local | required | Compose backup/restore plus `curie dev restore-drill`. | fake | `uv run pytest -q tools/restore-drill/tests apps/mail-adapter/tests/test_state_restore.py` on d93dd800: 13 passed. `bash cli/scripts/restore-drill.sh --check-backup ...` accepted a complete inventory and refused omitted bundles with recovery text. Full compose drill on the same candidate restored agent/version records and exact bundle digest `e65365eec9df15372c3f77042585d2fd48bb8919318a9ec8ff911722cdc62681`. Post-restore `curie local message` was then blocked because issue #2425 occupied host ports 28000/25432 and project `curie`; the drill does not take that stack down. |
| local-release | n/a | Source-checkout `curie dev` only; no released binary identity, install path, or release compose change. | | |
| cluster | n/a | No chart, RBAC, sandbox claim, or init-container change. Mail state is the existing SQLite file-copy path. | | |
| live provider | n/a | Does not reach model routing, credential resolution, or the MCP/workspace/coding-tool path set. The drill forces fake-model. | | |
| external integration | n/a | Does not reach Slack, git-push webhooks, connector OAuth, or live AgentMail. Adapter state is synthetic SQLite. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision.
