### PR TITLE
fix: fail the upgrade drain when a fenced quiesce write is refused

### DIFF
--- a/apps/worker/src/curie_worker/upgrade_drain.py
+++ b/apps/worker/src/curie_worker/upgrade_drain.py
@@ -117,10 +117,15 @@ end
 return 1
 """
 
-# Compare every applicable key before deleting any of them. A delayed release
-# must never clear one half of a newer mixed version marker. The bare ``1`` is
-# recognized only as the unversioned standalone predecessor (revision zero), so
-# a local release can still recover a marker written by the previous version.
+# Delete keys owned by this revision without splitting a newer mixed-version
+# pair. KEYS[1] is the authoritative scoped marker; later keys are the shared
+# legacy bridge. The owned scoped marker is safe to delete unilaterally when
+# it matches, so a foreign marker on the shared key cannot strand it. A
+# delayed release must still not clear the shared key while the scoped key
+# holds a newer revision -- that would resume legacy workers during the newer
+# drain. The bare ``1`` is recognized only as the unversioned standalone
+# predecessor (revision zero), so a local release can still recover a marker
+# written by the previous version.
 _CLEAR_OWNED_MARKER_LUA = """
 local function marker_revision(raw, requested)
   if raw == '1' and requested == 0 then return 0 end
@@ -133,14 +138,24 @@ local function marker_revision(raw, requested)
 end
 
 local requested = tonumber(ARGV[1])
-for _, key in ipairs(KEYS) do
+local auth_raw = redis.call('GET', KEYS[1])
+local auth_rev = nil
+if auth_raw then
+  auth_rev = marker_revision(auth_raw, requested)
+end
+local may_clear_siblings = (not auth_raw) or (auth_rev == requested)
+
+local deleted = 0
+for i, key in ipairs(KEYS) do
   local raw = redis.call('GET', key)
   if raw then
     local current = marker_revision(raw, requested)
-    if current == nil or current ~= requested then return 0 end
+    if current == requested and (i == 1 or may_clear_siblings) then
+      deleted = deleted + redis.call('DEL', key)
+    end
   end
 end
-return redis.call('DEL', unpack(KEYS))
+return deleted
 """
 
 
@@ -164,6 +179,14 @@ class DrainOutcome:
     drained: bool
     remaining: tuple[str, ...]
     waited_s: float
+
+
+class QuiesceWriteRefused(Exception):
+    """The fenced Lua write did not take pause authority.
+
+    Raised when an applicable key already holds a higher revision. The gate
+    must not report a drain over a fleet it never quiesced.
+    """
 
 
 class UpgradeDrainGate:
@@ -201,6 +224,9 @@ class UpgradeDrainGate:
         ALWAYS with an expiry. A permanent flag turns any upgrade that dies
         between this call and the post-upgrade release into a fleet that has
         stopped answering and looks perfectly healthy while doing it.
+
+        Raises :class:`QuiesceWriteRefused` when the fenced write does not take
+        effect, so a caller cannot proceed as if the fleet had paused.
         """
         ttl = self._config.upgrade_quiesce_ttl_s if ttl_s is None else ttl_s
         revision = self._revision()
@@ -212,7 +238,7 @@ class UpgradeDrainGate:
             separators=(",", ":"),
         )
         keys = self._marker_keys()
