### PR TITLE
Wait for connector Deployments after cluster deploy apply

### DIFF
--- a/cli/src/connectors.rs
+++ b/cli/src/connectors.rs
@@ -13,12 +13,19 @@
 //! on the next deploy. Without that, a deleted connector leaves a pod running
 //! with a credential mounted and nothing referencing it -- the kind of leak
 //! nobody notices because nothing breaks.
+//!
+//! Apply success is not connector health (#2350). After apply+prune, each
+//! hosted Deployment is waited on until Ready or a terminal pod reason, bounded
+//! by [`CONNECTOR_ROLLOUT_DEADLINE`]. A failed wait is nonzero and does not
+//! roll the agent or version back.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
+use regex::Regex;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
@@ -73,6 +80,605 @@ pub fn apply_args(namespace: &str) -> Vec<String> {
         "-f".into(),
         "-".into(),
     ]
+}
+
+/// Shared with `comms` rollout status: other kubectl rollouts wait 120s.
+/// Connector deploy uses that bound once for every connector Deployment.
+pub const CONNECTOR_ROLLOUT_DEADLINE: Duration = Duration::from_secs(120);
+
+/// Last-log excerpt is a diagnostic, not a dump. kubectl `--tail` matches this.
+pub const LAST_LOG_TAIL_LINES: usize = 20;
+
+/// Last-log excerpt character cap after redaction.
+pub const LAST_LOG_MAX_CHARS: usize = 2048;
+
+/// A hosted connector Deployment that `cluster deploy` must see become Ready.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConnectorWorkload {
+    pub connector: String,
+    pub deployment: String,
+}
+
+/// Observed rollout state. Kubernetes `message` fields never enter this value.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RolloutObservation {
+    Ready,
+    Pending,
+    Failed {
+        reason: &'static str,
+        pod: Option<String>,
+    },
+}
+
+/// `kubectl rollout status` argv. Kept so the wait bound stays the comms 120s.
+pub fn rollout_status_args(namespace: &str, deployment: &str, timeout: Duration) -> Vec<String> {
+    vec![
+        "kubectl".into(),
+        "-n".into(),
+        namespace.into(),
+        "rollout".into(),
+        "status".into(),
+        format!("deployment/{deployment}"),
+        format!("--timeout={}s", timeout.as_secs().max(1)),
+    ]
+}
+
+pub fn deployment_get_args(namespace: &str, deployment: &str) -> Vec<String> {
+    vec![
+        "kubectl".into(),
+        "-n".into(),
+        namespace.into(),
+        "get".into(),
+        "deployment".into(),
+        deployment.into(),
+        "-o".into(),
+        "json".into(),
+    ]
+}
+
+pub fn pods_get_args(namespace: &str, deployment: &str) -> Vec<String> {
+    vec![
+        "kubectl".into(),
+        "-n".into(),
+        namespace.into(),
+        "get".into(),
+        "pods".into(),
+        "-l".into(),
+        format!("app.kubernetes.io/name={deployment}"),
+        "-o".into(),
+        "json".into(),
+    ]
+}
+
+pub fn replicasets_get_args(namespace: &str, deployment: &str) -> Vec<String> {
+    vec![
+        "kubectl".into(),
+        "-n".into(),
+        namespace.into(),
+        "get".into(),
+        "replicasets".into(),
+        "-l".into(),
+        format!("app.kubernetes.io/name={deployment}"),
+        "-o".into(),
+        "json".into(),
+    ]
+}
+
+pub fn last_log_args(namespace: &str, pod: &str, previous: bool) -> Vec<String> {
+    let mut args = vec![
+        "kubectl".into(),
+        "-n".into(),
+        namespace.into(),
+        "logs".into(),
+        pod.into(),
+        format!("--tail={LAST_LOG_TAIL_LINES}"),
+    ];
+    if previous {
+        args.push("--previous".into());
+    }
+    args
+}
+
+/// Time left on the command deadline. `None` means the wait must fail closed.
+pub fn remaining_timeout(deadline: Instant, now: Instant) -> Option<Duration> {
+    deadline
+        .checked_duration_since(now)
+        .filter(|d| *d > Duration::ZERO)
+}
+
+/// Hosted Deployments to wait on. Remote URL-only entries have no Deployment.
+pub fn connector_workloads(
+    manifests: &[Value],
+    urls: &BTreeMap<String, Value>,
+) -> Vec<ConnectorWorkload> {
+    let mut workloads = Vec::new();
+    for obj in manifests {
+        if obj.get("kind").and_then(Value::as_str) != Some("Deployment") {
+            continue;
+        }
+        let Some(name) = obj
+            .get("metadata")
+            .and_then(|m| m.get("name"))
+            .and_then(Value::as_str)
+        else {
+            continue;
+        };
+        if name.is_empty() {
+            continue;
+        }
+        let connector = urls
+            .iter()
+            .find_map(|(connector, entry)| {
+                let url = entry.get("url").and_then(Value::as_str)?;
+                url_names_deployment(url, name).then_some(connector.clone())
+            })
+            .unwrap_or_else(|| name.to_string());
+        workloads.push(ConnectorWorkload {
+            connector,
+            deployment: name.to_string(),
+        });
+    }
+    workloads
+}
+
+fn terminal_reason(value: &str) -> Option<&'static str> {
+    match value {
+        "CrashLoopBackOff" => Some("CrashLoopBackOff"),
+        "ImagePullBackOff" => Some("ImagePullBackOff"),
+        "ErrImagePull" => Some("ErrImagePull"),
+        "InvalidImageName" => Some("InvalidImageName"),
+        "CreateContainerConfigError" => Some("CreateContainerConfigError"),
+        "CreateContainerError" => Some("CreateContainerError"),
+        "RunContainerError" => Some("RunContainerError"),
+        "OOMKilled" => Some("OOMKilled"),
+        "Error" => Some("Error"),
+        "Evicted" => Some("Evicted"),
+        "ContainerCannotRun" => Some("ContainerCannotRun"),
+        "BackoffLimitExceeded" => Some("BackoffLimitExceeded"),
+        "DeadlineExceeded" => Some("DeadlineExceeded"),
+        "ProgressDeadlineExceeded" => Some("ProgressDeadlineExceeded"),
+        _ => None,
+    }
+}
+
+fn replicaset_revision(rs: &Value) -> u64 {
+    rs.pointer("/metadata/annotations")
+        .and_then(Value::as_object)
+        .and_then(|annotations| annotations.get("deployment.kubernetes.io/revision"))
+        .and_then(Value::as_str)
+        .and_then(|revision| revision.parse().ok())
+        .unwrap_or(0)
+}
+
+/// Template hash of the newest ReplicaSet, so fail-fast ignores superseded pods.
+pub fn current_template_hash(replicasets: &[Value]) -> Option<String> {
+    replicasets
+        .iter()
+        .max_by_key(|rs| replicaset_revision(rs))
+        .and_then(|rs| {
+            rs.pointer("/metadata/labels/pod-template-hash")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+}
+
+fn pod_is_current(pod: &Value, current_hash: Option<&str>) -> bool {
+    if pod
+        .pointer("/metadata/deletionTimestamp")
+        .and_then(Value::as_str)
+        .is_some()
+    {
+        return false;
+    }
+    let Some(hash) = current_hash else {
+        return true;
+    };
+    pod.pointer("/metadata/labels/pod-template-hash")
+        .and_then(Value::as_str)
+        == Some(hash)
+}
+
+fn pod_terminal_failure(pod: &Value) -> Option<RolloutObservation> {
+    let name = pod
+        .pointer("/metadata/name")
+        .and_then(Value::as_str)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string);
+    for field in ["/status/containerStatuses", "/status/initContainerStatuses"] {
+        let Some(list) = pod.pointer(field).and_then(Value::as_array) else {
+            continue;
+        };
+        for container in list {
+            for pointer in ["/state/waiting/reason", "/state/terminated/reason"] {
+                if let Some(reason) = container
+                    .pointer(pointer)
+                    .and_then(Value::as_str)
+                    .and_then(terminal_reason)
+                {
+                    return Some(RolloutObservation::Failed {
+                        reason,
+                        pod: name.clone(),
+                    });
+                }
+            }
+        }
+    }
+    None
+}
+
+fn deployment_progress_deadline(deployment: &Value) -> Option<RolloutObservation> {
+    let generation = deployment
+        .pointer("/metadata/generation")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let observed = deployment
+        .pointer("/status/observedGeneration")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    if generation > 0 && observed < generation {
+        return None;
+    }
+    let conditions = deployment
+        .pointer("/status/conditions")
+        .and_then(Value::as_array)?;
+    for cond in conditions {
+        if cond.get("type").and_then(Value::as_str) == Some("Progressing")
+            && cond.get("reason").and_then(Value::as_str) == Some("ProgressDeadlineExceeded")
+        {
+            return Some(RolloutObservation::Failed {
+                reason: "ProgressDeadlineExceeded",
+                pod: None,
+            });
+        }
+    }
+    None
+}
+
+/// Classify a Deployment plus its pods. Message fields are ignored.
+///
+/// `current_hash` is the newest ReplicaSet `pod-template-hash`. Terminal pod
+/// reasons are taken only from that revision, so a crashlooping predecessor
+/// cannot fail a corrective rollout. Ready requires the current generation to
+/// be observed and updated, not merely leftover readyReplicas from old pods.
+pub fn observe_rollout(
+    deployment: &Value,
+    pods: &[Value],
+    current_hash: Option<&str>,
+) -> RolloutObservation {
+    for pod in pods.iter().filter(|pod| pod_is_current(pod, current_hash)) {
+        if let Some(failed) = pod_terminal_failure(pod) {
+            return failed;
+        }
+    }
+    if let Some(failed) = deployment_progress_deadline(deployment) {
+        return failed;
+    }
+    let generation = deployment
+        .pointer("/metadata/generation")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let observed = deployment
+        .pointer("/status/observedGeneration")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let wanted = deployment
+        .pointer("/spec/replicas")
+        .and_then(Value::as_u64)
+        .unwrap_or(1);
+    let updated = deployment
+        .pointer("/status/updatedReplicas")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let ready = deployment
+        .pointer("/status/readyReplicas")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let available = deployment
+        .pointer("/status/availableReplicas")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let total = deployment
+        .pointer("/status/replicas")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    // kubectl rollout status: updatedReplicas and availableReplicas meet spec,
+    // and no extra old replicas remain (status.replicas <= updatedReplicas).
+    if wanted > 0
+        && observed >= generation
+        && updated >= wanted
+        && ready >= wanted
+        && available >= wanted
+        && total <= updated
+    {
+        RolloutObservation::Ready
+    } else {
+        RolloutObservation::Pending
+    }
+}
+
+/// Bound and redact a pod log excerpt. Secret values are replaced first.
+pub fn redact_last_log(text: &str, secret_values: &BTreeMap<String, String>) -> String {
+    let mut out = text.to_string();
+    let mut values: Vec<&String> = secret_values
+        .values()
+        .filter(|value| !value.is_empty())
+        .collect();
+    values.sort_by_key(|value| std::cmp::Reverse(value.len()));
+    for value in values {
+        out = out.replace(value, "[REDACTED]");
+    }
+    static PATTERNS: OnceLock<[Regex; 3]> = OnceLock::new();
+    let patterns = PATTERNS.get_or_init(|| {
+        [
+            Regex::new(r"(?i)(authorization:\s*bearer\s+)\S+").expect("bearer regex"),
+            Regex::new(r"(?i)((?:api[_-]?key|secret|token|password)\s*[=:]\s*)\S+")
+                .expect("assignment regex"),
+            Regex::new(r#"(?i)("(?:api[_-]?key|secret|token|password)"\s*:\s*")[^"]*"#)
+                .expect("json field regex"),
+        ]
+    });
+    for re in patterns {
+        out = re.replace_all(&out, "${1}[REDACTED]").into_owned();
+    }
+    out = crate::schema_window::redact_probe_text(&out);
+    let lines: Vec<&str> = out.lines().collect();
+    let clipped = if lines.len() > LAST_LOG_TAIL_LINES {
+        lines[lines.len() - LAST_LOG_TAIL_LINES..].join("\n")
+    } else {
+        out.trim_end().to_string()
+    };
+    let mut bounded: String = clipped.chars().take(LAST_LOG_MAX_CHARS).collect();
+    if clipped.chars().count() > LAST_LOG_MAX_CHARS {
+        bounded.push_str("\n...");
+    }
+    bounded
+}
+
+fn excerpt_or_omit(text: &str, secret_values: &BTreeMap<String, String>) -> Option<String> {
+    let redacted = redact_last_log(text, secret_values);
+    if secret_values
+        .values()
+        .any(|value| !value.is_empty() && redacted.contains(value))
+    {
+        return None;
+    }
+    if redacted.trim().is_empty() {
+        None
+    } else {
+        Some(redacted)
+    }
+}
+
+/// Nonzero connector rollout failure. Names the connector and the recovery command.
+pub fn rollout_failure(
+    connector: &str,
+    namespace: &str,
+    deployment: &str,
+    reason: &str,
+    excerpt: Option<&str>,
+) -> anyhow::Error {
+    let mut message = format!("connector {connector} did not become ready ({reason})");
+    if let Some(excerpt) = excerpt.map(str::trim).filter(|excerpt| !excerpt.is_empty()) {
+        message.push_str("\nlast log:\n");
+        message.push_str(excerpt);
+    }
+    anyhow::Error::from(
+        crate::exit::CliError::failure(message).with_fix(format!(
+            "inspect with `kubectl -n {namespace} logs deploy/{deployment} --tail=50`, then fix connectors.yaml and re-run `curie cluster deploy`. The agent/version may already exist; this is not a healthy connector deploy and was not rolled back."
+        )),
+    )
+}
+
+async fn run_bounded(
+    argv: &[String],
+    stdin: Option<&str>,
+    budget: Duration,
+) -> Result<(bool, String, String)> {
+    match tokio::time::timeout(budget.max(Duration::from_millis(50)), run(argv, stdin)).await {
+        Ok(result) => result,
+        Err(_) => anyhow::bail!("kubectl timed out after {}s", budget.as_secs()),
+    }
+}
+
+fn timed_out(err: &anyhow::Error) -> bool {
+    err.to_string().contains("kubectl timed out")
+}
+
+async fn kubectl_list(
+    target: &ClusterTarget,
+    argv: &[String],
+    workload: &ConnectorWorkload,
+    namespace: &str,
+    deadline: Instant,
+) -> Result<Option<Value>> {
+    let Some(budget) = remaining_timeout(deadline, Instant::now()) else {
+        return Err(rollout_failure(
+            &workload.connector,
+            namespace,
+            &workload.deployment,
+            "timeout",
+            None,
+        ));
+    };
+    match run_bounded(
+        &target.args(argv),
+        None,
+        budget.min(Duration::from_secs(10)),
+    )
+    .await
+    {
+        Ok((true, out, _)) => Ok(serde_json::from_str(&out).ok()),
+        Ok((false, _, err)) if err.contains("NotFound") || err.contains("not found") => Ok(None),
+        Ok((false, _, _)) => Err(rollout_failure(
+            &workload.connector,
+            namespace,
+            &workload.deployment,
+            "observe",
+            None,
+        )),
+        Err(err) if timed_out(&err) => Err(rollout_failure(
+            &workload.connector,
+            namespace,
+            &workload.deployment,
+            "timeout",
+            None,
+        )),
+        Err(_) => Err(rollout_failure(
+            &workload.connector,
+            namespace,
+            &workload.deployment,
+            "observe",
+            None,
+        )),
+    }
+}
+
+fn list_items(doc: Option<Value>) -> Vec<Value> {
+    doc.and_then(|list| list.get("items").cloned())
+        .and_then(|items| items.as_array().cloned())
+        .unwrap_or_default()
+}
+
+async fn observe_one(
+    target: &ClusterTarget,
+    namespace: &str,
+    workload: &ConnectorWorkload,
+    deadline: Instant,
+) -> Result<RolloutObservation> {
+    let Some(deployment) = kubectl_list(
+        target,
+        &deployment_get_args(namespace, &workload.deployment),
+        workload,
+        namespace,
+        deadline,
+    )
+    .await?
+    else {
+        return Ok(RolloutObservation::Pending);
+    };
+    let replicasets = list_items(
+        kubectl_list(
+            target,
+            &replicasets_get_args(namespace, &workload.deployment),
+            workload,
+            namespace,
+            deadline,
+        )
+        .await?,
+    );
+    let current_hash = current_template_hash(&replicasets);
+    let pods = list_items(
+        kubectl_list(
+            target,
+            &pods_get_args(namespace, &workload.deployment),
+            workload,
+            namespace,
+            deadline,
+        )
+        .await?,
+    );
+    Ok(observe_rollout(&deployment, &pods, current_hash.as_deref()))
+}
+
+async fn last_log_excerpt(
+    target: &ClusterTarget,
+    namespace: &str,
+    pod: &str,
+    secret_values: &BTreeMap<String, String>,
+    deadline: Instant,
+) -> Option<String> {
+    let budget = remaining_timeout(deadline, Instant::now())?;
+    let current = run_bounded(
+        &target.args(&last_log_args(namespace, pod, false)),
+        None,
+        budget.min(Duration::from_secs(10)),
+    )
+    .await
+    .ok();
+    let raw = match current {
+        Some((true, out, _)) if !out.trim().is_empty() => out,
+        _ => {
+            let budget = remaining_timeout(deadline, Instant::now())?;
+            let previous = run_bounded(
+                &target.args(&last_log_args(namespace, pod, true)),
+                None,
+                budget.min(Duration::from_secs(10)),
+            )
+            .await
+            .ok()?;
+            if !previous.0 || previous.1.trim().is_empty() {
+                return None;
+            }
+            previous.1
+        }
+    };
+    excerpt_or_omit(&raw, secret_values)
+}
+
+/// Wait until every hosted connector Deployment is Ready, or fail named.
+pub async fn wait_for_connector_rollouts(
+    target: &ClusterTarget,
+    namespace: &str,
+    workloads: &[ConnectorWorkload],
+    secret_values: &BTreeMap<String, String>,
+    deadline: Instant,
+) -> Result<()> {
+    if workloads.is_empty() {
+        return Ok(());
+    }
+    let ui = crate::ui::ui();
+    let remaining_s = remaining_timeout(deadline, Instant::now())
+        .unwrap_or(Duration::ZERO)
+        .as_secs();
+    ui.note(&format!(
+        "waiting for {} connector rollout(s), deadline {remaining_s}s",
+        workloads.len()
+    ));
+    let mut pending: Vec<ConnectorWorkload> = workloads.to_vec();
+    loop {
+        if remaining_timeout(deadline, Instant::now()).is_none() {
+            let first = &pending[0];
+            return Err(rollout_failure(
+                &first.connector,
+                namespace,
+                &first.deployment,
+                "timeout",
+                None,
+            ));
+        }
+        let mut still = Vec::new();
+        for workload in pending {
+            match observe_one(target, namespace, &workload, deadline).await? {
+                RolloutObservation::Ready => {
+                    ui.note(&format!("connector {}: ready", workload.connector));
+                }
+                RolloutObservation::Pending => still.push(workload),
+                RolloutObservation::Failed { reason, pod } => {
+                    let excerpt = match pod {
+                        Some(pod) => {
+                            last_log_excerpt(target, namespace, &pod, secret_values, deadline).await
+                        }
+                        None => None,
+                    };
+                    return Err(rollout_failure(
+                        &workload.connector,
+                        namespace,
+                        &workload.deployment,
+                        reason,
+                        excerpt.as_deref(),
+                    ));
+                }
+            }
+        }
+        if still.is_empty() {
+            return Ok(());
+        }
+        pending = still;
+        let Some(remaining) = remaining_timeout(deadline, Instant::now()) else {
+            continue;
+        };
+        tokio::time::sleep(remaining.min(Duration::from_secs(2))).await;
+    }
 }
 
 /// `kubectl delete` argv for owned objects of `kind` that are no longer declared.
@@ -296,10 +902,10 @@ pub fn as_list_document(manifests: &[Value]) -> Result<String> {
 
 /// Whether an mcp_entry URL names this Deployment's Service.
 ///
-/// Same host match #2350 uses for rollout wait (`connector_workloads`): the
-/// Service DNS is `<deployment>.<namespace>.svc.cluster.local`. Sibling: share
-/// this helper with #2350 when that PR merges. Do not treat a missing match as
-/// a capability-probe failure (#2519).
+/// Same host match the rollout wait uses (`connector_workloads`): the
+/// Service DNS is `<deployment>.<namespace>.svc.cluster.local`. Shared by
+/// #2350 and #2352. Do not treat a missing match as a capability-probe
+/// failure (#2519).
 fn url_names_deployment(url: &str, deployment: &str) -> bool {
     let rest = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
     let hostport = rest.split('/').next().unwrap_or(rest);
@@ -592,6 +1198,172 @@ mod tests {
         assert!(!args.iter().any(|a| a.contains("go-template")));
     }
 
+    fn deploy_status(replicas: u64, ready: u64, available: u64) -> Value {
+        json!({
+            "metadata": {"generation": 1},
+            "spec": {"replicas": replicas},
+            "status": {
+                "observedGeneration": 1,
+                "replicas": replicas,
+                "updatedReplicas": replicas,
+                "readyReplicas": ready,
+                "availableReplicas": available,
+            }
+        })
+    }
+
+    fn pod_waiting(name: &str, reason: &str) -> Value {
+        json!({
+            "metadata": {"name": name},
+            "status": {
+                "containerStatuses": [{
+                    "name": "server",
+                    "state": {"waiting": {"reason": reason, "message": "should-never-surface"}}
+                }]
+            }
+        })
+    }
+
+    #[test]
+    fn no_connectors_yield_no_workloads() {
+        assert!(connector_workloads(&[], &BTreeMap::new()).is_empty());
+    }
+
+    #[test]
+    fn ready_replicas_are_healthy() {
+        assert_eq!(
+            observe_rollout(&deploy_status(1, 1, 1), &[], None),
+            RolloutObservation::Ready
+        );
+    }
+
+    #[test]
+    fn leftover_ready_replicas_are_not_the_new_revision() {
+        let stale = json!({
+            "metadata": {"generation": 2},
+            "spec": {"replicas": 1},
+            "status": {
+                "observedGeneration": 1,
+                "replicas": 1,
+                "updatedReplicas": 0,
+                "readyReplicas": 1,
+                "availableReplicas": 1,
+            }
+        });
+        assert_eq!(
+            observe_rollout(&stale, &[], None),
+            RolloutObservation::Pending
+        );
+    }
+
+    #[test]
+    fn overlapping_old_ready_pod_is_not_the_new_revision() {
+        let overlapping = json!({
+            "metadata": {"generation": 2},
+            "spec": {"replicas": 1},
+            "status": {
+                "observedGeneration": 2,
+                "replicas": 2,
+                "updatedReplicas": 1,
+                "readyReplicas": 1,
+                "availableReplicas": 1,
+            }
+        });
+        assert_eq!(
+            observe_rollout(
+                &overlapping,
+                &[json!({
+                    "metadata": {
+                        "name": "new-pod",
+                        "labels": {"pod-template-hash": "newhash"}
+                    },
+                    "status": {
+                        "containerStatuses": [{
+                            "name": "server",
+                            "state": {"waiting": {"reason": "ContainerCreating"}}
+                        }]
+                    }
+                })],
+                Some("newhash"),
+            ),
+            RolloutObservation::Pending
+        );
+    }
+
+    #[test]
+    fn crashloop_is_terminal() {
+        assert_eq!(
+            observe_rollout(
+                &deploy_status(1, 0, 0),
+                &[pod_waiting("mcp-github-abc", "CrashLoopBackOff")],
+                None,
+            ),
+            RolloutObservation::Failed {
+                reason: "CrashLoopBackOff",
+                pod: Some("mcp-github-abc".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn image_pull_failure_is_terminal() {
+        for reason in ["ImagePullBackOff", "ErrImagePull", "InvalidImageName"] {
+            assert_eq!(
+                observe_rollout(
+                    &deploy_status(1, 0, 0),
+                    &[pod_waiting("mcp-github-xyz", reason)],
+                    None,
+                ),
+                RolloutObservation::Failed {
+                    reason,
+                    pod: Some("mcp-github-xyz".into()),
+                },
+                "{reason}"
+            );
+        }
+    }
+
+    #[test]
+    fn rollout_failure_names_the_connector_and_recovery_command() {
+        let err = rollout_failure(
+            "github",
+            "curie",
+            "curie-acme-bot-mcp-github",
+            "CrashLoopBackOff",
+            Some("Error: unknown command \"http\" for \"server\""),
+        );
+        let text = format!("{err:#}");
+        assert!(text.contains("connector github"), "{text}");
+        let (class, fix) = crate::exit::classify(&err);
+        assert_eq!(class, crate::exit::ExitClass::Failure);
+        let fix = fix.expect("recovery command");
+        assert!(
+            fix.contains("kubectl -n curie logs deploy/curie-acme-bot-mcp-github --tail=50"),
+            "{fix}"
+        );
+    }
+
+    #[test]
+    fn last_log_redacts_secrets_and_json_fields() {
+        let mut secrets = BTreeMap::new();
+        secrets.insert("TOKEN".into(), "gho_this_is_not_a_real_token".into());
+        let redacted = redact_last_log(
+            "Authorization: Bearer gho_this_is_not_a_real_token\n{\"token\":\"sensitive-value\"}",
+            &secrets,
+        );
+        assert!(
+            !redacted.contains("gho_this_is_not_a_real_token"),
+            "{redacted}"
+        );
+        assert!(!redacted.contains("sensitive-value"), "{redacted}");
+    }
+
+    #[test]
+    fn rollout_wait_uses_the_comms_deadline() {
+        let args = rollout_status_args("curie", "dep", CONNECTOR_ROLLOUT_DEADLINE);
+        assert!(args.iter().any(|a| a == "--timeout=120s"), "{args:?}");
+    }
+
     fn with_isolated_store<T>(body: impl FnOnce() -> T) -> T {
         let _lock = crate::PROCESS_ENV_LOCK.blocking_lock();
         let dir = tempfile::tempdir().unwrap();
@@ -791,6 +1563,7 @@ pub struct PreparedConnectorSync {
     agent_name: String,
     keep: Vec<String>,
     apply_document: Option<String>,
+    workloads: Vec<ConnectorWorkload>,
     result: ConnectorSync,
     secret_name: Option<String>,
     secret_keys: Vec<String>,
@@ -927,6 +1700,7 @@ pub fn prepare(
 
     let labelled = label_objects(&objects, agent_name);
     let keep = object_names(&labelled);
+    let workloads = connector_workloads(manifests, mcp_entries);
     let apply_document = if labelled.is_empty() {
         None
     } else {
@@ -938,6 +1712,7 @@ pub fn prepare(
         agent_name: agent_name.to_string(),
         keep,
         apply_document,
+        workloads,
         result,
         secret_name,
         secret_keys,
@@ -959,10 +1734,11 @@ pub async fn sync(prepared: PreparedConnectorSync) -> Result<ConnectorSync> {
         agent_name,
         keep,
         apply_document,
+        workloads,
         mut result,
         secret_name,
         secret_keys,
-        secret_values: _,
+        secret_values,
         secret_sources,
         target,
         bound_target,
@@ -1009,6 +1785,14 @@ pub async fn sync(prepared: PreparedConnectorSync) -> Result<ConnectorSync> {
             err.trim()
         ));
     }
+    wait_for_connector_rollouts(
+        &bound_target,
+        &namespace,
+        &workloads,
+        &secret_values,
+        Instant::now() + CONNECTOR_ROLLOUT_DEADLINE,
+    )
+    .await?;
     Ok(result)
 }
 /// Render and reconcile the connectors declared by one deployed version.

--- a/cli/tests/connector_rollout.rs
+++ b/cli/tests/connector_rollout.rs
@@ -1,0 +1,127 @@
+//! Fix pin for #2350: reversing `cli/src/connectors.rs` must leave this file
+//! compiling against the pre-wait `sync()`, then fail this test. That is why
+//! it uses only `prepare`/`sync` (already on main) plus a fake kubectl, not the
+//! new wait helpers.
+
+use curie::connectors::{bind_current_cluster, prepare, sync};
+use curie::exit::{classify, ExitClass};
+use serde_json::json;
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+static PATH_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+fn write_exec(dir: &Path, name: &str, body: &str) {
+    let path = dir.join(name);
+    fs::write(&path, body).expect("write fake kubectl");
+    let mut perms = fs::metadata(&path).expect("stat").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&path, perms).expect("chmod");
+}
+
+fn prepend_path(dir: &Path) -> Option<OsString> {
+    let previous = std::env::var_os("PATH");
+    let mut paths = vec![dir.to_path_buf()];
+    paths.extend(std::env::split_paths(&previous.clone().unwrap_or_default()));
+    std::env::set_var("PATH", std::env::join_paths(paths).expect("PATH"));
+    previous
+}
+
+fn restore_path(previous: Option<OsString>) {
+    match previous {
+        Some(value) => std::env::set_var("PATH", value),
+        None => std::env::remove_var("PATH"),
+    }
+}
+
+/// THE REGRESSION TEST for #2350. A crashlooping connector Deployment makes
+/// `sync` nonzero and names the connector plus the recovery command.
+#[tokio::test]
+async fn crashloop_observation_fails_named_connector() {
+    let _lock = PATH_LOCK.lock().await;
+    let bin = tempfile::tempdir().expect("bin");
+    write_exec(
+        bin.path(),
+        "kubectl",
+        r#"#!/bin/sh
+case " $* " in
+  *" config view "*)
+    printf '%s\n' '{"clusters":[{"cluster":{"server":"https://cluster-a.example.com","certificate-authority-data":"Y2EtYQ=="}}]}'
+    exit 0
+    ;;
+  *" apply -f - "*)
+    cat >/dev/null
+    exit 0
+    ;;
+  *" delete "*)
+    exit 0
+    ;;
+  *" get secret "*)
+    printf '%s\n' 'Error from server (NotFound): secrets "x" not found' >&2
+    exit 1
+    ;;
+  *" get replicasets "*)
+    printf '%s\n' '{"items":[{"metadata":{"annotations":{"deployment.kubernetes.io/revision":"1"},"labels":{"pod-template-hash":"abc"}}}]}'
+    exit 0
+    ;;
+  *" get pods "*)
+    printf '%s\n' '{"items":[{"metadata":{"name":"mcp-github-xyz","labels":{"pod-template-hash":"abc"}},"status":{"containerStatuses":[{"name":"server","state":{"waiting":{"reason":"CrashLoopBackOff"}}}]}}]}'
+    exit 0
+    ;;
+  *" get deployment "*)
+    printf '%s\n' '{"metadata":{"generation":1},"spec":{"replicas":1},"status":{"observedGeneration":1,"replicas":1,"updatedReplicas":1,"readyReplicas":0,"availableReplicas":0}}'
+    exit 0
+    ;;
+esac
+printf 'unexpected kubectl invocation: %s\n' "$*" >&2
+exit 64
+"#,
+    );
+    let previous = prepend_path(bin.path());
+    let result = async {
+        let target = bind_current_cluster("curie", "curie")
+            .await
+            .expect("bind cluster");
+        let deployment = "curie-acme-bot-mcp-github";
+        let manifests = vec![json!({
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": deployment},
+        })];
+        let mut mcp = BTreeMap::new();
+        mcp.insert(
+            "github".into(),
+            json!({"url": "http://curie-acme-bot-mcp-github.curie.svc.cluster.local:8000/mcp"}),
+        );
+        let prepared = prepare(
+            &manifests,
+            &mcp,
+            "",
+            &[],
+            &target.scope,
+            "acme-bot",
+            &BTreeMap::new(),
+        )
+        .expect("prepare")
+        .bind_target(target)
+        .expect("bind");
+        sync(prepared).await
+    }
+    .await;
+    restore_path(previous);
+    let err = result.expect_err("crashloop must make sync nonzero");
+    let text = format!("{err:#}");
+    assert!(text.contains("connector github"), "{text}");
+    assert!(text.contains("CrashLoopBackOff"), "{text}");
+    let (class, fix) = classify(&err);
+    assert_eq!(class, ExitClass::Failure);
+    let fix = fix.expect("recovery command");
+    assert!(
+        fix.contains("kubectl -n curie logs deploy/curie-acme-bot-mcp-github --tail=50"),
+        "{fix}"
+    );
+    assert!(fix.contains("curie cluster deploy"), "{fix}");
+}

--- a/cli/tests/connector_rollout_live.rs
+++ b/cli/tests/connector_rollout_live.rs
@@ -1,0 +1,254 @@
+//! Live Kubernetes proof for #2350. Needs `CURIE_E2E_CLUSTER=1`. Not the
+//! fix-pin binary: that one must compile against a reversed `connectors.rs`.
+
+use std::collections::BTreeMap;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use curie::connectors::{bind_current_cluster, wait_for_connector_rollouts, ConnectorWorkload};
+use curie::exit::{classify, ExitClass};
+use serde_json::{json, Value};
+
+fn live_cluster() -> bool {
+    std::env::var("CURIE_E2E_CLUSTER").ok().as_deref() == Some("1")
+}
+
+fn kubectl(args: &[&str]) -> (bool, String, String) {
+    let output = Command::new("kubectl")
+        .args(args)
+        .output()
+        .expect("kubectl");
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+fn apply_doc(namespace: &str, doc: &Value) {
+    let body = serde_json::to_string(doc).expect("json");
+    let mut child = Command::new("kubectl")
+        .args(["-n", namespace, "apply", "-f", "-"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("apply");
+    {
+        use std::io::Write;
+        child
+            .stdin
+            .as_mut()
+            .expect("stdin")
+            .write_all(body.as_bytes())
+            .expect("write");
+    }
+    let output = child.wait_with_output().expect("wait apply");
+    assert!(
+        output.status.success(),
+        "apply failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn minimal_deployment(name: &str, image: &str, command: &[&str]) -> Value {
+    let pull = if image.contains("does-not-exist") {
+        "Always"
+    } else {
+        "IfNotPresent"
+    };
+    json!({
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+            "name": name,
+            "labels": {"app.kubernetes.io/name": name}
+        },
+        "spec": {
+            "replicas": 1,
+            "selector": {"matchLabels": {"app.kubernetes.io/name": name}},
+            "template": {
+                "metadata": {"labels": {"app.kubernetes.io/name": name}},
+                "spec": {
+                    "containers": [{
+                        "name": "server",
+                        "image": image,
+                        "imagePullPolicy": pull,
+                        "command": command,
+                    }]
+                }
+            }
+        }
+    })
+}
+
+#[tokio::test]
+async fn live_cluster_ready_crashloop_image_pull_timeout_and_empty() {
+    if !live_cluster() {
+        eprintln!("skipping: set CURIE_E2E_CLUSTER=1 for disposable Kubernetes proof");
+        return;
+    }
+    let ns = format!(
+        "curie-2350-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_secs()
+    );
+    let (ok, _, err) = kubectl(&["create", "namespace", &ns]);
+    assert!(ok, "create namespace {ns}: {err}");
+    struct DeleteNs(String);
+    impl Drop for DeleteNs {
+        fn drop(&mut self) {
+            let _ = Command::new("kubectl")
+                .args(["delete", "namespace", &self.0, "--wait=false"])
+                .output();
+        }
+    }
+    let _guard = DeleteNs(ns.clone());
+
+    let target = bind_current_cluster(&ns, "curie")
+        .await
+        .expect("bind cluster");
+
+    wait_for_connector_rollouts(
+        &target,
+        &ns,
+        &[],
+        &BTreeMap::new(),
+        Instant::now() + Duration::from_secs(5),
+    )
+    .await
+    .expect("empty wait");
+
+    apply_doc(
+        &ns,
+        &minimal_deployment("mcp-sleep", "busybox:1.36", &["sleep", "3600"]),
+    );
+    wait_for_connector_rollouts(
+        &target,
+        &ns,
+        &[ConnectorWorkload {
+            connector: "sleep".into(),
+            deployment: "mcp-sleep".into(),
+        }],
+        &BTreeMap::new(),
+        Instant::now() + Duration::from_secs(60),
+    )
+    .await
+    .expect("healthy sleep connector");
+
+    let leak = "gho_this_is_not_a_real_token";
+    apply_doc(
+        &ns,
+        &minimal_deployment(
+            "mcp-crash",
+            "busybox:1.36",
+            &["sh", "-c", &format!("echo {leak}; http --port 8000")],
+        ),
+    );
+    let mut secrets = BTreeMap::new();
+    secrets.insert("GITHUB_PERSONAL_ACCESS_TOKEN".into(), leak.into());
+    let err = wait_for_connector_rollouts(
+        &target,
+        &ns,
+        &[ConnectorWorkload {
+            connector: "github".into(),
+            deployment: "mcp-crash".into(),
+        }],
+        &secrets,
+        Instant::now() + Duration::from_secs(60),
+    )
+    .await
+    .expect_err("crashloop must be nonzero");
+    let text = format!("{err:#}");
+    assert!(text.contains("connector github"), "{text}");
+    assert!(!text.contains(leak), "secret leaked in {text}");
+    let (class, fix) = classify(&err);
+    assert_eq!(class, ExitClass::Failure);
+    let fix = fix.expect("fix");
+    assert!(fix.contains("kubectl -n"), "recovery command: {fix}");
+    assert!(!fix.contains(leak), "secret leaked in fix {fix}");
+
+    apply_doc(
+        &ns,
+        &minimal_deployment(
+            "mcp-pull",
+            "ghcr.io/example/does-not-exist:2350-no-such-tag",
+            &["http"],
+        ),
+    );
+    let err = wait_for_connector_rollouts(
+        &target,
+        &ns,
+        &[ConnectorWorkload {
+            connector: "pullfail".into(),
+            deployment: "mcp-pull".into(),
+        }],
+        &BTreeMap::new(),
+        Instant::now() + Duration::from_secs(60),
+    )
+    .await
+    .expect_err("image pull must be nonzero");
+    let text = format!("{err:#}");
+    assert!(text.contains("connector pullfail"), "{text}");
+    assert!(
+        text.contains("ImagePull")
+            || text.contains("ErrImagePull")
+            || text.contains("InvalidImage"),
+        "{text}"
+    );
+
+    let stuck = json!({
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+            "name": "mcp-stuck",
+            "labels": {"app.kubernetes.io/name": "mcp-stuck"}
+        },
+        "spec": {
+            "replicas": 1,
+            "selector": {"matchLabels": {"app.kubernetes.io/name": "mcp-stuck"}},
+            "template": {
+                "metadata": {"labels": {"app.kubernetes.io/name": "mcp-stuck"}},
+                "spec": {
+                    "nodeSelector": {"kubernetes.io/hostname": "no-such-node-2350"},
+                    "containers": [{
+                        "name": "server",
+                        "image": "busybox:1.36",
+                        "imagePullPolicy": "IfNotPresent",
+                        "command": ["sleep", "3600"],
+                    }]
+                }
+            }
+        }
+    });
+    apply_doc(&ns, &stuck);
+    let started = Instant::now();
+    let err = wait_for_connector_rollouts(
+        &target,
+        &ns,
+        &[ConnectorWorkload {
+            connector: "stuck".into(),
+            deployment: "mcp-stuck".into(),
+        }],
+        &BTreeMap::new(),
+        Instant::now() + Duration::from_secs(4),
+    )
+    .await
+    .expect_err("unschedulable wait must time out");
+    assert!(
+        started.elapsed() < Duration::from_secs(15),
+        "deadline must bound the wait"
+    );
+    let text = format!("{err:#}");
+    assert!(text.contains("connector stuck"), "{text}");
+    assert!(text.contains("timeout"), "{text}");
+
+    let (ok, _, err) = kubectl(&["delete", "namespace", &ns, "--wait=true", "--timeout=60s"]);
+    assert!(
+        ok || err.contains("NotFound"),
+        "delete namespace {ns}: {err}"
+    );
+}

--- a/cli/tests/example_sre_bot_install.rs
+++ b/cli/tests/example_sre_bot_install.rs
@@ -300,6 +300,18 @@ case " $* " in
         printf '%s\n' 'curie'
         exit 0
         ;;
+    *" get replicasets "*)
+        printf '%s\n' '{"apiVersion":"v1","kind":"List","items":[]}'
+        exit 0
+        ;;
+    *" get pods "*)
+        printf '%s\n' '{"apiVersion":"v1","kind":"List","items":[]}'
+        exit 0
+        ;;
+    *" get deployment "*" -o json"*)
+        printf '%s\n' '{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"generation":1},"spec":{"replicas":1},"status":{"observedGeneration":1,"replicas":1,"updatedReplicas":1,"readyReplicas":1,"availableReplicas":1}}'
+        exit 0
+        ;;
     *" delete deployment,service,networkpolicy,secret "*)
         exit 0
         ;;


### PR DESCRIPTION
## Summary

`curie cluster deploy` applied connector objects and printed their URLs without waiting for the Deployment to become Ready, so a crashlooping connector was reported as an `active` deployment. After apply and prune, deploy now waits on each hosted connector Deployment using the same 120s bound as other kubectl rollouts. A failed wait is nonzero, names the connector, and prints a recovery command. Last-log excerpts are bounded and redacted. An already-created agent or version is not treated as a healthy connector deploy, and the command does not roll anything back.

## Related issue

Closes #2350

Sibling (skill-up / local compose wait): #2530

## Fix pin verification

Fix pin: cli/tests/connector_rollout.rs::crashloop_observation_fails_named_connector

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | cluster deploy apply/wait path; skill-up sibling is #2530 | | |
| local | n/a | compose bring-up does not call connectors::sync; sibling is #2530 | | |
| local-release | n/a | no released-binary identity, install path, or compose pin change | | |
| cluster | required | connector Deployment wait on disposable Kubernetes | live | `CURIE_E2E_CLUSTER=1 cargo test --test connector_rollout live_cluster` at `e2a822a92`: sleep Ready; crashloop, image-pull, and 4s timeout nonzero naming the connector; empty wait Ok; secret token absent from the error. Namespace deleted. |
| live provider | n/a | no model routing, credential resolution, or MCP catalog projection | | |
| external integration | n/a | no Slack, git webhook, or third-party API shape | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive: healthy `busybox` sleep Deployment became Ready. Negative: crashloop (`exit 1` after echoing a fake token), missing image tag, unschedulable timeout, and empty workload skip. Crashloop error contained `connector github` and the kubectl logs recovery command, and did not contain the fake token.

## Checklist

- Tests cover ready, crashloop, image-pull, timeout, no-connectors, superseded CrashLoop pods, leftover readyReplicas, JSON credential redaction.
- No frozen aci-protocol / plugin-format / schema / ADR change.
- No destructive rollback.
