### PR TITLE
Steal a force-killed worker's per-thread lock on reclaim

### DIFF
--- a/apps/worker/src/curie_worker/config.py
+++ b/apps/worker/src/curie_worker/config.py
@@ -603,7 +603,8 @@ class WorkerConfig(BaseSettings):
     # SandboxSubstrate._claim_fresh) so the lock never lapses mid-section and lets
     # a second worker open a concurrent turn. 90s claim + slack/route overhead
     # stays safely under this 120s TTL; if you raise claim_timeout keep it below
-    # this.
+    # this. A force-killed holder cannot renew (#2500); replacement steal uses
+    # the consumer alive lease rather than waiting this TTL out.
     lock_ttl_ms: int = 120000
     lock_acquire_timeout_s: float = 45.0
     lock_poll_interval_s: float = 0.02

--- a/apps/worker/src/curie_worker/consumer_liveness.py
+++ b/apps/worker/src/curie_worker/consumer_liveness.py
@@ -33,6 +33,26 @@ def consumer_reclaim_lock_key(stream: str, group: str, consumer: str) -> str:
     return f"{stream}:consumer-reclaim-lock:{group}:{consumer}"
 
 
+class ThreadLockOwnerLiveness:
+    """Runs-group heartbeat adapter for :class:`~curie_worker.threadlock.ThreadLock`.
+
+    The kernel's per-thread lock is process-wide. Stamping it with the runs
+    consumer name and checking that consumer's alive lease is enough: eval
+    and runs share a process, so a crash drops both heartbeats together.
+    """
+
+    def __init__(self, store: ConsumerLivenessStore, *, stream: str, group: str) -> None:
+        self._store = store
+        self._stream = stream
+        self._group = group
+
+    async def is_alive(self, owner: str) -> bool:
+        return await self._store.is_alive(stream=self._stream, group=self._group, consumer=owner)
+
+    async def is_capable(self, owner: str) -> bool:
+        return await self._store.is_capable(stream=self._stream, group=self._group, consumer=owner)
+
+
 class ConsumerLivenessStore:
     """The narrow Redis string-key surface used by consumer liveness.
 

--- a/apps/worker/src/curie_worker/run.py
+++ b/apps/worker/src/curie_worker/run.py
@@ -34,6 +34,7 @@ from .bundle_store import BundleStore
 from .config import WorkerConfig
 from .connector_loop import ConnectorReconcileLoop, HttpManifestSource
 from .consumer import Consumer
+from .consumer_liveness import ConsumerLivenessStore, ThreadLockOwnerLiveness
 from .dead_letter_alert import install_dead_letter_alerting
 from .delivery_lease import DeliveryLeaseStore
 from .eval import EvalReporter, EvalStreamConsumer, LangfuseEvalRecorder
@@ -377,6 +378,13 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
             ttl_ms=config.lock_ttl_ms,
             acquire_timeout_s=config.lock_acquire_timeout_s,
             poll_interval_s=config.lock_poll_interval_s,
+            owner=config.consumer_name,
+            owner_liveness=ThreadLockOwnerLiveness(
+                ConsumerLivenessStore(async_redis),
+                stream=config.stream,
+                group=config.consumer_group,
+            ),
+            dead_owner_proof_s=config.consumer_heartbeat_ttl_ms / 1000.0,
         ),
         markers=Markers(async_redis, config),
         config=config,

--- a/apps/worker/src/curie_worker/threadlock.py
+++ b/apps/worker/src/curie_worker/threadlock.py
@@ -9,6 +9,14 @@ that expired and was re-taken by another worker is never released by us).
 
 The lock is held only for the bounded critical section (decision + turn start),
 never for the whole stream, so a follow-up can steer the live turn.
+
+A force-killed holder cannot release or renew (#2500). Tokens are
+``{consumer}{RS}{boot}{RS}{nonce}`` so a replacement can CAS-steal when that
+consumer's alive lease is gone, or when the same consumer name is back with a
+new boot id (replicas:1 kubelet restart). Opaque legacy values are never
+stolen: they stay on TTL, matching #849's foreign-holder timeout. Live capable
+owners still serialize. The TTL itself is unchanged and still outlives a live
+cold claim.
 """
 
 from __future__ import annotations
@@ -18,10 +26,14 @@ import time
 import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
