### PR TITLE
Bump channel-token generation on every mint

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -30,11 +30,12 @@ worker, Postgres, RustFS/S3, Langfuse, and GitHub.
   OR a `chn` token (`channel_token.py`) scoped to the binding row named in the
   request BODY -- its `channel_id` plus that row's current `generation` -- so an
   ingress adapter can enqueue turns for its own route without holding the
-  platform key. It is a SIBLING credential, never a widening of the sandbox
-  token: the two verify against different modules and neither authenticates as
-  the other. `POST /channels/token` (the mint) stays platform-key-only, and a
-  `chn` token is refused on every other router, `/approvals/{id}/resolve`
-  included. Extending it further still takes a new ADR.
+  platform key. `POST /channels/token` bumps that generation on every mint so a
+  remint revokes the previous token (#2379). It is a SIBLING credential, never a
+  widening of the sandbox token: the two verify against different modules and
+  neither authenticates as the other. `POST /channels/token` (the mint) stays
+  platform-key-only, and a `chn` token is refused on every other router,
+  `/approvals/{id}/resolve` included. Extending it further still takes a new ADR.
 - **The GitHub webhook is authenticated differently, on purpose.** `/github/webhook`
   verifies the HMAC signature GitHub sends (`x-hub-signature-256` against
   `settings.github_webhook_secret`), not the API key -- GitHub cannot send an

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -8292,7 +8292,7 @@
     },
     "/channels/token": {
       "post": {
-        "description": "Mint a `chn` token for one binding (platform key only).\n\nPlatform-key-only on purpose: a `chn` token does exactly one thing, enqueue\nfor the binding in its claims. If it could mint, a compromised adapter would\ndefeat both the TTL and the generation -- the only two things standing in for\na revocation list.\n\nThe token claims the ROW's id and its CURRENT generation, so it dies both\nwhen the pair is deleted and recreated (a new row id) and when the binding is\nre-pointed or merely re-asserted (a bumped generation).",
+        "description": "Mint a `chn` token for one binding (platform key only).\n\nPlatform-key-only on purpose: a `chn` token does exactly one thing, enqueue\nfor the binding in its claims. If it could mint, a compromised adapter would\ndefeat both the TTL and the generation -- the only two things standing in for\na revocation list.\n\nThe token claims the ROW's id and the generation this mint stamps. Minting\nis a rotation write: it bumps the row under `FOR UPDATE` and signs the NEW\nvalue, so a remint revokes the token it replaces (#2379). The token also\ndies when the pair is deleted and recreated (a new row id) and when the\nbinding is re-pointed or merely re-asserted (another bump).",
         "operationId": "mint_channel_token_channels_token_post",
         "parameters": [
           {

--- a/apps/api/src/curie_api/channel_token.py
+++ b/apps/api/src/curie_api/channel_token.py
@@ -18,7 +18,7 @@ and widening would also have broken the byte-identical api/worker twin of
 binding row IN PLACE and ``delete_agent`` frees the pair for reuse, so a token
 claiming the PAIR does not go inert when the route changes hands -- it goes live
 again against the new owner. The row id is a stable identity and ``generation``
-is what makes a rebind observable to a credential minted before it.
+is what makes a rebind or a remint observable to a credential minted before it.
 ``crud.delete_channel_binding`` is the third case and needs no counter: the row
 is gone, so the ``channel_id`` in the claim resolves to nothing and every token
 naming that binding is dead by construction.

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -313,7 +313,8 @@ async def update_channel_binding(
     whose values are identical -- an operator re-asserting a binding is the "I
     think something is wrong with this route" gesture that should invalidate
     outstanding credentials, and guarding the bump on a value change would leave
-    that case silently valid.
+    that case silently valid. `POST /channels/token` is the sibling bump: a
+    remint increments the same counter so rotation revokes (#2379).
 
     FLUSHES rather than commits, so the caller can run it inside a SAVEPOINT:
     the unique violation this raises has to be recoverable without discarding

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -218,9 +218,10 @@ class AgentChannel(Base):
     `endpoint`/`adapter` are the server-controlled reply route: where this kind's
     replies go back through, and which egress credential authenticates them. They
     are set here by the platform and never accepted from an ingress request body.
-    `generation` counts rebinds: `update_channel_binding` mutates this row IN PLACE,
-    so the row id is a stable identity and the generation is the only thing that
-    makes a rebind observable to a credential minted before it.
+    `generation` counts rotations: `update_channel_binding` mutates this row IN
+    PLACE, and `POST /channels/token` bumps it on every mint, so the row id is a
+    stable identity and the generation is the only thing that makes a rebind or
+    remint observable to a credential minted before it.
     """
 
     __tablename__ = "agent_channels"
@@ -263,9 +264,10 @@ class AgentChannel(Base):
     # the database so a half-configured route cannot be written out of band.
     endpoint: Mapped[str | None] = mapped_column(default=None)
     adapter: Mapped[str | None] = mapped_column(default=None)
-    # Rebind counter (ADR-0096 D5). Bumped on every binding write, including one
-    # that changes nothing: re-asserting a binding is the "something is wrong
-    # with this route" gesture that should invalidate outstanding credentials.
+    # Rotation counter (ADR-0096 D5, #2379). Bumped on every binding write,
+    # including one that changes nothing, and on every `POST /channels/token`
+    # mint: re-asserting a binding or reminting its credential both invalidate
+    # outstanding tokens.
     generation: Mapped[int] = mapped_column(server_default="0", default=0)
 
     agent: Mapped[Agent] = relationship(back_populates="channels")

--- a/apps/api/src/curie_api/routers/channels.py
+++ b/apps/api/src/curie_api/routers/channels.py
@@ -4,8 +4,9 @@ Two endpoints, and every request/response model they use lives here rather than
 in ``schemas.py``:
 
 - ``POST /channels/token`` (platform key only) mints a ``chn`` token over a
-  binding ROW's id plus its current generation, so an ingress adapter holds a
-  credential scoped to exactly one binding instead of the platform key.
+  binding ROW's id plus a bumped generation, so an ingress adapter holds a
+  credential scoped to exactly one binding instead of the platform key, and a
+  remint revokes the token it replaces.
 - ``POST /channels/turns`` (platform key OR a ``chn`` token) enqueues a
   ``QueuedTurn`` for the binding named in the BODY.
 
@@ -116,7 +117,8 @@ class ChannelTokenRequest(ChannelBinding):
     # An hour by default; a week is the ceiling. The TTL and the generation are
     # the only two things standing in for the revocation list phase 2
     # deliberately does not build, so an unbounded lifetime would remove one of
-    # them.
+    # them. Minting itself is a rotation write: it bumps generation so a remint
+    # revokes the token it replaces (#2379).
     ttl_s: int = Field(default=3600, gt=0, le=604800)
 
 
@@ -257,12 +259,23 @@ async def mint_channel_token(
     defeat both the TTL and the generation -- the only two things standing in for
     a revocation list.
 
-    The token claims the ROW's id and its CURRENT generation, so it dies both
-    when the pair is deleted and recreated (a new row id) and when the binding is
-    re-pointed or merely re-asserted (a bumped generation).
+    The token claims the ROW's id and the generation this mint stamps. Minting
+    is a rotation write: it bumps the row under `FOR UPDATE` and signs the NEW
+    value, so a remint revokes the token it replaces (#2379). The token also
+    dies when the pair is deleted and recreated (a new row id) and when the
+    binding is re-pointed or merely re-asserted (another bump).
     """
 
-    row = await _resolve_binding(session, data.kind, data.address)
+    # Locked, not the unlocked `_resolve_binding` the ingress uses: two concurrent
+    # mints that both read N and both write N+1 would stamp the same generation
+    # on two tokens, and neither rotation would revoke the other. `populate_existing`
+    # is the same load-bearing choice as `crud.lock_agent_bindings`.
+    row: AgentChannel | None = await session.scalar(
+        select(AgentChannel)
+        .where(AgentChannel.kind == data.kind, AgentChannel.address == data.address)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )
     if row is None:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,
@@ -274,6 +287,7 @@ async def mint_channel_token(
         # rather than as a fail-closed escalation mid-turn, in the worker, far
         # from the request that caused it. `ingest_turn` raises the same refusal.
         raise _unroutable(data.kind, data.address)
+    row.generation += 1
     token = channel_token.mint(
         get_settings().api_key,
         channel_id=str(row.id),
@@ -281,6 +295,7 @@ async def mint_channel_token(
         scope=CHANNEL_ENQUEUE_SCOPE,
         exp=int(time.time()) + data.ttl_s,
     )
+    await session.commit()
     return ChannelTokenOut(token=token)
 
 
@@ -451,13 +466,14 @@ async def ingest_turn(
     owner = f"pending:{secrets.token_hex(16)}"
 
     # The generation, re-read at the LAST moment before the claim. The row above
-    # was loaded at the top of the request, and `update_channel_binding` bumps the
-    # generation on a rebind, so a credential revoked mid-request would otherwise
-    # still enqueue against the binding it no longer names. Re-reading here
-    # narrows that race from the whole request to the gap below; it does NOT
-    # close it -- a rebind committing between this SELECT and the XADD still
-    # lands, and closing that honestly needs a row lock held across the enqueue,
-    # which phase 2 does not take (FU: revocation list).
+    # was loaded at the top of the request, and both a rebind
+    # (`update_channel_binding`) and a remint (`mint_channel_token`) bump the
+    # generation, so a credential revoked mid-request would otherwise still
+    # enqueue against the binding it no longer names. Re-reading here narrows
+    # that race from the whole request to the gap below; it does NOT close it --
+    # a bump committing between this SELECT and the XADD still lands, and
+    # closing that honestly needs a row lock held across the enqueue, which
+    # phase 2 does not take (FU: revocation list).
     if claims is not None:
         current_generation = await session.scalar(
             select(AgentChannel.generation).where(AgentChannel.id == row.id)

--- a/apps/api/tests/test_channel_token.py
+++ b/apps/api/tests/test_channel_token.py
@@ -11,8 +11,9 @@ The claims are `{channel_id, generation, scope, exp}` (plan D5, EB-C1):
 deliberately NOT `(kind, address)`. `crud.update_channel_binding` mutates the
 binding row in place and `delete_agent` frees the pair for reuse, so a token
 claiming the pair goes live again against a NEW owner (E12). The row id plus a
-rebind counter is what makes a rebind observable to a credential minted before
-it -- and it is what makes T-C8 and T-C9 fail under the rejected design.
+rotation counter is what makes a rebind or a remint observable to a credential
+minted before it -- and it is what makes T-C8, T-C9 and #2379 fail under the
+rejected design.
 
 Pure stdlib, nothing mocked, no database. An independent reimplementation of the
 signing format pins the exact encoding rather than round-tripping the module

--- a/apps/api/tests/test_channels.py
+++ b/apps/api/tests/test_channels.py
@@ -3,7 +3,7 @@
 ADR-0096 phase 2, Stream C. Two endpoints on a new `/channels` router:
 
 - `POST /channels/token` (platform key only) mints a `chn` token over a binding
-  row's `channel_id` + current `generation` (plan EB-C2).
+  row's `channel_id` + a bumped `generation` (plan EB-C2, #2379).
 - `POST /channels/turns` (platform key OR a `chn` token) enqueues a `QueuedTurn`
   for the binding named in the BODY. `kind` and `address` are in the body, not
   the path, because an address is an opaque routing key that may contain `@`,
@@ -118,6 +118,19 @@ def runs_stream() -> Iterator[str]:
 def channels_client(_disposable_db: Any, runs_stream: str) -> Iterator[TestClient]:
     """A TestClient whose app was built AFTER the stream override, so the
     ingress enqueue targets the isolated stream."""
+
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def rival_client(_disposable_db: Any, runs_stream: str) -> Iterator[TestClient]:
+    """A SECOND app instance on the same Postgres.
+
+    Two apps rather than two calls on one TestClient: a concurrent mint is a
+    different process in production, and one client's portal would serialize
+    the overlap under test.
+    """
 
     with TestClient(create_app()) as test_client:
         yield test_client
@@ -255,6 +268,16 @@ def _sha16(delivery_id: str) -> str:
     return hashlib.sha256(delivery_id.encode()).hexdigest()[:16]
 
 
+def _both(first: Any, second: Any) -> tuple[Any, Any]:
+    """Run two request thunks genuinely in parallel and return both responses."""
+
+    async def run() -> list[Any]:
+        return list(await asyncio.gather(asyncio.to_thread(first), asyncio.to_thread(second)))
+
+    left, right = asyncio.run(run())
+    return left, right
+
+
 # --- POST /channels/token: minting against a binding --------------------------
 
 
@@ -262,8 +285,9 @@ def test_the_mint_binds_the_row_identity_and_its_current_generation(
     channels_client: TestClient, auth_headers: dict[str, str], clean_db: None
 ) -> None:
     """EB-C2. The mint resolves the `(kind, address)` pair to a binding ROW and
-    signs that row's id plus its generation -- so the token names an identity
-    that survives neither a delete-and-recreate nor a rebind (T-C8, T-C9)."""
+    signs that row's id plus the generation the mint itself stamps -- so the
+    token names an identity that survives neither a delete-and-recreate nor a
+    rebind (T-C8, T-C9) nor a later remint (#2379)."""
 
     agent_id = _bind(
         channels_client,
@@ -271,12 +295,17 @@ def test_the_mint_binds_the_row_identity_and_its_current_generation(
         name="mint-agent",
         channel=_email_channel("ops@example.test"),
     )
-    row = _binding_row(agent_id)
+    before = _binding_row(agent_id)
+    assert before["generation"] == 0
 
     token = _mint(channels_client, auth_headers, kind="email", address="ops@example.test")
+    row = _binding_row(agent_id)
 
-    # The minted token verifies against exactly this row at exactly this
-    # generation, and against nothing else.
+    # Rotation is a write: the mint bumps the counter, then signs the NEW value.
+    # Reading the row before the mint and verifying against that snapshot would
+    # pass a stamp-current implementation that leaves the previous token live.
+    assert row["generation"] == before["generation"] + 1
+
     from curie_api.channel_token import verify
 
     assert (
@@ -289,6 +318,136 @@ def test_the_mint_binds_the_row_identity_and_its_current_generation(
         )
         is True
     )
+    assert (
+        verify(
+            token,
+            get_settings().api_key,
+            channel_id=str(row["id"]),
+            generation=before["generation"],
+            scope=CHANNEL_ENQUEUE_SCOPE,
+        )
+        is False
+    )
+
+
+def test_a_second_mint_rejects_the_first_token(
+    channels_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """#2379. Rotation revokes: a remint bumps generation so the token it
+    replaces cannot enqueue.
+
+    The three 2026-09-04 mints for one email binding all carried generation 0
+    because mint stamped the row without incrementing it. After a second mint
+    the first token is 401 at ingress, with the same detail string as every
+    other credential failure, and the new token still enqueues.
+    """
+
+    agent_id = _bind(
+        channels_client,
+        auth_headers,
+        name="remint-agent",
+        channel=_email_channel("remint@example.test"),
+    )
+    first = _mint(
+        channels_client, auth_headers, kind="email", address="remint@example.test"
+    )
+    after_first = _binding_row(agent_id)
+    accepted = _post_turn(
+        channels_client, first, _turn("email", "remint@example.test")
+    )
+    assert accepted.status_code == 200, accepted.text
+
+    second = _mint(
+        channels_client, auth_headers, kind="email", address="remint@example.test"
+    )
+    after_second = _binding_row(agent_id)
+    assert after_second["generation"] == after_first["generation"] + 1
+    assert second != first
+
+    refused = _post_turn(
+        channels_client, first, _turn("email", "remint@example.test")
+    )
+    assert refused.status_code == 401, refused.text
+    assert refused.json()["detail"] == AUTH_DETAIL
+
+    still_valid = _post_turn(
+        channels_client, second, _turn("email", "remint@example.test")
+    )
+    assert still_valid.status_code == 200, still_valid.text
+
+    from curie_api.channel_token import verify_claims
+
+    first_claims = verify_claims(
+        first, get_settings().api_key, scope=CHANNEL_ENQUEUE_SCOPE
+    )
+    second_claims = verify_claims(
+        second, get_settings().api_key, scope=CHANNEL_ENQUEUE_SCOPE
+    )
+    assert first_claims is not None and second_claims is not None
+    assert first_claims.generation == after_first["generation"]
+    assert second_claims.generation == after_second["generation"]
+    assert first_claims.generation < second_claims.generation
+    assert {turn.event_id for turn in _turns_on(valkey, runs_stream)} == {
+        accepted.json()["event_id"],
+        still_valid.json()["event_id"],
+    }
+
+
+def test_two_concurrent_mints_increment_generation_once_each(
+    channels_client: TestClient,
+    rival_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """No lost update on the mint counter.
+
+    Two overlapping remints that both read N and both write N+1 would stamp the
+    same generation on two tokens, so neither rotation would revoke the other.
+    Under the row lock the increments serialize and the counter ends at start+2.
+    """
+
+    agent_id = _bind(
+        channels_client,
+        auth_headers,
+        name="concurrent-mint",
+        channel=_email_channel("concurrent-mint@example.test"),
+    )
+    start = _binding_row(agent_id)["generation"]
+
+    def _mint_on(client: TestClient) -> Any:
+        return client.post(
+            "/channels/token",
+            json={
+                "kind": "email",
+                "address": "concurrent-mint@example.test",
+                "ttl_s": 60,
+            },
+            headers=auth_headers,
+        )
+
+    first, second = _both(
+        lambda: _mint_on(channels_client), lambda: _mint_on(rival_client)
+    )
+    assert [first.status_code, second.status_code] == [200, 200], (
+        first.text,
+        second.text,
+    )
+    assert _binding_row(agent_id)["generation"] == start + 2
+
+    from curie_api.channel_token import verify_claims
+
+    gens: set[int] = set()
+    for resp in (first, second):
+        claims = verify_claims(
+            resp.json()["token"], get_settings().api_key, scope=CHANNEL_ENQUEUE_SCOPE
+        )
+        assert claims is not None
+        gens.add(claims.generation)
+    assert gens == {start + 1, start + 2}
 
 
 def test_the_mint_404s_for_a_pair_with_no_bound_agent(
@@ -875,8 +1034,10 @@ def test_the_401_matrix_is_uniform_and_never_leaks_which_half_failed(
         name="matrix-agent",
         channel=_email_channel("matrix@example.test"),
     )
-    row = _binding_row(agent_id)
     valid = _mint(channels_client, auth_headers, kind="email", address="matrix@example.test")
+    # Generation is read AFTER the mint: minting is a rotation write, so a
+    # snapshot taken beforehand is the generation the new token replaced.
+    row = _binding_row(agent_id)
 
     api_key = get_settings().api_key
     expired = mint(

--- a/docs/guides/building-a-channel-adapter.md
+++ b/docs/guides/building-a-channel-adapter.md
@@ -89,11 +89,12 @@ Response is `{"token": "..."}`. `ttl_s` defaults to 3600 and is capped at
 binding has no reply route yet, so a half-configured route is caught at bind
 time instead of mid-turn.
 
-The token claims the binding row's id plus its current `generation`. Every
-binding write bumps that generation unconditionally, including a re-assert of
-identical values, so a rebind kills every outstanding token for it. Plan for
-re-minting: treat a 401 from ingress as "ask the operator for a fresh token",
-not as a bug.
+The token claims the binding row's id plus the `generation` the mint stamps.
+Every mint bumps that generation, and every binding write bumps it too,
+including a re-assert of identical values, so a remint or a rebind kills every
+outstanding token for the pair. Plan for re-minting: treat a 401 from ingress
+as "ask the operator for a fresh token", not as a bug. The previous token is
+already dead; installing the new one is what restores enqueue.
 
 **Outbound (the platform's credential for calling you).** The operator puts a
 shared secret under your adapter slug in the worker's credential map:

--- a/docs/interfaces/port-adapter-service/INTERFACE.md
+++ b/docs/interfaces/port-adapter-service/INTERFACE.md
@@ -63,8 +63,9 @@ generic endpoints as a plugin API:
   `POST /channels/token` plus `POST /channels/turns`
   (`apps/api/src/curie_api/routers/channels.py`). The platform mints a scoped
   `chn` token for one binding row and generation
-  (`apps/api/src/curie_api/channel_token.py`); that credential can enqueue only
-  for the current binding. The turn body supplies its channel identity and
+  (`apps/api/src/curie_api/channel_token.py`); minting bumps that generation so
+  a remint revokes the previous token, and the credential can enqueue only for
+  the current binding. The turn body supplies its channel identity and
   delivery content, while the API loads the binding and supplies `kind`,
   `endpoint`, and `adapter` itself. A caller therefore cannot turn a token into
   an authenticated request to a caller-selected endpoint. Raw broker produce

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -553,7 +553,8 @@ Two platform-side steps come first, in this order:
    mints through `POST /channels/token` with the platform key, writes the token
    into the Secret the adapter actually reads (the chart Secret, or
    `mailAdapter.channelTokenExistingSecret` when that is set), rolls the adapter,
-   and prints `exp`. It never prints the token and never writes it through Helm
+   and prints `exp`. Each mint bumps the binding's generation, so a remint
+   revokes the previous token. It never prints the token and never writes it through Helm
    values, so `helm get values` cannot undo the rotation. `--show-exp` reports
    the installed token's `exp` and whether the platform still accepts it, the
    same observation `curie doctor` uses. The mint refuses with 409 for a


### PR DESCRIPTION
## Summary

`POST /channels/token` now treats minting as a rotation write: it locks the binding row, increments `generation`, and signs the new value. A remint therefore 401s the previous token at ingress. Generation stays on the token claims so a rebind still revokes outstanding credentials (ADR-0096 phase-2 plan D5). Removing the field would have undone that.

## Related issue

Closes #2379

## Fix pin verification

Fix pin: apps/api/tests/test_channels.py::test_a_second_mint_rejects_the_first_token

Pinned locally:

```
curie dev verify-fix-pin HEAD apps/api/tests/test_channels.py::test_a_second_mint_rejects_the_first_token
```

Baseline: 1 passed. Reversed product hunks: `assert 0 == (0 + 1)` then PINNED.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | required | Mint and ingress live on the API. | live | Commit `48889cae`. `uv run pytest -q apps/api/tests/test_channels.py::test_a_second_mint_rejects_the_first_token` against compose Postgres and Valkey: 1 passed. First token 200, remint, first token 401 `missing or invalid credential`, second token 200. |
| local-release | n/a | Does not change released binary or image identity, the install path, version pins, or release compose. | | |
| cluster | n/a | Does not reach chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, or init containers. The issue does not ask for a k8scratch proof. | | |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, or token/cost accounting. | | |
| external integration | n/a | Does not change Slack, git webhooks, connector OAuth, or a third-party API shape. Mail-adapter still consumes the operator-installed token; a 401 means remint and reinstall. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive: after a second mint, the new token enqueues (200).
Negative: the first token is rejected with 401 and the uniform `missing or invalid credential` detail. Concurrent mints (`test_two_concurrent_mints_increment_generation_once_each`) are a second path: both 200, generations `{start+1, start+2}`. Rebind still 401s a pre-rebind token (`test_a_token_is_dead_after_the_binding_is_repointed`).

## Sibling paths

- Binding write (`update_channel_binding`) still bumps generation unconditionally, including a no-op re-assert.
- Ingress `_authorize` and the pre-claim re-read still use equality, so a lower generation 401s and a rolled-back row does not revive a future token.
- Mint stays platform-key-only; a `chn` token cannot remint itself.

## Checklist

- [x] Tests pass for the area I touched (`uv run pytest -q apps/api/tests/test_channels.py apps/api/tests/test_channel_token.py apps/api/tests/test_channel_ingress_idempotency.py apps/api/tests/test_agent_channels_subresource.py apps/api/tests/test_openapi_drift.py`: 169 passed).
- [x] Docs updated if behavior changed (adapter guide, operations mint step, port-adapter INTERFACE, API CLAUDE.md, OpenAPI mint description).
- [x] No new ADR. This is an additive write on the existing generation counter, not a new shape.
