### PR TITLE
Spell Langfuse Postgres TLS as Prisma sslmode=require

### DIFF
--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -547,15 +547,17 @@ A BYO Postgres that enforces TLS (RDS with `rds.force_ssl=1`, Cloud SQL, Neon)
 also needs `postgres.sslMode: require` alongside `postgres.deploy: false` and
 `postgres.host`. One helper (`curie.postgres.dsnParams`) renders the per-driver
 suffix onto every DSN: `?ssl=require` for the api and worker (SQLAlchemy +
-asyncpg) and `?sslmode=no-verify` for both Langfuse Deployments (Prisma). The
+asyncpg) and `?sslmode=require&sslaccept=accept_invalid_certs` for both Langfuse
+Deployments (Prisma). Prisma accepts only `disable|prefer|require` for
+`sslmode`; `no-verify` is not in that set and is treated as `prefer`. The
 api migrate init container lifts `ssl=` out of the DSN into the asyncpg connect
 kwarg, because asyncpg's DSN parser would otherwise forward `ssl` as a server
 setting and the API would never leave init. `postgres.sslMode: require` against
 the in-chart Postgres fails the render: that StatefulSet serves no TLS
-listener. Neither suffix verifies the server certificate, so Langfuse traffic
-is encrypted but not authenticated; a `verify-full` mode needs a mounted CA
-bundle and is a second step. Leave `sslMode` empty (the default) for the
-in-cluster store: the rendered DSNs stay suffix-free.
+listener. Neither suffix verifies the server certificate, so api, worker, and
+Langfuse traffic is encrypted but not authenticated; a `verify-full` mode needs
+a mounted CA bundle and is a second step. Leave `sslMode` empty (the default)
+for the in-cluster store: the rendered DSNs stay suffix-free.
 
 Flipping `postgres.deploy` to `false` removes the in-cluster StatefulSet and
 Service. Helm does not delete a StatefulSet PVC, so if

--- a/charts/curie/ci/postgres-ssl-mode-assertions.sh
+++ b/charts/curie/ci/postgres-ssl-mode-assertions.sh
@@ -13,7 +13,12 @@
 # operator cannot fix this from postgres.auth.database:
 #
 #   api, worker (SQLAlchemy + asyncpg)  ->  ?ssl=require
-#   Langfuse web + worker (Prisma)      ->  ?sslmode=no-verify
+#   Langfuse web + worker (Prisma)      ->  ?sslmode=require&sslaccept=accept_invalid_certs
+#
+# Prisma/quaint accepts only disable|prefer|require for sslmode. #2476 rendered
+# ?sslmode=no-verify, which Prisma logs at debug and treats as prefer, so the
+# Langfuse half did not enforce TLS (#2507). sslaccept=accept_invalid_certs is
+# the no-CA posture; verify-full still needs a mounted CA (#2508).
 #
 # One more consumer: the api migrate init container calls asyncpg.connect() on
 # the DSN directly. asyncpg's DSN parser knows sslmode, not ssl, so an ssl=
@@ -34,8 +39,9 @@
 #      query parameter. This is what makes assertion 3 non-vacuous: without
 #      it, a template that emitted the suffix unconditionally would pass.
 #   3. byo-require (deploy=false + host + sslMode=require): api/worker/migrate
-#      DSNs end in ?ssl=require; both Langfuse DSNs end in ?sslmode=no-verify.
-#      Host still resolves to the BYO host in the SAME render.
+#      DSNs end in ?ssl=require; both Langfuse DSNs end in
+#      ?sslmode=require&sslaccept=accept_invalid_certs. Host still resolves to
+#      the BYO host in the SAME render.
 #   4. NEGATIVE CONTROL -- the in-chart guard: helm template
 #      --set postgres.sslMode=require with postgres.deploy left true exits
 #      non-zero and stderr names BOTH postgres.sslMode and postgres.deploy.
@@ -50,6 +56,11 @@
 #   7. The same extracted probe runs against a closed port with the installed
 #      asyncpg driver (no fake), so a scheme or ssl-kwarg rejection cannot hide
 #      behind the argument stub.
+#   8. Prisma sslmode set: every rendered Langfuse DATABASE_URL's sslmode, if
+#      present, is one of disable|prefer|require. A synthetic no-verify (the
+#      #2476 spelling) and verify-full each fail that check, so a later
+#      helper that reintroduces a non-Prisma value cannot pass by updating
+#      assertion 3's expected string alone.
 #
 # Every render goes through --output-dir, never a stdout pipe: piping helm
 # template in this environment silently truncates a large render at exit 0