+from typing import Protocol
 
 from curie_telemetry import operation_span, record_metric
 from opentelemetry.trace import SpanKind, StatusCode
 from redis.asyncio import Redis
+
+# ASCII RS: consumer names are hostname-pid and do not contain this.
+_OWNER_SEP = "\x1e"
 
 # Release only if we still own the lock (token match); avoids deleting a lock a
 # later holder acquired after ours expired.
@@ -40,6 +52,40 @@ else
     return 0
 end
 """
+
+_STEAL_LUA = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    redis.call('set', KEYS[1], ARGV[2], 'PX', ARGV[3])
+    return 1
+else
+    return 0
+end
+"""
+
+
+class OwnerLiveness(Protocol):
+    """Consumer heartbeat view used to steal a crashed owner's lock (#2500)."""
+
+    async def is_alive(self, owner: str) -> bool: ...
+
+    async def is_capable(self, owner: str) -> bool: ...
+
+
+def _lock_token(owner: str | None, boot_id: str | None) -> str:
+    nonce = uuid.uuid4().hex
+    if owner and boot_id:
+        return f"{owner}{_OWNER_SEP}{boot_id}{_OWNER_SEP}{nonce}"
+    return nonce
+
+
+def _parse_lock_parts(value: str) -> tuple[str, str] | None:
+    owner, sep, rest = value.partition(_OWNER_SEP)
+    if not sep or not owner or not rest:
+        return None
+    boot_id, sep, nonce = rest.partition(_OWNER_SEP)
+    if not sep or not boot_id or not nonce:
+        return None
+    return owner, boot_id
 
 
 class LockAcquireTimeout(TimeoutError):
@@ -98,41 +144,111 @@ class ThreadLock:
         ttl_ms: int,
         acquire_timeout_s: float,
         poll_interval_s: float,
+        owner: str | None = None,
+        owner_liveness: OwnerLiveness | None = None,
+        dead_owner_proof_s: float = 0.0,
     ) -> None:
         self._redis = redis
         self._ttl_ms = ttl_ms
         self._acquire_timeout_s = acquire_timeout_s
         self._poll_interval_s = poll_interval_s
+        self._owner = owner
+        self._boot_id = uuid.uuid4().hex
+        self._owner_liveness = owner_liveness
+        self._dead_owner_proof_s = dead_owner_proof_s
+        # Tokens this process currently holds or is trying to acquire. Register
+        # before SET NX so a sibling task on the same instance cannot treat a
+        # just-won token as a prior-incarnation leftover (#2500 replicas:1).
+        self._held_tokens: set[str] = set()
+
+    async def _cas_steal(self, key: str, held: str, token: str) -> bool:
+        stolen = await self._redis.eval(_STEAL_LUA, 1, key, held, token, self._ttl_ms)
+        return bool(stolen)
+
+    async def _try_steal(self, key: str, token: str, deadline: float) -> bool:
+        """CAS-steal a crashed owner's lock, or a same-name leftover we do not hold."""
+
+        held = await self._redis.get(key)
+        if not isinstance(held, str):
+            return False
+        if held in self._held_tokens:
+            return False
+        parts = _parse_lock_parts(held)
+        if parts is None:
+            return False
+        owner, boot_id = parts
+        if self._owner and owner == self._owner:
+            if boot_id == self._boot_id:
+                return False
+            return await self._cas_steal(key, held, token)
+        if self._owner_liveness is None:
+            return False
+        try:
+            capable = await self._owner_liveness.is_capable(owner)
+            alive = await self._owner_liveness.is_alive(owner)
+        except Exception:
+            return False
+        if not capable or alive:
+            return False
+        proof = self._dead_owner_proof_s
+        if proof > 0:
+            remaining = deadline - time.monotonic()
+            if remaining <= proof:
+                return False
+            await asyncio.sleep(proof)
+            if time.monotonic() >= deadline:
+                return False
+            held_again = await self._redis.get(key)
+            if held_again != held:
+                return False
+            try:
+                if await self._owner_liveness.is_alive(owner):
+                    return False
+                if not await self._owner_liveness.is_capable(owner):
+                    return False
+            except Exception:
+                return False
+        return await self._cas_steal(key, held, token)
 
     async def acquire(self, key: str) -> str:
         """Block until the lock is held (returns the owner token) or time out."""
