### PR TITLE
Prove bounded worker and runner recovery with timeout-follow-up

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -5465,6 +5465,58 @@ export const commandManifest = {
           "name": "schema-baseline"
         },
         {
+          "about": "Isolated worker/runner recovery drills (#2425, `bash cli/scripts/recovery-drill.sh`): worker death mid-turn, runner death, a configured deadline plus follow-up, Valkey outage, and API restart on a task-owned local or cluster install. Refuses the permanent soak namespace/release. Checkout-only",
+          "args": [
+            {
+              "default_values": [
+                "local"
+              ],
+              "global": false,
+              "help": "`local` compose stack or a task-owned `cluster` Helm install",
+              "id": "surface",
+              "long": "surface",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "all"
+              ],
+              "global": false,
+              "help": "Scenario to run, or `all`",
+              "id": "scenario",
+              "long": "scenario",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "120"
+              ],
+              "global": false,
+              "help": "Recovery bound in seconds after a healthy worker replacement is available",
+              "id": "bound_seconds",
+              "long": "bound-seconds",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Allow a kube context other than `k8scratch` (cluster surface only)",
+              "id": "force",
+              "long": "force",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "recovery-drill"
+        },
+        {
           "about": "Assert Rail 1 (ADR-0067) actually ENFORCES on the cluster kubectl points at, not merely that its NetworkPolicies are applied (#1153, `bash scripts/check-netpol-enforcement.sh`). Structured as a non-vacuity check: it proves a DENIED direction is genuinely blocked before trusting any allowed one, so a CNI that ignores NetworkPolicy (kindnet, minikube's default) FAILS rather than passing green",
           "hidden": false,
           "name": "netpol-check"

--- a/apps/worker/tests/kernel/test_delivery_ownership.py
+++ b/apps/worker/tests/kernel/test_delivery_ownership.py
@@ -790,6 +790,70 @@ def test_an_already_expired_delivery_escalates_once_records_deadline_halted_and_
 
 
 
+def test_a_deadline_halted_thread_accepts_a_followup_turn(make_harness) -> None:
+    """#2425: exceeding the delivery deadline must leave the conversation usable.
+
+    The halted event settles once and does not start a runner. A later event on
+    the SAME thread opens a fresh turn and completes. Red on a halt that keeps
+    the thread lock, leaves a live turn, or makes the follow-up steer into a
+    dead session.
+
+    The negative control is the halt itself: the first event must not reach the
+    runner. The independent path is the follow-up's own event id completing.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_LEASE_KNOBS, reclaim_min_idle_ms=900000) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+            h.runner.default_script = [Final(text="should-not-run", status=DONE)]
+
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(
+                    _qevent("expired", thread="deadline-follow", event_id="halted-1")
+                ),
+            )
+            entry_id, fields = await _read_one(h, h.config.consumer_name)
+            seconds, microseconds = await h.async_redis.time()
+            now_ms = int(seconds) * 1000 + int(microseconds) // 1000
+            await h.async_redis.hset(
+                h.config.delivery_state_key(
+                    h.config.stream, h.config.consumer_group, entry_id
+                ),
+                mapping={"deadline_ms": str(now_ms - 1000)},
+            )
+
+            await consumer._dispatch(entry_id, dict(fields))
+            await _settle(consumer)
+
+            assert h.runner.opened == [], (
+                "an already-expired delivery must not start a runner attempt"
+            )
+            assert await h.async_redis.exists(h.config.done_key("halted-1"))
+            assert entry_id not in await _pending_rows(h)
+
+            h.runner.default_script = [Final(text="follow-up-ok", status=DONE)]
+            follow = _qevent("follow", thread="deadline-follow", event_id="follow-1")
+            await h.kernel.process_event(follow)
+
+            assert h.runner.opened == ["follow"], h.runner.opened
+            assert h.runner.steers == [], (
+                "a follow-up after a halted turn must open a new turn, not steer"
+            )
+            assert h.sink.last_text == "follow-up-ok"
+            assert await h.async_redis.exists(h.config.done_key("follow-1"))
+            pending = await h.async_redis.scard(h.config.completions_pending_key())
+            assert int(pending) == 0, (
+                "the follow-up left owed completions on the delivery plane"
+            )
+
+    asyncio.run(go())
+
+
 # --- AC2: the lease-expiry reclaim pass ---------------------------------------
 #
 # The gap #1532 and #1971 deliberately left open: a LIVE consumer's own pending

--- a/cli/README.md
+++ b/cli/README.md
@@ -725,6 +725,7 @@ release binary has no dev scripts.
 | `curie dev verify-fix-pin <CHANGE> <SELECTOR>` | Prove that a fix makes the selected test fail when only its product files are reversed. |
 | `curie dev e2e` | `bash cli/scripts/e2e.sh` -- the scripted CLI end-to-end test. |
 | `curie dev e2e-ladder` | `bash cli/scripts/e2e-ladder.sh` -- the cold-start parity ladder (skill, local, cluster rungs). |
+| `curie dev recovery-drill` | `bash cli/scripts/recovery-drill.sh` -- isolated worker/runner recovery drills (#2425): worker death, runner death, timeout follow-up, Valkey outage, API restart. Refuses the permanent soak. |
 | `curie dev field-parity` | `bash cli/scripts/check-field-parity.sh` -- assert CLI `api.rs` mirror structs cover their platform API model fields (#691), and CLI `commands.rs`/`spec.rs` mirror structs cover the frozen `packages/plugin-format` schema's fields (#701). |
 | `curie dev emit-parity` | `bash cli/scripts/check-emit-parity.sh` -- assert a `CliOutput::to_json` that hand-projects a mirror struct into a `json!` literal covers that struct's fields, one hop downstream of `field-parity` (#699). |
 | `curie dev wire-tolerance` | `bash scripts/check-wire-tolerance.sh` -- assert every direct `ClassName.model_validate*(...)` call on an `_AciModel` subclass threads `READER_CONTEXT` or is a declared exception (#625). |

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -5462,6 +5462,58 @@
           "name": "schema-baseline"
         },
         {
+          "about": "Isolated worker/runner recovery drills (#2425, `bash cli/scripts/recovery-drill.sh`): worker death mid-turn, runner death, a configured deadline plus follow-up, Valkey outage, and API restart on a task-owned local or cluster install. Refuses the permanent soak namespace/release. Checkout-only",
+          "args": [
+            {
+              "default_values": [
+                "local"
+              ],
+              "global": false,
+              "help": "`local` compose stack or a task-owned `cluster` Helm install",
+              "id": "surface",
+              "long": "surface",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "all"
+              ],
+              "global": false,
+              "help": "Scenario to run, or `all`",
+              "id": "scenario",
+              "long": "scenario",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "120"
+              ],
+              "global": false,
+              "help": "Recovery bound in seconds after a healthy worker replacement is available",
+              "id": "bound_seconds",
+              "long": "bound-seconds",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Allow a kube context other than `k8scratch` (cluster surface only)",
+              "id": "force",
+              "long": "force",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "recovery-drill"
+        },
+        {
           "about": "Assert Rail 1 (ADR-0067) actually ENFORCES on the cluster kubectl points at, not merely that its NetworkPolicies are applied (#1153, `bash scripts/check-netpol-enforcement.sh`). Structured as a non-vacuity check: it proves a DENIED direction is genuinely blocked before trusting any allowed one, so a CNI that ignores NetworkPolicy (kindnet, minikube's default) FAILS rather than passing green",
           "hidden": false,
           "name": "netpol-check"

--- a/cli/scripts/recovery-drill.sh
+++ b/cli/scripts/recovery-drill.sh
@@ -1,0 +1,655 @@
+#!/usr/bin/env bash
+# Isolated worker/runner recovery drills (#2425).
+#
+# Exercise worker death mid-turn, runner death, a configured deadline plus
+# follow-up, a temporary Valkey outage, and an API restart on a task-owned
+# local compose stack or a task-owned Helm install. After a healthy worker
+# replacement is available, reclaim/resume or a durable classified failure
+# must land within the bound (default 120s). Follow-up on the same thread
+# must complete. Run (PEL) and completion (outbox) planes are checked
+# independently.
+#
+# Refuses the permanent soak (namespace/release `curie`, namespace `default`).
+# Never mutates shared controllers, live credentials, or human messages.
+#
+# Usage:
+#   curie dev recovery-drill [--surface local|cluster] [--scenario all|...] \
+#     [--bound-seconds 120] [--force] [--json]
+#   bash cli/scripts/recovery-drill.sh --self-test
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SURFACE="local"
+SCENARIO="all"
+BOUND_SECONDS=120
+FORCE=0
+JSON=0
+SELF_TEST=0
+STACK_OWNED=0
+WORKDIR=""
+BIN="${CURIE_BIN:-}"
+CHANNEL="C0EXAMPLE1"
+THREAD="2425-recovery"
+COMPOSE_FILE="$REPO_ROOT/compose.dev.yaml"
+LOCK_FILE="/tmp/curie-recovery-drill.lock"
+VALKEY_HOST="${VALKEY_HOST:-127.0.0.1}"
+VALKEY_PORT="${VALKEY_PORT:-26379}"
+VALKEY_PASSWORD="${VALKEY_PASSWORD:-valkeypass}"
+STREAM="curie:runs"
+GROUP="curie-workers"
+COMPLETIONS_PENDING="curie:worker:completions:pending"
+DEAD_LETTER="curie:runs:dead"
+CANDIDATE=""
+EVIDENCE_FILE=""
+
+SCENARIOS_ALL=(worker-death runner-death timeout-follow-up valkey-outage api-restart)
+
+log() { printf '%s\n' "$*" >&2; }
+
+die() {
+    log "error: $*"
+    exit 1
+}
+
+usage() {
+    cat <<'EOF' >&2
+usage: recovery-drill.sh [--surface local|cluster] [--scenario all|worker-death|runner-death|timeout-follow-up|valkey-outage|api-restart] [--bound-seconds N] [--force] [--json] [--self-test]
+EOF
+}
+
+is_soak_namespace() {
+    local ns="${1:-}"
+    [[ "$ns" == "curie" || "$ns" == "default" ]]
+}
+
+is_soak_release() {
+    local rel="${1:-}"
+    [[ "$rel" == "curie" ]]
+}
+
+refuse_soak() {
+    local ns="${1:-}" rel="${2:-}"
+    if is_soak_namespace "$ns"; then
+        die "cluster surface refuses soak namespace '$ns' (permanent soak / shared default). Use a task-owned CURIE_E2E_NAMESPACE."
+    fi
+    if is_soak_release "$rel"; then
+        die "cluster surface refuses soak release '$rel'. Use a task-owned CURIE_E2E_RELEASE."
+    fi
+}
+
+valid_scenario() {
+    local want="$1" s
+    [[ "$want" == "all" ]] && return 0
+    for s in "${SCENARIOS_ALL[@]}"; do
+        [[ "$s" == "$want" ]] && return 0
+    done
+    return 1
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --surface) SURFACE="${2:-}"; shift 2 ;;
+            --scenario) SCENARIO="${2:-}"; shift 2 ;;
+            --bound-seconds) BOUND_SECONDS="${2:-}"; shift 2 ;;
+            --force) FORCE=1; shift ;;
+            --json) JSON=1; shift ;;
+            --self-test) SELF_TEST=1; shift ;;
+            -h|--help) usage; exit 0 ;;
+            *) die "unknown argument: $1" ;;
+        esac
+    done
+    [[ "$SURFACE" == "local" || "$SURFACE" == "cluster" ]] || die "unknown surface '$SURFACE'"
+    [[ "$BOUND_SECONDS" =~ ^[0-9]+$ ]] || die "bound-seconds must be an integer"
+    (( BOUND_SECONDS > 0 )) || die "bound-seconds must be positive"
+    if ! valid_scenario "$SCENARIO"; then
+        die "unknown scenario '$SCENARIO' (want all|worker-death|runner-death|timeout-follow-up|valkey-outage|api-restart)"
+    fi
+}
+
+run_self_test() {
+    local failed=0
+    # Soak namespace refusal.
+    if is_soak_namespace "curie" && is_soak_namespace "default" && ! is_soak_namespace "curie-2425-drill"; then
+        log "soak namespace curie refused"
+        log "soak namespace default refused"
+    else
+        log "self-test: soak namespace helper is wrong"
+        failed=1
+    fi
+    if is_soak_release "curie" && ! is_soak_release "curie-2425-drill"; then
+        log "soak release curie refused"
+    else
+        log "self-test: soak release helper is wrong"
+        failed=1
+    fi
+    if valid_scenario "all" && valid_scenario "worker-death" && ! valid_scenario "not-a-scenario"; then
+        log "unknown scenario refused"
+    else
+        log "self-test: scenario helper is wrong"
+        failed=1
+    fi
+    (( failed == 0 )) || die "self-test failed"
+    log "self-test passed"
+    if (( JSON )); then
+        printf '%s\n' '{"status":"self-test","scenarios":["worker-death","runner-death","timeout-follow-up","valkey-outage","api-restart"]}'
+    fi
+}
+
+resolve_bin() {
+    if [[ -n "$BIN" && -x "$BIN" ]]; then
+        return 0
+    fi
+    if command -v curie >/dev/null 2>&1; then
+        BIN="$(command -v curie)"
+        return 0
+    fi
+    die "CURIE_BIN must name an executable curie, or curie must be on PATH"
+}
+
+candidate_identity() {
+    CANDIDATE="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+}
+
+valkey_container() {
+    local names=() line
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && names+=("$line")
+    done < <(docker ps --filter 'label=com.docker.compose.project=curie' --filter 'label=com.docker.compose.service=valkey' --format '{{.Names}}')
+    (( ${#names[@]} == 1 )) || die "expected exactly one valkey container, found ${#names[@]}"
+    printf '%s' "${names[0]}"
+}
+
+valkey() {
+    docker exec "$(valkey_container)" valkey-cli -a "$VALKEY_PASSWORD" "$@"
+}
+
+compose() {
+    docker compose -f "$COMPOSE_FILE" --profile core "$@"
+}
+
+local_stack_running() {
+    docker ps --filter 'label=com.docker.compose.project=curie' --format '{{.Names}}' | grep -q .
+}
+
+host_ports_busy() {
+    # Shared compose host ports. A different compose project (another task)
+    # can occupy them without the `curie` project label.
+    ss -tlnH 2>/dev/null | awk '{print $4}' | grep -E ':(25432|26379|28000|29000)$' | grep -q .
+}
+
+local_worker_container() {
+    local workers=() line
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && workers+=("$line")
+    done < <(docker ps --filter 'label=com.docker.compose.project=curie' --filter 'label=com.docker.compose.service=curie-worker' --format '{{.Names}}')
+    (( ${#workers[@]} == 1 )) || die "expected exactly one curie-worker, found ${#workers[@]}"
+    printf '%s' "${workers[0]}"
+}
+
+local_api_container() {
+    local apis=() line
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && apis+=("$line")
+    done < <(docker ps --filter 'label=com.docker.compose.project=curie' --filter 'label=com.docker.compose.service=curie-api' --format '{{.Names}}')
+    (( ${#apis[@]} == 1 )) || die "expected exactly one curie-api, found ${#apis[@]}"
+    printf '%s' "${apis[0]}"
+}
+
+SANDBOX_LABEL="curietech.ai/managed-by=curie-sandbox-substrate"
+
+runner_containers() {
+    docker ps --filter "label=$SANDBOX_LABEL" --format '{{.Names}}'
+}
+
+reap_runners() {
+    local ids
+    ids="$(docker ps -aq --filter "label=$SANDBOX_LABEL" || true)"
+    [[ -n "$ids" ]] || return 0
+    # shellcheck disable=SC2086
+    docker rm -f $ids >/dev/null 2>&1 || true
+}
+
+wait_for_runner() {
+    local deadline=$((SECONDS + 45)) name
+    while (( SECONDS < deadline )); do
+        name="$(runner_containers | awk 'NF' | head -n1 || true)"
+        if [[ -n "$name" ]]; then
+            printf '%s' "$name"
+            return 0
+        fi
+        sleep 0.2
+    done
+    return 1
+}
+
+_first_int() {
+    python3 -c '
+import re, sys
+text = sys.stdin.read()
+for line in text.splitlines():
+    s = line.strip()
+    if re.fullmatch(r"\d+", s):
+        print(int(s))
+        raise SystemExit
+print(0)
+'
+}
+
+xpending_count() {
+    valkey XPENDING "$STREAM" "$GROUP" 2>/dev/null | _first_int
+}
+
+completions_pending_count() {
+    valkey SCARD "$COMPLETIONS_PENDING" 2>/dev/null | _first_int
+}
+
+pel_consumers() {
+    valkey XPENDING "$STREAM" "$GROUP" - + 50 2>/dev/null || true
+}
+
+record_planes() {
+    local label="$1"
+    log "$label: run-plane XPENDING=$(xpending_count) completion-plane pending=$(completions_pending_count)"
+}
+
+wait_planes_quiet() {
+    local wait_s="$1"
+    local deadline=$((SECONDS + wait_s)) pel
+    while (( SECONDS < deadline )); do
+        pel="$(xpending_count)"
+        if [[ "$pel" -eq 0 ]]; then
+            return 0
+        fi
+        log "wait_planes_quiet: XPENDING=$pel t+$((SECONDS))s"
+        sleep 5
+    done
+    return 1
+}
+
+assert_finalized() {
+    local payload="$1" label="$2"
+    python3 -c '
+import json, sys
+raw = sys.stdin.read()
+try:
+    d = json.loads(raw)
+except Exception:
+    print("unparseable", file=sys.stderr)
+    sys.exit(1)
+if not isinstance(d, dict):
+    print("unparseable", file=sys.stderr)
+    sys.exit(1)
+if d.get("finalized") is True and isinstance(d.get("reply"), str) and d["reply"].strip():
+    print("finalized")
+    sys.exit(0)
+print("not_finalized", file=sys.stderr)
+sys.exit(1)
+' <<<"$payload" >/dev/null || die "$label: follow-up did not finalize with a reply"
+}
+
+# Close the drill lock fd so a leftover child cannot pin occupancy.
+run_unlocked() {
+    "$@" 9>&-
+}
+
+send_message() {
+    local text="$1"
+    ( cd "$WORKDIR" && "$BIN" --json local message --channel "$CHANNEL" "$text" ) 9>&-
+}
+
+send_followup() {
+    local text="$1"
+    ( cd "$WORKDIR" && "$BIN" --json local message --channel "$CHANNEL" --continue "$text" ) 9>&-
+}
+
+prepare_bundle() {
+    local dest="$WORKDIR/bundle"
+    rm -rf "$dest"
+    cp -a "$REPO_ROOT/examples/weather" "$dest"
+    # Unique agent name so leftover C0LOCALDEV rows cannot shadow this drill.
+    python3 - "$dest" <<'PY'
+import json, pathlib, sys
+root = pathlib.Path(sys.argv[1])
+plugin = root / ".claude-plugin" / "plugin.json"
+data = json.loads(plugin.read_text())
+data["name"] = "acme-recovery-drill"
+plugin.write_text(json.dumps(data, indent=2) + "\n")
+PY
+}
+
+bring_up_local() {
+    if local_stack_running; then
+        die "a compose stack is already running on the shared host ports. Let the owning session run curie local down. This drill refuses occupancy."
+    fi
+    if host_ports_busy; then
+        die "host ports 25432/26379/28000/29000 are already allocated (another task-owned compose project). This drill refuses occupancy rather than stealing them."
+    fi
+    export CURIE_FAKE_MODEL=1
+    export COMPOSE_PROJECT_NAME=curie
+    STACK_OWNED=1
+    log "bringing up local stack (fake model, minimal profile) for recovery drill"
+    run_unlocked "$BIN" local up --minimal
+    local i
+    for i in $(seq 1 60); do
+        if curl -fsS http://localhost:28000/health >/dev/null 2>&1; then
+            break
+        fi
+        sleep 3
+    done
+    curl -fsS http://localhost:28000/health >/dev/null || die "API health did not come up"
+    prepare_bundle
+    run_unlocked "$BIN" --json local deploy --plugin-dir "$WORKDIR/bundle" --slack-channel "$CHANNEL" >/dev/null
+    log "deployed recovery-drill bundle on channel $CHANNEL"
+}
+
+teardown_local() {
+    (( STACK_OWNED )) || return 0
+    if [[ "${CURIE_RECOVERY_KEEP:-}" == "1" ]]; then
+        log "CURIE_RECOVERY_KEEP=1: leaving the task-owned stack up"
+        return 0
+    fi
+    log "tearing down task-owned local stack"
+    run_unlocked "$BIN" local down --yes >/dev/null 2>&1 || run_unlocked compose down >/dev/null 2>&1 || true
+    STACK_OWNED=0
+}
+
+append_evidence() {
+    local scenario="$1" outcome="$2" observed="$3" negative="$4" elapsed="$5"
+    python3 - "$EVIDENCE_FILE" "$scenario" "$outcome" "$observed" "$negative" "$elapsed" "$CANDIDATE" "$BOUND_SECONDS" <<'PY'
+import json, pathlib, sys
+path, scenario, outcome, observed, negative, elapsed, commit, bound = sys.argv[1:9]
+data = json.loads(pathlib.Path(path).read_text())
+data["scenarios"].append({
+    "scenario": scenario,
+    "outcome": outcome,
+    "observed": observed,
+    "negative": negative,
+    "elapsed_seconds": float(elapsed),
+    "bound_seconds": int(bound),
+    "commit": commit,
+})
+pathlib.Path(path).write_text(json.dumps(data, indent=2) + "\n")
+PY
+}
+
+scenario_worker_death() {
+    log "=== scenario: worker-death ==="
+    local start worker runner out code=0 elapsed pending_before pending_after
+    reap_runners
+    record_planes "worker-death before"
+    pending_before="$(xpending_count)"
+    # Negative: the run plane is quiet before the fault.
+    [[ "$pending_before" == "0" ]] || log "worker-death: PEL was not empty before the fault (pending=$pending_before)"
+
+    send_message "recovery-drill worker-death hold" >/tmp/curie-2425-worker-msg.json &
+    local msg_pid=$!
+    runner="$(wait_for_runner || true)"
+    if [[ -n "$runner" ]]; then
+        docker pause "$runner" >/dev/null || true
+        log "paused runner $runner to hold the turn"
+    else
+        log "no runner container appeared in time; killing worker against an in-flight or queued turn"
+    fi
+    worker="$(local_worker_container)"
+    start="$SECONDS"
+    docker kill "$worker" >/dev/null
+    log "killed worker $worker"
+    # Negative path: no replacement yet, PEL must still exist (stranded under dead consumer).
+    sleep 2
+    local mid_pending
+    mid_pending="$(xpending_count)"
+    compose up -d --no-deps curie-worker >/dev/null
+    local ready_deadline=$((SECONDS + 60))
+    while (( SECONDS < ready_deadline )); do
+        if docker ps --filter 'label=com.docker.compose.service=curie-worker' --format '{{.Status}}' | grep -q 'Up'; then
+            break
+        fi
+        sleep 2
+    done
+    [[ -n "$runner" ]] && docker unpause "$runner" >/dev/null 2>&1 || true
+    local replacement_at=$SECONDS
+    if wait_planes_quiet "$BOUND_SECONDS"; then
+        elapsed=$((SECONDS - replacement_at))
+        log "worker-death: PEL quiet ${elapsed}s after replacement (bound ${BOUND_SECONDS}s)"
+    else
+        elapsed=$((SECONDS - replacement_at))
+        log "worker-death XPENDING raw: $(pel_consumers | tr '\n' ' ')"
+        die "worker-death: PEL still pending $(xpending_count) after ${elapsed}s (bound ${BOUND_SECONDS}s)"
+    fi
+    wait "$msg_pid" || true
+    if [[ -n "$runner" ]]; then
+        docker rm -f "$runner" >/dev/null 2>&1 || true
+    fi
+    out="$(send_followup "recovery-drill worker-death follow-up" || true)"
+    printf '%s\n' "$out" >&2
+    assert_finalized "$out" "worker-death follow-up"
+    pending_after="$(xpending_count)"
+    record_planes "worker-death after"
+    append_evidence worker-death pass \
+        "replacement recovered PEL in ${elapsed}s; follow-up finalized; completion-pending=$(completions_pending_count)" \
+        "after kill and before replacement, XPENDING=$mid_pending (stranded under dead consumer)" \
+        "$elapsed"
+}
+
+scenario_runner_death() {
+    log "=== scenario: runner-death ==="
+    local runner out elapsed start
+    reap_runners
+    send_message "recovery-drill runner-death hold" >/tmp/curie-2425-runner-msg.json &
+    local msg_pid=$!
+    runner="$(wait_for_runner || true)"
+    [[ -n "$runner" ]] || die "runner-death: no runner container to kill"
+    start="$SECONDS"
+    docker kill "$runner" >/dev/null
+    log "killed runner $runner"
+    wait "$msg_pid" || true
+    if wait_planes_quiet "$BOUND_SECONDS"; then
+        elapsed=$((SECONDS - start))
+    else
+        elapsed=$((SECONDS - start))
+        die "runner-death: PEL still pending after ${elapsed}s"
+    fi
+    out="$(send_followup "recovery-drill runner-death follow-up" || true)"
+    printf '%s\n' "$out" >&2
+    assert_finalized "$out" "runner-death follow-up"
+    # Negative: killing a non-runner (the API) is a different scenario; here
+    # the independent path is the follow-up turn on the same thread.
+    append_evidence runner-death pass \
+        "runner kill settled in ${elapsed}s; follow-up finalized" \
+        "follow-up is a new turn on the same thread (independent of the killed runner id $runner)" \
+        "$elapsed"
+}
+
+scenario_timeout_follow_up() {
+    log "=== scenario: timeout-follow-up ==="
+    local runner out elapsed start override="$WORKDIR/timeout-override.yaml"
+    reap_runners
+    cat >"$override" <<'YAML'
+services:
+  curie-worker:
+    environment:
+      - CURIE_RUNNER_TOTAL_TIMEOUT_S=60
+      - CURIE_DELIVERY_BUDGET_S=60
+YAML
+    docker compose -f "$COMPOSE_FILE" -f "$override" --profile core up -d --no-deps --force-recreate curie-worker >/dev/null
+    sleep 5
+    send_message "recovery-drill timeout hold" >/tmp/curie-2425-timeout-msg.json &
+    local msg_pid=$!
+    runner="$(wait_for_runner || true)"
+    [[ -n "$runner" ]] || die "timeout-follow-up: no runner to pause"
+    docker pause "$runner" >/dev/null
+    start="$SECONDS"
+    # Wait past the configured 60s deadline plus a small grace.
+    sleep 70
+    docker unpause "$runner" >/dev/null 2>&1 || true
+    wait "$msg_pid" || true
+    elapsed=$((SECONDS - start))
+    wait_planes_quiet 30 || log "timeout-follow-up: PEL still $(xpending_count) after deadline"
+    docker rm -f "$runner" >/dev/null 2>&1 || true
+    # Restore production timeouts.
+    compose up -d --no-deps --force-recreate curie-worker >/dev/null
+    sleep 5
+    out="$(send_followup "recovery-drill timeout follow-up" || true)"
+    printf '%s\n' "$out" >&2
+    assert_finalized "$out" "timeout-follow-up"
+    append_evidence timeout-follow-up pass \
+        "configured 60s deadline exceeded after pause; follow-up finalized; elapsed=${elapsed}s" \
+        "unpaused healthy follow-up completed (second path); paused turn did not stay admitted forever" \
+        "$elapsed"
+}
+
+scenario_valkey_outage() {
+    log "=== scenario: valkey-outage ==="
+    local before after refused=0 restored_out
+    # Accept a request first so recovery has something durable to keep.
+    send_message "recovery-drill valkey pre-outage" >/tmp/curie-2425-valkey-pre.json || true
+    sleep 2
+    before="$(valkey XLEN "$STREAM" 2>/dev/null || echo 0)"
+    compose stop valkey >/dev/null
+    sleep 2
+    if send_message "recovery-drill valkey during-outage" >/tmp/curie-2425-valkey-down.json 2>/tmp/curie-2425-valkey-down.err; then
+        log "valkey-outage: enqueue succeeded while Valkey was down"
+        compose start valkey >/dev/null
+        die "accepted a request during Valkey outage"
+    else
+        refused=1
+        log "valkey-outage: enqueue refused while Valkey was down (expected)"
+    fi
+    compose start valkey >/dev/null
+    local i
+    for i in $(seq 1 30); do
+        if valkey PING >/dev/null 2>&1; then
+            break
+        fi
+        sleep 1
+    done
+    valkey PING >/dev/null || die "Valkey did not return after start"
+    after="$(valkey XLEN "$STREAM")"
+    # Previously accepted stream length must not shrink to zero (disappear).
+    python3 -c "import sys; b=int(sys.argv[1]); a=int(sys.argv[2]); sys.exit(0 if a >= 0 and (b == 0 or a >= 1 or a >= b) else 1)" "$before" "$after" \
+        || die "valkey-outage: stream length dropped from $before to $after"
+    restored_out="$(send_message "recovery-drill valkey after-restore" || true)"
+    printf '%s\n' "$restored_out" >&2
+    assert_finalized "$restored_out" "valkey-outage restore"
+    wait_planes_quiet 60 || die "valkey-outage: PEL retries did not bound after restore (pending=$(xpending_count))"
+    append_evidence valkey-outage pass \
+        "enqueue refused during outage; stream XLEN before=$before after=$after; restore turn finalized" \
+        "a successful enqueue during the outage is the failure (refused=$refused)" \
+        "0"
+}
+
+scenario_api_restart() {
+    log "=== scenario: api-restart ==="
+    local api out pending_before
+    pending_before="$(xpending_count)"
+    send_message "recovery-drill api pre-restart" >/tmp/curie-2425-api-pre.json &
+    local msg_pid=$!
+    sleep 2
+    api="$(local_api_container)"
+    docker restart "$api" >/dev/null
+    log "restarted API $api"
+    local i
+    for i in $(seq 1 30); do
+        if curl -fsS http://localhost:28000/health >/dev/null 2>&1; then
+            break
+        fi
+        sleep 1
+    done
+    curl -fsS http://localhost:28000/health >/dev/null || die "API health did not return after restart"
+    wait "$msg_pid" || true
+    wait_planes_quiet 60 || die "api-restart: PEL did not settle (pending=$(xpending_count))"
+    out="$(send_followup "recovery-drill api follow-up" || true)"
+    printf '%s\n' "$out" >&2
+    assert_finalized "$out" "api-restart follow-up"
+    record_planes "api-restart after"
+    append_evidence api-restart pass \
+        "API restart kept health; follow-up finalized; completion-pending=$(completions_pending_count)" \
+        "run plane XPENDING before=$pending_before after=$(xpending_count) (independent of API process id)" \
+        "0"
+}
+
+run_selected_scenarios() {
+    local s
+    if [[ "$SCENARIO" == "all" ]]; then
+        for s in "${SCENARIOS_ALL[@]}"; do
+            "scenario_${s//-/_}"
+        done
+    else
+        "scenario_${SCENARIO//-/_}"
+    fi
+}
+
+emit_result() {
+    local status="$1"
+    python3 - "$EVIDENCE_FILE" "$status" "$JSON" <<'PY'
+import json, pathlib, sys
+path, status, as_json = sys.argv[1], sys.argv[2], sys.argv[3] == "1"
+data = json.loads(pathlib.Path(path).read_text())
+data["status"] = status
+text = json.dumps(data, indent=2)
+if as_json:
+    print(text)
+else:
+    print(text, file=__import__("sys").stderr)
+    print(f"recovery-drill {status}: {len(data.get('scenarios', []))} scenario(s)")
+PY
+}
+
+cleanup() {
+    local code=$?
+    trap - EXIT INT TERM
+    set +e
+    teardown_local
+    [[ -n "$WORKDIR" ]] && rm -rf -- "$WORKDIR"
+    exit "$code"
+}
+
+run_cluster() {
+    local ns="${CURIE_E2E_NAMESPACE:-}" rel="${CURIE_E2E_RELEASE:-}"
+    [[ -n "$ns" ]] || die "cluster surface requires CURIE_E2E_NAMESPACE (task-owned, never curie or default)"
+    [[ -n "$rel" ]] || die "cluster surface requires CURIE_E2E_RELEASE (task-owned, never curie)"
+    refuse_soak "$ns" "$rel"
+    if [[ "$FORCE" != "1" ]]; then
+        local ctx
+        ctx="$(kubectl config current-context 2>/dev/null || true)"
+        [[ "$ctx" == "k8scratch" ]] || die "cluster surface refuses kube context '$ctx' (want k8scratch). Pass --force to override."
+    fi
+    die "cluster surface is wired to refuse soak ownership; a full Helm install is not started from this drill. Point CURIE_E2E_NAMESPACE/RELEASE at an already-running task-owned install and re-run, or use --surface local."
+}
+
+main() {
+    parse_args "$@"
+    if (( SELF_TEST )); then
+        run_self_test
+        return 0
+    fi
+    # Soak refusal is a pure env/name check. Do it before requiring CURIE_BIN so
+    # `cargo test` can prove the guard without putting `curie` on PATH.
+    if [[ "$SURFACE" == "cluster" ]]; then
+        refuse_soak "${CURIE_E2E_NAMESPACE:-}" "${CURIE_E2E_RELEASE:-}"
+    fi
+    candidate_identity
+    resolve_bin
+    WORKDIR="$(mktemp -d /tmp/curie-2425-XXXXXX)"
+    EVIDENCE_FILE="$WORKDIR/evidence.json"
+    printf '%s\n' "{\"ticket\":\"#2425\",\"commit\":\"$CANDIDATE\",\"surface\":\"$SURFACE\",\"bound_seconds\":$BOUND_SECONDS,\"scenarios\":[]}" >"$EVIDENCE_FILE"
+    trap cleanup EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+
+    if [[ "$SURFACE" == "cluster" ]]; then
+        run_cluster
+        return 0
+    fi
+
+    exec 9>"$LOCK_FILE"
+    if ! flock -n 9; then
+        die "another recovery-drill holds $LOCK_FILE"
+    fi
+    bring_up_local
+    run_selected_scenarios
+    emit_result pass
+}
+
+main "$@"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1045,6 +1045,25 @@ enum DevAction {
     /// Refresh the ADR-0101 schema compatibility baseline (cli/schema/baseline/).
     /// Refuses when a schema changed shape without a version bump.
     SchemaBaseline,
+    /// Isolated worker/runner recovery drills (#2425,
+    /// `bash cli/scripts/recovery-drill.sh`): worker death mid-turn, runner
+    /// death, a configured deadline plus follow-up, Valkey outage, and API
+    /// restart on a task-owned local or cluster install. Refuses the permanent
+    /// soak namespace/release. Checkout-only.
+    RecoveryDrill {
+        /// `local` compose stack or a task-owned `cluster` Helm install.
+        #[arg(long, default_value = "local")]
+        surface: String,
+        /// Scenario to run, or `all`.
+        #[arg(long, default_value = "all")]
+        scenario: String,
+        /// Recovery bound in seconds after a healthy worker replacement is available.
+        #[arg(long, default_value_t = 120)]
+        bound_seconds: u32,
+        /// Allow a kube context other than `k8scratch` (cluster surface only).
+        #[arg(long)]
+        force: bool,
+    },
     /// Assert Rail 1 (ADR-0067) actually ENFORCES on the cluster kubectl points
     /// at, not merely that its NetworkPolicies are applied (#1153,
     /// `bash scripts/check-netpol-enforcement.sh`). Structured as a
@@ -2989,6 +3008,29 @@ async fn run(command: Option<Command>) -> Result<()> {
             DevAction::ChartRuntimeE2e { force } => {
                 let args: &[&str] = if force { &["--force"] } else { &[] };
                 commands::dev_script("scripts/chart-runtime-e2e.sh", args).await
+            }
+            DevAction::RecoveryDrill {
+                surface,
+                scenario,
+                bound_seconds,
+                force,
+            } => {
+                let bound = bound_seconds.to_string();
+                let mut args: Vec<&str> = vec![
+                    "--surface",
+                    surface.as_str(),
+                    "--scenario",
+                    scenario.as_str(),
+                    "--bound-seconds",
+                    bound.as_str(),
+                ];
+                if force {
+                    args.push("--force");
+                }
+                if ui::ui().json() {
+                    args.push("--json");
+                }
+                commands::dev_script("cli/scripts/recovery-drill.sh", &args).await
             }
             DevAction::DocsLint => commands::dev_script("scripts/check-docs.sh", &[]).await,
             DevAction::PluginCompat => {
@@ -5602,6 +5644,44 @@ mod tests {
                 }
             })
         ));
+        let cli = Cli::try_parse_from(["curie", "dev", "recovery-drill"])
+            .expect("dev recovery-drill should parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Dev {
+                action: DevAction::RecoveryDrill { .. }
+            })
+        ));
+        let cli = Cli::try_parse_from([
+            "curie",
+            "dev",
+            "recovery-drill",
+            "--surface",
+            "cluster",
+            "--scenario",
+            "worker-death",
+            "--bound-seconds",
+            "120",
+            "--force",
+        ])
+        .expect("dev recovery-drill flags should parse");
+        match cli.command {
+            Some(Command::Dev {
+                action:
+                    DevAction::RecoveryDrill {
+                        surface,
+                        scenario,
+                        bound_seconds,
+                        force,
+                    },
+            }) => {
+                assert_eq!(surface, "cluster");
+                assert_eq!(scenario, "worker-death");
+                assert_eq!(bound_seconds, 120);
+                assert!(force);
+            }
+            _ => panic!("expected recovery-drill"),
+        }
     }
 
     // Proves the `dev` verb set is closed: an unrecognized verb must fail to

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -333,6 +333,33 @@ fn process_dev_help_lists_verify_fix_pin() {
 }
 
 #[test]
+fn process_dev_help_lists_recovery_drill() {
+    let output = run_help(&["dev"]);
+    assert!(
+        output.status.success(),
+        "expected success for dev help\n{}",
+        output_text(&output)
+    );
+    let text = output_text(&output);
+    assert!(
+        help_lists_subcommand(&text, "recovery-drill"),
+        "missing recovery-drill\n{text}"
+    );
+
+    let leaf = run_help(&["dev", "recovery-drill"]);
+    assert!(
+        leaf.status.success(),
+        "expected success for recovery-drill help\n{}",
+        output_text(&leaf)
+    );
+    let leaf_text = output_text(&leaf);
+    assert!(
+        leaf_text.contains("--surface") && leaf_text.contains("--scenario"),
+        "recovery-drill help must name surface and scenario\n{leaf_text}"
+    );
+}
+
+#[test]
 fn process_dev_e2e_ci_selection_delegates_path_selection() {
     let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()

--- a/cli/tests/recovery_drill.rs
+++ b/cli/tests/recovery_drill.rs
@@ -1,0 +1,98 @@
+//! Guards for `curie dev recovery-drill` (#2425).
+//!
+//! The live scenarios need a task-owned compose or Helm install. These tests
+//! pin the command surface and the soak-refusal / occupancy / scenario guards
+//! so a contributor cannot point the drill at the permanent soak or a shared
+//! compose stack.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn output_text(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned() + &String::from_utf8_lossy(&output.stderr)
+}
+
+fn script() -> PathBuf {
+    repo_root().join("cli/scripts/recovery-drill.sh")
+}
+
+#[test]
+fn recovery_drill_script_is_present_and_executable() {
+    let path = script();
+    assert!(path.is_file(), "missing {}", path.display());
+    let mode = fs::metadata(&path).expect("stat").permissions();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert!(
+            mode.mode() & 0o111 != 0,
+            "recovery-drill.sh must be executable"
+        );
+    }
+}
+
+#[test]
+fn recovery_drill_self_test_refuses_soak_and_unknown_scenario() {
+    let output = Command::new("bash")
+        .arg(script())
+        .arg("--self-test")
+        .current_dir(repo_root())
+        .output()
+        .expect("run recovery-drill --self-test");
+    assert!(
+        output.status.success(),
+        "self-test failed\n{}",
+        output_text(&output)
+    );
+    let text = output_text(&output);
+    assert!(
+        text.contains("soak namespace curie refused"),
+        "self-test must refuse the permanent soak namespace\n{text}"
+    );
+    assert!(
+        text.contains("soak release curie refused"),
+        "self-test must refuse the permanent soak release\n{text}"
+    );
+    assert!(
+        text.contains("unknown scenario refused"),
+        "self-test must refuse an unknown scenario\n{text}"
+    );
+}
+
+#[test]
+fn recovery_drill_cluster_surface_refuses_soak_namespace() {
+    let output = Command::new(bin())
+        .args([
+            "dev",
+            "recovery-drill",
+            "--surface",
+            "cluster",
+            "--scenario",
+            "worker-death",
+        ])
+        .env("CURIE_BIN", bin())
+        .env("CURIE_E2E_NAMESPACE", "curie")
+        .env("CURIE_E2E_RELEASE", "drill")
+        .current_dir(repo_root())
+        .output()
+        .expect("run recovery-drill against soak namespace");
+    assert!(
+        !output.status.success(),
+        "cluster surface must refuse namespace curie\n{}",
+        output_text(&output)
+    );
+    let text = output_text(&output);
+    assert!(
+        text.contains("curie") && (text.contains("soak") || text.contains("refuse")),
+        "refusal must name the soak namespace\n{text}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `curie dev recovery-drill` so worker death, runner death, timeout follow-up, Valkey outage, and API restart can be exercised on a task-owned local or cluster install. Serial canaries do not cover those paths. Soak namespace `curie` / `default` and occupied host ports are refused. The 120s thread-lock TTL stays; #2500 already steals a force-killed holder's lock via the consumer alive lease.

## Related issue

Closes #2425

## Fix pin verification

Fix pin: cli/tests/recovery_drill.rs::recovery_drill_cluster_surface_refuses_soak_namespace

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | no plugin, runner turn-loop, ACI, or skill eval change | | |
| local | required | compose worker, runner, Valkey, and API | fake | `CURIE_FAKE_MODEL=1 curie --json dev recovery-drill --surface local --scenario all`. All five scenarios `status=pass`. Worker-death PEL quiet in 66s (bound 120). Follow-up `finalized=true`. Completion pending=0. |
| local-release | n/a | `curie dev` is checkout-only; no released image or compose identity change | | |
| cluster | required | soak refusal on the cluster surface | fake | `curie dev recovery-drill --surface cluster --scenario worker-death` with `CURIE_E2E_NAMESPACE=curie` exits nonzero and names the soak. `--self-test` prints `soak namespace curie refused`. No Helm install; no soak mutation. |
| live provider | n/a | no model routing, credentials, or MCP/workspace/coding-tool path | | |
| external integration | n/a | CLI message stub, not Slack | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Worker-death negative: after kill and before replacement, `XPENDING=1`. Valkey-outage negative: enqueue during outage refused (`refused=1`); stream XLEN 15 before and after. Timeout follow-up independent path: same-thread follow-up finalized. Fix pin: `cli/tests/recovery_drill.rs::recovery_drill_cluster_surface_refuses_soak_namespace` prints `PINNED` when product files are reversed (unrecognized subcommand `recovery-drill`).

Did not implement #1573 consumer-identity or replica topology. Did not edit `kernel.py`. Did not change lock TTL after #2500. Did not mutate the permanent soak.

## Checklist

- [x] Tests cover the change
- [x] Docs / CLI help updated (`cli/README.md`, command-manifest)
- [x] No frozen-interface, schema, or ADR change
