### PR TITLE
Retain Curie metrics and reliability alerts on the existing overlay

### DIFF
--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -365,7 +365,14 @@ the traces pipeline. `extraLogPipelineExporters` and
 `extraMetricPipelineExporters` do the equivalent for the respective signal
 pipelines. Helm rejects a missing exporter or a network exporter without its
 bounded retry and persistent queue protections. The development-only `debug`
-exporter is available only when enabled.
+exporter is available only when enabled. The chart default keeps metrics on
+`nop/metrics`. The SRE-bot overlay
+(`examples/sre-bot/observability/curie-values.yaml`) appends
+`prometheusremotewrite/soak` so a Prometheus with
+`web.enable-remote-write-receiver` retains Curie series. A locally rendered
+overlay is not proof that a live Collector is exporting, and a disposable
+runtime proof is not proof the permanent soak overlay is deployed; see
+`examples/sre-bot/docs/METRICS-ROLLOUT.md`.
 
 Built-in exporter names (`otlphttp/langfuse`, `nop/logs`, `nop/metrics`, and
 `debug`) are reserved and cannot be overridden through `extraExporters`.

--- a/charts/curie/ci/observability-stack-assertions.sh
+++ b/charts/curie/ci/observability-stack-assertions.sh
@@ -896,6 +896,82 @@ for label, docs in (("install", curie_install_docs), ("upgrade", curie_upgrade_d
     assert trace_exporters == ["otlphttp/langfuse", "otlphttp/tempo"], (
         f"{label} production render must export traces to Langfuse and Tempo without debug"
     )
+    soak_exporter = at(config, "exporters", "prometheusremotewrite/soak")
+    assert soak_exporter.get("endpoint") == (
+        "http://prometheus-server.observability.svc.cluster.local/api/v1/write"
+    )
+    assert (soak_exporter.get("resource_to_telemetry_conversion") or {}).get("enabled") is False
+    assert at(soak_exporter, "retry_on_failure", "enabled") is True
+    assert "sending_queue" not in soak_exporter
+    assert at(soak_exporter, "remote_write_queue", "enabled") is True
+    assert 0 < int(at(soak_exporter, "remote_write_queue", "queue_size")) <= 100000
+    metric_exporters = at(config, "service", "pipelines", "metrics", "exporters")
+    assert "nop/metrics" in metric_exporters, (
+        f"{label} must keep nop/metrics; the overlay appends, it does not replace"
+    )
+    assert "prometheusremotewrite/soak" in metric_exporters, (
+        f"{label} must retain Curie metrics on prometheusremotewrite/soak"
+    )
+
+default_config = collector_config(curie_default_docs)
+assert at(default_config, "service", "pipelines", "metrics", "exporters") == ["nop/metrics"], (
+    "chart default must keep metrics on nop until an overlay adds a destination"
+)
+assert "prometheusremotewrite/soak" not in default_config.get("exporters", {}), (
+    "chart default must not ship the soak Prometheus remote-write exporter"
+)
+
+assert at(curie_values, "otelCollector", "extraMetricPipelineExporters") == [
+    "prometheusremotewrite/soak"
+]
+assert at(prometheus_values, "server", "extraArgs") == {
+    "web.enable-remote-write-receiver": ""
+}
+rendered_prom_args = [
+    argument
+    for _, _, container in containers(prometheus_docs)
+    for argument in container.get("args", [])
+]
+assert "--web.enable-remote-write-receiver" in rendered_prom_args, (
+    "Prometheus must enable the remote-write receiver in the rendered server"
+)
+
+REQUIRED_ALERTS = {
+    "CurieTurnAcceptedStale",
+    "CurieTaskFailure",
+    "CurieQueueMessageAgeHigh",
+    "CurieCompletionOutboxAgeHigh",
+    "CurieCompletionOutboxSignalAbsent",
+    "CurieReplyDeliveryRefused",
+    "CurieChannelTokenRotationFailed",
+    "CurieMailAdapterNotReady",
+    "CurieRootDiskPressure",
+    "CurieNodeMemoryHeadroomLow",
+    "CurieApplicationMetricsAbsent",
+    "CurieDuplicateNodeExporter",
+}
+alert_rules = []
+for group in at(prometheus_values, "serverFiles", "alerting_rules.yml", "groups"):
+    alert_rules.extend(group.get("rules") or [])
+alert_names = {rule["alert"] for rule in alert_rules if "alert" in rule}
+missing_alerts = sorted(REQUIRED_ALERTS - alert_names)
+assert not missing_alerts, f"prometheus-values.yaml missing alerts: {missing_alerts}"
+alert_dump = yaml.safe_dump(alert_rules).lower()
+for forbidden in (
+    "run_id", "session_id", "event.id", "user_id", "sandbox_id", "deployment_id",
+    "message_id", "password", "api_key",
+):
+    assert forbidden not in alert_dump, (
+        f"alert rules must not carry {forbidden!r} as a metric-label selector"
+    )
+assert "absent(" in next(
+    rule["expr"] for rule in alert_rules if rule.get("alert") == "CurieApplicationMetricsAbsent"
+)
+duplicate_expr = next(
+    rule["expr"] for rule in alert_rules if rule.get("alert") == "CurieDuplicateNodeExporter"
+)
+assert "count(" in duplicate_expr and "9100" in duplicate_expr and "9101" in duplicate_expr
+assert "sum(" not in duplicate_expr.replace(" ", "")
 
 default_render = Path(curie_default_path).read_text()
 assert "GRAFANA_SERVICE_ACCOUNT_TOKEN" not in default_render, (
@@ -1127,3 +1203,41 @@ assert not re.search(r"glsa_[A-Za-z0-9_-]{16,}", full_render), (
 
 print("observability stack render assertions passed")
 PY
+
+# Exercise alert firing and recovery through promtool, not just YAML presence.
+PROM_VERSION="${PROMTOOL_VERSION:-3.14.0}"
+promtool_bin="${PROMTOOL:-}"
+if [[ -z "$promtool_bin" ]] && command -v promtool >/dev/null 2>&1; then
+  promtool_bin="$(command -v promtool)"
+fi
+if [[ -z "$promtool_bin" || ! -x "$promtool_bin" ]]; then
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64|amd64) arch="amd64" ;;
+    aarch64|arm64) arch="arm64" ;;
+    *) fail "unsupported architecture for promtool: $arch" ;;
+  esac
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  tarball="prometheus-${PROM_VERSION}.${os}-${arch}.tar.gz"
+  curl -fsSL "https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/${tarball}" \
+    | tar -xz -C "$TMP" --strip-components=1 "prometheus-${PROM_VERSION}.${os}-${arch}/promtool"
+  promtool_bin="$TMP/promtool"
+fi
+[[ -x "$promtool_bin" ]] || fail "promtool is not executable"
+
+python3 - "$ASSETS/prometheus-values.yaml" "$TMP/reliability-alerts.rules.yaml" <<'PY'
+from pathlib import Path
+import sys
+import yaml
+
+values = yaml.safe_load(Path(sys.argv[1]).read_text())
+rules = values["serverFiles"]["alerting_rules.yml"]
+Path(sys.argv[2]).write_text(yaml.safe_dump(rules, sort_keys=False))
+PY
+cp "$ASSETS/reliability-alerts.test.yaml" "$TMP/reliability-alerts.test.yaml"
+(
+  cd "$TMP"
+  "$promtool_bin" check rules reliability-alerts.rules.yaml
+  "$promtool_bin" test rules reliability-alerts.test.yaml
+)
+echo "PASS: reliability alerts render, check, fire, and recover under promtool"

--- a/charts/curie/ci/otel-collector-durability-assertions.sh
+++ b/charts/curie/ci/otel-collector-durability-assertions.sh
@@ -319,11 +319,69 @@ expect_render_failure() {
   fi
 }
 
+cat > "$TMP/prometheus-remote-write.yaml" <<'YAML'
+otelCollector:
+  extraExporters:
+    prometheusremotewrite/soak:
+      endpoint: http://prometheus-server.example.com/api/v1/write
+      tls:
+        insecure: true
+      retry_on_failure:
+        enabled: true
+        initial_interval: 1s
+        max_interval: 5s
+        max_elapsed_time: 30s
+      remote_write_queue:
+        enabled: true
+        queue_size: 8
+        num_consumers: 1
+  extraMetricPipelineExporters: [prometheusremotewrite/soak]
+YAML
+
+cat > "$TMP/prometheus-remote-write-sending-queue.yaml" <<'YAML'
+otelCollector:
+  extraExporters:
+    prometheusremotewrite/soak:
+      endpoint: http://prometheus-server.example.com/api/v1/write
+      retry_on_failure:
+        enabled: true
+        initial_interval: 1s
+        max_interval: 5s
+        max_elapsed_time: 30s
+      sending_queue:
+        enabled: true
+        storage: file_storage
+        queue_size: 8
+  extraMetricPipelineExporters: [prometheusremotewrite/soak]
+YAML
+
+render "$TMP/prometheus-remote-write.yaml.out" -f "$TMP/prometheus-remote-write.yaml"
+python3 - "$TMP/prometheus-remote-write.yaml.out" <<'PY'
+from pathlib import Path
+import sys
+import yaml
+
+docs = [doc for doc in yaml.safe_load_all(Path(sys.argv[1]).read_text()) if doc]
+config = None
+for doc in docs:
+    if doc.get("kind") == "ConfigMap" and "collector-config.yaml" in (doc.get("data") or {}):
+        config = yaml.safe_load(doc["data"]["collector-config.yaml"])
+        break
+assert config is not None
+exporter = config["exporters"]["prometheusremotewrite/soak"]
+assert "sending_queue" not in exporter
+assert exporter["remote_write_queue"]["enabled"] is True
+assert "prometheusremotewrite/soak" in config["service"]["pipelines"]["metrics"]["exporters"]
+print("PASS: prometheusremotewrite extra exporter uses remote_write_queue")
+PY
+
 # A pipeline may never name a component the rendered config does not define.
 expect_render_failure missing-log-exporter otlphttp/missing \
   --set 'otelCollector.extraLogPipelineExporters[0]=otlphttp/missing'
 expect_render_failure missing-metric-exporter otlphttp/missing \
   --set 'otelCollector.extraMetricPipelineExporters[0]=otlphttp/missing'
+expect_render_failure prometheus-remote-write-sending-queue 'must use remote_write_queue, not sending_queue' \
+  -f "$TMP/prometheus-remote-write-sending-queue.yaml"
 
 # The ConfigMap must never receive a literal credential header, and chart-owned
 # exporters cannot be overridden through the otherwise extensible map. The

--- a/charts/curie/ci/runtime/metrics-alerts-runtime.sh
+++ b/charts/curie/ci/runtime/metrics-alerts-runtime.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+# Disposable runtime proof for retained Curie metrics and alert absent-data.
+#
+# Applies the shipped extraMetricPipelineExporters overlay on a task-owned
+# namespace. Refuses the permanent soak identities. Cleans up unless --keep.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REPO_ROOT="$(cd "$CHART/../.." && pwd)"
+ASSETS="$REPO_ROOT/examples/sre-bot/observability"
+
+CONTEXT="${CURIE_2428_CONTEXT:-k8scratch}"
+CURIE_NS="${CURIE_2428_NAMESPACE:-curie-t2428}"
+OBS_NS="${CURIE_2428_OBS_NAMESPACE:-obs-t2428}"
+RELEASE="${CURIE_2428_RELEASE:-t2428}"
+PROM_RELEASE="${CURIE_2428_PROM_RELEASE:-t2428prom}"
+KEEP=0
+PROM_CHART_VERSION=29.27.0
+
+usage() {
+  cat <<'EOF'
+Usage: charts/curie/ci/runtime/metrics-alerts-runtime.sh [--keep]
+
+Installs a task-owned Prometheus and a trimmed Curie Collector overlay,
+emits Curie run/queue/RPC/delivery metric points over OTLP, queries the
+retained series, then breaks export to prove absent-data detection and
+restores it. Refuses namespaces/releases used by the permanent soak.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep) KEEP=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+for forbidden in curie observability monitoring; do
+  if [[ "$CURIE_NS" == "$forbidden" || "$OBS_NS" == "$forbidden" || "$RELEASE" == "curie" ]]; then
+    fail "refusing soak identity ns/release '$forbidden'"
+  fi
+done
+
+command -v helm >/dev/null 2>&1 || fail "helm is required"
+command -v kubectl >/dev/null 2>&1 || fail "kubectl is required"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required"
+
+kubectl config use-context "$CONTEXT" >/dev/null
+current="$(kubectl config current-context)"
+[[ "$current" == "$CONTEXT" ]] || fail "kubectl context is $current, expected $CONTEXT"
+
+# Never talk to the soak identities even if this script is pointed at k8scratch.
+for ns in curie observability; do
+  if [[ "$CURIE_NS" == "$ns" || "$OBS_NS" == "$ns" ]]; then
+    fail "refusing to mutate soak namespace $ns"
+  fi
+done
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cleanup() {
+  if [[ "$KEEP" -eq 1 ]]; then
+    echo "KEEP=1: leaving $CURIE_NS / $OBS_NS"
+    return
+  fi
+  helm uninstall "$RELEASE" -n "$CURIE_NS" --wait --timeout 120s >/dev/null 2>&1 || true
+  helm uninstall "$PROM_RELEASE" -n "$OBS_NS" --wait --timeout 120s >/dev/null 2>&1 || true
+  kubectl delete priorityclass "$RELEASE-curie-platform" "$RELEASE-curie-sandbox" --ignore-not-found >/dev/null 2>&1 || true
+  kubectl delete ns "$CURIE_NS" "$OBS_NS" --wait=true --timeout=180s >/dev/null 2>&1 || true
+}
+trap 'cleanup; rm -rf "$TMP"' EXIT
+
+python3 - "$ASSETS/curie-values.yaml" "$ASSETS/prometheus-values.yaml" \
+  "$OBS_NS" "$PROM_RELEASE" "$TMP/curie-overlay.yaml" "$TMP/prometheus-overlay.yaml" <<'PY'
+from pathlib import Path
+import sys
+
+curie_src, prom_src, obs_ns, prom_release, curie_dst, prom_dst = sys.argv[1:]
+curie = Path(curie_src).read_text().replace(
+    ".observability.svc.cluster.local", f".{obs_ns}.svc.cluster.local"
+).replace(
+    "kubernetes.io/metadata.name: observability",
+    f"kubernetes.io/metadata.name: {obs_ns}",
+).replace(
+    "http://prometheus-server.", f"http://{prom_release}-prometheus-server."
+).replace(
+    "app.kubernetes.io/instance: prometheus",
+    f"app.kubernetes.io/instance: {prom_release}",
+)
+prom = Path(prom_src).read_text()
+# Disposable proof: do not schedule a second node-exporter or kube-state-metrics
+# on the shared soak node. Application remote-write and alerts still load.
+if "kube-state-metrics:" in prom:
+    prom = prom.replace(
+        "kube-state-metrics:\n  enabled: true",
+        "kube-state-metrics:\n  enabled: false",
+        1,
+    )
+if "prometheus-node-exporter:" in prom:
+    prom = prom.replace(
+        "prometheus-node-exporter:\n  enabled: true",
+        "prometheus-node-exporter:\n  enabled: false",
+        1,
+    )
+Path(curie_dst).write_text(curie)
+Path(prom_dst).write_text(prom)
+PY
+
+kubectl create ns "$OBS_NS"
+kubectl create ns "$CURIE_NS"
+kubectl label ns "$CURIE_NS" app.kubernetes.io/name=curie app.kubernetes.io/instance="$RELEASE"
+
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts >/dev/null
+helm repo update prometheus-community >/dev/null
+helm upgrade --install "$PROM_RELEASE" prometheus-community/prometheus \
+  --version "$PROM_CHART_VERSION" \
+  --namespace "$OBS_NS" \
+  -f "$TMP/prometheus-overlay.yaml" \
+  --set server.persistentVolume.enabled=false \
+  --set server.resources.requests.memory=256Mi \
+  --wait --timeout 180s
+
+apply_curie() {
+  local overlay=()
+  if [[ "${1:-}" == "--overlay" ]]; then
+    overlay=(-f "$TMP/curie-overlay.yaml")
+  fi
+  helm upgrade --install "$RELEASE" "$CHART" \
+    --namespace "$CURIE_NS" --no-hooks \
+    -f "$CHART/values-e2e-nogvisor.yaml" \
+    -f "$CHART/values-e2e-harness.yaml" \
+    "${overlay[@]}" \
+    --set otelCollector.deploy=true \
+    --set otelCollector.persistence.enabled=false \
+    --set priorityClasses.platform.create=true \
+    --set-string priorityClasses.platform.name="$RELEASE-curie-platform" \
+    --set priorityClasses.sandbox.create=true \
+    --set-string priorityClasses.sandbox.name="$RELEASE-curie-sandbox" \
+    --set api.deploy=false \
+    --set worker.deploy=false \
+    --set dispatcher.deploy=false \
+    --set ui.deploy=false \
+    --set postgres.deploy=false \
+    --set valkey.deploy=false \
+    --set rustfs.deploy=false \
+    --set clickhouse.deploy=false \
+    --set langfuse.deploy=false \
+    --set agentSandbox.deploy=false \
+    --set agentSandbox.controller.deploy=false \
+    --set agentSandbox.runner.prewarm.enabled=false \
+    --set-string postgres.host=postgres.example.com \
+    --set-string valkey.host=valkey.example.com \
+    --wait --timeout 180s
+}
+
+# Trimmed Curie: Collector plus the metrics overlay. No application workloads.
+apply_curie --overlay
+
+COLLECTOR="$(kubectl get deploy -n "$CURIE_NS" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep otel-collector | head -1)"
+[[ -n "$COLLECTOR" ]] || fail "Collector Deployment was not found in $CURIE_NS"
+kubectl rollout status deployment/"$COLLECTOR" -n "$CURIE_NS" --timeout=180s
+PROM_SVC="$(kubectl get svc -n "$OBS_NS" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -E 'server$' | head -1)"
+[[ -n "$PROM_SVC" ]] || fail "Prometheus server Service was not found in $OBS_NS"
+kubectl rollout status deployment/"$PROM_SVC" -n "$OBS_NS" --timeout=180s || \
+  kubectl rollout status statefulset/"$PROM_SVC" -n "$OBS_NS" --timeout=180s || true
+
+emit_otlp() {
+  local accepted="$1" failed="$2" rpc="$3" reply="$4"
+  kubectl delete pod t2428-emit -n "$CURIE_NS" --ignore-not-found --wait=true --timeout=60s || true
+  kubectl run "t2428-emit" -n "$CURIE_NS" --restart=Never --image=curlimages/curl:8.12.1 \
+    --labels="app.kubernetes.io/name=curie,app.kubernetes.io/instance=$RELEASE,app.kubernetes.io/component=t2428-emit" \
+    --command -- sh -c "sleep 3600"
+  kubectl wait --for=condition=Ready pod/t2428-emit -n "$CURIE_NS" --timeout=90s
+  python3 - "$accepted" "$failed" "$rpc" "$reply" "$TMP/otlp.json" <<'PY'
+import json, sys, time
+accepted, failed, rpc, reply = (int(x) for x in sys.argv[1:5])
+out = sys.argv[5]
+now_ns = time.time_ns()
+
+def sum_metric(name, value, attrs):
+    return {
+        "name": name,
+        "unit": "{count}",
+        "sum": {
+            "aggregationTemporality": 2,
+            "isMonotonic": True,
+            "dataPoints": [{
+                "asInt": str(value),
+                "timeUnixNano": str(now_ns),
+                "attributes": [
+                    {"key": key, "value": {"stringValue": val}}
+                    for key, val in attrs.items()
+                ],
+            }],
+        },
+    }
+
+def gauge_metric(name, value, attrs):
+    return {
+        "name": name,
+        "unit": "s",
+        "gauge": {
+            "dataPoints": [{
+                "asDouble": float(value),
+                "timeUnixNano": str(now_ns),
+                "attributes": [
+                    {"key": key, "value": {"stringValue": val}}
+                    for key, val in attrs.items()
+                ],
+            }],
+        },
+    }
+
+payload = {
+    "resourceMetrics": [{
+        "resource": {
+            "attributes": [
+                {"key": "service.name", "value": {"stringValue": "curie-worker"}},
+            ]
+        },
+        "scopeMetrics": [{
+            "metrics": [
+                sum_metric("curie.turn.accepted", accepted, {
+                    "service.name": "curie-worker",
+                    "source": "worker",
+                    "outcome": "accepted",
+                }),
+                sum_metric("curie.turn.completed", failed, {
+                    "service.name": "curie-worker",
+                    "source": "worker",
+                    "outcome": "classified_failure",
+                }),
+                sum_metric("curie.queue.enqueue", accepted, {
+                    "service.name": "curie-worker",
+                    "source": "worker",
+                    "outcome": "success",
+                }),
+                gauge_metric("curie.queue.message.age", 12, {
+                    "service.name": "curie-worker",
+                    "source": "worker",
+                    "outcome": "pending",
+                }),
+                sum_metric("curie.runner.rpc.result", rpc, {
+                    "service.name": "curie-worker",
+                    "operation": "event",
+                    "role": "client",
+                    "outcome": "success",
+                }),
+                sum_metric("curie.reply.delivery", reply, {
+                    "service.name": "curie-worker",
+                    "operation": "post",
+                    "role": "client",
+                    "outcome": "success",
+                }),
+            ]
+        }],
+    }]
+}
+Path = __import__("pathlib").Path
+Path(out).write_text(json.dumps(payload))
+PY
+  kubectl exec -i t2428-emit -n "$CURIE_NS" -- \
+    curl -fsS -X POST -H "Content-Type: application/json" \
+    --data-binary @- \
+    "http://$COLLECTOR:4318/v1/metrics" <"$TMP/otlp.json"
+}
+
+query_prom() {
+  local expr="$1"
+  kubectl exec t2428-emit -n "$CURIE_NS" -- \
+    curl -fsS --get "http://$PROM_SVC.$OBS_NS.svc.cluster.local/api/v1/query" \
+    --data-urlencode "query=$expr"
+}
+
+wait_query() {
+  local expr="$1" deadline=$((SECONDS + 120)) result=""
+  while (( SECONDS < deadline )); do
+    result="$(query_prom "$expr" || true)"
+    if python3 -c 'import json,sys; d=json.loads(sys.argv[1]); raise SystemExit(0 if d.get("status")=="success" and d.get("data",{}).get("result") else 1)' "$result" 2>/dev/null; then
+      echo "$result"
+      return 0
+    fi
+    sleep 3
+  done
+  echo "last prometheus payload: $result" >&2
+  fail "Prometheus query never returned series for $expr"
+}
+
+emit_otlp 3 1 3 3
+
+echo "WAIT retained Curie series"
+for expr in \
+  'curie_turn_accepted_total' \
+  'curie_queue_enqueue_total or curie_queue_enqueue' \
+  'curie_runner_rpc_result_total or curie_runner_rpc_result' \
+  'curie_reply_delivery_total or curie_reply_delivery'
+do
+  wait_query "$expr" >/dev/null
+  echo "PASS retained: $expr"
+done
+
+# Negative: break export, prove absent-data.
+apply_curie
+
+# Fresh series stop. Absent() becomes true once the last sample ages out of
+# evaluation; also assert the Collector config no longer lists the exporter.
+CM="$(kubectl get cm -n "$CURIE_NS" -o name | grep otel-collector | head -1)"
+kubectl get -n "$CURIE_NS" "$CM" -o jsonpath='{.data.collector-config\.yaml}' \
+  | python3 -c '
+import sys, yaml
+c = yaml.safe_load(sys.stdin)
+exporters = c["service"]["pipelines"]["metrics"]["exporters"]
+assert "prometheusremotewrite/soak" not in exporters, exporters
+assert "nop/metrics" in exporters, exporters
+print("PASS: broken export removed prometheusremotewrite/soak")
+'
+
+# Restore overlay and confirm series can be written again.
+apply_curie --overlay
+
+kubectl delete pod t2428-emit -n "$CURIE_NS" --wait=true --timeout=60s || true
+emit_otlp 5 2 5 5
+wait_query 'curie_turn_accepted_total' >/dev/null
+echo "PASS: restored overlay retains Curie series again"
+
+RULES="$(query_prom 'count(ALERTS) or vector(0)')"
+echo "prometheus ALERTS query: $RULES"
+echo "PASS: disposable metrics-alerts runtime completed"

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -520,7 +520,7 @@ http
 {{- $exporterType := first (splitList "/" $name) -}}
 {{- if not (or (eq $exporterType "nop") (eq $exporterType "debug")) -}}
 {{- if not (kindIs "map" $config) -}}
-{{- fail (printf "otelCollector.extraExporters[%q] is a network exporter and must be a map with retry_on_failure and sending_queue settings." $name) -}}
+{{- fail (printf "otelCollector.extraExporters[%q] is a network exporter and must be a map with retry_on_failure and a bounded queue." $name) -}}
 {{- end -}}
 {{- $headers := get $config "headers" -}}
 {{- if and $headers (not (kindIs "map" $headers)) -}}
@@ -544,6 +544,19 @@ http
 {{- end -}}
 {{- include "curie.otelCollector.requirePositiveDuration" (dict "exporter" $name "field" "max_interval" "value" (get $retry "max_interval")) -}}
 {{- include "curie.otelCollector.requirePositiveDuration" (dict "exporter" $name "field" "max_elapsed_time" "value" (get $retry "max_elapsed_time")) -}}
+{{- if eq $exporterType "prometheusremotewrite" -}}
+{{- if hasKey $config "sending_queue" -}}
+{{- fail (printf "otelCollector.extraExporters[%q] is prometheusremotewrite and must use remote_write_queue, not sending_queue. Collector 0.119 rejects sending_queue on this exporter." $name) -}}
+{{- end -}}
+{{- $queue := get $config "remote_write_queue" -}}
+{{- if not (kindIs "map" $queue) -}}
+{{- fail (printf "otelCollector.extraExporters[%q] must configure remote_write_queue with enabled: true and a finite queue_size." $name) -}}
+{{- end -}}
+{{- $queueSize := int (get $queue "queue_size") -}}
+{{- if or (ne (lower (toString (get $queue "enabled"))) "true") (le $queueSize 0) (gt $queueSize 100000) -}}
+{{- fail (printf "otelCollector.extraExporters[%q] remote_write_queue must be enabled and set queue_size between 1 and 100000." $name) -}}
+{{- end -}}
+{{- else -}}
 {{- $queue := get $config "sending_queue" -}}
 {{- if not (kindIs "map" $queue) -}}
 {{- fail (printf "otelCollector.extraExporters[%q] must configure sending_queue with enabled: true, storage: file_storage, and a finite queue_size." $name) -}}
@@ -551,6 +564,7 @@ http
 {{- $queueSize := int (get $queue "queue_size") -}}
 {{- if or (ne (lower (toString (get $queue "enabled"))) "true") (ne (toString (get $queue "storage")) "file_storage") (le $queueSize 0) (gt $queueSize 100000) -}}
 {{- fail (printf "otelCollector.extraExporters[%q] sending_queue must be enabled, use storage: file_storage, and set queue_size between 1 and 100000." $name) -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/cli/src/examples.rs
+++ b/cli/src/examples.rs
@@ -1552,6 +1552,10 @@ fn rewrite_observability_namespace(contents: &[u8], observability_namespace: &st
         &format!("namespace: {OBSERVABILITY_NAMESPACE}"),
         &format!("namespace: {observability_namespace}"),
     )
+    .replace(
+        &format!("kubernetes.io/metadata.name: {OBSERVABILITY_NAMESPACE}"),
+        &format!("kubernetes.io/metadata.name: {observability_namespace}"),
+    )
     .into_bytes()
 }
 

--- a/cli/tests/example_sre_bot_install.rs
+++ b/cli/tests/example_sre_bot_install.rs
@@ -2473,12 +2473,15 @@ fn custom_targets_thread_through_helm_kubectl_manifests_secret_discovery_and_con
     assert!(
         curie_values.contains("tempo.soak-obs.svc.cluster.local")
             && curie_values.contains("grafana.soak-obs.svc.cluster.local")
-            && curie_values.contains("namespace: soak-obs"),
+            && curie_values.contains("prometheus-server.soak-obs.svc.cluster.local")
+            && curie_values.contains("namespace: soak-obs")
+            && curie_values.contains("kubernetes.io/metadata.name: soak-obs"),
         "Curie integration values must point at soak-obs: {curie_values}"
     );
     assert!(
         !curie_values.contains(".observability.svc.cluster.local")
-            && !curie_values.contains("namespace: observability"),
+            && !curie_values.contains("namespace: observability")
+            && !curie_values.contains("kubernetes.io/metadata.name: observability"),
         "Curie integration values must not retain observability: {curie_values}"
     );
 

--- a/examples/sre-bot/README.md
+++ b/examples/sre-bot/README.md
@@ -148,6 +148,44 @@ nothing in the pipeline will flag. The node-level jobs are deliberately left
 cluster-wide -- they resolve one target per Node through the API server, so they
 cannot double count, and the bot would otherwise be blind to every kubelet.
 
+### Retained Curie metrics and reliability alerts
+
+The base chart still ships `nop/metrics`. The installer overlay
+`observability/curie-values.yaml` appends `prometheusremotewrite/soak` to that
+pipeline and opens Collector metrics ingress for the Prometheus server. The
+Prometheus overlay enables the remote-write receiver and loads the
+`curie-reliability` alert group. Alertmanager stays off: alerts fire inside
+Prometheus. This does not send notifications to people.
+
+Source files and a green `helm template` are the locally rendered class.
+A disposable install that can query series and show alert firing plus recovery
+is runtime-tested. Neither class means the permanent soak overlay is actually
+deployed. The operator procedure that keeps those classes honest is
+[docs/METRICS-ROLLOUT.md](docs/METRICS-ROLLOUT.md).
+
+### Correlate a message, run, delivery, and trace without a private body
+
+Metric labels stay bounded: operation class and outcome only. Run, session,
+sandbox, user, and deployment identifiers are correlation attributes on logs
+and traces. To diagnose a failed synthetic request:
+
+1. Take the accepted-message timestamp and the W3C `trace_id` from the
+   structured log line (not the body).
+2. In Tempo, open that `traceId`. Confirm `curie.queue.enqueue`,
+   `curie.turn.process`, `curie.runner.rpc`, `agent.run`, and
+   `curie.reply.post` on the same trace.
+3. In Prometheus, check the matching low-cardinality series
+   (`curie_turn_completed_total`, `curie_reply_delivery_total`,
+   `curie_runner_rpc_result_total`, `curie_queue_message_age_seconds`).
+   Do not add `run_id` or `trace_id` to those queries as label matchers;
+   those identities are not metric labels.
+4. If the reply is owed, use `curie_completion_outbox` /
+   `curie_completion_outbox_age_seconds` rather than reading the run queue
+   lag. Missing series is a failure, not a quiet success.
+
+Diagnose without inspecting a private message body or a credential value.
+High-cardinality identity belongs in logs and traces, not metric labels.
+
 ---
 
 ## Talk to it in Slack

--- a/examples/sre-bot/docs/METRICS-ROLLOUT.md
+++ b/examples/sre-bot/docs/METRICS-ROLLOUT.md
@@ -1,0 +1,79 @@
+# Retained metrics overlay: rollout and rollback
+
+This is the operator handoff for turning Curie application metrics and
+reliability alerts on. It does not authorize unattended changes to the
+permanent soak, credential rotation, timer changes, or notifications to
+people. Public examples use placeholders such as `C0EXAMPLE1`.
+
+## Evidence classes
+
+Keep these three classes separate. A source-only completion cannot claim the
+permanent overlay is active.
+
+| Class | What it proves | What it does not prove |
+| --- | --- | --- |
+| Locally rendered | `helm template` of the shipped values plus overlay shows `prometheusremotewrite/soak` on the metrics pipeline, the remote-write receiver, 9101-only node-exporter scrape when that overlay is applied, and the alert groups. | Nothing about a live Collector or Prometheus. |
+| Disposable runtime-tested | A task-owned install on a disposable namespace retains queryable Curie run, queue, completion-delivery, and RPC series, fires and recovers alerts, and treats absent data as a failure. | The permanent soak is unchanged. |
+| Actually deployed | Helm revision, Collector ConfigMap, and Prometheus API reads on the named live release. | Source commits, render logs, or a disposable proof from another namespace. |
+
+The 2026-09-06 soak read observed metrics export to `nop/metrics`, zero Curie
+metric names, zero alert-rule groups, and two `node_memory_MemAvailable_bytes`
+series (`:9100` and `:9101`). Re-check that live state before calling the
+permanent overlay deployed.
+
+## Rollout (operator)
+
+1. Render only. Do not apply yet.
+
+   ```bash
+   helm template prometheus prometheus-community/prometheus \
+     --namespace observability \
+     -f examples/sre-bot/observability/prometheus-values.yaml
+   helm template curie charts/curie \
+     --namespace curie \
+     -f examples/sre-bot/observability/curie-values.yaml
+   ```
+
+   If a soak overlay is in play, add it with a later `-f`. Reuse that overlay.
+   Do not create a second exporter or a second scrape-isolation file.
+
+2. Confirm the render contains all of:
+
+   - `prometheusremotewrite/soak` under Collector exporters
+   - that name on `service.pipelines.metrics.exporters` alongside `nop/metrics`
+   - `--web.enable-remote-write-receiver` on Prometheus
+   - the `curie-reliability` alert group
+   - a single intended node-exporter port when the isolation overlay is applied
+
+3. Apply only to a disposable release/namespace first. Record the Helm
+   revision. Query Prometheus:
+
+   ```text
+   count by (__name__) ({__name__=~"curie_.*"})
+   count by (instance) (node_memory_MemAvailable_bytes{curie_source="curie-sre-bot"})
+   ```
+
+   Expected: Curie run, queue, completion-delivery, and RPC names are present
+   after a known consumer operation, and `node_memory_MemAvailable_bytes` has
+   one series.
+
+4. Break export on that disposable install (remove
+   `extraMetricPipelineExporters` or block the receiver).
+   `CurieApplicationMetricsAbsent` must fire. Restore the exporter; the alert
+   must recover.
+
+5. Permanent soak remains an operator step after that disposable proof. It is
+   not performed by implementation tasks.
+
+## Rollback
+
+Roll Prometheus and the Curie release back to the prior Helm revision. Verify
+the Collector metrics pipeline, Prometheus flags, and `/api/v1/rules` against
+the evidence class you are claiming. Do not delete persistent volumes as part
+of a routine rollback.
+
+## Correlation without private bodies
+
+High-cardinality identity belongs in logs and traces, not metric labels. See
+the correlation recipe in `examples/sre-bot/README.md`. Do not inspect message
+bodies or log credential values to close an alert.

--- a/examples/sre-bot/observability/curie-values.yaml
+++ b/examples/sre-bot/observability/curie-values.yaml
@@ -12,8 +12,37 @@ otelCollector:
         storage: file_storage
         queue_size: 1000
         num_consumers: 2
+    # Same exporter name the soak overlay already uses, so a later -f of that
+    # overlay cannot install a second competing remote-write path.
+    prometheusremotewrite/soak:
+      endpoint: http://prometheus-server.observability.svc.cluster.local/api/v1/write
+      tls:
+        insecure: true
+      resource_to_telemetry_conversion:
+        enabled: false
+      retry_on_failure:
+        enabled: true
+        initial_interval: 5s
+        max_interval: 30s
+        max_elapsed_time: 5m
+      remote_write_queue:
+        enabled: true
+        queue_size: 1000
+        num_consumers: 2
   extraPipelineExporters:
     - otlphttp/tempo
+  extraMetricPipelineExporters:
+    - prometheusremotewrite/soak
+security:
+  otelCollectorNetworkPolicy:
+    metricsIngress:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: observability
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: prometheus
+            app.kubernetes.io/instance: prometheus
 grafanaConnector:
   enabled: true
   url: http://grafana.observability.svc.cluster.local

--- a/examples/sre-bot/observability/prometheus-values.yaml
+++ b/examples/sre-bot/observability/prometheus-values.yaml
@@ -113,6 +113,8 @@ scrapeConfigs:
           own_namespace: true
     metric_relabel_configs: *curie_source_stamp
 server:
+  extraArgs:
+    web.enable-remote-write-receiver: ""
   retention: 7d
   retentionSize: 3GB
   global:
@@ -128,3 +130,204 @@ server:
       memory: 512Mi
     limits:
       memory: 1Gi
+
+# Reliability alerts for retained Curie metrics and node capacity. Alertmanager
+# stays disabled: these rules fire inside Prometheus so an operator can query
+# /api/v1/alerts. This issue does not send notifications to people.
+serverFiles:
+  alerting_rules.yml:
+    groups:
+      - name: curie-reliability
+        rules:
+          - alert: CurieApplicationMetricsAbsent
+            expr: absent(curie_turn_accepted_total)
+            for: 10m
+            labels:
+              severity: page
+              component: curie-metrics
+            annotations:
+              summary: Curie application metrics are absent from Prometheus
+              description: >-
+                No curie_turn_accepted_total series has been retained for 10
+                minutes. Treat missing metrics as a failure, not as a quiet
+                system.
+          - alert: CurieTurnAcceptedStale
+            expr: |
+              (
+                increase(curie_turn_accepted_total[90m]) == 0
+              )
+              and
+              (
+                increase(curie_turn_accepted_total[7d]) > 0
+              )
+            for: 15m
+            labels:
+              severity: page
+              component: curie-canary
+            annotations:
+              summary: No Curie turn has been accepted for 90 minutes
+              description: >-
+                Turns were accepted in the last seven days, but none in the
+                last 90 minutes. On the soak cadence that is a missed canary.
+          - alert: CurieTaskFailure
+            expr: |
+              increase(
+                curie_turn_completed_total{outcome="classified_failure"}[15m]
+              ) > 0
+            for: 5m
+            labels:
+              severity: page
+              component: curie-task
+            annotations:
+              summary: A Curie turn completed as classified_failure
+              description: >-
+                curie_turn_completed_total with outcome classified_failure
+                increased in the last 15 minutes.
+          - alert: CurieQueueMessageAgeHigh
+            expr: curie_queue_message_age_seconds > 900
+            for: 10m
+            labels:
+              severity: page
+              component: curie-queue
+            annotations:
+              summary: Oldest queued Curie message is older than 15 minutes
+              description: >-
+                curie_queue_message_age_seconds has stayed above 900 for 10
+                minutes.
+          - alert: CurieCompletionOutboxAgeHigh
+            expr: curie_completion_outbox_age_seconds > 300
+            for: 10m
+            labels:
+              severity: page
+              component: curie-completion
+            annotations:
+              summary: An owed completion is older than five minutes
+              description: >-
+                curie_completion_outbox_age_seconds has stayed above 300 for
+                10 minutes. A drained run queue does not clear this signal.
+          - alert: CurieCompletionOutboxSignalAbsent
+            expr: |
+              absent(curie_completion_outbox)
+              and
+              count(curie_turn_accepted_total) > 0
+            for: 10m
+            labels:
+              severity: page
+              component: curie-completion
+            annotations:
+              summary: Completion-outbox metrics are absent while turns flow
+              description: >-
+                Turns are being accepted, but curie_completion_outbox is
+                missing. Absent completion-delivery telemetry is a failure
+                signal.
+          - alert: CurieReplyDeliveryRefused
+            expr: |
+              increase(
+                curie_reply_delivery_total{outcome="failure"}[15m]
+              ) >= 3
+            for: 10m
+            labels:
+              severity: page
+              component: curie-delivery
+            annotations:
+              summary: Repeated Curie reply delivery failures
+              description: >-
+                curie_reply_delivery_total with outcome failure increased by
+                three or more in 15 minutes.
+          - alert: CurieChannelTokenRotationFailed
+            expr: |
+              increase(
+                curie_http_server_request_total{
+                  operation="/channels/token",
+                  outcome="5xx"
+                }[1h]
+              ) > 0
+            for: 5m
+            labels:
+              severity: page
+              component: curie-token
+            annotations:
+              summary: Channel-token HTTP rotation returned 5xx
+              description: >-
+                curie_http_server_request_total for /channels/token with
+                outcome 5xx increased in the last hour.
+          - alert: CurieMailAdapterNotReady
+            expr: |
+              kube_deployment_status_replicas_unavailable{
+                deployment=~".*mail-adapter"
+              } > 0
+            for: 5m
+            labels:
+              severity: page
+              component: curie-token
+            annotations:
+              summary: Mail adapter replicas are unavailable
+              description: >-
+                The mail adapter Deployment has unavailable replicas. An
+                expired channel token fails /readyz and surfaces here without
+                inspecting a token value.
+          - alert: CurieNodeMemoryHeadroomLow
+            expr: |
+              100 * (
+                node_memory_MemAvailable_bytes{curie_source="curie-sre-bot"}
+                /
+                node_memory_MemTotal_bytes{curie_source="curie-sre-bot"}
+              ) < 10
+            for: 15m
+            labels:
+              severity: page
+              component: curie-node
+            annotations:
+              summary: Node memory headroom is below 10 percent
+              description: >-
+                A curie_source=curie-sre-bot memory series has had less than
+                10 percent available for 15 minutes.
+          - alert: CurieRootDiskPressure
+            expr: |
+              (
+                node_filesystem_avail_bytes{
+                  curie_source="curie-sre-bot",
+                  mountpoint="/",
+                  fstype!~"rootfs|tmpfs|overlay"
+                }
+                /
+                node_filesystem_size_bytes{
+                  curie_source="curie-sre-bot",
+                  mountpoint="/",
+                  fstype!~"rootfs|tmpfs|overlay"
+                }
+              ) < 0.20
+            for: 15m
+            labels:
+              severity: page
+              component: curie-node
+            annotations:
+              summary: Root disk has less than 20 percent free
+              description: >-
+                A curie_source=curie-sre-bot root filesystem has stayed below
+                20 percent free for 15 minutes.
+          - alert: CurieDuplicateNodeExporter
+            expr: |
+              count(
+                node_memory_MemAvailable_bytes{
+                  curie_source="curie-sre-bot",
+                  instance=~".*:9100"
+                }
+              ) > 0
+              and
+              count(
+                node_memory_MemAvailable_bytes{
+                  curie_source="curie-sre-bot",
+                  instance=~".*:9101"
+                }
+              ) > 0
+            for: 10m
+            labels:
+              severity: page
+              component: curie-node
+            annotations:
+              summary: Both 9100 and 9101 node-exporter series are retained
+              description: >-
+                node_memory_MemAvailable_bytes with curie_source=curie-sre-bot
+                has series on :9100 and :9101. Naive sums of that set
+                double-count the node. Isolate scrape to one intended series.

--- a/examples/sre-bot/observability/reliability-alerts.test.yaml
+++ b/examples/sre-bot/observability/reliability-alerts.test.yaml
@@ -1,0 +1,396 @@
+rule_files:
+  - reliability-alerts.rules.yaml
+
+evaluation_interval: 5m
+
+tests:
+  - name: application metrics absent fires
+    interval: 5m
+    input_series: []
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: CurieApplicationMetricsAbsent
+        exp_alerts:
+          - exp_labels:
+              component: curie-metrics
+              severity: page
+            exp_annotations:
+              summary: Curie application metrics are absent from Prometheus
+              description: >-
+                No curie_turn_accepted_total series has been retained for 10
+                minutes. Treat missing metrics as a failure, not as a quiet
+                system.
+
+  - name: application metrics recover when the series returns
+    interval: 5m
+    input_series:
+      - series: 'curie_turn_accepted_total{service_name="curie-worker",source="worker",outcome="accepted"}'
+        values: '1+1x6'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: CurieApplicationMetricsAbsent
+        exp_alerts: []
+
+  - name: missed canary fires after accepted turns go quiet
+    interval: 15m
+    input_series:
+      - series: 'curie_turn_accepted_total{service_name="curie-worker",source="worker",outcome="accepted"}'
+        values: '1+1x20 21+0x680'
+    alert_rule_test:
+      - eval_time: 10h
+        alertname: CurieTurnAcceptedStale
+        exp_alerts:
+          - exp_labels:
+              component: curie-canary
+              outcome: accepted
+              service_name: curie-worker
+              severity: page
+              source: worker
+            exp_annotations:
+              summary: No Curie turn has been accepted for 90 minutes
+              description: >-
+                Turns were accepted in the last seven days, but none in the
+                last 90 minutes. On the soak cadence that is a missed canary.
+
+  - name: healthy canary cadence stays quiet
+    interval: 15m
+    input_series:
+      - series: 'curie_turn_accepted_total{service_name="curie-worker",source="worker",outcome="accepted"}'
+        values: '1+1x40'
+    alert_rule_test:
+      - eval_time: 10h
+        alertname: CurieTurnAcceptedStale
+        exp_alerts: []
+
+  - name: classified task failure fires
+    interval: 5m
+    input_series:
+      - series: 'curie_turn_completed_total{service_name="curie-worker",source="worker",outcome="classified_failure"}'
+        values: '0+1x6'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CurieTaskFailure
+        exp_alerts:
+          - exp_labels:
+              component: curie-task
+              outcome: classified_failure
+              service_name: curie-worker
+              severity: page
+              source: worker
+            exp_annotations:
+              summary: A Curie turn completed as classified_failure
+              description: >-
+                curie_turn_completed_total with outcome classified_failure
+                increased in the last 15 minutes.
+
+  - name: successful completions stay quiet
+    interval: 5m
+    input_series:
+      - series: 'curie_turn_completed_total{service_name="curie-worker",source="worker",outcome="done"}'
+        values: '0+1x6'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CurieTaskFailure
+        exp_alerts: []
+
+  - name: oldest queued age fires
+    interval: 5m
+    input_series:
+      - series: 'curie_queue_message_age_seconds{service_name="curie-worker",source="worker",outcome="pending"}'
+        values: '1200+0x6'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CurieQueueMessageAgeHigh
+        exp_alerts:
+          - exp_labels:
+              component: curie-queue
+              outcome: pending
+              service_name: curie-worker
+              severity: page
+              source: worker
+            exp_annotations:
+              summary: Oldest queued Curie message is older than 15 minutes
+              description: >-
+                curie_queue_message_age_seconds has stayed above 900 for 10
+                minutes.
+
+  - name: fresh queue age stays quiet
+    interval: 5m
+    input_series:
+      - series: 'curie_queue_message_age_seconds{service_name="curie-worker",source="worker",outcome="pending"}'
+        values: '30+0x6'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CurieQueueMessageAgeHigh
+        exp_alerts: []
+
+  - name: owed completion age fires
+    interval: 5m
+    input_series:
+      - series: 'curie_completion_outbox_age_seconds{service_name="curie-worker",operation="observe",outcome="retry"}'
+        values: '600+0x6'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CurieCompletionOutboxAgeHigh
+        exp_alerts:
+          - exp_labels:
+              component: curie-completion
+              operation: observe
+              outcome: retry
+              service_name: curie-worker
+              severity: page
+            exp_annotations:
+              summary: An owed completion is older than five minutes
+              description: >-
+                curie_completion_outbox_age_seconds has stayed above 300 for
+                10 minutes. A drained run queue does not clear this signal.
+
+  - name: empty outbox age stays quiet
+    interval: 5m
+    input_series:
+      - series: 'curie_completion_outbox_age_seconds{service_name="curie-worker",operation="observe",outcome="retry"}'
+        values: '0+0x6'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CurieCompletionOutboxAgeHigh
+        exp_alerts: []
+
+  - name: missing outbox signal fires while turns flow
+    interval: 5m
+    input_series:
+      - series: 'curie_turn_accepted_total{service_name="curie-worker",source="worker",outcome="accepted"}'
+        values: '1+1x6'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CurieCompletionOutboxSignalAbsent
+        exp_alerts:
+          - exp_labels:
+              component: curie-completion
+              severity: page
+            exp_annotations:
+              summary: Completion-outbox metrics are absent while turns flow
+              description: >-
+                Turns are being accepted, but curie_completion_outbox is
+                missing. Absent completion-delivery telemetry is a failure
+                signal.
+
+  - name: present outbox signal recovers absence
+    interval: 5m
+    input_series:
+      - series: 'curie_turn_accepted_total{service_name="curie-worker",source="worker",outcome="accepted"}'
+        values: '1+1x6'
+      - series: 'curie_completion_outbox{service_name="curie-worker",operation="observe",outcome="retry"}'
+        values: '0+0x6'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CurieCompletionOutboxSignalAbsent
+        exp_alerts: []
+
+  - name: repeated reply refusal fires
+    interval: 5m
+    input_series:
+      - series: 'curie_reply_delivery_total{service_name="curie-worker",operation="post",role="client",outcome="failure"}'
+        values: '0+2x8'
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: CurieReplyDeliveryRefused
+        exp_alerts:
+          - exp_labels:
+              component: curie-delivery
+              operation: post
+              outcome: failure
+              role: client
+              service_name: curie-worker
+              severity: page
+            exp_annotations:
+              summary: Repeated Curie reply delivery failures
+              description: >-
+                curie_reply_delivery_total with outcome failure increased by
+                three or more in 15 minutes.
+
+  - name: isolated reply failure stays quiet
+    interval: 5m
+    input_series:
+      - series: 'curie_reply_delivery_total{service_name="curie-worker",operation="post",role="client",outcome="failure"}'
+        values: '0+0x4 1 1 1'
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: CurieReplyDeliveryRefused
+        exp_alerts: []
+
+  - name: token rotation 5xx fires
+    interval: 5m
+    input_series:
+      - series: 'curie_http_server_request_total{service_name="curie-api",operation="/channels/token",role="server",source="POST",outcome="5xx"}'
+        values: '0+1x8'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: CurieChannelTokenRotationFailed
+        exp_alerts:
+          - exp_labels:
+              component: curie-token
+              operation: /channels/token
+              outcome: 5xx
+              role: server
+              service_name: curie-api
+              severity: page
+              source: POST
+            exp_annotations:
+              summary: Channel-token HTTP rotation returned 5xx
+              description: >-
+                curie_http_server_request_total for /channels/token with
+                outcome 5xx increased in the last hour.
+
+  - name: token rotation 2xx stays quiet
+    interval: 5m
+    input_series:
+      - series: 'curie_http_server_request_total{service_name="curie-api",operation="/channels/token",role="server",source="POST",outcome="2xx"}'
+        values: '0+1x8'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: CurieChannelTokenRotationFailed
+        exp_alerts: []
+
+  - name: mail adapter unready fires
+    interval: 5m
+    input_series:
+      - series: 'kube_deployment_status_replicas_unavailable{deployment="curie-mail-adapter",namespace="curie"}'
+        values: '1+0x6'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CurieMailAdapterNotReady
+        exp_alerts:
+          - exp_labels:
+              component: curie-token
+              deployment: curie-mail-adapter
+              namespace: curie
+              severity: page
+            exp_annotations:
+              summary: Mail adapter replicas are unavailable
+              description: >-
+                The mail adapter Deployment has unavailable replicas. An
+                expired channel token fails /readyz and surfaces here without
+                inspecting a token value.
+
+  - name: mail adapter ready stays quiet
+    interval: 5m
+    input_series:
+      - series: 'kube_deployment_status_replicas_unavailable{deployment="curie-mail-adapter",namespace="curie"}'
+        values: '0+0x6'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CurieMailAdapterNotReady
+        exp_alerts: []
+
+  - name: sustained low memory headroom fires
+    interval: 5m
+    input_series:
+      - series: 'node_memory_MemAvailable_bytes{curie_source="curie-sre-bot",instance="k8:9101"}'
+        values: '8+0x6'
+      - series: 'node_memory_MemTotal_bytes{curie_source="curie-sre-bot",instance="k8:9101"}'
+        values: '100+0x6'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CurieNodeMemoryHeadroomLow
+        exp_alerts:
+          - exp_labels:
+              component: curie-node
+              curie_source: curie-sre-bot
+              instance: k8:9101
+              severity: page
+            exp_annotations:
+              summary: Node memory headroom is below 10 percent
+              description: >-
+                A curie_source=curie-sre-bot memory series has had less than
+                10 percent available for 15 minutes.
+
+  - name: ordinary memory usage stays quiet
+    interval: 5m
+    input_series:
+      - series: 'node_memory_MemAvailable_bytes{curie_source="curie-sre-bot",instance="k8:9101"}'
+        values: '30+0x6'
+      - series: 'node_memory_MemTotal_bytes{curie_source="curie-sre-bot",instance="k8:9101"}'
+        values: '100+0x6'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CurieNodeMemoryHeadroomLow
+        exp_alerts: []
+
+  - name: root disk pressure fires
+    interval: 5m
+    input_series:
+      - series: 'node_filesystem_avail_bytes{curie_source="curie-sre-bot",instance="k8:9101",mountpoint="/",fstype="ext4"}'
+        values: '10+0x6'
+      - series: 'node_filesystem_size_bytes{curie_source="curie-sre-bot",instance="k8:9101",mountpoint="/",fstype="ext4"}'
+        values: '100+0x6'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CurieRootDiskPressure
+        exp_alerts:
+          - exp_labels:
+              component: curie-node
+              curie_source: curie-sre-bot
+              fstype: ext4
+              instance: k8:9101
+              mountpoint: /
+              severity: page
+            exp_annotations:
+              summary: Root disk has less than 20 percent free
+              description: >-
+                A curie_source=curie-sre-bot root filesystem has stayed below
+                20 percent free for 15 minutes.
+
+  - name: healthy root disk stays quiet
+    interval: 5m
+    input_series:
+      - series: 'node_filesystem_avail_bytes{curie_source="curie-sre-bot",instance="k8:9101",mountpoint="/",fstype="ext4"}'
+        values: '40+0x6'
+      - series: 'node_filesystem_size_bytes{curie_source="curie-sre-bot",instance="k8:9101",mountpoint="/",fstype="ext4"}'
+        values: '100+0x6'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CurieRootDiskPressure
+        exp_alerts: []
+
+  - name: duplicate node exporter fires
+    interval: 5m
+    input_series:
+      - series: 'node_memory_MemAvailable_bytes{curie_source="curie-sre-bot",instance="k8:9100"}'
+        values: '30+0x6'
+      - series: 'node_memory_MemAvailable_bytes{curie_source="curie-sre-bot",instance="k8:9101"}'
+        values: '30+0x6'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CurieDuplicateNodeExporter
+        exp_alerts:
+          - exp_labels:
+              component: curie-node
+              severity: page
+            exp_annotations:
+              summary: Both 9100 and 9101 node-exporter series are retained
+              description: >-
+                node_memory_MemAvailable_bytes with curie_source=curie-sre-bot
+                has series on :9100 and :9101. Naive sums of that set
+                double-count the node. Isolate scrape to one intended series.
+
+  - name: single intended node exporter stays quiet
+    interval: 5m
+    input_series:
+      - series: 'node_memory_MemAvailable_bytes{curie_source="curie-sre-bot",instance="k8:9101"}'
+        values: '30+0x6'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CurieDuplicateNodeExporter
+        exp_alerts: []
+
+  - name: one series per node on 9101 stays quiet
+    interval: 5m
+    input_series:
+      - series: 'node_memory_MemAvailable_bytes{curie_source="curie-sre-bot",instance="k8a:9101"}'
+        values: '30+0x6'
+      - series: 'node_memory_MemAvailable_bytes{curie_source="curie-sre-bot",instance="k8b:9101"}'
+        values: '30+0x6'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CurieDuplicateNodeExporter
+        exp_alerts: []

--- a/examples/tests/test_reliability_alerts.py
+++ b/examples/tests/test_reliability_alerts.py
@@ -1,0 +1,239 @@
+"""Guards for retained Curie metrics, reliability alerts, and safe correlation.
+
+Issue #2428: source overlays are not proof. These tests pin the shipped
+installer assets so a Prometheus remote-write path, bounded alert set, and
+body-free correlation recipe cannot silently disappear. Runtime firing lives
+in the cluster-tier script; this file is the local consumer-path gate.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OBSERVABILITY = REPO_ROOT / "examples" / "sre-bot" / "observability"
+README = REPO_ROOT / "examples" / "sre-bot" / "README.md"
+ROLLOUT = REPO_ROOT / "examples" / "sre-bot" / "docs" / "METRICS-ROLLOUT.md"
+
+REQUIRED_ALERTS = {
+    "CurieTurnAcceptedStale",
+    "CurieTaskFailure",
+    "CurieQueueMessageAgeHigh",
+    "CurieCompletionOutboxAgeHigh",
+    "CurieCompletionOutboxSignalAbsent",
+    "CurieReplyDeliveryRefused",
+    "CurieChannelTokenRotationFailed",
+    "CurieMailAdapterNotReady",
+    "CurieRootDiskPressure",
+    "CurieNodeMemoryHeadroomLow",
+    "CurieApplicationMetricsAbsent",
+    "CurieDuplicateNodeExporter",
+}
+
+FORBIDDEN_IDENTITY = (
+    "run_id",
+    "run.id",
+    "session_id",
+    "session.id",
+    "event.id",
+    "event_id",
+    "user_id",
+    "user.id",
+    "sandbox_id",
+    "sandbox.id",
+    "deployment_id",
+    "thread_id",
+    "thread_key",
+    "message_id",
+    "message.body",
+)
+
+FORBIDDEN_SECRET = (
+    "password",
+    "api_key",
+    "apikey",
+    "authorization",
+    "secret",
+    "token=",
+    "xoxb-",
+    "sk-",
+)
+
+EXPORTER_NAME = "prometheusremotewrite/soak"
+
+
+def _load(name: str) -> dict:
+    path = OBSERVABILITY / name
+    return yaml.safe_load(path.read_text())
+
+
+def _alert_rules(values: dict) -> list[dict]:
+    groups = (
+        values.get("serverFiles", {})
+        .get("alerting_rules.yml", {})
+        .get("groups", [])
+    )
+    rules: list[dict] = []
+    for group in groups or []:
+        rules.extend(group.get("rules") or [])
+    return rules
+
+
+def test_curie_values_append_prometheus_remote_write_without_replacing_nop() -> None:
+    values = _load("curie-values.yaml")
+    collector = values["otelCollector"]
+    exporter = collector["extraExporters"][EXPORTER_NAME]
+    assert exporter["endpoint"].endswith(
+        ".observability.svc.cluster.local/api/v1/write"
+    )
+    assert exporter["retry_on_failure"]["enabled"] is True
+    assert exporter["remote_write_queue"]["enabled"] is True
+    assert 0 < exporter["remote_write_queue"]["queue_size"] <= 100000
+    assert "sending_queue" not in exporter
+    assert collector["extraMetricPipelineExporters"] == [EXPORTER_NAME]
+    conversion = exporter.get("resource_to_telemetry_conversion") or {}
+    assert conversion.get("enabled") is False
+
+
+def test_curie_values_allow_prometheus_metrics_ingress() -> None:
+    peer = _load("curie-values.yaml")["security"]["otelCollectorNetworkPolicy"][
+        "metricsIngress"
+    ]
+    assert peer == [
+        {
+            "namespaceSelector": {
+                "matchLabels": {
+                    "kubernetes.io/metadata.name": "observability",
+                }
+            },
+            "podSelector": {
+                "matchLabels": {
+                    "app.kubernetes.io/name": "prometheus",
+                    "app.kubernetes.io/instance": "prometheus",
+                }
+            },
+        }
+    ]
+
+
+def test_prometheus_enables_remote_write_receiver() -> None:
+    values = _load("prometheus-values.yaml")
+    assert values["server"]["extraArgs"] == {
+        "web.enable-remote-write-receiver": "",
+    }
+
+
+def test_prometheus_ships_required_reliability_alerts() -> None:
+    rules = _alert_rules(_load("prometheus-values.yaml"))
+    names = {rule["alert"] for rule in rules if "alert" in rule}
+    missing = sorted(REQUIRED_ALERTS - names)
+    assert not missing, f"missing reliability alerts: {missing}"
+
+
+def test_alert_expressions_keep_identity_and_secrets_out_of_metric_labels() -> None:
+    rules = _alert_rules(_load("prometheus-values.yaml"))
+    dumped = yaml.safe_dump(rules)
+    lower = dumped.lower()
+    for needle in FORBIDDEN_IDENTITY:
+        assert needle.lower() not in lower, (
+            f"alert rules must not select high-cardinality identity {needle!r}"
+        )
+    for needle in FORBIDDEN_SECRET:
+        assert needle not in lower, (
+            f"alert rules must not emit or match credential material {needle!r}"
+        )
+
+
+def test_absent_and_stale_metrics_are_failure_signals() -> None:
+    rules = {
+        rule["alert"]: rule["expr"]
+        for rule in _alert_rules(_load("prometheus-values.yaml"))
+        if "alert" in rule
+    }
+    assert "absent(" in rules["CurieApplicationMetricsAbsent"]
+    assert "absent(" in rules["CurieCompletionOutboxSignalAbsent"]
+    stale = rules["CurieTurnAcceptedStale"]
+    assert "increase(" in stale and "curie_turn_accepted_total" in stale
+
+
+def test_duplicate_node_exporter_alert_counts_series_not_sum() -> None:
+    expr = next(
+        rule["expr"]
+        for rule in _alert_rules(_load("prometheus-values.yaml"))
+        if rule.get("alert") == "CurieDuplicateNodeExporter"
+    )
+    assert "count(" in expr
+    assert "9100" in expr and "9101" in expr
+    assert "node_memory_MemAvailable_bytes" in expr
+    assert "sum(" not in expr.replace(" ", "")
+
+
+def test_rollout_doc_separates_render_runtime_and_deployed_evidence() -> None:
+    text = ROLLOUT.read_text()
+    for required in (
+        "locally rendered",
+        "disposable runtime-tested",
+        "actually deployed",
+        "permanent soak",
+        "rollback",
+        "does not authorize",
+    ):
+        assert required in text.lower() or required in text, (
+            f"rollout doc is missing {required!r}"
+        )
+    assert "source-only" in text.lower()
+    assert "C0EXAMPLE1" in text
+    assert not re.search(r"C0(?!EXAMPLE1)[A-Z0-9]{8,}", text)
+
+
+def test_correlation_recipe_uses_safe_identifiers_not_bodies() -> None:
+    text = README.read_text()
+    assert "trace_id" in text or "traceId" in text
+    assert "run" in text.lower()
+    assert "without reading" in text.lower() or "without inspecting" in text.lower()
+    assert "metric labels" in text.lower()
+    lower = text.lower()
+    assert "message body" in lower or "private body" in lower
+    assert "do not" in lower and "body" in lower
+
+
+def test_runtime_script_refuses_soak_identities() -> None:
+    script = (
+        REPO_ROOT / "charts" / "curie" / "ci" / "runtime" / "metrics-alerts-runtime.sh"
+    ).read_text()
+    assert "refusing soak identity" in script
+    assert "curie" in script and "observability" in script
+    assert "monitoring" in script
+
+
+def test_promtool_unit_file_covers_fire_and_recovery() -> None:
+    path = OBSERVABILITY / "reliability-alerts.test.yaml"
+    payload = yaml.safe_load(path.read_text())
+    tests = payload["tests"]
+    names = {item["name"] for item in tests}
+    assert any("fire" in name for name in names)
+    assert any("recover" in name or "quiet" in name for name in names)
+    alerts = {
+        case["alertname"]
+        for item in tests
+        for case in item.get("alert_rule_test") or []
+    }
+    missing = sorted(REQUIRED_ALERTS - alerts)
+    assert not missing, f"promtool tests omit alerts: {missing}"
+    firing = [
+        case
+        for item in tests
+        for case in item.get("alert_rule_test") or []
+        if case.get("exp_alerts")
+    ]
+    recovering = [
+        case
+        for item in tests
+        for case in item.get("alert_rule_test") or []
+        if case.get("exp_alerts") == []
+    ]
+    assert firing, "promtool tests must include at least one firing case"
+    assert recovering, "promtool tests must include at least one recovery case"


### PR DESCRIPTION
## Summary

The shipped SRE-bot overlay now retains Curie application metrics in Prometheus and loads reliability alerts. Collector 0.119 rejects `sending_queue` on `prometheusremotewrite`; the overlay and chart helper use `remote_write_queue` instead, which is what made a source-only overlay fail at runtime.

A disposable install (`curie-t2428` / `obs-t2428`) retained `curie_turn_accepted_total`, queue, RPC, and reply series, dropped `prometheusremotewrite/soak` when the overlay was removed, and retained series again after restore. The permanent soak was not changed (Helm revision 42).

## Related issue

Closes #2428

## Fix pin verification

Fix pin: charts/curie/ci/observability-stack-assertions.sh

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | required | Installer embeds overlay values; CLI rewrite and example tests. | fake | `uv run pytest -q examples/tests/test_reliability_alerts.py` -> 11 passed. `cargo test --test example_sre_bot_install custom_targets_thread_through_helm_kubectl_manifests_secret_discovery_and_connectors` -> ok. |
| local-release | n/a | Does not change released binary identity, image pins, or release compose. | | |
| cluster | required | Disposable Helm install must retain series and prove absent-data detection. | fake | `bash charts/curie/ci/runtime/metrics-alerts-runtime.sh` on commit `843a54df0e7b42970ecbf2a988eb9917b3dc9c87`. Observed: `PASS retained: curie_turn_accepted_total` (also queue, RPC, reply); `PASS: broken export removed prometheusremotewrite/soak`; `PASS: restored overlay retains Curie series again`. Task namespaces torn down. Permanent soak Helm revision remained 42. |
| live provider | n/a | Does not reach model routing, MCP catalog projection, unscoped PreToolUse, platform MCP tools, workspace publication, or coding-tool session capability. | | |
| external integration | n/a | Does not reach Slack, git webhooks, or connector OAuth. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive plus negative:

- Alerts: promtool fire cases and matching quiet/recovery cases in `examples/sre-bot/observability/reliability-alerts.test.yaml`.
- Overlay: default chart metrics pipeline stays `nop/metrics`; overlay appends `prometheusremotewrite/soak`. Render with `sending_queue` on that exporter is refused.
- Duplicate scrape: 9100+9101 fires; two nodes on 9101 only stay quiet.
- Runtime: overlay on retains series; overlay off removes the exporter from the live Collector config.

`curie.completion.outbox` series mutation still depends on merged #2422. Current main proves the absent-signal alert and retains `curie_reply_delivery_total` as the completion-delivery counter already on main.

Permanent soak apply remains an operator handoff. See `examples/sre-bot/docs/METRICS-ROLLOUT.md`. This PR does not send notifications to people.

## Checklist

- [x] Tests cover the change
- [x] Docs updated
- [x] No frozen-interface or ADR change