@@ -100,6 +111,7 @@ BYO_REQUIRE_DIR="$BYO_REQUIRE_DIR" BYO_HOST="$BYO_HOST" \
 python3 <<'PY'
 import os
 import sys
+from urllib.parse import parse_qs, urlparse
 
 import yaml
 
@@ -214,8 +226,60 @@ for label, containers, expected in consumers(BYO_REQUIRE_DIR, BYO_HOST):
     if label in {"api", "worker", "migrate"}:
         expected = expected + "?ssl=require"
     else:
-        expected = expected + "?sslmode=no-verify"
+        expected = expected + "?sslmode=require&sslaccept=accept_invalid_certs"
     check_url("3", containers, label, expected, "byo-require render")
+
+# Prisma/quaint sslmode values: https://www.prisma.io/docs/orm/overview/databases/postgresql
+# sslmode=(disable|prefer|require). Unknown values (no-verify, verify-full, ...)
+# are logged at debug and treated as prefer, so they cannot enforce TLS.
+PRISMA_SSLMODES = frozenset({"disable", "prefer", "require"})
+
+
+def prisma_sslmode_violations(url):
+    modes = parse_qs(urlparse(url).query).get("sslmode", [])
+    return [mode for mode in modes if mode not in PRISMA_SSLMODES]
+
+
+for ctx, templates_dir in (
+    ("default render", DEFAULT_DIR),
+    ("byo-plain render", BYO_PLAIN_DIR),
+    ("byo-require render", BYO_REQUIRE_DIR),
+):
+    for label, containers, _expected in consumers(templates_dir, "unused"):
+        if label not in {"langfuse-web", "langfuse-worker"}:
+            continue
+        actual = database_url(containers, f"{ctx}:{label}")
+        if actual is None:
+            continue
+        for mode in prisma_sslmode_violations(actual):
+            failures.append(
+                f"[8] {ctx}: {label} DATABASE_URL sslmode={mode!r} is outside "
+                f"Prisma's {sorted(PRISMA_SSLMODES)}"
+            )
+
+for synthetic, label in (
+    (
+        "postgresql://postgres:$(POSTGRES_PASSWORD)@pg.acme.internal:5432/postgres?sslmode=no-verify",
+        "no-verify",
+    ),
+    (
+        "postgresql://postgres:$(POSTGRES_PASSWORD)@pg.acme.internal:5432/postgres?sslmode=verify-full",
+        "verify-full",
+    ),
+):
+    found = prisma_sslmode_violations(synthetic)
+    if not found:
+        failures.append(
+            f"[8] prisma sslmode set check did not reject synthetic sslmode={label!r}"
+        )
+
+require_ok = prisma_sslmode_violations(
+    "postgresql://postgres:x@pg.acme.internal:5432/postgres?sslmode=require&sslaccept=accept_invalid_certs"
+)
+if require_ok:
+    failures.append(
+        f"[8] prisma sslmode set check rejected a valid require DSN: {require_ok!r}"
+    )
 
 if failures:
     for message in failures:
@@ -225,7 +289,8 @@ if failures:
 
 print("  [1] default: DATABASE_URL has no TLS query parameter on all five consumers: OK")
 print("  [2] byo-plain: still no TLS query parameter (require is not unconditional): OK")
-print("  [3] byo-require: ?ssl=require on asyncpg, ?sslmode=no-verify on Prisma: OK")
+print("  [3] byo-require: ?ssl=require on asyncpg, ?sslmode=require&sslaccept=accept_invalid_certs on Prisma: OK")
+print("  [8] Prisma sslmode is disable|prefer|require; synthetic no-verify and verify-full are rejected: OK")
 PY
 
 echo
@@ -494,7 +559,7 @@ PY
 
 echo
 echo "PASS: postgres.sslMode renders a TLS parameter on every Postgres DSN"
