### PR TITLE
Document that the tool deny list is not a capability boundary

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -65,7 +65,13 @@ readinessProbe hits `/healthz`).
   the three ACI POST routes; enforced only when set), `CURIE_FAKE_MODEL`
   (offline smoke; no model call), `CURIE_DISALLOWED_TOOLS` (optional
   comma-separated tool names removed from the session and refused even under
-  bypassPermissions; unset keeps every tool available).
+  bypassPermissions; unset keeps every tool available). This stops the named
+  tools, not the underlying capability (#2429): denying
+  `mcp__curie-state__append`/`set`/`delete` does not revoke
+  `CURIE_STATE_TOKEN`, which stays in the sandbox environment, so a
+  still-permitted shell tool (e.g. `Bash`) can reach the same HTTP state API
+  directly. Naming `Bash` alongside the state tools closes that path today;
+  removing the token itself needs a code change, not a config knob.
 
 ## Build and smoke
 

--- a/runner/src/curie_runner/adapter.py
+++ b/runner/src/curie_runner/adapter.py
@@ -141,7 +141,9 @@ def build_options(
         include_partial_messages=True,
         # Optional operator deny list (#2429). Empty/None keeps the SDK default
         # (no tools removed). Names are removed from the model context and cannot
-        # be used even under bypassPermissions.
+        # be used even under bypassPermissions. This removes a tool, not the
+        # capability behind it: it does not revoke CURIE_STATE_TOKEN, which a
+        # still-permitted tool can still use to reach the same API directly.
         disallowed_tools=list(disallowed_tools or ()),
     )
 


### PR DESCRIPTION
## Summary

Runtime acceptance of #2429 on a task-owned disposable v0.8.7 install confirmed that `CURIE_DISALLOWED_TOOLS` refuses the named `curie-state` write tools and that no row reaches the store. It also reproduced a residual vector: the state credential stays in the sandbox environment, so a still-permitted shell tool reaches the same HTTP state API and the persistent write succeeds.

This records that where an operator reads the flag. Documentation only; no behavior change. The enforcement question is filed separately as #2525.

## Related issue

Ref #2429

## End-to-end verification

| Tier | Required / n/a | Reason | Mode | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | required | The touched comment sits on the option this diff describes | fake | `uv run pytest -q runner/tests/test_disallowed_tools.py` on the candidate commit — 7 passed |
| local | n/a | Documentation only; no parsed value, boot env, or option shape changes | | |
| local-release | n/a | Does not change binary identity, install path, version pins, or generated release compose | | |
| cluster | n/a | Does not change chart templates, RBAC, sandbox claims, or init containers | | |
| live provider | required | The claim being documented is a live runtime observation, not a source reading | live | Disposable release `curie-2429` on chart `0.8.7`, images `ghcr.io/curie-eng/curie-*:0.8.7`, model `z-ai/glm-5.3-flash`. With the deny list applied and read back off the rendered SandboxTemplate, a live turn was refused (`Permission to use mcp__curie-state__append has been denied`) and no row appeared in `curie.workflow_state_entries`. In the same install a `Bash` turn issued `PUT $CURIE_STATE_URL/<ns>/<key>` with an `X-API-Key` header and received `200` with the row written; confirmed independently by operator `kubectl exec`. Negative control: with the deny list unset, the identical prompt wrote state despite prompt wording forbidding it |
| external integration | n/a | Does not change Slack, git webhooks, connector OAuth, or third-party API shape | | |

- [x] Every required tier names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each claim in the diff has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved.

Shipped: this PR once merged. Deployed: not applied to the permanent soak. Live-observed: the behavior being documented, on the disposable install above.

## Checklist

- [x] Tests pass for the area I touched.
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. Not one; the architectural question is #2525.