-        await self._redis.eval(
+        written = await self._redis.eval(
             _WRITE_OWNED_MARKER_LUA,
             len(keys),
             *keys,
@@ -220,6 +246,11 @@ class UpgradeDrainGate:
             marker,
             max(1, int(ttl * 1000)),
         )
+        if written != 1:
+            raise QuiesceWriteRefused(
+                "refusing to quiesce: a higher revision marker already holds "
+                "pause authority"
+            )
 
     async def clear_quiesce(self) -> None:
         """Clear only markers owned by this revision. Idempotent."""
@@ -351,16 +382,19 @@ class UpgradeDrainGate:
     ) -> DrainOutcome:
         """Quiesce, then wait for the in-flight deliveries to settle.
 
-        Sets the flag FIRST and unconditionally: the wait is only meaningful
-        while nothing new is being admitted, and a wait that admitted new work
-        could never terminate under load.
+        Sets the flag FIRST: the wait is only meaningful while nothing new is
+        being admitted, and a wait that admitted new work could never terminate
+        under load. A fenced write that does not take effect raises
+        :class:`QuiesceWriteRefused` rather than proceeding into the wait --
+        reporting drained over a fleet that is still claiming is the failure
+        the gate exists to prevent.
 
-        The flag is deliberately left set on BOTH outcomes. On success it is what
-        keeps the replacement pods from reclaiming while the roll is in progress,
-        and the post-upgrade release clears it; on refusal, clearing it is the
-        caller's decision (see :func:`main`), because a caller that wants to
-        retry the gate immediately should not have to re-quiesce a fleet that
-        just resumed.
+        The flag is deliberately left set on BOTH outcomes of a write that
+        succeeded. On success it is what keeps the replacement pods from
+        reclaiming while the roll is in progress, and the post-upgrade release
+        clears it; on refusal, clearing it is the caller's decision (see
+        :func:`main`), because a caller that wants to retry the gate immediately
+        should not have to re-quiesce a fleet that just resumed.
         """
         timeout = self._config.upgrade_drain_timeout_s if timeout_s is None else timeout_s
         interval = (
@@ -420,7 +454,15 @@ async def run_gate(config: WorkerConfig, *, mode: str) -> int:
             )
             return 0
         gate = UpgradeDrainGate(redis, config)