-echo "      (asyncpg ?ssl=require, Prisma ?sslmode=no-verify), the default and"
+echo "      (asyncpg ?ssl=require, Prisma ?sslmode=require&sslaccept=accept_invalid_certs), the default and"
 echo "      BYO-plain renders stay suffix-free, invalid values and require+"
 echo "      in-chart deploy are refused by name, and the migrate probe lifts"
 echo "      ssl='require' out of the DSN before asyncpg.connect, including"

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -162,11 +162,11 @@ ANTHROPIC_BASE_URL ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_AUTH_TOKE
 {{- end -}}
 {{- end -}}
 
-{{/* Per-driver TLS query suffix for a Postgres DSN (#2431). ONE helper,
+{{/* Per-driver TLS query suffix for a Postgres DSN (#2431, #2507). ONE helper,
      included from BOTH curie.env.postgres (SQLAlchemy/asyncpg: ?ssl=require)
-     and curie.langfuse.env (Prisma/node-postgres: ?sslmode=no-verify): the
-     two driver families disagree on the spelling, so an operator cannot put
-     a suffix in postgres.auth.database.
+     and curie.langfuse.env (Prisma: ?sslmode=require&sslaccept=accept_invalid_certs):
+     the two driver families disagree on the spelling, so an operator cannot
+     put a suffix in postgres.auth.database.
 
      Empty (the default, and a missing key on --reuse-values of a release
      created before this existed) renders nothing, so an existing in-cluster
@@ -179,7 +179,12 @@ ANTHROPIC_BASE_URL ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_AUTH_TOKE
      listener, so sslMode=require against it would break every consumer at
      once behind a healthy-looking manifest. Refuse at render, naming both
      keys. Neither rendered suffix verifies the server certificate; a
-     verify-full mode needs a mounted CA bundle and is a second step. */}}
+     verify-full mode needs a mounted CA bundle and is a second step (#2508).
+
+     Why not sslmode=no-verify for Prisma. Prisma/quaint accepts only
+     disable|prefer|require; an unknown value is logged at debug and treated
+     as prefer, so #2476's no-verify suffix did not enforce TLS. sslaccept=
+     accept_invalid_certs is the no-CA posture matching asyncpg ssl=require. */}}
 {{- define "curie.postgres.dsnParams" -}}
 {{- $root := required "curie.postgres.dsnParams requires root" .root -}}
 {{- $driver := required "curie.postgres.dsnParams requires driver" .driver -}}
@@ -193,7 +198,7 @@ ANTHROPIC_BASE_URL ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_AUTH_TOKE
 {{- if $root.Values.postgres.deploy -}}
 {{- fail "postgres.sslMode is require but postgres.deploy is also true: the in-chart Postgres serves no TLS listener, so every consumer would fail to connect. Set postgres.deploy=false and point postgres.host at your external TLS store, or leave postgres.sslMode empty." -}}
 {{- end -}}
-{{- if eq $driver "asyncpg" -}}?ssl=require{{- else -}}?sslmode=no-verify{{- end -}}
+{{- if eq $driver "asyncpg" -}}?ssl=require{{- else -}}?sslmode=require&sslaccept=accept_invalid_certs{{- end -}}
 {{- else -}}
 {{- fail (printf "postgres.sslMode must be empty or \"require\", got %q" (printf "%v" $mode)) -}}
 {{- end -}}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -357,14 +357,16 @@ postgres:
     password: postgres
     database: postgres
   existingSecret: ""
-  # TLS query parameter on every Postgres DSN (#2431). Empty (the default)
-  # renders no suffix, so an in-cluster install is unchanged on upgrade.
-  # "require" is for a BYO store that enforces TLS: SQLAlchemy/asyncpg gets
-  # ?ssl=require, Prisma/Langfuse gets ?sslmode=no-verify. Neither suffix
-  # verifies the server certificate; verify-full needs a mounted CA bundle
-  # and is a second step. require with deploy=true fails the render: the
-  # in-chart StatefulSet serves no TLS listener. Any other value fails at
-  # render. Read raw: Sprig default would swallow false and 0.
+  # TLS query parameter on every Postgres DSN (#2431, #2507). Empty (the
+  # default) renders no suffix, so an in-cluster install is unchanged on
+  # upgrade. "require" is for a BYO store that enforces TLS:
+  # SQLAlchemy/asyncpg gets ?ssl=require, Prisma/Langfuse gets
+  # ?sslmode=require&sslaccept=accept_invalid_certs. Neither suffix verifies
+  # the server certificate, so api, worker, and Langfuse traffic is
+  # encrypted but not authenticated; verify-full needs a mounted CA bundle
+  # and is a second step (#2508). require with deploy=true fails the render:
+  # the in-chart StatefulSet serves no TLS listener. Any other value fails
+  # at render. Read raw: Sprig default would swallow false and 0.
   sslMode: ""
   # fsGroup that owns the mounted data volume: the gid (and uid) of the
   # `postgres` user INSIDE the pinned image above, read with

