### PR TITLE
Derive the hosted connector Bearer header and bind its secret into the sandbox

### DIFF
--- a/apps/api/tests/test_bundle_connectors.py
+++ b/apps/api/tests/test_bundle_connectors.py
@@ -696,3 +696,26 @@ def test_the_same_bundle_still_renders_for_an_unambiguous_agent(
         f"{name}-allow-ingress",
     }
     assert name in body["mcp_entries"]["grafana"]["url"]
+
+
+GITHUB = (
+    "connectors:\n"
+    "  github:\n"
+    "    image: ghcr.io/github/github-mcp-server:v0.20.1\n"
+    "    secrets: [GITHUB_PERSONAL_ACCESS_TOKEN]\n"
+)
+
+
+def test_the_returned_entry_carries_the_connector_credential(tmp_path: Path) -> None:
+    # The CLI mounts what this endpoint returns, so an entry that loses the
+    # header here is a 401 in the sandbox no matter what plugin-format derives.
+    # github-mcp-server's HTTP transport requires `Authorization: Bearer <PAT>`
+    # per GitHub's docs; without it the agent lists no `mcp__github__*` tools
+    # and nothing errors (#2503).
+    root = _bundle(tmp_path, GITHUB)
+    entries = bundles.connector_mcp_entries(
+        bundles.read_connectors(root), release=RELEASE, agent=AGENT, namespace=NAMESPACE
+    )
+    assert entries["github"]["headers"] == {
+        "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
+    }

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1543,7 +1543,7 @@ export const commandManifest = {
             },
             {
               "global": false,
-              "help": "Bind a per-agent connector secret by NAME (ADR-0009, #429). The value is resolved from your environment or the host secret vault (`curie secrets set <NAME>`) and sent to the platform, which stores it on the agent so the worker forwards it into the sandbox for a bundle's authed MCP server. The value never appears in argv. Repeatable",
+              "help": "Bind a per-agent connector secret by NAME (ADR-0009, #429). The value is resolved from your environment or the host secret vault (`curie secrets set <NAME>`) and sent to the platform, which stores it on the agent so the worker forwards it into the sandbox for a bundle's authed MCP server. The value never appears in argv. Repeatable. A hosted connector's own declared `secrets:` names are bound automatically (from the value this deploy already resolved for the connector) so its derived Bearer header expands; this flag is for names beyond that (#2503)",
               "id": "secret",
               "long": "secret",
               "positional": false,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1540,7 +1540,7 @@
             },
             {
               "global": false,
-              "help": "Bind a per-agent connector secret by NAME (ADR-0009, #429). The value is resolved from your environment or the host secret vault (`curie secrets set <NAME>`) and sent to the platform, which stores it on the agent so the worker forwards it into the sandbox for a bundle's authed MCP server. The value never appears in argv. Repeatable",
+              "help": "Bind a per-agent connector secret by NAME (ADR-0009, #429). The value is resolved from your environment or the host secret vault (`curie secrets set <NAME>`) and sent to the platform, which stores it on the agent so the worker forwards it into the sandbox for a bundle's authed MCP server. The value never appears in argv. Repeatable. A hosted connector's own declared `secrets:` names are bound automatically (from the value this deploy already resolved for the connector) so its derived Bearer header expands; this flag is for names beyond that (#2503)",
               "id": "secret",
               "long": "secret",
               "positional": false,

--- a/cli/src/cluster_secrets.rs
+++ b/cli/src/cluster_secrets.rs
@@ -58,10 +58,22 @@ pub fn resolve_named_secrets(names: &[String]) -> Result<BTreeMap<String, String
     Ok(secrets)
 }
 
-/// Names-only map written to the agent record at the cluster tier.
-pub fn agent_record_secrets(secrets: &BTreeMap<String, String>) -> BTreeMap<String, String> {
-    secrets
-        .keys()
+/// Names-only placeholder map written to the agent record at the cluster tier,
+/// built from NAMES that have no resolved value on this box.
+///
+/// The cluster tier's agent record is placeholders either way -- the value
+/// lives in the per-agent Helm Secret, never in the record -- so a connector
+/// secret whose value is resolved later, cluster-scoped (#1913), still belongs
+/// in it. It has to: the worker keys `inject_connector_secrets` off this map,
+/// and `sandbox.types` routes the claim to the per-agent pool only when the
+/// marker is present. A record built from `--secret` alone routes the pod to
+/// the generic pool with no connector secret env at all (#2503).
+pub fn agent_record_secret_names<'a, I>(names: I) -> BTreeMap<String, String>
+where
+    I: IntoIterator<Item = &'a String>,
+{
+    names
+        .into_iter()
         .map(|name| (name.clone(), CLUSTER_SECRET_PLACEHOLDER.to_string()))
         .collect()
 }
@@ -158,7 +170,7 @@ mod tests {
 
     #[test]
     fn agent_record_keeps_names_and_drops_values() {
-        let stored = agent_record_secrets(&secrets());
+        let stored = agent_record_secret_names(secrets().keys());
         assert_eq!(
             stored["GITHUB_PERSONAL_ACCESS_TOKEN"],
             CLUSTER_SECRET_PLACEHOLDER
@@ -167,6 +179,34 @@ mod tests {
         assert!(!stored
             .values()
             .any(|v| v.contains("ghp_") || v.contains("jira-a")));
+    }
+
+    #[test]
+    fn record_from_names_alone_is_the_same_placeholder_map() {
+        // #2503: a connector secret whose value is resolved cluster-scoped
+        // later has no value on this box, but the record still has to carry
+        // its NAME -- the worker keys `inject_connector_secrets` (and the
+        // per-agent sandbox pool routing) off this map. Names-only and
+        // value-bearing inputs must produce byte-identical records for the
+        // same key set, so the two deploy paths cannot diverge.
+        let names: Vec<String> = secrets().keys().cloned().collect();
+        let from_names = agent_record_secret_names(names.iter());
+        assert_eq!(from_names, agent_record_secret_names(secrets().keys()));
+        assert_eq!(
+            from_names["GITHUB_PERSONAL_ACCESS_TOKEN"],
+            CLUSTER_SECRET_PLACEHOLDER
+        );
+        assert_eq!(from_names["JIRA_TOKEN"], CLUSTER_SECRET_PLACEHOLDER);
+    }
+
+    #[test]
+    fn record_from_names_carries_a_name_that_has_no_local_value() {
+        // The #2503 case proper: the name reaches the record even though
+        // nothing on this box ever resolved a value for it, and no value-like
+        // material is invented for it.
+        let stored = agent_record_secret_names(["CONNECTOR_ONLY".to_string()].iter());
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored["CONNECTOR_ONLY"], CLUSTER_SECRET_PLACEHOLDER);
     }
 
     #[test]

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1552,7 +1552,12 @@ const OAUTH_TOKEN_PREFIX: &str = "sk-ant-oat";
 /// fake/local model run: a bundle's authed MCP server needs its token
 /// regardless of which model drives the session. Names already present (a user
 /// passing a model-credential var as a secret) are not duplicated.
-fn merge_secret_env(mut passthrough: Vec<String>, secrets: &[String]) -> Vec<String> {
+///
+/// Also the union used for the connector-owned secret NAMES resolved from a
+/// bundle's `connectors.yaml` (#2503): same order-preserving dedupe, so the
+/// explicit `--secret` order wins and an owned name already named by a flag is
+/// bound once.
+pub fn merge_secret_env(mut passthrough: Vec<String>, secrets: &[String]) -> Vec<String> {
     for name in secrets {
         if !passthrough.contains(name) {
             passthrough.push(name.clone());
@@ -4560,14 +4565,15 @@ async fn prepare_deploy_with_commit_sha(
     // failure names the operator's own directory rather than a temp path, and
     // long before anything is applied. `opts.plugin_dir` (not the canonicalized
     // copy) is the path they typed.
+    let connector_decl = crate::connector_build::load(&plugin_dir)?;
     {
-        let decl = crate::connector_build::load(&plugin_dir)?;
+        let decl = &connector_decl;
         if decl.connectors.values().any(|spec| spec.build.is_some()) {
-            let recomputed = recompute_source_digests(&plugin_dir, &decl)?;
+            let recomputed = recompute_source_digests(&plugin_dir, decl)?;
             let lock = crate::connector_build::load_lock(&plugin_dir)?;
             lock_preflight(
                 &opts.plugin_dir,
-                &decl,
+                decl,
                 lock.as_ref(),
                 &recomputed,
                 opts.tier,
@@ -4576,7 +4582,7 @@ async fn prepare_deploy_with_commit_sha(
             // claims about it, is what a node has to pull (see
             // `registry_preflight`). Cluster only: no local deploy pulls this.
             if opts.tier == DeployTier::Cluster {
-                run_registry_preflight(&decl, lock.as_ref()).await?;
+                run_registry_preflight(decl, lock.as_ref()).await?;
             }
         }
     }
@@ -4598,9 +4604,27 @@ async fn prepare_deploy_with_commit_sha(
     // name-set diff on `opts.secret` (the bound NAME set) and needs no packed
     // bundle or resolved values, so a declared-but-unbound policy fails fast
     // without doing any of that work.
+    // The NAMES this deploy will actually bind into the agent sandbox: the
+    // explicit `--secret` flags, plus every env-var secret the bundle's hosted
+    // connectors declare (#2503). Curie resolves those itself, so a
+    // plugin.json-declared name that connectors.yaml already auto-binds is not
+    // a gap and must not be diffed against the flags alone -- the #464 gate
+    // below would otherwise refuse a deploy that needs no flag. A manifest
+    // secret nothing binds still fails, unchanged.
+    let connector_env_secret_names =
+        crate::connector_build::hosted_env_secret_names(&connector_decl);
+    // Automatic delivery of connectors.yaml secrets exists only for
+    // DeployTier::Cluster (#2503 follow-up); `local deploy` has no delivery
+    // path yet, so its effective set must stay exactly `opts.secret`.
+    let effective_secret_names = if opts.tier == DeployTier::Cluster {
+        merge_secret_env(opts.secret.clone(), &connector_env_secret_names)
+    } else {
+        opts.secret.clone()
+    };
+
     if opts.secret_binding_supported {
         let declared = read_declared_secrets(&plugin_dir)?;
-        let unbound = unbound_declared_secrets(&declared, &opts.secret);
+        let unbound = unbound_declared_secrets(&declared, &effective_secret_names);
         if !unbound.is_empty() {
             return Err(crate::exit::usage(format!(
                 "{plugin_name} declares connector secret(s) that were not bound on deploy: {}. \
@@ -4756,7 +4780,17 @@ async fn prepare_deploy_with_commit_sha(
             archive,
             &match opts.tier {
                 DeployTier::Local => secrets.clone(),
-                DeployTier::Cluster => crate::cluster_secrets::agent_record_secrets(&secrets),
+                // Names-only placeholders over the EFFECTIVE set, not just
+                // the resolved `--secret` values: the worker keys
+                // `inject_connector_secrets` -- and with it the per-agent
+                // sandbox pool routing -- off this map, so a connector secret
+                // missing from it lands the claim on the generic pool with no
+                // connector env at all (#2503). The connector's own value is
+                // resolved cluster-scoped later (#1913) and reaches the pod
+                // through the per-agent Helm Secret, never through the record.
+                DeployTier::Cluster => {
+                    crate::cluster_secrets::agent_record_secret_names(&effective_secret_names)
+                }
             },
             opts.repo.as_deref(),
             commit_sha.as_deref(),
@@ -8721,6 +8755,44 @@ mod tests {
         );
     }
 
+    #[test]
+    fn gate_accepts_a_declared_name_that_connectors_yaml_auto_binds() {
+        // #2503 x #464: the gate diffs the declared names against the
+        // EFFECTIVE bind set, not the `--secret` flags alone. A name Curie
+        // itself resolves from connectors.yaml is bound, so a deploy that
+        // needs no flag must not be refused.
+        let declared = vec!["GH".to_string()];
+        let effective = super::merge_secret_env(vec![], &["GH".to_string()]);
+        assert!(
+            super::unbound_declared_secrets(&declared, &effective).is_empty(),
+            "an auto-bound connector secret is not a gap"
+        );
+    }
+
+    #[test]
+    fn gate_still_reports_a_name_bound_by_neither_source() {
+        // The gate must not go vacuous: a manifest secret that neither a
+        // `--secret` flag nor connectors.yaml binds still fails the deploy.
+        let declared = vec!["GH".to_string(), "SLACK".to_string()];
+        let effective = super::merge_secret_env(vec![], &["GH".to_string()]);
+        assert_eq!(
+            super::unbound_declared_secrets(&declared, &effective),
+            vec!["SLACK".to_string()]
+        );
+    }
+
+    #[test]
+    fn secret_env_binds_owned_connector_name_with_no_explicit_flag() {
+        // #2503: a hosted connector's declared GITHUB_PERSONAL_ACCESS_TOKEN
+        // must reach the sandbox env with zero `--secret` flags, so the
+        // derived `Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}` header (ADR-0009 /
+        // #1488 delivery path) expands instead of sending a literal `${...}`.
+        assert_eq!(
+            merge_secret_env(vec![], &["GITHUB_PERSONAL_ACCESS_TOKEN".to_string()]),
+            vec!["GITHUB_PERSONAL_ACCESS_TOKEN".to_string()]
+        );
+    }
+
     #[tokio::test]
     async fn deploy_fails_when_declared_secret_is_not_bound() {
         // AC3: a declared secret NAME with no matching --secret binding fails the
@@ -8755,6 +8827,90 @@ mod tests {
         assert!(
             !rendered.contains("UNREACHABLE-HINT-SENTINEL"),
             "gate must fire before any network attempt (no connect hint): {rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn deploy_local_tier_still_refuses_a_connectors_yaml_auto_bound_secret() {
+        // #2503 round-2 review finding: automatic hosted-connector secret
+        // delivery is Cluster-only (no sandbox delivery path on Local yet), so
+        // a bundle that declares GH in plugin.json AND connectors.yaml, with no
+        // `--secret` flag, must still be refused on `local deploy` -- the same
+        // bundle passes the gate on `cluster deploy` (see the paired test
+        // below). This drives the real gate through `deploy()`, not the pure
+        // helper functions.
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_with_secrets(dir.path(), "test-agent", &["GH"]);
+        write_manifest(
+            dir.path(),
+            "connectors.yaml",
+            "connectors:\n  gh:\n    image: ghcr.io/example/gh:1\n    secrets:\n      - GH\n",
+        );
+
+        let opts = super::DeployOpts {
+            agent: None,
+            target: None,
+            plugin_dir: dir.path().to_path_buf(),
+            api_url: "http://127.0.0.1:1".to_string(),
+            api_key: "k".to_string(),
+            slack_channel: None,
+            repo: None,
+            workspace: super::WorkspaceIntent::Preserve,
+            env: Some(super::DeployEnv::Dev),
+            label: Some("v0".to_string()),
+            secret: vec![],
+            secret_binding_supported: true,
+            connect_hint: "UNREACHABLE-HINT-SENTINEL".to_string(),
+            tier: super::DeployTier::Local,
+        };
+        let err = super::deploy(opts).await.unwrap_err();
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("GH"),
+            "local deploy has no auto-delivery path, so the gate must still name GH: {rendered}"
+        );
+        assert!(
+            !rendered.contains("UNREACHABLE-HINT-SENTINEL"),
+            "the gate must fire before any network attempt: {rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn deploy_cluster_tier_passes_the_gate_on_a_connectors_yaml_auto_bound_secret() {
+        // The paired case: the SAME bundle (GH declared in both plugin.json and
+        // connectors.yaml, no `--secret` flag) reaches the network on Cluster,
+        // because the effective bind set there is the union with
+        // `hosted_env_secret_names`, not `opts.secret` alone.
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_with_secrets(dir.path(), "test-agent", &["GH"]);
+        write_manifest(
+            dir.path(),
+            "connectors.yaml",
+            "connectors:\n  gh:\n    image: ghcr.io/example/gh:1\n    secrets:\n      - GH\n",
+        );
+
+        let opts = super::DeployOpts {
+            agent: None,
+            target: None,
+            plugin_dir: dir.path().to_path_buf(),
+            api_url: "http://127.0.0.1:1".to_string(),
+            api_key: "k".to_string(),
+            slack_channel: None,
+            repo: None,
+            workspace: super::WorkspaceIntent::Preserve,
+            env: Some(super::DeployEnv::Dev),
+            label: Some("v0".to_string()),
+            secret: vec![],
+            secret_binding_supported: true,
+            connect_hint: "UNREACHABLE-HINT-SENTINEL".to_string(),
+            tier: super::DeployTier::Cluster,
+        };
+        let err = super::deploy(opts).await.unwrap_err();
+        let rendered = format!("{err:#}");
+        assert!(
+            !rendered.contains("declares connector secret(s) that were not bound on deploy"),
+            "cluster's effective bind set auto-includes GH via connectors.yaml, \
+             so the gate must pass and the error must be the network path: {rendered}"
         );
     }
 

--- a/cli/src/connector_build.rs
+++ b/cli/src/connector_build.rs
@@ -1639,6 +1639,42 @@ pub fn hosted_secret_names(decl: &ConnectorsFileDecl) -> Vec<String> {
     names.into_iter().collect()
 }
 
+/// The secret NAMES a hosted connector's SANDBOX must also receive (#2503).
+///
+/// These are the names the derived `Authorization: Bearer ${NAME}` header on
+/// the mounted `.mcp.json` entry expands from: the expansion happens in the
+/// sandbox where the MCP client runs, not in the connector pod, so a name that
+/// only reaches the pod's `secretKeyRef` ships the literal `${NAME}` and the
+/// server answers 401.
+///
+/// Scope, deliberately narrower than [`hosted_secret_names`]:
+/// - A connector Curie itself runs -- one declaring `image:` or `build:` -- is
+///   the only one whose credential this box resolves and delivers. A
+///   `unhosted_url:` override still points at that same connector's image
+///   declaration, so it stays in scope; a pure `url:` remote is the MCP
+///   client's own config and is not.
+/// - `SecretDecl::Name` only. A `SecretDecl::Ref` names a Secret someone else
+///   provisioned, which ADR-0090 keeps out of the deploy path entirely -- no
+///   value for it exists here to bind.
+/// - No `secret_files` and no `sealed_secrets`: those are file mounts and
+///   out-of-band material, never a sandbox env var a header can expand.
+///
+/// Sorted and deduped. Names only; no value ever travels through this seam.
+pub fn hosted_env_secret_names(decl: &ConnectorsFileDecl) -> Vec<String> {
+    let mut names = std::collections::BTreeSet::new();
+    for spec in decl.connectors.values() {
+        if spec.image.is_none() && spec.build.is_none() {
+            continue;
+        }
+        for declared in &spec.secrets {
+            if let SecretDecl::Name(name) = declared {
+                names.insert(name.clone());
+            }
+        }
+    }
+    names.into_iter().collect()
+}
+
 /// The non-`CURIE_`-prefixed names a connector secret must never claim.
 ///
 /// The twin of `_CREDENTIAL_KEYS | _REDIRECT_CAPTURE_KEYS` in
@@ -1736,4 +1772,115 @@ pub fn refuse_out_of_band_secrets(connector: &str, spec: &ConnectorSpecDecl) -> 
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod hosted_env_secret_names_tests {
+    use super::*;
+
+    fn decl(document: &str) -> ConnectorsFileDecl {
+        parse_connectors(document).expect("fixture connectors.yaml should parse")
+    }
+
+    #[test]
+    fn image_connector_yields_bare_names_only() {
+        // #2503: the sandbox must receive exactly the names the derived
+        // `Bearer ${NAME}` header expands. A `SecretRef` names a Secret
+        // somebody else provisioned, which ADR-0090 keeps out of this path,
+        // and a `secret_files` entry is a file mount, never an env var.
+        let decl = decl(
+            r#"
+connectors:
+  gh:
+    image: ghcr.io/example/gh:1
+    secrets:
+      - A
+      - name: B
+        from_secret: s
+        key: k
+    secret_files:
+      C: /x
+"#,
+        );
+        assert_eq!(hosted_env_secret_names(&decl), vec!["A".to_string()]);
+    }
+
+    #[test]
+    fn remote_url_connector_is_excluded() {
+        // A pure `url:` remote is the MCP client's own config; Curie resolves
+        // and delivers no credential for it, so binding its name would put an
+        // unrelated value in the sandbox env.
+        let decl = decl(
+            r#"
+connectors:
+  remote:
+    url: https://mcp.example.com/sse
+    secrets:
+      - REMOTE_TOKEN
+"#,
+        );
+        assert!(hosted_env_secret_names(&decl).is_empty());
+    }
+
+    #[test]
+    fn unhosted_url_override_on_an_image_connector_stays_included() {
+        // `unhosted_url:` only points at an already-running instance of the
+        // SAME declared image, so the credential is still Curie's to deliver.
+        let decl = decl(
+            r#"
+connectors:
+  gh:
+    image: ghcr.io/example/gh:1
+    unhosted_url: http://127.0.0.1:9000/mcp
+    secrets:
+      - GITHUB_PERSONAL_ACCESS_TOKEN
+"#,
+        );
+        assert_eq!(
+            hosted_env_secret_names(&decl),
+            vec!["GITHUB_PERSONAL_ACCESS_TOKEN".to_string()]
+        );
+    }
+
+    #[test]
+    fn two_hosted_connectors_sharing_a_name_dedupe_and_sort() {
+        // The result keys a bind map, so a duplicate must collapse and the
+        // order must be deterministic rather than connector-declaration order.
+        let decl = decl(
+            r#"
+connectors:
+  zeta:
+    image: ghcr.io/example/zeta:1
+    secrets:
+      - SHARED
+      - ZETA_ONLY
+  alpha:
+    build:
+      context: ./alpha
+      platforms:
+        - linux/amd64
+    secrets:
+      - SHARED
+      - ALPHA_ONLY
+"#,
+        );
+        assert_eq!(
+            hosted_env_secret_names(&decl),
+            vec![
+                "ALPHA_ONLY".to_string(),
+                "SHARED".to_string(),
+                "ZETA_ONLY".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn bundle_without_a_connectors_file_binds_nothing() {
+        // The overwhelmingly common bundle. It must add no names at all, so
+        // the #464 gate and the sandbox bind set are unchanged for it.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let loaded = load(dir.path()).expect("a bundle with no connectors.yaml loads as empty");
+        assert!(hosted_env_secret_names(&loaded).is_empty());
+        assert!(hosted_env_secret_names(&ConnectorsFileDecl::default()).is_empty());
+    }
 }

--- a/cli/src/connectors.rs
+++ b/cli/src/connectors.rs
@@ -683,6 +683,12 @@ pub struct PreparedConnectorSync {
     result: ConnectorSync,
     secret_name: Option<String>,
     secret_keys: Vec<String>,
+    /// The connector-owned secret VALUES as resolved for THIS cluster scope
+    /// (#1913). Retained so `cluster deploy` binds the sandbox with the very
+    /// same credential the connector pod receives rather than re-resolving the
+    /// name from the environment or unscoped host storage, which can differ.
+    /// Private: nothing outside this module may take ownership of a value.
+    secret_values: BTreeMap<String, String>,
     secret_sources: BTreeMap<String, String>,
     target: SecretScope,
     bound_target: Option<ClusterTarget>,
@@ -695,6 +701,15 @@ impl PreparedConnectorSync {
         }
         self.bound_target = Some(target);
         Ok(self)
+    }
+
+    /// The connector-owned secrets, keyed by NAME, with the cluster-scoped
+    /// value already resolved for the deploy's target. Read by `cluster deploy`
+    /// to bind those names into the agent sandbox (#2503) with the scoped value
+    /// -- one cluster, one credential (#1913) -- instead of resolving the name
+    /// a second time from a possibly stale environment.
+    pub fn owned_secret_values(&self) -> &BTreeMap<String, String> {
+        &self.secret_values
     }
 
     pub fn write_intent(&self) -> Option<String> {
@@ -765,6 +780,7 @@ pub fn prepare(
     let mut objects = Vec::new();
     let mut secret_name = None;
     let mut secret_keys = Vec::new();
+    let mut secret_values = BTreeMap::new();
     let mut secret_sources = BTreeMap::new();
 
     if let Some((name, keys)) = owned_secret(owned_secret_name, owned_secret_keys) {
@@ -772,6 +788,7 @@ pub fn prepare(
         objects.push(render_secret(&name, &target.namespace, &values));
         secret_name = Some(name);
         secret_keys = keys;
+        secret_values = values;
         secret_sources = sources;
     }
     objects.extend_from_slice(manifests);
@@ -802,6 +819,7 @@ pub fn prepare(
         result,
         secret_name,
         secret_keys,
+        secret_values,
         secret_sources,
         target: target.clone(),
         bound_target: None,
@@ -822,6 +840,7 @@ pub async fn sync(prepared: PreparedConnectorSync) -> Result<ConnectorSync> {
         mut result,
         secret_name,
         secret_keys,
+        secret_values: _,
         secret_sources,
         target,
         bound_target,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -333,7 +333,11 @@ struct ClusterAgentTarget {
 /// A bundle with no `connectors.yaml` still reaches the prune: that is the case
 /// where a connector was REMOVED, and leaving it running with a credential
 /// mounted and nothing referencing it is the leak nobody notices.
-async fn sync_connectors(
+///
+/// This half only RESOLVES: it discovers the cluster binding and renders the
+/// objects, so the caller can read the owned secret names off the prepared sync
+/// (#2503) before handing it to [`apply_connectors`].
+async fn prepare_cluster_connectors(
     api_url: &str,
     api_key: &str,
     namespace: &str,
@@ -341,7 +345,7 @@ async fn sync_connectors(
     agent_id: &str,
     agent_name: &str,
     version_id: &str,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<curie::connectors::PreparedConnectorSync> {
     let target = curie::connectors::bind_current_cluster(namespace, release).await?;
     let app_name = curie::connectors::discover_app_name(&target).await?;
     let connector_version = ConnectorVersion {
@@ -349,7 +353,7 @@ async fn sync_connectors(
         agent_name,
         version_id,
     };
-    let prepared = prepare_connectors(
+    prepare_connectors(
         api_url,
         api_key,
         namespace,
@@ -358,8 +362,7 @@ async fn sync_connectors(
         connector_version,
         target,
     )
-    .await?;
-    apply_connectors(prepared).await
+    .await
 }
 
 struct ConnectorVersion<'a> {
@@ -1735,7 +1738,11 @@ enum LocalAction {
         /// is resolved from your environment or the host secret vault (`curie
         /// secrets set <NAME>`) and sent to the platform, which stores it on the
         /// agent so the worker forwards it into the sandbox for a bundle's authed
-        /// MCP server. The value never appears in argv. Repeatable.
+        /// MCP server. The value never appears in argv. Repeatable. A hosted
+        /// connector's own declared `secrets:` names are bound automatically
+        /// (from the value this deploy already resolved for the connector) so
+        /// its derived Bearer header expands; this flag is for names beyond
+        /// that (#2503).
         #[arg(long = "secret", value_name = "NAME")]
         secret: Vec<String>,
     },
@@ -2771,14 +2778,39 @@ async fn resolve_compose_file(file: Option<String>, dry_run: bool) -> Result<Str
     materialize_artifact(resolved, dry_run, "compose").await
 }
 
+/// The sandbox connector-secret bind map for a cluster deploy (#2503).
+///
+/// Two sources, deliberately resolved differently:
+/// - an explicit `--secret NAME` keeps its existing semantics -- env first,
+///   then unscoped host storage, and a hard error when neither has it;
+/// - a hosted connector's declared name reuses the value the connector plan
+///   ALREADY resolved for this cluster scope. It is never re-resolved here: a
+///   scoped-only credential would not resolve at all, and a stale environment
+///   value would put a different credential in the sandbox than the connector
+///   pod holds. On overlap the scoped connector value therefore wins, because
+///   that is the credential the connector itself authenticates with and #1913's
+///   guarantee is one cluster, one credential.
+fn cluster_connector_bind_values(
+    explicit: &[String],
+    connector_names: &[String],
+    connector_values: &std::collections::BTreeMap<String, String>,
+) -> Result<std::collections::BTreeMap<String, String>> {
+    let mut values = curie::cluster_secrets::resolve_named_secrets(explicit)?;
+    for name in connector_names {
+        if let Some(value) = connector_values.get(name) {
+            values.insert(name.clone(), value.clone());
+        }
+    }
+    Ok(values)
+}
+
 async fn bind_cluster_connector_secrets(
     namespace: &str,
     release: &str,
     chart: Option<&str>,
     agent_name: &str,
-    secret_names: &[String],
+    secrets: std::collections::BTreeMap<String, String>,
 ) -> Result<()> {
-    let secrets = curie::cluster_secrets::resolve_named_secrets(secret_names)?;
     if secrets.is_empty() {
         return Ok(());
     }
@@ -2801,6 +2833,31 @@ async fn bind_cluster_connector_secrets(
         secrets,
     })
     .await
+}
+
+/// Bind the sandbox connector secrets for one deployed agent and then apply its
+/// prepared connector objects (#2503). The union of explicit `--secret` names
+/// and the bundle's connector-owned names is resolved against the values the
+/// connector plan already resolved for this cluster scope, bound into the
+/// per-agent Helm Secret, and only then are the connector objects applied --
+/// the one order both the single-target and `--all-targets` cluster deploy
+/// paths use.
+async fn bind_and_apply_cluster_connectors(
+    namespace: &str,
+    release: &str,
+    chart: Option<&str>,
+    agent_name: &str,
+    explicit_secrets: &[String],
+    connector_env_secret_names: &[String],
+    prepared: curie::connectors::PreparedConnectorSync,
+) -> Result<()> {
+    let bind_values = cluster_connector_bind_values(
+        explicit_secrets,
+        connector_env_secret_names,
+        prepared.owned_secret_values(),
+    )?;
+    bind_cluster_connector_secrets(namespace, release, chart, agent_name, bind_values).await?;
+    apply_connectors(prepared).await
 }
 
 async fn materialize_artifact(
@@ -4259,6 +4316,14 @@ async fn run(command: Option<Command>) -> Result<()> {
                 // The list comes from the API, not a Rust YAML parse: ADR-0089
                 // keeps exactly one parser for this file, and a second could
                 // disagree with it about where a deploy lands.
+                // The env-var secrets this bundle's hosted connectors declare
+                // (#2503). Read once here, from the same connectors.yaml the
+                // deploy packs, so both cluster paths bind the sandbox with the
+                // names whose `${NAME}` the derived Bearer header expands.
+                let connector_env_secret_names = curie::connector_build::hosted_env_secret_names(
+                    &curie::connector_build::load(&plugin_dir)?,
+                );
+
                 let targets: Vec<Option<String>> = if all_targets {
                     let path = plugin_dir.join("deploy.yaml");
                     let content = std::fs::read_to_string(&path).map_err(|err| {
@@ -4407,27 +4472,23 @@ async fn run(command: Option<Command>) -> Result<()> {
                             }
                         };
 
-                        if !secret.is_empty() {
-                            if let Err(err) = bind_cluster_connector_secrets(
-                                &namespace,
-                                &release,
-                                chart.as_deref(),
-                                &deployed.agent_name,
-                                &secret,
-                            )
-                            .await
-                            {
-                                let payload = commands::all_targets_deploy_failure_json(
-                                    &target,
-                                    &completed,
-                                    Some(&deployed),
-                                    &err,
-                                );
-                                return Err(curie::exit::with_json_payload(err, payload));
-                            }
-                        }
-
-                        if let Err(err) = apply_connectors(prepared_connectors).await {
+                        // #2503: bind the connector's own declared secret
+                        // names alongside the explicit `--secret` set, with the
+                        // cluster-scoped values this plan already resolved
+                        // (#1913), so a hosted connector's derived Bearer header
+                        // expands in the sandbox. Binding precedes the apply that
+                        // consumes `prepared_connectors`.
+                        if let Err(err) = bind_and_apply_cluster_connectors(
+                            &namespace,
+                            &release,
+                            chart.as_deref(),
+                            &deployed.agent_name,
+                            &secret,
+                            &connector_env_secret_names,
+                            prepared_connectors,
+                        )
+                        .await
+                        {
                             let payload = commands::all_targets_deploy_failure_json(
                                 &target,
                                 &completed,
@@ -4436,6 +4497,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                             );
                             return Err(curie::exit::with_json_payload(err, payload));
                         }
+
                         completed.push(commands::AllTargetsDeployResult {
                             target,
                             result: deployed,
@@ -4465,24 +4527,17 @@ async fn run(command: Option<Command>) -> Result<()> {
                     })
                     .await?;
 
-                    if !secret.is_empty() {
-                        bind_cluster_connector_secrets(
-                            &namespace,
-                            &release,
-                            chart.as_deref(),
-                            &deployed.agent_name,
-                            &secret,
-                        )
-                        .await?;
-                    }
-
                     // Stand up whatever the bundle's connectors.yaml declares
                     // (ADR-0086, #1063). After the deploy, so the objects exist
                     // before the next turn reaches for them; the credentials here
                     // are the CONNECTOR's, resolved locally and written straight to
                     // a K8s Secret, which is a different path from the sandbox
-                    // secret delivery #440 tracks.
-                    sync_connectors(
+                    // secret delivery #440 tracks. The connector's own declared
+                    // secret NAMES are bound into the sandbox too (#2503),
+                    // unioned with the explicit `--secret` set, so a hosted
+                    // connector's derived Bearer header expands in the sandbox.
+                    // Resolved before binding, applied after it.
+                    let prepared_connectors = prepare_cluster_connectors(
                         &api_url,
                         &api_key,
                         &namespace,
@@ -4490,6 +4545,17 @@ async fn run(command: Option<Command>) -> Result<()> {
                         &deployed.agent_id,
                         &deployed.agent_name,
                         &deployed.version_id,
+                    )
+                    .await?;
+
+                    bind_and_apply_cluster_connectors(
+                        &namespace,
+                        &release,
+                        chart.as_deref(),
+                        &deployed.agent_name,
+                        &secret,
+                        &connector_env_secret_names,
+                        prepared_connectors,
                     )
                     .await?;
                     emit(deployed)
@@ -5002,6 +5068,91 @@ mod tests {
     #[test]
     fn clap_surface_is_valid() {
         Cli::command().debug_assert();
+    }
+
+    /// Serializes the `cluster_connector_bind_values` cases that mutate the
+    /// process environment, for the same reason and with the same limits as
+    /// `GITHUB_TOKEN_ENV_LOCK` below: `set_var` is not thread-safe against a
+    /// concurrent `getenv` from a test that does not take this lock. The
+    /// precedent in this crate is `cli/src/slack.rs`.
+    static BIND_VALUES_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn bind_values_env_lock() -> std::sync::MutexGuard<'static, ()> {
+        BIND_VALUES_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn bind_values_binds_a_connector_secret_with_no_explicit_flag() {
+        // #2503: with zero `--secret` flags the connector's own declared name
+        // still reaches the sandbox bind map, carrying the value the connector
+        // plan already resolved for THIS cluster scope (#1913). No `--secret`
+        // means `resolve_named_secrets` iterates nothing, so neither the
+        // environment nor the host vault is consulted at all.
+        let values = super::cluster_connector_bind_values(
+            &[],
+            &["GH".to_string()],
+            &std::collections::BTreeMap::from([("GH".to_string(), "scoped".to_string())]),
+        )
+        .expect("an owned connector value needs no local resolution");
+        assert_eq!(
+            values,
+            std::collections::BTreeMap::from([("GH".to_string(), "scoped".to_string())])
+        );
+    }
+
+    #[test]
+    fn bind_values_prefers_the_scoped_connector_value_over_the_environment() {
+        // The overlap case: the operator also passed `--secret GH` and the
+        // environment holds a DIFFERENT credential. The connector pod
+        // authenticates with the cluster-scoped value, so the sandbox must get
+        // that one -- #1913 is one cluster, one credential, and a split would
+        // 401 exactly the derived Bearer header #2503 exists to make work.
+        let _guard = bind_values_env_lock();
+        let previous = std::env::var("CURIE_TEST_BIND_GH").ok();
+        std::env::set_var("CURIE_TEST_BIND_GH", "env-sentinel");
+
+        let values = super::cluster_connector_bind_values(
+            &["CURIE_TEST_BIND_GH".to_string()],
+            &["CURIE_TEST_BIND_GH".to_string()],
+            &std::collections::BTreeMap::from([(
+                "CURIE_TEST_BIND_GH".to_string(),
+                "scoped-sentinel".to_string(),
+            )]),
+        );
+
+        match previous {
+            Some(value) => std::env::set_var("CURIE_TEST_BIND_GH", value),
+            None => std::env::remove_var("CURIE_TEST_BIND_GH"),
+        }
+
+        let values = values.expect("an env-resolvable --secret must not error");
+        assert_eq!(
+            values.get("CURIE_TEST_BIND_GH").map(String::as_str),
+            Some("scoped-sentinel"),
+            "the connector-scoped value must win over the environment value"
+        );
+        assert_eq!(values.len(), 1);
+    }
+
+    #[test]
+    fn bind_values_with_nothing_to_bind_is_empty() {
+        // Baseline: no `--secret` and no connector-owned values binds nothing,
+        // preserving the pre-#2503 behavior for an ordinary bundle.
+        let values =
+            super::cluster_connector_bind_values(&[], &[], &std::collections::BTreeMap::new())
+                .expect("nothing to resolve");
+        assert!(values.is_empty());
+        // A declared connector name with no resolved value adds nothing
+        // either: the bind map never invents a value for a name.
+        let values = super::cluster_connector_bind_values(
+            &[],
+            &["GH".to_string()],
+            &std::collections::BTreeMap::new(),
+        )
+        .expect("nothing to resolve");
+        assert!(values.is_empty());
     }
 
     #[test]

--- a/docs/interfaces/bundle-format/INTERFACE.md
+++ b/docs/interfaces/bundle-format/INTERFACE.md
@@ -79,7 +79,13 @@ files**, each absent from a bundle that needs none, all three invisible to Claud
   `name` / `from_secret` / `key`) and `secret_files` is by NAME only; neither form
   carries a value. Intake refuses any `sealed_secrets` declaration with
   `connectors.sealed_secrets_unsupported` until a decrypt path exists (see
-  [sealed-credential](../sealed-credential/INTERFACE.md)). Validated by `packages/plugin-format/src/plugin_format/validate.py::_validate_connectors`,
+  [sealed-credential](../sealed-credential/INTERFACE.md)). For a hosted (`image`/`build`) connector
+  with `secrets:` declared, the rendered `.mcp.json` entry derives
+  `headers.Authorization: Bearer ${<first declared secret>}` -- the author still writes no `headers:`
+  on a hosted connector (`connectors.hosted_has_headers`) -- and `cluster deploy` binds that secret
+  name into the sandbox alongside any explicit `--secret` so the placeholder expands (#2503; a
+  `SecretRef` value does not reach the sandbox under ADR-0090, and the `url` fallback used by tiers
+  below cluster derives no header, both tracked as follow-ups). Validated by `packages/plugin-format/src/plugin_format/validate.py::_validate_connectors`,
   which emits `connectors.*` codes (`connectors.not_object`, `connectors.ambiguous`,
   `connectors.underspecified`, `connectors.reserved_name`, `connectors.duplicate_connector`,
   `connectors.duplicate_server`, `connectors.build_context_escapes`,

--- a/packages/plugin-format/src/plugin_format/connector_render.py
+++ b/packages/plugin-format/src/plugin_format/connector_render.py
@@ -567,12 +567,47 @@ def render(
     ]
 
 
+def _derived_headers(spec: ConnectorSpec) -> dict[str, Any]:
+    """The ``Authorization`` header for a hosted connector, or ``{}``.
+
+    ``github-mcp-server``'s HTTP transport authenticates the CLIENT, so an entry
+    without ``Authorization: Bearer`` gets a 401 on the capability probe and the
+    agent silently lists no tools -- no error the author can see (#2503).
+
+    Derived, not authored, for the same reason the URL above is: under ADR-0086
+    the author writes no URL and no header, so there is nothing to get wrong.
+    The value is the ``${NAME}`` placeholder the MCP client expands from the
+    sandbox env -- the same expansion ``unhosted_url`` documents -- so no secret
+    VALUE is ever read or rendered here. The FIRST declared secret is the one
+    used: a single-credential HTTP MCP server is the shape this covers, and the
+    remaining secrets keep their pod-side ``secretKeyRef`` delivery.
+
+    With the header present, a wrong token surfaces from the tool call as
+    GitHub's ``401 Bad credentials``; a MISSING value is refused at deploy
+    (``connectors.yaml declares secret(s) with no value available``). A
+    ``SecretRef`` value never reaches the sandbox under ADR-0090, so the
+    placeholder expands empty and the runner's capability probe still only
+    logs the failure -- a known gap, tracked as a follow-up issue.
+    """
+
+    if not spec.secrets:
+        return {}
+    declared = spec.secrets[0]
+    name = declared if isinstance(declared, str) else declared.name
+    return {"headers": {"Authorization": f"Bearer ${{{name}}}"}}
+
+
 def unhosted_mcp_entry(spec: ConnectorSpec) -> dict[str, Any] | None:
     """The entry for a tier that cannot host this connector, or None.
 
     None is a real answer, not a failure: a hosted connector with nowhere to
     point at IS "declared but not exercisable here" (#1093). Mounting a URL that
     resolves nowhere would turn that into a connection refused mid-turn.
+
+    Unlike ``mcp_entry``, this fallback deliberately does not derive the
+    ``Authorization`` header: no non-cluster tier stages the declared secret
+    into the runner env, so there is nothing yet to derive it from (follow-up
+    issue noted in the PR).
     """
 
     if not spec.is_hosted:
@@ -589,13 +624,16 @@ def mcp_entry(
 
     For a hosted connector the URL is derived from the Service that Curie just
     created; hand-writing it is how a bundle ends up with an address that does
-    not resolve in the tier it is deployed to.
+    not resolve in the tier it is deployed to. Its ``Authorization`` header is
+    derived from the first declared secret for the same reason, so the author
+    writes no header either -- see ``_derived_headers``.
     """
 
     if spec.is_hosted:
         return {
             "type": "http",
             "url": f"http://{service_dns(release, agent, connector, namespace)}:{spec.port}/mcp",
+            **_derived_headers(spec),
         }
     entry: dict[str, Any] = {"type": "http", "url": spec.url}
     if spec.headers:

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import pytest
 import yaml
 from plugin_format import connector_render as r
-from plugin_format.connectors import ConnectorSpec, validate_connectors
+from plugin_format.connectors import ConnectorSpec, SecretRef, validate_connectors
 
 HOSTED = ConnectorSpec(
     image="grafana/mcp-grafana:0.17.2",
@@ -1467,3 +1467,81 @@ def test_the_dns_corpus_covers_the_truncation_branch() -> None:
     assert all(len(v["object_name"]) <= 63 for v in truncated)
     assert all(not v["object_name"].endswith("-") for v in truncated)
     assert len({v["object_name"] for v in truncated}) == len(truncated)
+
+
+# --------------------------------------------------------------------------- #
+# The Authorization header a hosted HTTP MCP server needs -- #2503
+#
+# `ghcr.io/github/github-mcp-server` over HTTP authenticates the CLIENT: per
+# GitHub's docs its streamable-HTTP transport requires `Authorization: Bearer
+# <PAT>` on every request, and an unauthenticated `GET /mcp` is a 401. Until
+# now the hosted entry carried a URL and nothing else, so the probe failed and
+# the agent simply listed no `mcp__github__*` tools -- a silent no-tools, not
+# an error. The header is DERIVED from the first declared secret for the same
+# reason the URL is derived (ADR-0086): the author writes neither.
+# --------------------------------------------------------------------------- #
+GITHUB = ConnectorSpec(
+    image="ghcr.io/github/github-mcp-server:v0.20.1",
+    secrets=["GITHUB_PERSONAL_ACCESS_TOKEN"],
+)
+
+
+def _github_entry(spec: ConnectorSpec = GITHUB) -> dict:
+    return r.mcp_entry("acme-rel", "acme-bot", "acme-ns", "github", spec)
+
+
+def test_a_hosted_connector_carries_a_bearer_header_for_its_declared_secret() -> None:
+    # Without this the mounted entry is a bare URL, github-mcp-server answers
+    # 401, and the failure surfaces only as an agent with no tools (#2503).
+    entry = _github_entry()
+    assert entry["headers"] == {"Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"}
+    # The URL derivation is untouched: the header rides alongside it.
+    assert entry["url"] == (
+        "http://acme-rel-acme-bot-mcp-github.acme-ns.svc.cluster.local:8000/mcp"
+    )
+
+
+def test_a_secret_ref_contributes_its_env_var_name_not_the_secret_it_points_at() -> None:
+    # `secrets:` is `list[str | SecretRef]`. The header names the ENV VAR the
+    # MCP client expands, which for a SecretRef is `.name` -- `from_secret` is
+    # a Kubernetes Secret name and would expand to nothing in the sandbox.
+    spec = ConnectorSpec(
+        image="ghcr.io/github/github-mcp-server:v0.20.1",
+        secrets=[SecretRef(name="GITHUB_PERSONAL_ACCESS_TOKEN", from_secret="gh-pat")],
+    )
+    assert _github_entry(spec)["headers"] == {
+        "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
+    }
+
+
+def test_a_hosted_connector_with_no_secrets_renders_exactly_as_it_did_before() -> None:
+    # Regression guard on the byte-identical claim: a connector that declares
+    # no credential has no env var to reference, so emitting an empty or
+    # literal header would change the mounted entry of every existing bundle.
+    spec = ConnectorSpec(image="ghcr.io/github/github-mcp-server:v0.20.1")
+    assert _github_entry(spec) == {
+        "type": "http",
+        "url": "http://acme-rel-acme-bot-mcp-github.acme-ns.svc.cluster.local:8000/mcp",
+    }
+
+
+def test_a_remote_connector_keeps_the_headers_its_author_wrote() -> None:
+    # Derivation is scoped to the hosted form. A `url:` connector's headers are
+    # author input, so deriving over them would silently replace a hand-written
+    # Authorization (or drop a second header) on every existing remote bundle.
+    assert r.mcp_entry("acme-rel", "acme-bot", "acme-ns", "internal", REMOTE) == {
+        "type": "http",
+        "url": "https://mcp.internal/mcp",
+        "headers": {"Authorization": "Bearer ${T}"},
+    }
+
+
+def test_only_the_placeholder_is_emitted_never_a_resolved_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # `${VAR}` is expanded by the MCP client from the sandbox environment. If
+    # the renderer ever read the value instead, the credential would land in
+    # the mounted `.mcp.json` -- a plaintext copy on disk in every tier, and in
+    # anything that logs the rendered entry.
+    monkeypatch.setenv("GITHUB_PERSONAL_ACCESS_TOKEN", "ghp_sentinel")
+    assert "ghp_sentinel" not in json.dumps(_github_entry())

--- a/runner/tests/test_connectors.py
+++ b/runner/tests/test_connectors.py
@@ -671,3 +671,31 @@ def test_an_agent_name_that_only_looks_like_the_join_still_mounts(tmp_path: Path
     assert servers["grafana"]["url"] == (
         "http://curie-mcp-x-mcp-grafana.curie.svc.cluster.local:8000/mcp"
     )
+
+
+# --------------------------------------------------------------------------- #
+# What the sandbox actually mounts for an authenticated hosted server -- #2503
+#
+# github-mcp-server's HTTP transport authenticates the client: GitHub's docs
+# require `Authorization: Bearer <PAT>` on every request, and without it the
+# tool-capability probe logs `MCP tool-capability probe failed` and the agent
+# lists no `mcp__github__*` tool at all. This file is the one that pins what
+# the runner hands the MCP client, so the header has to be provable here and
+# not only in plugin-format.
+# --------------------------------------------------------------------------- #
+GITHUB = (
+    "connectors:\n"
+    "  github:\n"
+    "    image: ghcr.io/github/github-mcp-server:v0.20.1\n"
+    "    secrets: [GITHUB_PERSONAL_ACCESS_TOKEN]\n"
+)
+
+_BEARER = {"Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"}
+
+
+def test_the_mounted_hosted_server_carries_the_declared_credential(tmp_path: Path) -> None:
+    # The credential name is the only thing the author writes; the header, like
+    # the URL, is derived. `${VAR}` is expanded by the MCP client from the
+    # sandbox environment, so nothing resolved is written to disk here.
+    servers = derive_mcp_servers(_bundle(tmp_path, GITHUB), **SCOPE)
+    assert servers["github"]["headers"] == _BEARER


### PR DESCRIPTION
Closes #2503. Refs #1118 (the injection half landed there; this is the remaining gap), ADR-0086, ADR-0009, #1488, #1913, #464.

Fix pin: packages/plugin-format/tests/test_connector_render.py::test_a_hosted_connector_carries_a_bearer_header_for_its_declared_secret

## What

- `plugin_format.connector_render.mcp_entry` derives `headers.Authorization = "Bearer ${<first declared secret>}"` for a hosted connector. The author still writes no URL and no header; `connectors.hosted_has_headers` is unchanged. No plugin-format artifact drifted (no model field changed; `scripts/check-contracts.sh` is clean).
- `curie cluster deploy` binds the hosted connectors.yaml env secret names into the sandbox on the existing `--secret` path: the agent record carries the names so the worker routes the claim to the per-agent pool, and the sandbox Secret reuses the cluster-scoped values already resolved for the connector Secret (#1913). The #464 gate sees that effective set on the cluster tier only; `local deploy` keeps the explicit `--secret` set. Single-target and `--all-targets` share one bind-and-apply sequence.

## Cluster proof (kind + Calico, source images, live OpenRouter model, live GitHub)

Hosted-only bundle exactly as in the issue (github-mcp-server v1.12.0 over http on 8000, `secrets: [GITHUB_PERSONAL_ACCESS_TOKEN]`, empty `.mcp.json`), PAT only in the operator environment, no `--secret`:

- deploy: `binding connector secrets for agent ghmcp on release curie: ok`; the sandbox claim came from `curie-agent-ghmcp-runner-pool` and the pod env carries `GITHUB_PERSONAL_ACCESS_TOKEN` via secretKeyRef (AC2).
- `curie cluster message 'Do you have any tool whose name starts with mcp__github? ...'` -> `YES`, then 26 `mcp__github__*` names (get_me, list_commits, search_code, ...) (AC3).
- `--continue 'Call mcp__github__get_me ... then mcp__github__list_commits curie-eng/curie perPage 1'` -> login `TheConnMan`, id `1328448`; newest sha `45ef6f82aaf9e0b74760634ff63f8d9178bc2bff`, which matched `gh api repos/curie-eng/curie/commits?per_page=1` at that moment (AC4).
- Missing value: `cluster deploy` with the var unset -> `Error: connectors.yaml declares secret(s) with no value available for cluster ... GITHUB_PERSONAL_ACCESS_TOKEN` (exit 2). Garbage token: redeploy, connector rolled, pool recycled, `Call mcp__github__get_me` -> `failed to get user: GET https://api.github.com/user: 401 Bad credentials []` in the agent's reply (AC5).
- Negative control before the agent-record change: same deploy, agent answered `NO` with only curie/curie-state tools; runner logged `MCP tool-capability probe failed server=github`; pod from the generic pool with zero secret env entries. Direct probe of the Service: no Authorization -> 401 on `POST /mcp`; garbage Bearer -> 200 + tool list + `401 Bad credentials` on calls; real Bearer -> the login.

## Out of scope, filed

- #2518: skill and local tiers do not stage the declared secret into the runner env, so the `unhosted_url` fallback still derives no header and local deploy still requires `--secret`.
- #2519: a `SecretRef` (`from_secret`) value never reaches the sandbox (ADR-0090), so an empty Bearer still fails silently at the capability probe.

## Done-check

- [x] Failing tests committed first (`dc08d0b6f` before the squash)
- [x] All production edits by delegated sub-agents; driver ran git, tests, and bookkeeping only
- [x] Broadened return types: none reported by any Implementer; `bind_cluster_connector_secrets` changed its parameter, callers updated
- [x] Agent-router Code review (codex gpt-6-astra): round 1 REVISE (3 P1, 1 P2), round 2 REVISE (1 P1), all fixed; consolidation re-check ACCEPT
- [x] Agent-router Scope review (codex): round 1 REVISE (unhosted fallback dropped, docstring claim qualified), round 2 REVISE (unused accessor removed)
- [x] Sibling-path parity: cluster paths (single-target, --all-targets) both covered; skill/local tiers and the `unhosted_url` fallback filed as #2518
- [x] Guard demonstration: #464 gate executed through `deploy()` for both tiers in tests; deploy refusal on a missing value executed live (exit 2, names the credential)
- [x] Consolidation: `/simplify` applied 4 cleanups; validation re-run; codex re-check ACCEPT
- [ ] Security reviewer: N/A (scale-up not flagged; the existing connector-secret path is reused)
- [ ] Observable verification: N/A (no UI surface)
- [x] E2E on a deployed system: kind cluster observations above
- [x] Train check: contract names main explicitly (general bug on both lines); milestone v0.9.0 noted
- [x] Discovery-surface proof: cluster/live ticket, proven at cluster tier with live GitHub
- [ ] Re-fix mechanism: N/A (no prior fix of this symptom; #1118 landed the injection half)
- [x] Affected suites: plugin-format 642, runner 868, api bundle tests, cli lib 1204 + bin 67 pass; ruff, mypy, fmt, clippy, docs-lint, check-contracts clean. `chart_check_passes_on_the_unmodified_chart` (`mail-adapter-wiring-assertions.sh`) fails identically at origin/main head and is untouched here.
