### PR TITLE
Declare the v0.8.7 rollback schema window

### DIFF
--- a/cli/src/application_schema_windows.json
+++ b/cli/src/application_schema_windows.json
@@ -68,6 +68,10 @@
     "0.8.6": {
       "schema_min": "0001",
       "schema_head": "0039"
+    },
+    "0.8.7": {
+      "schema_min": "0001",
+      "schema_head": "0039"
     }
   }
 }

--- a/cli/tests/cluster_rollback_schema.rs
+++ b/cli/tests/cluster_rollback_schema.rs
@@ -14,6 +14,18 @@ use curie::ops::{
     parse_helm_history, rollback, select_rollback_revision, ClusterRollbackOutput, CommonOpts,
     HelmRevision, RollbackOpts,
 };
+use curie::schema_window::{live_in_window, window_for};
+
+/// Release v0.8.7 carries the same Alembic head as v0.8.6. Pin both the
+/// accepted live head and the fail-closed boundary for an unknown successor.
+#[test]
+fn v087_accepts_0039_and_refuses_an_unknown_newer_revision() {
+    let window = window_for("0.8.7").expect("0.8.7 is catalogued");
+    assert_eq!(window.schema_min, "0001");
+    assert_eq!(window.schema_head, "0039");
+    assert!(live_in_window("0039", &window));
+    assert!(!live_in_window("0040", &window));
+}
 
 fn write_exec(dir: &Path, name: &str, body: &str) {
     let path = dir.join(name);


### PR DESCRIPTION
## Summary

Declare v0.8.7's rollback schema window at the unchanged Alembic range `0001..0039`, and pin both the accepted head and fail-closed unknown-successor boundary. This unblocks the separate five-file v0.8.7 release preparation without mixing the fix into that candidate.

## Related issue

Closes #2506

## Fix pin verification

Fix pin: cli/tests/cluster_rollback_schema.rs::v087_accepts_0039_and_refuses_an_unknown_newer_revision

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | The change does not reach plugin or skill packaging, the runner turn loop, ACI events, or skill eval/check. | n/a | n/a |
| local | required | The versioned catalog changes the `curie cluster rollback` result and refusal exit path for a v0.8.7 target. | fake | At `924000471a2e8469bd449fd130792869ce737374`, source-built `cargo run --locked --quiet -- --json cluster rollback --namespace agent-ns --release prod-release --yes` returned `rolled_back: true`, revision 2 to 1, for live schema `0039`; the same command with live `0040` exited 1 with an actionable v0.8.7/head-0039 refusal and did not invoke `helm rollback`. |
| local-release | n/a | This fix does not change a released binary or image identity, install path, Cargo/Chart release version, or release Compose; those remain isolated to the replacement release-prep PR. | n/a | n/a |
| cluster | n/a | The change does not reach chart templates, RBAC, security contexts, NetworkPolicy, sandbox claims, or init containers; the pre-mutation CLI consumer is exercised through deterministic Helm and kubectl fixtures. | n/a | n/a |
| live provider | n/a | The change does not reach model routing, provider credentials/auth, tokens, costs, MCP, workspace publication, or coding-tool capability. | n/a | n/a |
| external integration | n/a | The change does not reach Slack, webhooks, connector OAuth, or any third-party API shape. | n/a | n/a |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Verification

- `curie dev verify-fix-pin 924000471a2e8469bd449fd130792869ce737374 cli/tests/cluster_rollback_schema.rs::v087_accepts_0039_and_refuses_an_unknown_newer_revision` - `PINNED`; the selected test passes on the fix and fails on its parent because v0.8.7 is absent.
- `cd cli && cargo fmt --check` - passed.
- `cd cli && cargo clippy --locked --all-targets -- -D warnings` - passed.
- `cd cli && CI_REQUIRE_VALKEY_TESTS=1 TEST_VALKEY_URL=<isolated endpoint> KUBECONFIG=/dev/null cargo test --locked` - passed with exit 0, including 1,192 library tests, 64 binary tests, all 52 chart assertions through `chart_check`, the Valkey-backed integration tests, and all remaining Rust integration/doc tests. The isolated Valkey container was removed afterward.
- `git diff --check` - passed.
- `scripts/check-commit-messages.sh origin/main..HEAD` - passed.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed. No prose change is needed; the release-specific catalog and regression test are the complete contract update.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. No new architectural decision is introduced.