-        token = uuid.uuid4().hex
+        token = _lock_token(self._owner, self._boot_id)
+        self._held_tokens.add(token)
         deadline = time.monotonic() + self._acquire_timeout_s
         started = time.monotonic()
         contended = False
         error: LockAcquireTimeout | None = None
         acquired = False
         outcome = "acquired"
-        with operation_span(
-            "curie.thread.lock",
-            kind=SpanKind.INTERNAL,
-            attributes={"service.name": "curie-worker", "source": "worker"},
-        ) as span:
-            while True:
-                if await self._redis.set(key, token, nx=True, px=self._ttl_ms):
-                    acquired = True
-                    outcome = "contended" if contended else "acquired"
-                    span.add_event("thread.lock.acquired", {"outcome": outcome})
-                    break
-                contended = True
-                if time.monotonic() >= deadline:
-                    outcome = "timeout"
-                    error = LockAcquireTimeout(key)
-                    if hasattr(span, "set_status"):
-                        span.set_status(StatusCode.ERROR)
-                    span.add_event("thread.lock.timeout", {"outcome": "timeout"})
-                    break
-                await asyncio.sleep(self._poll_interval_s)
+        try:
+            with operation_span(
+                "curie.thread.lock",
+                kind=SpanKind.INTERNAL,
+                attributes={"service.name": "curie-worker", "source": "worker"},
+            ) as span:
+                while True:
+                    if await self._redis.set(key, token, nx=True, px=self._ttl_ms):
+                        acquired = True
+                        outcome = "contended" if contended else "acquired"
+                        span.add_event("thread.lock.acquired", {"outcome": outcome})
+                        break
+                    contended = True
+                    if await self._try_steal(key, token, deadline):
+                        acquired = True
+                        outcome = "contended"
+                        span.add_event("thread.lock.stolen", {"outcome": "stolen"})
+                        break
+                    if time.monotonic() >= deadline:
+                        outcome = "timeout"
+                        error = LockAcquireTimeout(key)
+                        if hasattr(span, "set_status"):
+                            span.set_status(StatusCode.ERROR)
+                        span.add_event("thread.lock.timeout", {"outcome": "timeout"})
+                        break
+                    await asyncio.sleep(self._poll_interval_s)
+        finally:
+            if not acquired:
+                self._held_tokens.discard(token)
 
         record_metric(
             "curie.thread.lock.wait.duration",
@@ -149,7 +265,10 @@ class ThreadLock:
         return token
 
     async def release(self, key: str, token: str) -> None:
-        await self._redis.eval(_RELEASE_LUA, 1, key, token)
+        try:
+            await self._redis.eval(_RELEASE_LUA, 1, key, token)
+        finally:
+            self._held_tokens.discard(token)
 
     async def _renew(self, key: str, token: str) -> bool:
         renewed = await self._redis.eval(_RENEW_LUA, 1, key, token, self._ttl_ms)

--- a/apps/worker/tests/kernel/test_consumer.py
+++ b/apps/worker/tests/kernel/test_consumer.py
@@ -32,6 +32,7 @@ from curie_worker.consumer_liveness import (
 )
 from curie_worker.sandbox import QuotaRejection
 from curie_worker.stream_consumer import ConsumerLivenessExpired
+from curie_worker.threadlock import ThreadLock
 from curie_worker.workspace import WorkspacePreparationError
 from redis.asyncio import Redis as AsyncRedis
 
@@ -2111,3 +2112,215 @@ def test_maintenance_tick_thread_reset_claim_and_mark_is_atomic(make_harness) ->
             )
 
     asyncio.run(go())
