### PR TITLE
Redact Curie credential shapes in the shared log filter

### DIFF
--- a/apps/mail-adapter/CLAUDE.md
+++ b/apps/mail-adapter/CLAUDE.md
@@ -63,16 +63,12 @@ the enforceable-rule summary.
   reintroduce `logging.basicConfig` (it installs a root handler and the same
   record is then emitted twice, once unformatted), and do not attach a handler
   that bypasses the service logger -- either move re-opens the unfiltered path
-  this closed. What the filter does **not** do is the load-bearing half:
-  `packages/telemetry/src/curie_telemetry/redact.py`'s `REDACTION_RULES` has no
-  rule for any of this adapter's own credential shapes. A `chn-` channel token,
-  an AgentMail API key and `CURIE_EGRESS_SECRET` all pass through verbatim
-  unless they happen to appear as a URL query parameter (`?token=`,
-  `?api_key=`), as a bare `token=`/`secret=`/`api_key=` assignment, or after
-  `Authorization: Bearer`. `CURIE_CHANNEL_TOKEN=<value>` is specifically **not**
-  redacted -- the `secret_assignment` rule needs a word boundary before `token`,
-  and the preceding `_` denies it -- and neither is an `X-API-Key: <value>`
-  header rendered into a message. The "no raw mail PII" rule above is likewise a
+  this closed. The shared `REDACTION_RULES` now match this adapter's credential
+  *shapes*: a bare `chn.{payload}.{signature}` token, an AgentMail `am_` key,
+  `CURIE_*_TOKEN=` / `*_SECRET=` assignments, and an `X-API-Key: <value>`
+  header. An unprefixed `CURIE_EGRESS_SECRET` value still needs that
+  assignment or header context -- the filter will not claim to recognize the
+  secret as an arbitrary string. The "no raw mail PII" rule above is likewise a
   code-level obligation the filter cannot enforce: no rule matches an address,
   subject, body or provider id. Keep credentials and mail content out of the
   record in the first place; the filter only catches the shapes it knows.

