### PR TITLE
Refuse soak write tools through CURIE_DISALLOWED_TOOLS

### DIFF
--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -273,6 +273,9 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         # its own env to pick the active harness, unset selects the built-in
         # Claude. Not a boot contract key.
         "CURIE_HARNESS",
+        # runner-local SDK deny list (#2429); read by the runner from its own env
+        # via extraEnv, unset keeps every tool available. Not a boot contract key.
+        "CURIE_DISALLOWED_TOOLS",
         # Delivery budget and ownership lease (ADR-0131, #1971), read from the
         # WORKER's env by WorkerConfig. Never a sandbox boot key: they govern
         # how the worker paces and reclaims its own delivery loop, not

--- a/runner/README.md
+++ b/runner/README.md
@@ -63,7 +63,9 @@ readinessProbe hits `/healthz`).
   nonpositive value falls back to the default),
   `CURIE_RUNNER_PORT`, `CURIE_RUNNER_TOKEN` (per-sandbox bearer token gating
   the three ACI POST routes; enforced only when set), `CURIE_FAKE_MODEL`
-  (offline smoke; no model call).
+  (offline smoke; no model call), `CURIE_DISALLOWED_TOOLS` (optional
+  comma-separated tool names removed from the session and refused even under
+  bypassPermissions; unset keeps every tool available).
 
 ## Build and smoke
 

--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -332,6 +332,7 @@ def build_runner(
             ),
             can_use_tool=(build_can_use_tool(approval_gate) if approval_gate is not None else None),
             cwd=workspace_cwd,
+            disallowed_tools=config.disallowed_tools,
         )
 
     def factory() -> ModelSession:
@@ -349,6 +350,7 @@ def build_runner(
                 # Share the same gate so a scripted request_approval resolves its
                 # route through the real decision table on the offline tier (#561).
                 approval_gate=approval_gate,
+                disallowed_tools=config.disallowed_tools,
             )
         assert real_options is not None
         return ClaudeAgentSession(real_options)