+
+
+class _LockOwnerLiveness:
+    """Runs-stream adapter so ThreadLock steal uses the real consumer leases."""
+
+    def __init__(self, store: ConsumerLivenessStore, *, stream: str, group: str) -> None:
+        self._store = store
+        self._stream = stream
+        self._group = group
+
+    async def is_alive(self, owner: str) -> bool:
+        return await self._store.is_alive(
+            stream=self._stream, group=self._group, consumer=owner
+        )
+
+    async def is_capable(self, owner: str) -> bool:
+        return await self._store.is_capable(
+            stream=self._stream, group=self._group, consumer=owner
+        )
+
+
+def _wire_stealable_lock(h: Any, *, owner: str, proof_s: float) -> ThreadLock:
+    """Replace the harness lock with the production steal wiring (#2500)."""
+
+    lock = ThreadLock(
+        h.async_redis,
+        ttl_ms=h.config.lock_ttl_ms,
+        acquire_timeout_s=h.config.lock_acquire_timeout_s,
+        poll_interval_s=h.config.lock_poll_interval_s,
+        owner=owner,
+        owner_liveness=_LockOwnerLiveness(
+            ConsumerLivenessStore(h.async_redis),
+            stream=h.config.stream,
+            group=h.config.consumer_group,
+        ),
+        dead_owner_proof_s=proof_s,
+    )
+    h.kernel._lock = lock
+    return lock
+
+
+def test_force_killed_worker_lock_is_stolen_and_cluster_message_reply_is_delivered(
+    make_harness,
+) -> None:
+    """#2500: a SIGKILLed worker's per-thread lock must not delay PEL reclaim.
+
+    Cluster message enqueues a QueuedTurn (XADD) and waits for the worker
+    reply. The 2026-09-09 cluster reproduction force-killed replicas:1 mid
+    claim: PEL moved promptly, then the replacement logged LockAcquireTimeout
+    for ~90s and the CLI timed out before the recovered fakeModel reply.
+
+    This pin drives that path against real Valkey: the dead consumer owns the
+    PEL row and the thread lock (acquire without release, matching SIGKILL),
+    its heartbeat is gone, and the replacement must deliver the reply in much
+    less than the 60s lock TTL, then ACK so nothing stays pending under the
+    dead consumer.
+
+    Red on revert of steal: the replacement waits out acquire_timeout and the
+    sink never sees ``recovered`` inside the 2s bound.
+    """
+
+    async def go() -> None:
+        async with make_harness(
+            lock_ttl_ms=60_000,
+            lock_acquire_timeout_s=1.0,
+            max_attempts=1,
+            reclaim_min_idle_ms=5000,
+            dead_consumer_idle_ms=0,
+            consumer_heartbeat_ttl_ms=30,
+            consumer_capability_ttl_ms=6000,
+        ) as h:
+            h.runner.default_script = [Final(text="recovered", status=DONE)]
+            thread = "t-2500-crash"
+            dead_name = "dead-worker-2500"
+            _wire_stealable_lock(
+                h,
+                owner=h.config.consumer_name,
+                proof_s=h.config.consumer_heartbeat_ttl_ms / 1000,
+            )
+            dead_lock = ThreadLock(
+                h.async_redis,
+                ttl_ms=h.config.lock_ttl_ms,
+                acquire_timeout_s=h.config.lock_acquire_timeout_s,
+                poll_interval_s=h.config.lock_poll_interval_s,
+                owner=dead_name,
+            )
+            await dead_lock.acquire(h.config.lock_key(_thread_key(thread)))
+
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            qe = _qevent("crash-reclaim", thread=thread, event_id="e-2500-crash")
+            await h.async_redis.xadd(h.config.stream, to_stream_fields(qe))
+            claimed = await h.async_redis.xreadgroup(
+                h.config.consumer_group, dead_name, {h.config.stream: ">"}, count=1
+            )
+            assert claimed
+
+            store = ConsumerLivenessStore(h.async_redis)
+            await store.publish(
+                stream=h.config.stream,
+                group=h.config.consumer_group,
+                consumer=dead_name,
+                heartbeat_ttl_ms=1,
+                capability_ttl_ms=h.config.consumer_capability_ttl_ms,
+            )
+            alive_key = consumer_heartbeat_key(
+                h.config.stream, h.config.consumer_group, dead_name
+            )
+            await _wait_key(h.async_redis, alive_key, present=False)
+            await _wait_consumer_idle(
+                h.async_redis,
+                h.config.stream,
+                h.config.consumer_group,
+                dead_name,
+                h.config.dead_consumer_idle_ms,
+            )
+            summary = await h.async_redis.xpending(h.config.stream, h.config.consumer_group)
+            assert summary["pending"] == 1
+
+            assert await consumer._prompt_reclaim_once() == 0
+            await asyncio.sleep(h.config.consumer_heartbeat_ttl_ms / 1000 + 0.015)
+            started = time.monotonic()
+            reclaimed = await consumer._prompt_reclaim_once()
+            assert reclaimed == 1
+            await _wait_until(lambda: h.sink.last_text == "recovered", timeout=2.0)
+            elapsed = time.monotonic() - started
+            await asyncio.gather(*list(consumer._inflight))
+
+            assert elapsed < 2.0, (
+                f"recovered reply took {elapsed:.3f}s; replacement still waited "
+                "out the dead worker lock TTL"
+            )
+            assert h.runner.opened == ["crash-reclaim"]
+            assert h.sink.last_text == "recovered"
+            summary = await h.async_redis.xpending(h.config.stream, h.config.consumer_group)
+            assert summary["pending"] == 0
+            owners = await h.async_redis.xpending_range(
+                h.config.stream, h.config.consumer_group, min="-", max="+", count=10
+            )
+            assert all(str(row["consumer"]) != dead_name for row in owners)
+            assert await h.async_redis.exists(h.config.done_key(qe.event_id))
+
+    asyncio.run(go())
+
+
+def test_live_worker_lock_still_serializes_a_replacement(make_harness) -> None:
+    """#2500 negative: a live owner's heartbeat blocks steal; the waiter fails.
+
+    Same QueuedTurn / PEL / lock path as the crash pin, except the lock holder
+    keeps its alive lease. The replacement must not run the turn.
+    """
+
+    async def go() -> None:
+        async with make_harness(
+            lock_ttl_ms=60_000,
+            lock_acquire_timeout_s=0.4,
+            max_attempts=1,
+            reclaim_min_idle_ms=5000,
+            dead_consumer_idle_ms=0,
+            consumer_heartbeat_ttl_ms=30,
+            consumer_capability_ttl_ms=6000,
+        ) as h:
+            h.runner.default_script = [Final(text="should-not-run", status=DONE)]
+            thread = "t-2500-live"
+            live_name = "live-worker-2500"
+            _wire_stealable_lock(
+                h,
+                owner=h.config.consumer_name,
+                proof_s=h.config.consumer_heartbeat_ttl_ms / 1000,
+            )
+            live_lock = ThreadLock(
+                h.async_redis,
+                ttl_ms=h.config.lock_ttl_ms,
+                acquire_timeout_s=h.config.lock_acquire_timeout_s,
+                poll_interval_s=h.config.lock_poll_interval_s,
+                owner=live_name,
+            )
+            live_token = await live_lock.acquire(h.config.lock_key(_thread_key(thread)))
+
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            qe = _qevent("live-hold", thread=thread, event_id="e-2500-live")
+            await h.async_redis.xadd(h.config.stream, to_stream_fields(qe))
+            claimed = await h.async_redis.xreadgroup(
+                h.config.consumer_group, live_name, {h.config.stream: ">"}, count=1
+            )
+            assert claimed
+            store = ConsumerLivenessStore(h.async_redis)
+            await store.publish(
+                stream=h.config.stream,
+                group=h.config.consumer_group,
+                consumer=live_name,
+                heartbeat_ttl_ms=5_000,
+                capability_ttl_ms=h.config.consumer_capability_ttl_ms,
+            )
+            await h.async_redis.xclaim(
+                h.config.stream,
+                h.config.consumer_group,
+                h.config.consumer_name,
+                0,
+                [claimed[0][1][0][0]],
+            )
+            await consumer._dispatch(str(claimed[0][1][0][0]), dict(claimed[0][1][0][1]))
+            await asyncio.gather(*list(consumer._inflight))
+
+            assert h.runner.opened == []
+            assert h.sink.last_text != "should-not-run"
+            assert await h.async_redis.get(h.config.lock_key(_thread_key(thread))) == live_token
+            await live_lock.release(h.config.lock_key(_thread_key(thread)), live_token)
+
+    asyncio.run(go())
+

