### PR TITLE
Refuse final release tags that never reached main

### DIFF
--- a/.github/workflows/chart-index.yaml
+++ b/.github/workflows/chart-index.yaml
@@ -68,13 +68,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_COMMIT: ${{ steps.release.outputs.commit }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -euo pipefail
           git checkout origin/main -- release/
           python3 release/authorize.py "$RELEASE_COMMIT" \
             --repo "$GITHUB_REPOSITORY" \
             --reviewed-ref origin/main \
-            --reviewed-ref origin/next
+            --reviewed-ref origin/next \
+            --tag "$RELEASE_TAG"
 
       - name: Download every release asset
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,7 +88,8 @@ jobs:
         run: |
           python3 release/authorize.py "$GITHUB_SHA" --repo "$GITHUB_REPOSITORY" \
             --reviewed-ref origin/${{ env.RELEASE_MAIN_BRANCH }} \
-            --reviewed-ref origin/${{ env.RELEASE_NEXT_BRANCH }}
+            --reviewed-ref origin/${{ env.RELEASE_NEXT_BRANCH }} \
+            --tag "$GITHUB_REF_NAME"
       - name: Tag must carry its architecture atlas snapshot
         run: |
           python3 release/atlas.py \

--- a/release/authorize.py
+++ b/release/authorize.py
@@ -9,7 +9,10 @@ pipeline, and it fails closed on either of two questions:
   ancestry  Is the tagged commit reachable from an explicitly supplied
             reviewed branch? A tag on a feature branch, a rebased commit, or
             anything that bypassed a merged PR is refused here, before any
-            image builds.
+            image builds. A final semver tag must be reachable from the
+            primary reviewed ref (the first `--reviewed-ref`, `origin/main`
+            in the release workflow). A prerelease may come from any
+            reviewed ref so `next` RCs still publish (issues #1476, #1560).
 
   checks    Does that commit's check-runs list show every REQUIRED_CHECK_NAMES
             entry successful (or neutral)? An explicit allowlist,
@@ -41,6 +44,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from collections.abc import Sequence
@@ -93,6 +97,38 @@ REQUIRED_CHECK_NAMES = frozenset(
 
 class AuthorizationError(Exception):
     """A tagged commit is not authorized to publish a release."""
+
+
+# Semver 2.0.0 with an optional leading `v`. A non-empty prerelease
+# identifier is the tag class; build metadata does not make a tag a
+# prerelease.
+_SEMVER_TAG = re.compile(
+    r"^v?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?$"
+)
+
+
+def classify_release_tag(tag: str) -> str:
+    """Return `final` or `prerelease` for a semver `v*` tag.
+
+    Strips a `refs/tags/` prefix so either `GITHUB_REF` or `GITHUB_REF_NAME`
+    can be passed. Raises AuthorizationError on a non-semver name so a tag
+    that the workflow's `v*` glob accepted but that has no prerelease
+    component we can trust cannot publish as a final release by accident.
+    """
+    raw = tag.strip()
+    if raw.startswith("refs/tags/"):
+        raw = raw.removeprefix("refs/tags/")
+    match = _SEMVER_TAG.fullmatch(raw)
+    if match is None:
+        raise AuthorizationError(
+            f"tag {tag!r} is not a semver v* tag; refusing to authorize this tag"
+        )
+    if match.group("prerelease"):
+        return "prerelease"
+    return "final"
 
 
 def commit_is_on_reviewed_branch(
@@ -208,8 +244,16 @@ def authorize(
     cwd: Path | None = None,
     exclude_run_id: str | None = None,
     required_names: frozenset[str] | None = None,
+    tag: str | None = None,
 ) -> None:
-    """Raise AuthorizationError unless `sha` may publish a release."""
+    """Raise AuthorizationError unless `sha` may publish a release.
+
+    `tag` is the pushed tag name (`v0.7.0`, `v0.7.0-rc.1`). A missing tag
+    is treated as final (fail closed) so omitting the class cannot widen
+    the reviewed-ref set. `main()` always passes `--tag`. A final tag must
+    be reachable from the first reviewed ref (the stable line); a
+    prerelease may use any reviewed ref (issue #1560).
+    """
     if not reviewed_refs:
         raise AuthorizationError(
             "at least one reviewed ref is required; refusing to authorize this tag"
@@ -225,6 +269,17 @@ def authorize(
             f"commit {sha} is not reachable from any reviewed ref "
             f"({checked_refs}); refusing to authorize this tag"
         )
+    tag_class = "final" if tag is None else classify_release_tag(tag)
+    if tag_class == "final":
+        primary_ref = reviewed_refs[0]
+        if not reachability[0]:
+            tag_label = tag if tag is not None else "unspecified"
+            raise AuthorizationError(
+                f"commit {sha} is not reachable from {primary_ref}; "
+                f"a final tag ({tag_label}) requires the merge-then-tag sequence: "
+                f"merge the reviewed branch into {primary_ref}, then tag. "
+                "Refusing to authorize this tag"
+            )
     other_runs = exclude_current_workflow_run(check_runs, exclude_run_id)
     missing = missing_required_checks(other_runs, required_names)
     if missing:
@@ -307,6 +362,11 @@ def main(argv: list[str] | None = None) -> int:
         help="a reviewed branch ref; repeat for every allowed branch",
     )
     parser.add_argument(
+        "--tag",
+        required=True,
+        help="the pushed tag name, e.g. v0.7.0 or v0.7.0-rc.1",
+    )
+    parser.add_argument(
         "--run-id",
         default=os.environ.get("GITHUB_RUN_ID"),
         help="this workflow run's id; its own check-runs are excluded from the gate",
@@ -315,7 +375,13 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         check_runs = fetch_check_runs(args.sha, args.repo)
-        authorize(args.sha, check_runs, args.reviewed_ref, exclude_run_id=args.run_id)
+        authorize(
+            args.sha,
+            check_runs,
+            args.reviewed_ref,
+            exclude_run_id=args.run_id,
+            tag=args.tag,
+        )
     except AuthorizationError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -255,6 +255,7 @@ class TestAuthorize:
             REVIEWED_REFS,
             cwd=git_repo,
             required_names=TEST_REQUIRED_NAMES,
+            tag="v0.7.0-rc.5",
         )
 
     def test_commit_reachable_only_from_main_is_authorized(
@@ -326,6 +327,108 @@ class TestAuthorize:
                 cwd=git_repo,
                 required_names=TEST_REQUIRED_NAMES,
             )
+
+
+class TestTagClassAuthorization:
+    """Issue #1560: final tags require the primary reviewed ref; prereleases may use any.
+
+    The four cases are the issue's acceptance criteria. Reverting the
+    classification in `authorize()` makes `test_final_tag_on_next_only_commit_is_refused`
+    fail: that commit is reachable from `origin/next` and would authorize again.
+    """
+
+    def test_final_tag_on_next_only_commit_is_refused(self, reviewed_refs_repo):
+        git_repo, commits = reviewed_refs_repo
+
+        with pytest.raises(authorize_module.AuthorizationError) as exc_info:
+            authorize_module.authorize(
+                commits["next"],
+                CHECK_RUNS_ALL_GREEN,
+                REVIEWED_REFS,
+                cwd=git_repo,
+                required_names=TEST_REQUIRED_NAMES,
+                tag="v0.7.0",
+            )
+
+        message = str(exc_info.value)
+        assert "origin/main" in message
+        assert "merge" in message.lower()
+        assert "tag" in message.lower()
+
+    def test_prerelease_tag_on_next_only_commit_is_authorized(self, reviewed_refs_repo):
+        git_repo, commits = reviewed_refs_repo
+
+        authorize_module.authorize(
+            commits["next"],
+            CHECK_RUNS_ALL_GREEN,
+            REVIEWED_REFS,
+            cwd=git_repo,
+            required_names=TEST_REQUIRED_NAMES,
+            tag="v0.7.0-rc.5",
+        )
+
+    def test_final_tag_on_main_commit_is_authorized(self, reviewed_refs_repo):
+        git_repo, commits = reviewed_refs_repo
+
+        authorize_module.authorize(
+            commits["main"],
+            CHECK_RUNS_ALL_GREEN,
+            REVIEWED_REFS,
+            cwd=git_repo,
+            required_names=TEST_REQUIRED_NAMES,
+            tag="v0.7.0",
+        )
+
+    def test_commit_reachable_from_neither_ref_is_still_refused(
+        self, reviewed_refs_repo
+    ):
+        git_repo, commits = reviewed_refs_repo
+
+        with pytest.raises(authorize_module.AuthorizationError) as exc_info:
+            authorize_module.authorize(
+                commits["feature"],
+                CHECK_RUNS_ALL_GREEN,
+                REVIEWED_REFS,
+                cwd=git_repo,
+                required_names=TEST_REQUIRED_NAMES,
+                tag="v0.7.0",
+            )
+
+        message = str(exc_info.value)
+        assert "not reachable from any reviewed ref" in message
+        assert "origin/main" in message
+        assert "origin/next" in message
+
+    def test_omitted_tag_on_next_only_commit_is_treated_as_final(
+        self, reviewed_refs_repo
+    ):
+        git_repo, commits = reviewed_refs_repo
+
+        with pytest.raises(authorize_module.AuthorizationError) as exc_info:
+            authorize_module.authorize(
+                commits["next"],
+                CHECK_RUNS_ALL_GREEN,
+                REVIEWED_REFS,
+                cwd=git_repo,
+                required_names=TEST_REQUIRED_NAMES,
+            )
+
+        assert "origin/main" in str(exc_info.value)
+
+
+class TestClassifyReleaseTag:
+    def test_final_semver_is_final(self):
+        assert authorize_module.classify_release_tag("v0.7.0") == "final"
+
+    def test_rc_prerelease_is_prerelease(self):
+        assert authorize_module.classify_release_tag("v0.7.0-rc.5") == "prerelease"
+
+    def test_build_metadata_without_prerelease_is_final(self):
+        assert authorize_module.classify_release_tag("v0.7.0+build.1") == "final"
+
+    def test_invalid_tag_is_refused(self):
+        with pytest.raises(authorize_module.AuthorizationError, match="semver"):
+            authorize_module.classify_release_tag("vnext")
 
 
 class TestRequiredCheckAllowlist:
@@ -713,7 +816,15 @@ class TestMain:
         monkeypatch.setenv("GITHUB_RUN_ID", CURRENT_RUN_ID)
 
         exit_code = authorize_module.main(
-            [sha, "--repo", "curie-eng/curie", "--reviewed-ref", "main"]
+            [
+                sha,
+                "--repo",
+                "curie-eng/curie",
+                "--reviewed-ref",
+                "main",
+                "--tag",
+                "v0.7.0",
+            ]
         )
 
         assert exit_code == 0
@@ -731,7 +842,15 @@ class TestMain:
         monkeypatch.delenv("GITHUB_RUN_ID", raising=False)
 
         exit_code = authorize_module.main(
-            [sha, "--repo", "curie-eng/curie", "--reviewed-ref", "main"]
+            [
+                sha,
+                "--repo",
+                "curie-eng/curie",
+                "--reviewed-ref",
+                "main",
+                "--tag",
+                "v0.7.0",
+            ]
         )
 
         assert exit_code == 0
@@ -752,10 +871,71 @@ class TestMain:
         monkeypatch.setenv("GITHUB_RUN_ID", OTHER_RUN_ID)
 
         exit_code = authorize_module.main(
-            [sha, "--repo", "curie-eng/curie", "--reviewed-ref", "main"]
+            [
+                sha,
+                "--repo",
+                "curie-eng/curie",
+                "--reviewed-ref",
+                "main",
+                "--tag",
+                "v0.7.0",
+            ]
         )
 
         assert exit_code == 1
+
+    def test_main_refuses_a_final_tag_on_a_next_only_commit(
+        self, reviewed_refs_repo, monkeypatch, capsys
+    ):
+        git_repo, commits = reviewed_refs_repo
+        self._use_test_required_names(monkeypatch)
+        self._stub_fetch_check_runs(monkeypatch, self._runs_with_gate_own_in_progress())
+        monkeypatch.chdir(git_repo)
+        monkeypatch.setenv("GITHUB_RUN_ID", CURRENT_RUN_ID)
+
+        exit_code = authorize_module.main(
+            [
+                commits["next"],
+                "--repo",
+                "curie-eng/curie",
+                "--reviewed-ref",
+                "origin/main",
+                "--reviewed-ref",
+                "origin/next",
+                "--tag",
+                "v0.7.0",
+            ]
+        )
+
+        assert exit_code == 1
+        err = capsys.readouterr().err
+        assert "origin/main" in err
+        assert "merge" in err.lower()
+
+    def test_main_authorizes_a_prerelease_tag_on_a_next_only_commit(
+        self, reviewed_refs_repo, monkeypatch
+    ):
+        git_repo, commits = reviewed_refs_repo
+        self._use_test_required_names(monkeypatch)
+        self._stub_fetch_check_runs(monkeypatch, self._runs_with_gate_own_in_progress())
+        monkeypatch.chdir(git_repo)
+        monkeypatch.setenv("GITHUB_RUN_ID", CURRENT_RUN_ID)
+
+        exit_code = authorize_module.main(
+            [
+                commits["next"],
+                "--repo",
+                "curie-eng/curie",
+                "--reviewed-ref",
+                "origin/main",
+                "--reviewed-ref",
+                "origin/next",
+                "--tag",
+                "v0.7.0-rc.5",
+            ]
+        )
+
+        assert exit_code == 0
 
 
 class TestMainLookupFailures:
@@ -782,7 +962,15 @@ class TestMainLookupFailures:
         monkeypatch.chdir(git_repo)
         monkeypatch.setenv("GITHUB_RUN_ID", CURRENT_RUN_ID)
         return authorize_module.main(
-            [sha, "--repo", "curie-eng/curie", "--reviewed-ref", "main"]
+            [
+                sha,
+                "--repo",
+                "curie-eng/curie",
+                "--reviewed-ref",
+                "main",
+                "--tag",
+                "v0.7.0",
+            ]
         )
 
     def test_gh_api_failure_refuses_with_a_message_naming_the_lookup(
@@ -1110,6 +1298,8 @@ class TestReleaseWorkflowContract:
         assert set(reviewed_ref_envs) == set(authorization_env)
         assert len(reviewed_ref_envs) == len(authorization_env) == 2
         assert {authorization_env[name] for name in reviewed_ref_envs} == {"main", "next"}
+        assert authorization_env[reviewed_ref_envs[0]] == "main"
+        assert re.search(r'--tag\s+"\$GITHUB_REF_NAME"', command)
 
         overlay = re.search(
             r"git checkout origin/\$\{\{\s*env\.([A-Za-z_][A-Za-z0-9_]*)\s*\}\}\s+-- release/",

--- a/release/tests/test_chart_index_workflow.py
+++ b/release/tests/test_chart_index_workflow.py
@@ -161,8 +161,10 @@ class TestChartIndexWorkflowContract:
             r"git\s+checkout\s+origin/main\s+--\s+release/",
             authorization_script,
         )
-        assert "--reviewed-ref origin/main" in authorization_script
-        assert "--reviewed-ref origin/next" in authorization_script
+        reviewed_refs = re.findall(r"--reviewed-ref\s+(\S+)", authorization_script)
+        assert reviewed_refs[0] == "origin/main"
+        assert "origin/next" in reviewed_refs
+        assert re.search(r'--tag\s+"\$RELEASE_TAG"', authorization_script)
 
         resolve_script = run_script(
             next(step for step in steps if step.get("id") == "release")


### PR DESCRIPTION
## Summary

A final `v*` tag on a commit that lives only on `next` can no longer publish. The authorization gate now classifies the tag by its semver prerelease component: finals must be reachable from the primary reviewed ref (`origin/main`, the first `--reviewed-ref`); prereleases may still use any reviewed ref so `next` RCs keep working. A commit on neither ref is still refused with the same message. Both `release.yaml` and `chart-index.yaml` pass `--tag` into the real consumer.

## Related issue

Closes #1560

## Fix pin verification

Fix pin: n/a - gate tests live in release/tests, which is not a supported selector form

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin or skill packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | n/a | Does not reach compose services, dispatcher, worker, API wiring, the console UI, or any curie verb output/exit/--json shape. | | |
| local-release | required | This is the release-publication authorization gate. Proof is the real `release/authorize.py` consumer against local fixture repos, plus workflow argument wiring. The e2e-ladder local-release rung does not invoke this script. No real tag is pushed and nothing is published. | live | Candidate `828fcdca7`. `uv run --python 3.13 python .projects/plans/verify-1560-consumer.py`: AC1 next-only `v0.7.0` REFUSED naming `origin/main` and the merge-then-tag sequence; AC2 `v0.7.0-rc.5` AUTHORIZED; AC3 final on main AUTHORIZED; AC4 neither-ref REFUSED with `not reachable from any reviewed ref`. Workflow-shaped CLI: AC1 exit 1, AC2 exit 0, AC3 exit 0, AC4 exit 1. `uv run --python 3.13 pytest release/tests/test_authorize.py release/tests/test_chart_index_workflow.py -q` -> 106 passed. |
| cluster | n/a | Does not reach chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, or init containers. | | |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, token/cost accounting, or the MCP/workspace/coding-tool path set. | | |
| external integration | n/a | Does not reach Slack, git push webhooks, connector OAuth, or a third-party API shape. No real tag is pushed. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive plus negative per criterion (candidate `828fcdca7`):

1. Final `v0.7.0` on next-only: REFUSED, message names `origin/main` and merge-then-tag. Negative: same commit with `v0.7.0-rc.5` AUTHORIZED. Reverting the classification made `test_final_tag_on_next_only_commit_is_refused` fail with DID NOT RAISE.
2. Prerelease on that commit: AUTHORIZED via `authorize()` and via `main()` CLI. Negative: final tag on the same SHA refused.
3. Final tag on main: AUTHORIZED. Negative: neither-ref commit with the same final tag still refused.
4. Neither-ref: REFUSED with the unchanged `not reachable from any reviewed ref` message. Second path: omitted `--tag` on CLI is SystemExit 2; omitted tag on `authorize()` for a next-only commit is treated as final and refused.
5. Four cases live in `release/tests/test_authorize.py::TestTagClassAuthorization`. Workflow `--tag "$GITHUB_REF_NAME"` and chart-index `--tag "$RELEASE_TAG"` are pinned; first reviewed ref is `origin/main`.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed. AGENTS.md already states the merge-then-tag rule; the gate now enforces it.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. Not an ADR: this is the missing tag-class distinction on the existing #628 / #1483 gate.