--- a/packages/telemetry/src/curie_telemetry/redact.py
+++ b/packages/telemetry/src/curie_telemetry/redact.py
@@ -58,8 +58,25 @@ REDACTION_RULES: tuple[RedactionRule, ...] = (
     ),
     RedactionRule(
         "api_key",
-        re.compile(r"\b(?:sk|xai)[-_][A-Za-z0-9_-]{16,}"),
+        # sk-/xai- are the in-tree model-key prefixes. AgentMail documents
+        # ``am_`` (https://docs.agentmail.to/knowledge-base/getting-api-key.md).
+        re.compile(r"\b(?:(?:sk|xai)[-_]|am_)[A-Za-z0-9_-]{16,}"),
         _placeholder("api_key"),
+    ),
+    RedactionRule(
+        "channel_token",
+        # Curie-minted ingress credential: ``chn.{payload}.{signature}``
+        # (``curie_api.channel_token``, prefix ``chn``). Hyphenated
+        # ``chn-{id}-{digest}`` values are event ids, not credentials.
+        re.compile(r"\bchn\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"),
+        _placeholder("channel_token"),
+    ),
+    RedactionRule(
+        "x_api_key",
+        # Opaque header values have no unique prefix; match the header
+        # name the mail adapter and channel clients send.
+        re.compile(r"(X-API-Key:\s*)(?!\[REDACTED:)\S+", re.IGNORECASE),
+        r"\1[REDACTED:x_api_key]",
     ),
     RedactionRule(
         "aws_access_key_id",
@@ -88,11 +105,15 @@ REDACTION_RULES: tuple[RedactionRule, ...] = (
     ),
     RedactionRule(
         "secret_assignment",
+        # ``\b`` does not fire before ``token`` in ``CURIE_CHANNEL_TOKEN=``
+        # because ``_`` is a word character. Require a non-alphanumeric
+        # predecessor so ``*_TOKEN=`` / ``*_SECRET=`` match while
+        # ``mytoken=`` does not. Keep the key name; drop only the value.
         re.compile(
-            r"\b(?:secret|password|passwd|pwd|api_key|apikey|access_token|token)=\S+",
+            r"(?<![A-Za-z0-9])((?:secret|password|passwd|pwd|api_key|apikey|access_token|token)=)(?!\[REDACTED:)\S+",
             re.IGNORECASE,
         ),
-        _placeholder("secret_assignment"),
+        r"\1[REDACTED:secret_assignment]",
     ),
     RedactionRule(
         "home_path",

--- a/packages/telemetry/tests/test_logging.py
+++ b/packages/telemetry/tests/test_logging.py
@@ -35,6 +35,11 @@ _SECRET_VECTORS = (
     "https://example.invalid/hook?token=" + "0000FAKEFAKEFAKEFAKE",
     "secret=" + "0000FAKEFAKEFAKEVALUE",
     "/home/example-user/.config/curie/settings.json",
+    "chn." + "ZXhhbXBsZWNoYW5uZWxwYXlsb2Fk." + "FAKEFAKEFAKESIG0000",
+    "am_" + "FAKEFAKEFAKEFAKEFAKE0000",
+    "CURIE_CHANNEL_TOKEN=" + "FAKEFAKEFAKEHEADERVALUE0000",
+    "CURIE_EGRESS_SECRET=" + "FAKEFAKEFAKEEGRESS0000",
+    "X-API-Key: " + "FAKEFAKEFAKEHEADERVALUE0000",
 )
 
 
@@ -360,6 +365,52 @@ def test_exception_keeps_redacted_stderr_traceback_but_closes_otlp_fields() -> N
         assert "exception.message" not in attributes
         assert "exception.stacktrace" not in attributes
         assert redaction_probe not in repr(attributes)
+    finally:
+        logger.handlers[:] = original_handlers
+        logger.setLevel(original_level)
+        logger.propagate = original_propagate
+        logger_provider.shutdown()
+
+
+def test_curie_credential_in_exception_is_redacted_on_the_service_logger() -> None:
+    redaction_probe = "chn." + "ZXhhbXBsZWNoYW5uZWxwYXlsb2Fk." + "FAKEFAKEFAKESIG0000"
+    resource = build_resource(
+        "curie-mail-adapter",
+        service_version="0.8.8",
+        service_instance_id="acme-mail-exception",
+        deployment_environment="test",
+    )
+    exporter = InMemoryLogRecordExporter()
+    logger_provider = LoggerProvider(resource=resource)
+    logger_provider.add_log_record_processor(SimpleLogRecordProcessor(exporter))
+    stderr = io.StringIO()
+    logger = logging.getLogger("curie.telemetry.curie-credential-exception")
+    original_handlers = list(logger.handlers)
+    original_level = logger.level
+    original_propagate = logger.propagate
+
+    try:
+        configure_service_logging(
+            logger,
+            service_name="curie-mail-adapter",
+            stream=stderr,
+            logger_provider=logger_provider,
+        )
+        try:
+            raise RuntimeError(f"CURIE_CHANNEL_TOKEN={redaction_probe}")
+        except RuntimeError:
+            logger.exception("request handler escaped credential=%s", redaction_probe)
+
+        stderr_record = json.loads(stderr.getvalue())
+        assert "Traceback (most recent call last)" in stderr_record["exception"]
+        assert "RuntimeError" in stderr_record["exception"]
+        assert redaction_probe not in stderr_record["message"]
+        assert redaction_probe not in stderr_record["exception"]
+        assert "[REDACTED:" in stderr_record["exception"]
+
+        (exported,) = exporter.get_finished_logs()
+        assert redaction_probe not in _body(exported)
+        assert redaction_probe not in repr(_attributes(exported))
     finally:
         logger.handlers[:] = original_handlers
         logger.setLevel(original_level)

--- a/packages/telemetry/tests/test_redact.py
+++ b/packages/telemetry/tests/test_redact.py
@@ -1,6 +1,26 @@
 """Redaction closes authentication formats before any telemetry export."""
 
-from curie_telemetry.redact import redact_text
+from __future__ import annotations
+
+import io
+import logging
+
+from curie_telemetry.redact import RedactingLogFilter, redact_text
+
+# Hoisted synthetic values. The check-secrets hook false-positives on inline
+# token literals, so prefixes are split rather than written at the call site.
+#
+# Channel tokens are minted as ``chn.{payload}.{signature}``
+# (``apps/api/src/curie_api/channel_token.py``, prefix ``chn``). The issue's
+# ``chn-{channel_id}-{digest}`` shape is ``_event_id``, not a credential.
+FAKE_CHANNEL_TOKEN = "chn." + "ZXhhbXBsZWNoYW5uZWxwYXlsb2Fk." + "FAKEFAKEFAKESIG0000"
+# Provider docs: "API keys start with `am_`"
+# https://docs.agentmail.to/knowledge-base/getting-api-key.md
+FAKE_AGENTMAIL_API_KEY = "am_" + "FAKEFAKEFAKEFAKEFAKE0000"
+FAKE_EGRESS_SECRET = "FAKEFAKEFAKEEGRESS0000"
+FAKE_HEADER_VALUE = "FAKEFAKEFAKEHEADERVALUE0000"
+# Delivery correlation id from the channel protocol tests, not a credential.
+BENIGN_EVENT_ID = "chn-7f3-a1b2c3d4e5f60718"
 
 
 def test_basic_authorization_value_is_removed() -> None:
@@ -31,3 +51,124 @@ def test_slack_app_level_token_is_removed() -> None:
 
     assert token not in redacted
     assert "[REDACTED:slack_token]" in redacted
+
+
+def test_bare_channel_token_shape_is_redacted() -> None:
+    redacted = redact_text(f"adapter credential {FAKE_CHANNEL_TOKEN}")
+
+    assert FAKE_CHANNEL_TOKEN not in redacted
+    assert "[REDACTED:channel_token]" in redacted
+    assert "adapter credential " in redacted
+
+
+def test_channel_event_id_is_not_treated_as_a_credential() -> None:
+    line = f"inbound admitted event_id={BENIGN_EVENT_ID}"
+
+    assert redact_text(line) == line
+
+
+def test_curie_channel_token_assignment_is_redacted() -> None:
+    value = FAKE_HEADER_VALUE
+    redacted = redact_text(f"boot CURIE_CHANNEL_TOKEN={value} ready")
+
+    assert value not in redacted
+    assert "CURIE_CHANNEL_TOKEN=" in redacted
+    assert "[REDACTED:secret_assignment]" in redacted
+    assert "boot " in redacted
+    assert " ready" in redacted
+
+
+def test_curie_egress_secret_assignment_is_redacted() -> None:
+    redacted = redact_text(f"boot CURIE_EGRESS_SECRET={FAKE_EGRESS_SECRET} ready")
+
+    assert FAKE_EGRESS_SECRET not in redacted
+    assert "CURIE_EGRESS_SECRET=" in redacted
+    assert "[REDACTED:secret_assignment]" in redacted
+
+
+def test_unprefixed_secret_without_assignment_or_header_context_is_not_redacted() -> None:
+    # CURIE_EGRESS_SECRET has no unique prefix. A regex that claimed to
+    # recognize the value itself would also redact ordinary diagnostic text.
+    line = f"retry after {FAKE_EGRESS_SECRET} milliseconds"
+
+    assert redact_text(line) == line
+
+
+def test_x_api_key_header_value_is_redacted() -> None:
+    redacted = redact_text(f"upstream X-API-Key: {FAKE_HEADER_VALUE} rejected")
+
+    assert FAKE_HEADER_VALUE not in redacted
+    assert "X-API-Key:" in redacted
+    assert "[REDACTED:x_api_key]" in redacted
+    assert "upstream " in redacted
+    assert " rejected" in redacted
+
+
+def test_x_api_key_header_is_matched_case_insensitively() -> None:
+    redacted = redact_text(f"x-api-key: {FAKE_HEADER_VALUE}")
+
+    assert FAKE_HEADER_VALUE not in redacted
+    assert "[REDACTED:x_api_key]" in redacted
+
+
+def test_agentmail_api_key_prefix_is_redacted() -> None:
+    # AgentMail documents the `am_` prefix
+    # (https://docs.agentmail.to/knowledge-base/getting-api-key.md).
+    redacted = redact_text(f"provider credential {FAKE_AGENTMAIL_API_KEY}")
+
+    assert FAKE_AGENTMAIL_API_KEY not in redacted
+    assert "[REDACTED:api_key]" in redacted
+
+
+def test_short_am_prefix_is_not_treated_as_an_api_key() -> None:
+    line = "label am_short stays visible"
+
+    assert redact_text(line) == line
+
+
+def test_alphanumeric_token_suffix_is_not_an_assignment() -> None:
+    line = "mytoken=" + FAKE_EGRESS_SECRET
+
+    assert redact_text(line) == line
+
+
+def test_benign_near_matches_are_preserved() -> None:
+    line = f"session token_count=12 channel=email event_id={BENIGN_EVENT_ID} X-Request-Id: abc"
+
+    assert redact_text(line) == line
+
+
+def test_installed_filter_redacts_formatted_args() -> None:
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.addFilter(RedactingLogFilter())
+    logger = logging.getLogger("curie.telemetry.redact.args")
+    logger.handlers.clear()
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    try:
+        logger.info("ingress X-API-Key: %s", FAKE_CHANNEL_TOKEN)
+    finally:
+        logger.removeHandler(handler)
+
+    out = stream.getvalue()
+    assert FAKE_CHANNEL_TOKEN not in out
+    assert "[REDACTED:" in out
+    assert "ingress " in out
+
+
+def test_exception_text_carrying_a_channel_token_assignment_is_redacted() -> None:
+    traceback_text = (
+        "Traceback (most recent call last):\n"
+        '  File "adapter.py", line 1, in handle\n'
+        f"RuntimeError: CURIE_CHANNEL_TOKEN={FAKE_CHANNEL_TOKEN}"
+    )
+
+    redacted = redact_text(traceback_text)
+
+    assert FAKE_CHANNEL_TOKEN not in redacted
+    assert "Traceback (most recent call last):" in redacted
+    assert "RuntimeError:" in redacted
+    assert "CURIE_CHANNEL_TOKEN=" in redacted
+    assert "[REDACTED:channel_token]" in redacted

--- a/runner/tests/test_redact.py
+++ b/runner/tests/test_redact.py
@@ -64,6 +64,8 @@ FAKE_JWT = "eyJ" + "hbGciOiJIUzI1NiJ9.eyJzdWIiOiJmYWtlIn0.FAKEFAKEFAKEFAKEFAKEFA
 FAKE_URL_WITH_TOKEN = "https://example.invalid/hook?token=" + "0000FAKEFAKEFAKEFAKE"
 FAKE_SECRET_ASSIGNMENT = "secret=" + "0000FAKEFAKEFAKEVALUE"
 FAKE_HOME_PATH = "/home/theconnman/.config/curie/settings.json"
+FAKE_CHANNEL_TOKEN = "chn." + "ZXhhbXBsZWNoYW5uZWxwYXlsb2Fk." + "FAKEFAKEFAKESIG0000"
+FAKE_X_API_KEY_HEADER = "X-API-Key: " + "FAKEFAKEFAKEHEADERVALUE0000"
 
 # The sensitive substring that must be absent from every boundary's output,
 # keyed by rule name. VECTORS is derived from this so the two cannot drift.
@@ -82,6 +84,8 @@ SECRET_LITERALS: dict[str, str] = {
     "url_secret_param": FAKE_URL_WITH_TOKEN,
     "secret_assignment": FAKE_SECRET_ASSIGNMENT,
     "home_path": FAKE_HOME_PATH,
+    "channel_token": FAKE_CHANNEL_TOKEN,
+    "x_api_key": FAKE_X_API_KEY_HEADER,
 }
 
 # One frozen vector per rule: a realistic runner output line carrying that class


### PR DESCRIPTION
## Summary

The shared `RedactingLogFilter` policy now matches Curie credential shapes that previously passed through in the clear: minted `chn.{payload}.{signature}` channel tokens, AgentMail `am_` keys, `X-API-Key` header values, and `CURIE_*_TOKEN=` / `*_SECRET=` assignments.

The issue text cited `chn-{channel_id}-{digest}` at `channels.py`. That helper is `_event_id`, not the minted credential. `channel_token.mint` emits `chn.{payload}.{signature}`. Hyphenated event ids stay visible so delivery correlation is not erased.

Opaque values with no unique prefix (including `CURIE_EGRESS_SECRET`) are redacted only in assignment or `X-API-Key` header context. The filter does not invent a regex for arbitrary strings.

## Related issue

Closes #2359

## Fix pin verification

Fix pin: packages/telemetry/tests/test_redact.py::test_curie_channel_token_assignment_is_redacted

`curie dev verify-fix-pin ee78a2a44 packages/telemetry/tests/test_redact.py::test_curie_channel_token_assignment_is_redacted` reported `PINNED`: the selector passed on the candidate and failed after product hunks were reversed (`CURIE_CHANNEL_TOKEN=FAKEFAKEFAKEHEADERVALUE0000` remained in the string).

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, ACI events, skill eval/check, or the runner turn protocol. Runner stdout/span coverage is the existing redact tripwire. | | |
| local | required | Shared filter is what compose services emit through `configure_service_logging`; the installed logging path is the runtime surface. | fake | `uv run pytest packages/telemetry/tests/test_redact.py packages/telemetry/tests/test_logging.py runner/tests/test_redact.py -q` on `ee78a2a44`: 102 passed. Installed `RedactingLogFilter` and `configure_service_logging` both drop synthetic `chn.` tokens, `am_` keys, `CURIE_*_TOKEN=` / `*_SECRET=` assignments, and `X-API-Key` values from formatted args and exception text. |
| local-release | n/a | Does not change released binary or image identity, install path, version pins, or release compose. | | |
| cluster | n/a | Does not reach chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, or init containers. | | |
| live provider | n/a | Does not reach model routing, product credential resolution, token accounting, MCP catalog, PreToolUse, platform MCP tools, workspace publication, or coding-tool session capability. | | |
| external integration | n/a | Does not reach Slack, git webhooks, connector OAuth, or a live third-party API. AgentMail `am_` is cited from https://docs.agentmail.to/knowledge-base/getting-api-key.md | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive and negative per criterion (all on `ee78a2a44`):

- Bare `chn.` token: `test_bare_channel_token_shape_is_redacted` replaces the value with `[REDACTED:channel_token]`. Negative: `test_channel_event_id_is_not_treated_as_a_credential` leaves `chn-7f3-a1b2c3d4e5f60718` intact.
- `CURIE_CHANNEL_TOKEN=` / `CURIE_EGRESS_SECRET=`: assignment tests keep the key name and drop the value. Negative: `test_alphanumeric_token_suffix_is_not_an_assignment` leaves `mytoken=` visible; `test_unprefixed_secret_without_assignment_or_header_context_is_not_redacted` leaves a bare egress-shaped string visible.
- `X-API-Key`: header tests drop the value and keep the header name, including `x-api-key`. Negative: `X-Request-Id: abc` is unchanged.
- Args / installed filter: `test_installed_filter_redacts_formatted_args` and the service-logger parametrization. Second path: runner stdout and gen_ai span tripwire for the new rule names.
- Exception text: service-logger exception test and `redact_text` traceback test. Negative: surrounding `Traceback` / `RuntimeError` text remains.
- AgentMail `am_`: `test_agentmail_api_key_prefix_is_redacted`. Negative: `am_short` is unchanged.
- Benign near-matches: `token_count=12 channel=email` unchanged.

Sibling path: `runner/tests/test_redact.py` `SECRET_LITERALS` now includes `channel_token` and `x_api_key`, so `test_every_rule_has_a_frozen_vector` still binds every named rule to stdout and gen_ai_span.

Out of scope: `sbx.` sandbox tokens use the same mint shape with a different prefix. This ticket named `chn` tokens, not sandbox tokens.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision.