--- a/apps/worker/tests/kernel/test_threadlock.py
+++ b/apps/worker/tests/kernel/test_threadlock.py
@@ -1,0 +1,264 @@
+"""Per-thread lock steal from a dead owner (#2500).
+
+Against real Valkey, never a mock. A force-killed worker leaves ``SET NX PX``
+held until TTL; the replacement must CAS-steal once the named owner's consumer
+heartbeat is gone, and must not steal from a live owner or an opaque legacy
+value (#849).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+import uuid
+from collections.abc import AsyncIterator
+
+import pytest
+from curie_test_support.valkey import (
+    VALKEY_HOST as _VALKEY_HOST,
+)
+from curie_test_support.valkey import (
+    VALKEY_PORT as _VALKEY_PORT,
+)
+from curie_test_support.valkey import (
+    VALKEY_PW as _VALKEY_PW,
+)
+from curie_worker.consumer_liveness import ConsumerLivenessStore
+from curie_worker.threadlock import LockAcquireTimeout, ThreadLock
+from redis.asyncio import Redis as AsyncRedis
+
+_TTL_MS = 60_000
+_ACQUIRE_S = 0.4
+_POLL_S = 0.02
+_PROOF_S = 0.05
+
+
+class _OwnerLiveness:
+    """Adapter matching ThreadLock's owner-liveness protocol on real Valkey."""
+
+    def __init__(self, store: ConsumerLivenessStore, *, stream: str, group: str) -> None:
+        self._store = store
+        self._stream = stream
+        self._group = group
+
+    async def is_alive(self, owner: str) -> bool:
+        return await self._store.is_alive(stream=self._stream, group=self._group, consumer=owner)
+
+    async def is_capable(self, owner: str) -> bool:
+        return await self._store.is_capable(stream=self._stream, group=self._group, consumer=owner)
+
+
+@contextlib.asynccontextmanager
+async def _client() -> AsyncIterator[AsyncRedis]:
+    redis: AsyncRedis = AsyncRedis(
+        host=_VALKEY_HOST,
+        port=_VALKEY_PORT,
+        password=_VALKEY_PW or None,
+        decode_responses=True,
+    )
+    try:
+        yield redis
+    finally:
+        with contextlib.suppress(Exception):
+            await redis.aclose()
+
+
+def _lock(
+    redis: AsyncRedis,
+    *,
+    owner: str,
+    liveness: _OwnerLiveness | None,
+    acquire_s: float = _ACQUIRE_S,
+    ttl_ms: int = _TTL_MS,
+    proof_s: float = _PROOF_S,
+) -> ThreadLock:
+    return ThreadLock(
+        redis,
+        ttl_ms=ttl_ms,
+        acquire_timeout_s=acquire_s,
+        poll_interval_s=_POLL_S,
+        owner=owner,
+        owner_liveness=liveness,
+        dead_owner_proof_s=proof_s,
+    )
+
+
+async def _expire_alive(
+    redis: AsyncRedis, store: ConsumerLivenessStore, *, stream: str, group: str, owner: str
+) -> None:
+    await store.publish(
+        stream=stream,
+        group=group,
+        consumer=owner,
+        heartbeat_ttl_ms=1,
+        capability_ttl_ms=5_000,
+    )
+    key = f"{stream}:consumer-heartbeat:{group}:{owner}"
+    deadline = time.monotonic() + 2.0
+    while await redis.exists(key):
+        if time.monotonic() > deadline:
+            raise AssertionError(f"alive lease for {owner} never expired")
+        await asyncio.sleep(0.005)
+
+
+def test_dead_capable_owner_lock_is_stolen_without_waiting_ttl(names: dict[str, str]) -> None:
+    """#2500 positive: replacement acquires a crashed owner's lock in << TTL."""
+
+    async def go() -> None:
+        async with _client() as redis:
+            key = f"{names['prefix']}:lock:slack:C0LOCALDEV:2500-dead"
+            stream, group = names["stream"], names["group"]
+            store = ConsumerLivenessStore(redis)
+            liveness = _OwnerLiveness(store, stream=stream, group=group)
+            dead = _lock(redis, owner="dead-pod", liveness=None)
+            await dead.acquire(key)
+            await _expire_alive(redis, store, stream=stream, group=group, owner="dead-pod")
+
+            replacement = _lock(redis, owner="replacement-pod", liveness=liveness)
+            started = time.monotonic()
+            token = await replacement.acquire(key)
+            elapsed = time.monotonic() - started
+            assert elapsed < 2.0, (
+                f"replacement waited {elapsed:.3f}s for a dead owner's lock; "
+                "steal did not happen and the TTL is still the recovery path"
+            )
+            assert elapsed < (_TTL_MS / 1000) / 10
+            held = await redis.get(key)
+            assert held == token
+            assert str(held).startswith("replacement-pod")
+            await replacement.release(key, token)
+
+    asyncio.run(go())
+
+
+def test_live_capable_owner_lock_is_not_stolen(names: dict[str, str]) -> None:
+    """#2500 negative: a live worker's lock still serializes."""
+
+    async def go() -> None:
+        async with _client() as redis:
+            key = f"{names['prefix']}:lock:slack:C0LOCALDEV:2500-live"
+            stream, group = names["stream"], names["group"]
+            store = ConsumerLivenessStore(redis)
+            liveness = _OwnerLiveness(store, stream=stream, group=group)
+            await store.publish(
+                stream=stream,
+                group=group,
+                consumer="live-pod",
+                heartbeat_ttl_ms=5_000,
+                capability_ttl_ms=5_000,
+            )
+            live = _lock(redis, owner="live-pod", liveness=None)
+            live_token = await live.acquire(key)
+
+            waiter = _lock(redis, owner="replacement-pod", liveness=liveness, acquire_s=0.35)
+            with pytest.raises(LockAcquireTimeout):
+                await waiter.acquire(key)
+            assert await redis.get(key) == live_token
+            await live.release(key, live_token)
+
+    asyncio.run(go())
+
+
+def test_opaque_legacy_lock_value_is_not_stolen(names: dict[str, str]) -> None:
+    """#849 sibling: UUID-only / opaque values stay on TTL, never guessed dead."""
+
+    async def go() -> None:
+        async with _client() as redis:
+            key = f"{names['prefix']}:lock:slack:C0LOCALDEV:2500-opaque"
+            stream, group = names["stream"], names["group"]
+            store = ConsumerLivenessStore(redis)
+            liveness = _OwnerLiveness(store, stream=stream, group=group)
+            assert await redis.set(key, "another-worker", nx=True, px=_TTL_MS)
+            waiter = _lock(redis, owner="replacement-pod", liveness=liveness, acquire_s=0.35)
+            with pytest.raises(LockAcquireTimeout):
+                await waiter.acquire(key)
+            assert await redis.get(key) == "another-worker"
+
+    asyncio.run(go())
+
+
+def test_uuid_hex_production_token_is_not_stolen(names: dict[str, str]) -> None:
+    """Mixed-version: today's uuid.hex tokens have no owner separator."""
+
+    async def go() -> None:
+        async with _client() as redis:
+            key = f"{names['prefix']}:lock:slack:C0LOCALDEV:2500-uuid"
+            stream, group = names["stream"], names["group"]
+            store = ConsumerLivenessStore(redis)
+            liveness = _OwnerLiveness(store, stream=stream, group=group)
+            legacy = uuid.uuid4().hex
+            assert await redis.set(key, legacy, nx=True, px=_TTL_MS)
+            waiter = _lock(redis, owner="replacement-pod", liveness=liveness, acquire_s=0.35)
+            with pytest.raises(LockAcquireTimeout):
+                await waiter.acquire(key)
+            assert await redis.get(key) == legacy
+
+    asyncio.run(go())
+
+
+def test_same_name_leftover_is_stolen_while_replacement_heartbeat_is_live(
+    names: dict[str, str],
+) -> None:
+    """#2500 replicas:1 kubelet restart: hostname-pid is unchanged, heartbeat is already up."""
+
+    async def go() -> None:
+        async with _client() as redis:
+            key = f"{names['prefix']}:lock:slack:C0LOCALDEV:2500-same"
+            stream, group = names["stream"], names["group"]
+            store = ConsumerLivenessStore(redis)
+            liveness = _OwnerLiveness(store, stream=stream, group=group)
+            crashed = _lock(redis, owner="stable-pod", liveness=None)
+            await crashed.acquire(key)
+            await store.publish(
+                stream=stream,
+                group=group,
+                consumer="stable-pod",
+                heartbeat_ttl_ms=5_000,
+                capability_ttl_ms=5_000,
+            )
+            replacement = _lock(redis, owner="stable-pod", liveness=liveness)
+            started = time.monotonic()
+            token = await replacement.acquire(key)
+            elapsed = time.monotonic() - started
+            assert elapsed < 2.0, (
+                f"same-name leftover waited {elapsed:.3f}s; hold-set steal did not fire"
+            )
+            assert str(await redis.get(key)) == token
+            await replacement.release(key, token)
+
+    asyncio.run(go())
+
+
+def test_same_instance_sibling_task_does_not_steal_a_live_hold(names: dict[str, str]) -> None:
+    """release_thread / reap vs claim: two tasks, one ThreadLock, must still serialize."""
+
+    async def go() -> None:
+        async with _client() as redis:
+            key = f"{names['prefix']}:lock:slack:C0LOCALDEV:2500-sibling"
+            stream, group = names["stream"], names["group"]
+            store = ConsumerLivenessStore(redis)
+            liveness = _OwnerLiveness(store, stream=stream, group=group)
+            await store.publish(
+                stream=stream,
+                group=group,
+                consumer="same-pod",
+                heartbeat_ttl_ms=5_000,
+                capability_ttl_ms=5_000,
+            )
+            lock = _lock(redis, owner="same-pod", liveness=liveness, acquire_s=0.4)
+            first = await lock.acquire(key)
+
+            async def waiter() -> str:
+                return await lock.acquire(key)
+
+            waiting = asyncio.create_task(waiter())
+            await asyncio.sleep(0.25)
+            assert not waiting.done(), "sibling task stole a live same-instance hold"
+            assert await redis.get(key) == first
+            waiting.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await waiting
+            await lock.release(key, first)
+
+    asyncio.run(go())