-        outcome = await gate.await_drained()
+        try:
+            outcome = await gate.await_drained()
+        except QuiesceWriteRefused:
+            logger.error(
+                "refusing the upgrade: quiesce marker write was fenced by a "
+                "higher revision; workers were never asked to stop claiming. "
+                "Nothing was rolled."
+            )
+            return 1
         if outcome.drained:
             logger.info(
                 "upgrade drain complete after %.1fs; no delivery is in flight",

--- a/apps/worker/tests/test_upgrade_drain.py
+++ b/apps/worker/tests/test_upgrade_drain.py
@@ -13,7 +13,9 @@ one: the quiesce TTL must strictly outlast the drain wait.
 The API this file pins:
 
     UpgradeDrainGate(redis: Redis, config: WorkerConfig)
-      .request_quiesce(*, ttl_s=None)     -> None   (always with an expiry)
+      .request_quiesce(*, ttl_s=None)     -> None   (always with an expiry;
+                                                     raises if the fenced write
+                                                     is refused)
       .clear_quiesce()                    -> None
       .is_quiescing()                     -> bool
       .unsettled_deliveries()             -> tuple[str, ...]  ("stream/group/entry")
@@ -350,7 +352,8 @@ def test_marker_json_fences_numeric_revisions_and_retains_same_revision_since(
             assert revision_10_raw is not None
             assert json.loads(revision_10_raw)["revision"] == 10
 
-            await gate_9.request_quiesce()
+            with pytest.raises(Exception, match="(?i)higher revision"):
+                await gate_9.request_quiesce()
             assert await client.get(key) == revision_10_raw, (
                 "numeric revision 9 replaced the newer revision 10 marker"
             )
@@ -442,6 +445,183 @@ def test_first_mixed_version_upgrade_atomically_writes_and_clears_both_keys(
 
             await gate.clear_quiesce()
             assert await client.mget(legacy_key, scoped_key) == [None, None]
+        finally:
+            await client.delete(legacy_key, scoped_key)
+            await client.aclose()
+
+    asyncio.run(go())
+
+
+def test_run_gate_refuses_when_a_higher_revision_fences_the_quiesce_write(
+    names,
+) -> None:  # noqa: ANN001
+    """A fenced Lua write must fail the hook, not report a drain that never happened.
+
+    Chief-of-staff review 2026-09-09 finding 4 (follow-up to #2471):
+    ``_WRITE_OWNED_MARKER_LUA`` returns 0 and writes nothing when an applicable
+    key already holds a higher revision, but ``request_quiesce`` discarded that
+    result and ``await_drained`` proceeded into the settle loop. Reachable on
+    the legacy-bridge upgrade, where the shared unscoped key is in KEYS, and
+    on the standalone/Compose path, where ``_revision()`` is 0.
+    """
+
+    async def go() -> None:
+        bridge = _config(
+            names,
+            installation_id="install-fenced-write",
+            upgrade_revision=9,
+            upgrade_legacy_quiesce=True,
+        )
+        standalone = _config(names, installation_id="")
+        client: AsyncRedis = AsyncRedis(
+            host=_VALKEY_HOST,
+            port=_VALKEY_PORT,
+            password=_VALKEY_PW or None,
+            decode_responses=True,
+        )
+        legacy_key = _legacy_quiesce_key(bridge)
+        scoped_key = _scoped_quiesce_key(bridge, "install-fenced-write")
+        foreign = json.dumps(
+            {"since": "2026-09-08T00:00:00+00:00", "revision": 11},
+            separators=(",", ":"),
+        )
+        try:
+            await client.delete(legacy_key, scoped_key)
+            await client.set(legacy_key, foreign, ex=30)
+
+            gate = UpgradeDrainGate(client, bridge)
+            # Match the refusal text rather than importing QuiesceWriteRefused:
+            # verify-fix-pin reverses only product files, so a new exception
+            # class would fail collection instead of failing the selected test.
+            with pytest.raises(Exception, match="(?i)higher revision"):
+                await gate.request_quiesce()
+            assert not await client.exists(scoped_key), (
+                "a fenced mixed-version write still authored the scoped marker"
+            )
+            assert await client.get(legacy_key) == foreign
+            assert await gate.is_quiescing() is False, (
+                "this installation's workers were quiesced even though the write "
+                "was refused"
+            )
+
+            with pytest.raises(Exception, match="(?i)higher revision"):
+                await gate.await_drained()
+
+            assert await run_gate(bridge, mode="drain") == 1
+            assert not await client.exists(scoped_key)
+            assert await client.get(legacy_key) == foreign
+
+            await client.delete(legacy_key, scoped_key)
+            await client.set(legacy_key, foreign, ex=30)
+            assert await run_gate(standalone, mode="drain") == 1
+            assert json.loads(await client.get(legacy_key))["revision"] == 11
+        finally:
+            await client.delete(legacy_key, scoped_key)
+            await client.aclose()
+
+    asyncio.run(go())
+
+
+def test_mixed_version_release_clears_owned_scoped_marker_when_shared_key_is_foreign(
+    names,
+) -> None:  # noqa: ANN001
+    """A foreign marker on the shared key must not strand this install's scoped one.
+
+    Chief-of-staff review 2026-09-09 finding 4b: ``_CLEAR_OWNED_MARKER_LUA``
+    returned 0 on the first non-matching key before deleting anything, so a
+    legacy-bridge release left the installation's own scoped marker for the
+    full ``upgrade_quiesce_ttl_s``.
+    """
+
+    async def go() -> None:
+        config = _config(
+            names,
+            installation_id="install-clear-owned",
+            upgrade_revision=9,
+            upgrade_legacy_quiesce=True,
+        )
+        client: AsyncRedis = AsyncRedis(
+            host=_VALKEY_HOST,
+            port=_VALKEY_PORT,
+            password=_VALKEY_PW or None,
+            decode_responses=True,
+        )
+        gate = UpgradeDrainGate(client, config)
+        legacy_key = _legacy_quiesce_key(config)
+        scoped_key = _scoped_quiesce_key(config, "install-clear-owned")
+        foreign = json.dumps(
+            {"since": "2026-09-08T00:00:00+00:00", "revision": 11},
+            separators=(",", ":"),
+        )
+        try:
+            await client.delete(legacy_key, scoped_key)
+            await gate.request_quiesce()
+            assert await client.exists(scoped_key)
+            await client.set(legacy_key, foreign, ex=30)
+
+            await gate.clear_quiesce()
+            assert not await client.exists(scoped_key), (
+                "a foreign shared-key marker stranded this installation's "
+                "owned scoped quiesce flag"
+            )
+            assert await client.get(legacy_key) == foreign, (
+                "clear_quiesce deleted a foreign higher-revision shared marker"
+            )
+        finally:
+            await client.delete(legacy_key, scoped_key)
+            await client.aclose()
+
+    asyncio.run(go())
+
+
+def test_mixed_version_release_does_not_clear_legacy_when_scoped_holds_newer_revision(
+    names,
+) -> None:  # noqa: ANN001
+    """A delayed lower-revision release must not resume legacy workers.
+
+    The owned scoped marker is safe to delete unilaterally, but the shared
+    key is one half of the mixed-version pair. If the scoped key already
+    holds a newer revision, clearing a matching legacy key would let
+    pre-scoped replicas claim during the newer drain.
+    """
+
+    async def go() -> None:
+        config = _config(
+            names,
+            installation_id="install-clear-asymmetric",
+            upgrade_revision=9,
+            upgrade_legacy_quiesce=True,
+        )
+        client: AsyncRedis = AsyncRedis(
+            host=_VALKEY_HOST,
+            port=_VALKEY_PORT,
+            password=_VALKEY_PW or None,
+            decode_responses=True,
+        )
+        gate = UpgradeDrainGate(client, config)
+        legacy_key = _legacy_quiesce_key(config)
+        scoped_key = _scoped_quiesce_key(config, "install-clear-asymmetric")
+        newer = json.dumps(
+            {"since": "2026-09-08T00:00:00+00:00", "revision": 10},
+            separators=(",", ":"),
+        )
+        older = json.dumps(
+            {"since": "2026-09-08T00:00:00+00:00", "revision": 9},
+            separators=(",", ":"),
+        )
+        try:
+            await client.delete(legacy_key, scoped_key)
+            await client.set(scoped_key, newer, ex=30)
+            await client.set(legacy_key, older, ex=30)
+
+            await gate.clear_quiesce()
+            assert await client.get(scoped_key) == newer, (
+                "a delayed revision 9 release cleared the newer scoped marker"
+            )
+            assert await client.get(legacy_key) == older, (
+                "a delayed revision 9 release cleared the shared key while "
+                "scoped held a newer revision"
+            )
         finally:
             await client.delete(legacy_key, scoped_key)
             await client.aclose()
@@ -773,7 +953,8 @@ def test_a_lane_that_cannot_be_read_refuses_the_upgrade(names) -> None:  # noqa:
 
 def test_await_drained_quiesces_before_it_waits(names) -> None:  # noqa: ANN001
     """A wait that kept admitting new work could never terminate under load, so
-    the flag goes up first and unconditionally."""
+    the flag goes up first. A fenced write that does not take effect must not
+    proceed into that wait."""
 
     async def go() -> None:
         async with _gate(names) as (gate, config, client):


### PR DESCRIPTION
## Summary

The pre-upgrade drain gate treated a fenced quiesce write as success. `_WRITE_OWNED_MARKER_LUA` already returned 0 and wrote nothing when an applicable key held a higher revision, but `request_quiesce` discarded that result and `await_drained` went on to report `drained=True` while this installation's workers were still claiming. That is reachable on the legacy-bridge upgrade (shared unscoped key in KEYS) and on the standalone/Compose path (`_revision()` is 0).

`request_quiesce` now raises `QuiesceWriteRefused` when the Lua write is refused, and the hook returns 1 without claiming a drain. The same change deletes this installation's owned scoped marker when the shared key is foreign, without clearing a matching legacy key while the scoped key holds a newer revision.

Cited from the 2026-09-09 chief-of-staff review, finding 4 (follow-up to #2471). Finding 4c (old worker image argparse on `--installation-id-observed`) is out of scope.

## Related issue

Ref #2471

## Fix pin verification

Fix pin: apps/worker/tests/test_upgrade_drain.py::test_run_gate_refuses_when_a_higher_revision_fences_the_quiesce_write

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin or skill packaging, the runner turn loop, ACI events, or skill eval/check | | |
| local | required | Worker upgrade-drain gate is worker runtime against Valkey; the real surface is `request_quiesce` / `run_gate` on real Valkey | live (real Valkey) | Commit `a6177304f`. `uv run pytest apps/worker/tests/test_upgrade_drain.py -q` -> `31 passed`. Pin `test_run_gate_refuses_when_a_higher_revision_fences_the_quiesce_write` failed on the old code (`Failed: DID NOT RAISE Exception`) and passed after the fix. |
| local-release | n/a | Does not change released binary or image identity, the install path, version pins, or release compose | | |
| cluster | n/a | Does not change chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, or init containers; the hook command is unchanged | | |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, or token or cost accounting | | |
| external integration | n/a | Does not reach Slack, git push webhooks, connector OAuth, or a third-party API shape | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive proof: on `a6177304f`, `run_gate(..., mode="drain")` returns 1 when a higher-revision marker already holds the shared key, the scoped key is not written, and `is_quiescing()` stays false for this installation.

Falsifiable negative / second path: the same pin failed on the pre-fix code because `request_quiesce` did not raise. The standalone/Compose revision-0 path is asserted in the same test. The clear path has a matching owned-scoped cleanup test plus the reverse-mismatch test that a delayed lower-revision release must not delete the shared key while scoped holds a newer revision.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision.