--- a/docs/interfaces/relational-db/managed-postgres-swap.md
+++ b/docs/interfaces/relational-db/managed-postgres-swap.md
@@ -35,10 +35,11 @@ and the one validation that proves it.
      DSN stays a plain host/port.
    - **Neon:** use the pooled or direct endpoint host, and set
      `postgres.sslMode: require` on the chart path. That renders `?ssl=require`
-     for the api and worker (SQLAlchemy + asyncpg) and `?sslmode=no-verify` for
-     Langfuse (Prisma). `no-verify` encrypts without authenticating the server
-     certificate; a `verify-full` mode needs a mounted CA bundle and is not
-     this knob.
+     for the api and worker (SQLAlchemy + asyncpg) and
+     `?sslmode=require&sslaccept=accept_invalid_certs` for Langfuse (Prisma).
+     Neither suffix authenticates the server certificate, so api, worker, and
+     Langfuse traffic is encrypted but not authenticated; a `verify-full` mode
+     needs a mounted CA bundle and is not this knob.
    - The role must own (or be able to create) the `curie` schema. Migration
      `0001_initial` issues `CREATE SCHEMA IF NOT EXISTS curie`.
 


### PR DESCRIPTION
## Summary

`postgres.sslMode: require` still rendered `?sslmode=no-verify` on both Langfuse `DATABASE_URL`s. Prisma/quaint accepts only `disable|prefer|require`, treats unknown values as `prefer`, and so #2476's Langfuse half did not enforce TLS.

`curie.postgres.dsnParams` for `driver=prisma` now renders `?sslmode=require&sslaccept=accept_invalid_certs` (encrypt without a CA, matching the chart's current no-CA posture). Chart CI fails if a rendered Langfuse DSN carries an `sslmode` outside that Prisma set. The README caveat that traffic is encrypted but not authenticated now names api, worker, and Langfuse.

`verify-full` still needs a mounted CA; that residual is #2508, not this PR. #2431 stays closed.

## Related issue

Closes #2507
Ref #2508
Ref #2431

## Fix pin verification

Fix pin: charts/curie/ci/postgres-ssl-mode-assertions.sh

Verified locally with `cli/scripts/verify-fix-pin.sh 9d881c7bd96bf5c067f114dd6be6dc2327070049 charts/curie/ci/postgres-ssl-mode-assertions.sh`: the script fails on the pre-fix tree at assertions 3 and 8 (`sslmode=no-verify` where `sslmode=require&sslaccept=accept_invalid_certs` is expected, and `no-verify` outside Prisma's set) and passes on this commit (`PINNED`).

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | chart helper and helm render only; no runner or skill surface | | |
| local | n/a | compose.dev.yaml does not consume postgres.sslMode | | |
| local-release | n/a | no released binary, image identity, or release compose change | | |
| cluster | required | chart templates render Langfuse DATABASE_URL via curie.postgres.dsnParams | fake | `bash charts/curie/ci/postgres-ssl-mode-assertions.sh` on 9d881c7bd: assertions 1-8 PASS, including [8] Prisma sslmode is disable\|prefer\|require; synthetic no-verify and verify-full are rejected. Second path: `helm template rel charts/curie --set postgres.deploy=false --set-string postgres.host=pg.acme.internal --set-string postgres.sslMode=require` rendered both Langfuse DSNs as `...?sslmode=require&sslaccept=accept_invalid_certs`. Negative: pre-fix tree still emits `sslmode=no-verify` and assertion 8 fails on it; synthetic `sslmode=verify-full` is also rejected. |
| live provider | n/a | no model routing, credential resolution, or provider auth | | |
| external integration | n/a | no Slack, git webhook, or third-party API shape | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Sibling docs that named the old Prisma suffix (`charts/curie/values.yaml`, `docs/interfaces/relational-db/managed-postgres-swap.md`) were updated with the same helper output. `helm lint charts/curie` (0 failed). `scripts/check-docs.sh` (OK).

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