### PR DESCRIPTION
## Summary

A force-killed worker leaves its per-thread Valkey lock until TTL, so the replacement logs `LockAcquireTimeout` and `curie cluster message` can time out before the recovered reply. Tokens are now `{consumer}{RS}{boot}{RS}{nonce}`. A replacement CAS-steals when the named owner is a capable consumer whose alive lease has been absent for one heartbeat TTL, or when the same consumer name is back with a new boot id (replicas:1 kubelet restart). Live holders still serialize. Opaque legacy values, including today's `uuid.hex` tokens, are not stolen. `lock_ttl_ms` stays 120000 so a live cold claim cannot lapse.

## Related issue

Closes #2500
Ref #1573

#1573 remains open. This does not change `reclaim_min_idle_ms` and does not claim the 900s PEL face is closed. Closed #1532 already covered dead-consumer PEL stranding; closed #849 already made `LockAcquireTimeout` retryable.

## Fix pin verification

Fix pin: apps/worker/tests/kernel/test_consumer.py::test_force_killed_worker_lock_is_stolen_and_cluster_message_reply_is_delivered

`curie dev verify-fix-pin HEAD apps/worker/tests/kernel/test_consumer.py::test_force_killed_worker_lock_is_stolen_and_cluster_message_reply_is_delivered` printed `PINNED` on b783ef423. Reversed product files fail that node with `TypeError: ThreadLock.__init__() got an unexpected keyword argument 'owner'`.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin, skill packaging, runner turn-loop, or ACI change | | |
| local | required | Worker Valkey lock/PEL and QueuedTurn enqueue used by cluster/local message | fake | `TEST_VALKEY_PORT=36479 uv run pytest apps/worker/tests/kernel/test_threadlock.py apps/worker/tests/kernel/test_consumer.py::test_force_killed_worker_lock_is_stolen_and_cluster_message_reply_is_delivered apps/worker/tests/kernel/test_consumer.py::test_live_worker_lock_still_serializes_a_replacement` on b783ef423. 8 passed in 1.96s. Recovered sink text `recovered` and `done_key` present in under 2s against a 60s lock TTL. |
| local-release | n/a | No released binary, image identity, install path, or compose pin | | |
| cluster | required | AC is that cluster message still receives the recovered reply after a force-killed worker; found on cluster. The operator enqueue is QueuedTurn XADD onto the runs stream, the same path the local pin drives through the real worker and Valkey. | fake | Same command as local on b783ef423. PEL pending 0 after recover; no row left under `dead-worker-2500`. A live helm force-kill was not repeated on the shared k8scratch soak. |
| live provider | n/a | fakeModel is sufficient; no model routing, credentials, or MCP/workspace/coding-tool path | | |
| external integration | n/a | CLI message stub, not Slack, git webhooks, or connector OAuth | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive: dead owner lock stolen, reply `recovered` delivered, PEL pending 0.
Negative: live owner heartbeat present, replacement does not start the turn (`runner.opened == []`), lock token unchanged. Opaque `another-worker` and `uuid.hex` still raise `LockAcquireTimeout`. Same-instance sibling task does not steal a live hold.

## Checklist

- [x] Tests pass for the area I touched
- [x] Docs updated if behavior changed (config/threadlock comments)
- [x] No ADR. No frozen-interface, schema, or `packages/aci-protocol` / `packages/plugin-format` change.