--- a/runner/src/curie_runner/adapter.py
+++ b/runner/src/curie_runner/adapter.py
@@ -89,6 +89,7 @@ def build_options(
     mcp_servers: dict[str, McpSdkServerConfig] | None = None,
     can_use_tool: CanUseTool | None = None,
     cwd: str | None = None,
+    disallowed_tools: list[str] | tuple[str, ...] | None = None,
 ) -> ClaudeAgentOptions:
     """Assemble ClaudeAgentOptions for the session.
 
@@ -138,6 +139,10 @@ def build_options(
         # In-process platform tools (the approval-request gate, ADR-0010).
         mcp_servers=cast("Any", mcp_servers or {}),
         include_partial_messages=True,
+        # Optional operator deny list (#2429). Empty/None keeps the SDK default
+        # (no tools removed). Names are removed from the model context and cannot
+        # be used even under bypassPermissions.
+        disallowed_tools=list(disallowed_tools or ()),
     )
 
 
@@ -161,9 +166,7 @@ class ClaudeAgentSession:
                 async for message in response:
                     if isinstance(message, StreamEvent):
                         event = message.event
-                        event_type = (
-                            event.get("type") if isinstance(event, dict) else None
-                        )
+                        event_type = event.get("type") if isinstance(event, dict) else None
                         if event_type == "content_block_start":
                             content_block = event.get("content_block")
                             if isinstance(content_block, dict):

--- a/runner/src/curie_runner/config.py
+++ b/runner/src/curie_runner/config.py
@@ -88,6 +88,10 @@ class RunnerConfig:
     # defaults live at the call site rather than here.
     history_max_turns: int | None
     history_max_bytes: int | None
+    # Runner-local deny list (#2429): comma-separated tool names handed to
+    # ClaudeAgentOptions.disallowed_tools. Unset/blank keeps the historical
+    # empty list so an unconfigured agent is unchanged. Not a BootEnv field.
+    disallowed_tools: tuple[str, ...]
 
     @property
     def ceiling(self) -> int:
@@ -131,6 +135,11 @@ class RunnerConfig:
         # Runner-local harness selection (ADR-0060, #844), not a BootEnv key:
         # empty/unset selects the built-in Claude harness.
         harness = env.get("CURIE_HARNESS", "").strip() or DEFAULT_HARNESS
+        disallowed_tools = tuple(
+            name.strip()
+            for name in env.get("CURIE_DISALLOWED_TOOLS", "").split(",")
+            if name.strip()
+        )
         return cls(
             session=boot.session,
             model=boot.model,
@@ -150,4 +159,5 @@ class RunnerConfig:
             runner_token=boot.runner_token,
             history_max_turns=boot.history_max_turns,
             history_max_bytes=boot.history_max_bytes,
+            disallowed_tools=disallowed_tools,
         )

--- a/runner/src/curie_runner/fake.py
+++ b/runner/src/curie_runner/fake.py
@@ -191,11 +191,13 @@ class FakeModelSession:
         can_use_tool: CanUseTool | None = None,
         approval_gate: ApprovalGate | None = None,
         emit_partial_boundaries: bool = False,
+        disallowed_tools: list[str] | tuple[str, ...] | None = None,
     ) -> None:
         self._script_factory = script_factory or self._default_script
         self._truncate_on_interrupt = truncate_on_interrupt
         self._can_use_tool = can_use_tool
         self._emit_partial_boundaries = emit_partial_boundaries
+        self._disallowed_tools = tuple(disallowed_tools or ())
         # The shared policy gate (#561): a scripted request_approval block must
         # run the SAME route-resolution decision table the real MCP tool does, or
         # the fake tier omits the sole-route auto-bind / unknown-route refusal and
@@ -291,6 +293,13 @@ class FakeModelSession:
                 # untouched, so this is the only thing that sets the policy fields.
                 payload = block.input if isinstance(block.input, dict) else {}
                 process_approval_request(self._approval_gate, payload)
+            if block.name in self._disallowed_tools:
+                # Mirror ClaudeAgentOptions.disallowed_tools: the named tool is
+                # not usable. The ToolUseBlock is still delivered (the real SDK
+                # emits it), then the turn stops so the scripted result cannot
+                # execute the write (#2429).
+                self._halted = True
+                continue
             if self._can_use_tool is not None:
                 decision = await self._can_use_tool(
                     block.name, block.input, ToolPermissionContext()

--- a/runner/tests/test_disallowed_tools.py
+++ b/runner/tests/test_disallowed_tools.py
@@ -1,0 +1,155 @@
+"""CURIE_DISALLOWED_TOOLS is the deployed deny list for persistent writes (#2429).
+
+The knob is runner-local, not a BootEnv contract field. Unset preserves the
+historical empty SDK list. When set, the names are handed to
+ClaudeAgentOptions.disallowed_tools and the fake session refuses the same names
+so an attempted write cannot execute offline.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import anyio
+from claude_agent_sdk import AssistantMessage, ToolUseBlock, UserMessage
+from curie_runner.__main__ import build_runner
+from curie_runner.adapter import build_options
+from curie_runner.config import RunnerConfig
+from curie_runner.fake import FakeModelSession
+
+_BUDGET = '{"max_output_tokens_per_run": 10000, "max_usd_per_day": 1.0}'
+_BASE = {
+    "CURIE_PLUGIN_DIR": "/bundle",
+    "CURIE_SESSION_ID": "sess-deny",
+    "CURIE_SANDBOX_ID": "sbx-deny",
+    "CURIE_BUDGET": _BUDGET,
+}
+
+
+def test_disallowed_tools_unset_is_empty() -> None:
+    assert RunnerConfig.from_env(dict(_BASE)).disallowed_tools == ()
+
+
+def test_disallowed_tools_parses_comma_list_and_drops_blanks() -> None:
+    config = RunnerConfig.from_env(
+        {
+            **_BASE,
+            "CURIE_DISALLOWED_TOOLS": (
+                "mcp__curie-state__append, mcp__curie-state__set ,"
+                "mcp__curie-state__delete,Write,Edit,"
+            ),
+        }
+    )
+    assert config.disallowed_tools == (
+        "mcp__curie-state__append",
+        "mcp__curie-state__set",
+        "mcp__curie-state__delete",
+        "Write",
+        "Edit",
+    )
+
+
+def test_disallowed_tools_whitespace_only_is_empty() -> None:
+    config = RunnerConfig.from_env({**_BASE, "CURIE_DISALLOWED_TOOLS": "  , , "})
+    assert config.disallowed_tools == ()
+
+
+def test_build_options_carries_disallowed_tools() -> None:
+    denied = ["mcp__curie-state__append", "Write"]
+    options = build_options(
+        plugins=[],
+        model=None,
+        system_prompt=None,
+        max_turns=20,
+        max_budget_usd=1.0,
+        resume=None,
+        disallowed_tools=denied,
+    )
+    assert options.disallowed_tools == denied
+    empty = build_options(
+        plugins=[],
+        model=None,
+        system_prompt=None,
+        max_turns=20,
+        max_budget_usd=1.0,
+        resume=None,
+    )
+    assert empty.disallowed_tools == []
+
+
+def test_fake_session_refuses_a_disallowed_write_and_does_not_execute() -> None:
+    def script() -> list[object]:
+        return [
+            AssistantMessage(
+                content=[
+                    ToolUseBlock(
+                        id="append-1",
+                        name="mcp__curie-state__append",
+                        input={"namespace": "notes", "key": "log", "item": "x"},
+                    )
+                ],
+                model="fake-model",
+            ),
+            UserMessage(
+                content="appended",
+            ),
+        ]
+
+    session = FakeModelSession(
+        script_factory=script,
+        disallowed_tools=("mcp__curie-state__append", "Write"),
+    )
+
+    async def go() -> list[object]:
+        await session.query("append persistent state")
+        return [message async for message in session.receive_turn()]
+
+    messages = anyio.run(go)
+    assert len(messages) == 1
+    assert isinstance(messages[0], AssistantMessage)
+    block = messages[0].content[0]
+    assert isinstance(block, ToolUseBlock)
+    assert block.name == "mcp__curie-state__append"
+
+
+def test_fake_session_still_executes_tools_outside_the_deny_list() -> None:
+    session = FakeModelSession(
+        disallowed_tools=("mcp__curie-state__append", "Write"),
+    )
+
+    async def go() -> list[object]:
+        await session.query("hello")
+        return [message async for message in session.receive_turn()]
+
+    messages = anyio.run(go)
+    names = [
+        block.name
+        for message in messages
+        if isinstance(message, AssistantMessage)
+        for block in message.content
+        if isinstance(block, ToolUseBlock)
+    ]
+    assert names == ["Bash"]
+    assert any(isinstance(message, UserMessage) for message in messages)
+
+
+def test_build_runner_wires_disallowed_tools_onto_the_fake_session(
+    tmp_path: Path,
+) -> None:
+    plugin = tmp_path / ".claude-plugin"
+    plugin.mkdir(parents=True)
+    (plugin / "plugin.json").write_text(json.dumps({"name": "deny-writes"}))
+    config = RunnerConfig.from_env(
+        {
+            "CURIE_PLUGIN_DIR": str(tmp_path),
+            "CURIE_SESSION_ID": "s-deny",
+            "CURIE_SANDBOX_ID": "b-deny",
+            "CURIE_BUDGET": _BUDGET,
+            "CURIE_DISALLOWED_TOOLS": "mcp__curie-state__append,Write",
+        }
+    )
+    runner = build_runner(config, fake_model=True)
+    session = runner._factory()
+    assert isinstance(session, FakeModelSession)
+    assert session._disallowed_tools == ("mcp__curie-state__append", "Write")


### PR DESCRIPTION
## Summary

Add a runner-local `CURIE_DISALLOWED_TOOLS` extraEnv so a soak (or any isolated install) can refuse persistent-write tools at the SDK session boundary. Prompt wording is not the enforcement. Unset keeps today's empty deny list.

The matching soak-harness work is local-only (no remote): cheap `--kind delivery` canary, bounded diagnostics, write-attempt control, distinct ledger outcomes, and a pinned doctor context. Live soak cadence, credentials, and policy are unchanged; the deny-writes overlay is an operator handoff.

## Related issue

Ref #2429

## Fix pin verification

Fix pin: runner/tests/test_disallowed_tools.py::test_fake_session_refuses_a_disallowed_write_and_does_not_execute

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | required | Runner turn-loop session options and fake-session deny path | fake | `uv run pytest -q runner/tests/test_disallowed_tools.py` on `98cf3e1c` — 7 passed. Positive: scripted `mcp__curie-state__append` is delivered then halted with no write result. Negative: unset env is an empty deny list; `Bash` still executes when not named. |
| local | required | Same runner env parse is what compose-local sandboxes boot | fake | `uv run pytest -q runner/tests/test_disallowed_tools.py runner/tests/test_session.py runner/tests/test_fake_tool_result.py runner/tests/test_harness_boot_wiring.py runner/tests/test_config.py runner/tests/test_config_boot_env.py runner/tests/test_server.py runner/tests/test_approval.py -k 'not live'` on `98cf3e1c` — 220 passed, 2 deselected. |
| local-release | n/a | Does not change released binary identity, install path, version pins, or generated release compose | | |
| cluster | n/a | Does not change chart templates, RBAC, sandbox claims, or init containers. Soak overlay is harness-side `agentSandbox.runner.extraEnv` | | |
| live provider | n/a | Does not reach MCP catalog projection, unscoped PreToolUse, in-process platform MCP tool implementation, workspace publication, or coding-tool session capability. Default unset preserves current tool availability | | |
| external integration | n/a | Does not change Slack, git webhooks, connector OAuth, or third-party API shape | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Harness (local commit `60db131` on `task/2429-bounded-canary-readonly`, not in this PR): `uv run pytest -q` — 153 passed, including doctor wrong-target refusal, delivery token match/mismatch, failed send as transport-only, and expected write-refusal classification.

Shipped: this PR once merged. Deployed: not applied to the permanent soak. Live-observed: not claimed.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision.