### PR TITLE
Prevent local verification from shallowing shared Git history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,12 +93,16 @@ git fetch --force --tags origin refs/heads/main:refs/remotes/origin/main
   uv run python scripts/check-released-upgrade.py --self-test
   uv run python scripts/check-released-upgrade.py
   (cd apps/api && uv run alembic upgrade head)
-  git fetch --no-tags --depth=1 origin "$base" || true
+  git fetch --no-tags origin "$base" || true
   git show "origin/$base:packages/aci-protocol/schema/wire.lock" > "$wire_lock" 2>/dev/null || true
   uv run python -m aci_protocol.wire_lock --check-base "$wire_lock"
   uv run pytest -q
 )
 ```
+
+Linked worktrees share their repository's Git shallow metadata. Never use a
+shallow fetch in this checkout or one of its linked worktrees; if a shallow
+fetch is needed, use an independent clone instead.
 
 Occupied default ports are a reason to isolate the job, not by themselves a
 failed precondition. Preserve the existing owner and follow the instructions


### PR DESCRIPTION
## Summary

Remove `--depth=1` from the repository-local Python verification baseline so copying and running the documented command cannot shallow the shared repository. The instructions now state that linked worktrees share Git shallow metadata and require an independent clone for any shallow fetch.

The equivalent-instance audit intentionally leaves the remaining shallow operations unchanged: the GitHub Actions fetch runs in an independent CI checkout, and the worker fetches run in independent sandbox/workspace clones. The earlier investigation did not retain an executed command proving a named 02:00 job was the culprit, so this PR makes no such attribution; it prevents the documented shared-checkout hazard.

## Fix pin verification

Fix pin: n/a - documentation-only prevention; no product file or runtime test selector changes

## End-to-end verification

This change does not alter Curie runtime behavior because it changes only contributor verification instructions.

Scoped verification at commit `f1e6f94c`:

- `bash scripts/check-docs.sh` — passed: interface catalog drift-free, every citation resolved, and every verification-contract command resolved.
- `git diff --check` — passed with no whitespace errors.
- Independent blocking diff review — `APPROVE`, no findings; remaining shallow operations confirmed as independent CI/sandbox clones.

Disposable local fixture proof used a full clone plus a linked worktree, advanced remote `main`, and ran the revised baseline fetch exactly:

```bash
base=main
git fetch --no-tags origin "$base" || true
```

Assertions and observed results:

```text
before_is_shallow=false
after_is_shallow=false
merge_base_expected=53dab3dfc5af4f2e1e20c58d6e462bf96353af78
merge_base_actual=53dab3dfc5af4f2e1e20c58d6e462bf96353af78
fetched_main_history_count=3
root_is_ancestor_of_FETCH_HEAD=true
```

The fixture was created under `/tmp` with its own bare origin and clone; no live shared Git state was modified to reproduce the hazard.

## Checklist

- [x] Tests pass for the area touched: documentation checks passed.
- [x] Documentation accurately explains the linked-worktree shallow-metadata boundary.
- [x] No ADR is needed; this preserves repository verification behavior and changes no architecture.
