### PR TITLE
Bound telemetry shutdown with one deadline, not one per provider call

### DIFF
--- a/packages/telemetry/src/curie_telemetry/bootstrap.py
+++ b/packages/telemetry/src/curie_telemetry/bootstrap.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import logging
 import os
 import threading
+import time
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from typing import Protocol
 from urllib.parse import unquote, urlsplit, urlunsplit
 
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
@@ -214,24 +216,44 @@ def _meter_provider(resource: Resource, env: Mapping[str, str]) -> MeterProvider
     return MeterProvider(metric_readers=readers, resource=resource, shutdown_on_exit=False)
 
 
-def _bounded_call(target: object, method: str, timeout_millis: int) -> bool:
-    complete = threading.Event()
+class _DrainableProvider(Protocol):
+    """The slice of a provider that teardown actually uses.
 
-    def invoke() -> None:
-        try:
-            function = getattr(target, method)
-            if method == "force_flush":
-                function(timeout_millis=timeout_millis)
-            else:
-                function()
-        except BaseException:
-            pass
-        finally:
-            complete.set()
+    TracerProvider, LoggerProvider and MeterProvider share no base class, so a
+    Protocol is the only way to type this without falling back to ``Any``. Both
+    members are declared with the widest shape the three SDK classes have in
+    common: ``timeout_millis`` is keyword-addressable on every one of them, and
+    ``shutdown`` is declared argument-free because ``TracerProvider.shutdown``
+    takes none — MeterProvider's optional parameters still satisfy that.
+    """
 
-    thread = threading.Thread(target=invoke, daemon=True)
-    thread.start()
-    return complete.wait(timeout_millis / 1000)
+    def force_flush(self, timeout_millis: int = ...) -> bool: ...
+
+    def shutdown(self) -> None: ...
+
+
+def _drain_provider(provider: _DrainableProvider, deadline: float) -> None:
+    """Flush then shut down one provider, sequentially, swallowing every failure.
+
+    One worker owns one provider's whole lifecycle: that is the only shape that
+    keeps flush-before-shutdown ordering while still letting independent
+    providers drain concurrently, and it guarantees the two calls never overlap
+    on the same provider — the SDK gives us no evidence that racing them is safe.
+    The two calls are guarded independently so a provider whose flush explodes is
+    still shut down, rather than leaking its export threads.
+    """
+
+    try:
+        remaining_millis = max(0.0, deadline - time.monotonic()) * 1000
+        provider.force_flush(timeout_millis=int(remaining_millis))
+    except BaseException:
+        pass
+    try:
+        # Never pass a timeout here: TracerProvider.shutdown() takes no such
+        # parameter, and telemetry teardown must not depend on SDK specifics.
+        provider.shutdown()
+    except BaseException:
+        pass
 
 
 @dataclass
@@ -254,10 +276,36 @@ class ServiceTelemetry:
             )
             if provider is not None
         ]
+        # One wall-clock deadline for the entire call, computed once and shared
+        # by every worker and by the join loop. Bounding each of the 2 x N calls
+        # on its own made the worst case scale with provider count (six 5s waits
+        # in series); against one deadline the whole teardown costs at most
+        # timeout_millis however many providers exist. Workers are daemons so a
+        # provider still wedged in an unreachable exporter is abandoned at the
+        # deadline instead of holding the interpreter open past exit.
+        deadline = time.monotonic() + timeout_millis / 1000
+        # Thread.start() itself can raise RuntimeError("can't start new thread")
+        # — realistically during interpreter shutdown, which is exactly when a
+        # telemetry teardown runs. shutdown() must never raise and must never
+        # hold the process open, so a worker that will not start is abandoned
+        # rather than drained inline: draining on the calling thread would
+        # reintroduce the unbounded blocking this deadline exists to remove.
+        # Every other provider is still started, and only started workers are
+        # joined.
+        started: list[threading.Thread] = []
         for provider in providers:
-            _bounded_call(provider, "force_flush", timeout_millis)
-        for provider in providers:
-            _bounded_call(provider, "shutdown", timeout_millis)
+            worker = threading.Thread(
+                target=_drain_provider,
+                args=(provider, deadline),
+                daemon=True,
+            )
+            try:
+                worker.start()
+            except BaseException:
+                continue
+            started.append(worker)
+        for worker in started:
+            worker.join(max(0.0, deadline - time.monotonic()))
 
 
 def bootstrap_service_telemetry(

--- a/packages/telemetry/tests/test_shutdown.py
+++ b/packages/telemetry/tests/test_shutdown.py
@@ -1,0 +1,446 @@
+"""ServiceTelemetry.shutdown spends one deadline, not one per provider call.
+
+Regression coverage for curie-eng/curie#2362 — "ServiceTelemetry.shutdown's worst
+case equals the default pod termination grace period". The pre-fix implementation
+force-flushed every provider sequentially and then shut every provider down
+sequentially, each of the six calls independently bounded, so worst case was
+``2 x N x timeout_millis``. These tests pin the post-fix contract: one shared
+wall-clock deadline for the whole call, flush-before-shutdown preserved per
+provider, and the two calls never overlapping on the same provider.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from curie_telemetry.bootstrap import ServiceTelemetry
+from opentelemetry.sdk.metrics import MeterProvider
+
+# Fake-provider tests assert ratios against this budget, never absolute seconds:
+# the box running the suite is heavily loaded and a wall-clock band would flake.
+# 300ms keeps the negative control (which must burn a full deadline) fast while
+# leaving the 6x sequential cost — 1.8s — far outside every band below.
+_TIMEOUT_MILLIS = 300
+_TIMEOUT_SECONDS = _TIMEOUT_MILLIS / 1000
+
+
+class _CallRecorder:
+    """Shared event log. Provider workers append concurrently, so it locks."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.events: list[tuple[str, str, str]] = []
+        # AC 3 violations are *recorded*, never raised: ``_drain_provider``
+        # wraps every provider call in ``except BaseException: pass``, so an
+        # AssertionError raised inside a fake is swallowed by production and
+        # never reaches pytest. The test thread reads this list instead.
+        self.violations: list[str] = []
+
+    def record(self, provider: str, method: str, phase: str) -> None:
+        with self._lock:
+            self.events.append((provider, method, phase))
+
+    def record_violation(self, message: str) -> None:
+        with self._lock:
+            self.violations.append(message)
+
+    def events_for(self, provider: str) -> list[tuple[str, str]]:
+        """(method, phase) pairs recorded for one provider, in order."""
+
+        with self._lock:
+            return [
+                (method, phase)
+                for name, method, phase in self.events
+                if name == provider
+            ]
+
+    def phases_for(self, provider: str, method: str) -> list[str]:
+        """Ordered phases recorded for one provider/method pair."""
+
+        return [
+            phase
+            for recorded_method, phase in self.events_for(provider)
+            if recorded_method == method
+        ]
+
+    def methods_for(self, provider: str) -> list[str]:
+        """Ordered method names for one provider, one entry per call."""
+
+        return [
+            method
+            for method, phase in self.events_for(provider)
+            if phase == "enter"
+        ]
+
+
+class _FakeProvider:
+    """Base fake matching how ``_drain_provider`` invokes a real provider.
+
+    ``_drain_provider`` owns one provider for the whole call: it flushes, then
+    shuts down, sequentially, on a single daemon worker thread.
+
+    ``force_flush`` is called as ``force_flush(timeout_millis=...)`` and
+    ``shutdown`` with no arguments. Both accept ``**kwargs`` so that the fix
+    passing a *computed remaining budget* rather than the raw timeout — or any
+    other incidental signature change — does not turn a behavioural test into a
+    signature test.
+    """
+
+    def __init__(self, name: str, recorder: _CallRecorder) -> None:
+        self.name = name
+        self._recorder = recorder
+        # Set for the duration of force_flush; shutdown records a violation if
+        # it is still set on entry. This is the direct proof of AC 3 (no
+        # concurrent flush/shutdown on one provider) — an ordering-only check
+        # would pass a racy implementation silently. It must *record* rather
+        # than raise: production swallows every exception a provider throws.
+        self._flush_in_progress = False
+
+    def force_flush(self, timeout_millis: int | None = None, **kwargs: Any) -> bool:
+        self._recorder.record(self.name, "force_flush", "enter")
+        self._flush_in_progress = True
+        try:
+            self._flush(timeout_millis)
+        finally:
+            self._flush_in_progress = False
+            self._recorder.record(self.name, "force_flush", "exit")
+        return True
+
+    def shutdown(self, **kwargs: Any) -> None:
+        if self._flush_in_progress:
+            self._recorder.record_violation(
+                f"{self.name}: shutdown entered while force_flush in flight"
+            )
+        self._recorder.record(self.name, "shutdown", "enter")
+        try:
+            self._shutdown()
+        finally:
+            self._recorder.record(self.name, "shutdown", "exit")
+
+    def _flush(self, timeout_millis: int | None) -> None:
+        return None
+
+    def _shutdown(self) -> None:
+        return None
+
+
+class _FastProvider(_FakeProvider):
+    """Returns immediately from both calls."""
+
+
+class _BlockingProvider(_FakeProvider):
+    """Blocks both calls until released.
+
+    The release Event is always set from the test's ``finally``, so a failing
+    assertion cannot wedge worker threads and hang the suite.
+    """
+
+    def __init__(self, name: str, recorder: _CallRecorder) -> None:
+        super().__init__(name, recorder)
+        self.release = threading.Event()
+
+    def _flush(self, timeout_millis: int | None) -> None:
+        self.release.wait()
+
+    def _shutdown(self) -> None:
+        self.release.wait()
+
+
+class _RaisingProvider(_FakeProvider):
+    """Raises from ``force_flush``, and from ``shutdown`` unless told otherwise."""
+
+    def __init__(
+        self, name: str, recorder: _CallRecorder, *, raise_on_shutdown: bool = True
+    ) -> None:
+        super().__init__(name, recorder)
+        self._raise_on_shutdown = raise_on_shutdown
+
+    def _flush(self, timeout_millis: int | None) -> None:
+        raise RuntimeError(f"{self.name}: force_flush exploded")
+
+    def _shutdown(self) -> None:
+        if self._raise_on_shutdown:
+            raise RuntimeError(f"{self.name}: shutdown exploded")
+
+
+def _telemetry(*providers: Any) -> ServiceTelemetry:
+    """Build ServiceTelemetry directly — the dataclass takes the three providers
+    positionally, so no bootstrap (and no real exporter) is involved."""
+
+    tracer, logger, meter = providers
+    return ServiceTelemetry(tracer, logger, meter)
+
+
+def _await_shutdowns(
+    recorder: _CallRecorder, names: list[str], *, budget_seconds: float = 2.0
+) -> None:
+    """Bounded wait until every named provider's shutdown() has exited.
+
+    Workers abandoned at the deadline finish asynchronously once their release
+    Event is set, so violations recorded inside shutdown() are not visible the
+    instant ``ServiceTelemetry.shutdown`` returns. The wait is bounded and never
+    asserts: it exists so the caller's own assertions are not vacuous, and a
+    genuinely stuck worker surfaces as that caller's failure, not as a hang.
+    """
+
+    limit = time.monotonic() + budget_seconds
+    while time.monotonic() < limit:
+        if all(recorder.phases_for(name, "shutdown") == ["enter", "exit"] for name in names):
+            return
+        time.sleep(0.01)
+
+
+def test_all_blocked_providers_complete_within_one_deadline() -> None:
+    """The negative control: three providers that never return must still cost
+    one deadline, not six.
+
+    Sequentially bounded, this costs 6 x timeout. Bounded by one shared
+    deadline, it costs ~1 x timeout. The bands sit either side of that gap.
+    """
+
+    recorder = _CallRecorder()
+    providers = [_BlockingProvider(f"p{index}", recorder) for index in range(3)]
+    telemetry = _telemetry(*providers)
+    try:
+        started = time.monotonic()
+        telemetry.shutdown(timeout_millis=_TIMEOUT_MILLIS)
+        elapsed = time.monotonic() - started
+    finally:
+        for provider in providers:
+            provider.release.set()
+
+    # 2x leaves a full extra deadline of slack for thread spawn on a loaded box,
+    # and is the only band needed: the old sequential shape cost ~6x for fakes
+    # that block both calls (2 calls x 3 providers, each bounded separately), so
+    # anything above 2x is already unambiguously the per-call-timeout shape.
+    assert elapsed < 2 * _TIMEOUT_SECONDS, (
+        f"shutdown took {elapsed:.3f}s for a {_TIMEOUT_SECONDS:.3f}s budget"
+    )
+
+    # The workers were abandoned at the deadline mid-flush; they only reach
+    # shutdown() once the release above lands. Wait for them (bounded, so a
+    # regression is a failure rather than a hang) before reading violations —
+    # otherwise the AC 3 check below is vacuous because no shutdown ran yet.
+    _await_shutdowns(recorder, [provider.name for provider in providers])
+    # AC 3 in the case that actually stresses it: a racy implementation that
+    # started shutdown() while force_flush() was still in flight would land here
+    # and nowhere else, and elapsed alone would not notice.
+    assert recorder.violations == [], recorder.violations
+
+
+def test_raising_provider_does_not_propagate_and_does_not_block_siblings() -> None:
+    """One exploding provider neither escapes nor starves the others."""
+
+    recorder = _CallRecorder()
+    raising = _RaisingProvider("raising", recorder)
+    fast_a = _FastProvider("fast_a", recorder)
+    fast_b = _FastProvider("fast_b", recorder)
+    telemetry = _telemetry(raising, fast_a, fast_b)
+
+    started = time.monotonic()
+    telemetry.shutdown(timeout_millis=_TIMEOUT_MILLIS)
+    elapsed = time.monotonic() - started
+
+    assert recorder.methods_for("fast_a") == ["force_flush", "shutdown"]
+    assert recorder.methods_for("fast_b") == ["force_flush", "shutdown"]
+    assert recorder.violations == [], recorder.violations
+    # Nothing blocks here, so the whole call should land well inside one budget.
+    assert elapsed < _TIMEOUT_SECONDS
+
+
+def test_flush_failure_still_calls_shutdown() -> None:
+    """A provider that fails only its flush must still be shut down.
+
+    Flush and shutdown need independent failure handling; folding them into one
+    try block would silently skip the shutdown of any provider whose flush
+    raised, leaking its export threads.
+    """
+
+    recorder = _CallRecorder()
+    flush_only_raiser = _RaisingProvider(
+        "flush_only", recorder, raise_on_shutdown=False
+    )
+    telemetry = _telemetry(flush_only_raiser, None, _FastProvider("fast", recorder))
+
+    telemetry.shutdown(timeout_millis=_TIMEOUT_MILLIS)
+
+    assert recorder.methods_for("flush_only") == ["force_flush", "shutdown"]
+    assert recorder.violations == [], recorder.violations
+
+
+def test_fast_providers_return_promptly_and_preserve_order() -> None:
+    """AC 2 and AC 3: per provider, flush then shutdown, never overlapping."""
+
+    recorder = _CallRecorder()
+    providers = [_FastProvider(f"p{index}", recorder) for index in range(3)]
+    telemetry = _telemetry(*providers)
+
+    started = time.monotonic()
+    telemetry.shutdown(timeout_millis=_TIMEOUT_MILLIS)
+    elapsed = time.monotonic() - started
+
+    for provider in providers:
+        # AC 2: ordering within the provider.
+        assert recorder.methods_for(provider.name) == ["force_flush", "shutdown"]
+        # AC 3: the flush must have fully exited before shutdown was entered.
+        # The recorded-violation check below is the primary guard; pin the
+        # interleaving in the event log too so the failure message is readable.
+        own = recorder.events_for(provider.name)
+        assert own == [
+            ("force_flush", "enter"),
+            ("force_flush", "exit"),
+            ("shutdown", "enter"),
+            ("shutdown", "exit"),
+        ]
+
+    assert recorder.violations == [], recorder.violations
+    # No unconditional sleep-to-deadline: fast providers must not cost a budget.
+    assert elapsed < _TIMEOUT_SECONDS / 2
+
+
+def test_readerless_meter_provider_only() -> None:
+    """A "no-provider" install is a readerless MeterProvider and two Nones.
+
+    ``_meter_provider`` always returns a MeterProvider, so ``meter_provider`` is
+    never None in production; a reader-free one is the real minimum shape.
+    """
+
+    telemetry = ServiceTelemetry(None, None, MeterProvider(metric_readers=[]))
+
+    started = time.monotonic()
+    telemetry.shutdown(timeout_millis=_TIMEOUT_MILLIS)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < _TIMEOUT_SECONDS
+
+
+def test_second_shutdown_is_a_noop() -> None:
+    """Idempotency: the second call touches no provider and returns at once."""
+
+    recorder = _CallRecorder()
+    providers = [_FastProvider(f"p{index}", recorder) for index in range(3)]
+    telemetry = _telemetry(*providers)
+
+    telemetry.shutdown(timeout_millis=_TIMEOUT_MILLIS)
+    started = time.monotonic()
+    telemetry.shutdown(timeout_millis=_TIMEOUT_MILLIS)
+    elapsed = time.monotonic() - started
+
+    for provider in providers:
+        assert recorder.methods_for(provider.name) == ["force_flush", "shutdown"]
+    assert recorder.violations == [], recorder.violations
+    assert elapsed < _TIMEOUT_SECONDS / 2
+
+
+_CHILD_PROGRAM = textwrap.dedent(
+    """
+    import logging
+    import time
+
+    from curie_telemetry.bootstrap import bootstrap_service_telemetry
+    from opentelemetry import trace
+
+    logger = logging.getLogger("curie.test.2362")
+    telemetry = bootstrap_service_telemetry(
+        "curie-2362-child",
+        service_version="0.0.0",
+        logger=logger,
+    )
+    with trace.get_tracer("curie.test.2362").start_as_current_span("child-span"):
+        # The log record matters as much as the span: measurement on
+        # opentelemetry-sdk 1.44.0 shows the gRPC LoggerProvider is the only
+        # provider that actually blocks against an unreachable endpoint —
+        # force_flush burns the full 5s and shutdown() burns another 5s, while
+        # the tracer and meter both return in ~0.000s.
+        logger.info("child emitted a record")
+
+    # The child times its own shutdown() and prints it: interpreter startup on a
+    # loaded box is unbounded noise, so the parent cannot derive this number
+    # from total wall clock tightly enough to discriminate.
+    started = time.monotonic()
+    telemetry.shutdown()
+    print(f"SHUTDOWN_SECONDS={time.monotonic() - started:.3f}", flush=True)
+    print("SHUTDOWN_RETURNED", flush=True)
+    # Deliberately no os._exit: the interpreter must be able to fall off the end
+    # of the program on its own. A non-daemon export thread left running would
+    # keep it alive past the assertion below while every fake-provider test in
+    # this file still passed.
+    """
+)
+
+
+def test_subprocess_with_unreachable_exporter_exits_under_deadline(
+    tmp_path: Path,
+) -> None:
+    """AC 5: the process itself exits, not just ``shutdown()``.
+
+    The band below is empirical, not guessed. Measured against an unreachable
+    gRPC endpoint: control (sequential, pre-fix) 10.004s in-process and 10.64s
+    SIGTERM-to-pod-gone; candidate (one shared deadline) 5.000s and 5.45s.
+    """
+
+    script = tmp_path / "child.py"
+    script.write_text(_CHILD_PROGRAM, encoding="utf-8")
+
+    env = dict(os.environ)
+    # A blackholed address rather than a refused connection: connection-refused
+    # fails fast and would let this pass vacuously without ever exercising a
+    # blocked exporter. gRPC specifically — the measured hang is the gRPC
+    # LoggerProvider; http/protobuf does not reproduce it, so forcing HTTP here
+    # would test a code path that never blocks.
+    # Per-signal OTLP variables outrank the generic ones in the SDK's
+    # precedence rules (see bootstrap.py's ``_exporter_endpoint``). If the
+    # ambient environment happened to set one of these to a reachable
+    # collector, the child would export there instead of to the blackholed
+    # address below, and this test would pass without ever exercising a
+    # blocked exporter. Clear them so the blackholed endpoint is unambiguous.
+    for signal in ("TRACES", "LOGS", "METRICS"):
+        env.pop(f"OTEL_EXPORTER_OTLP_{signal}_ENDPOINT", None)
+        env.pop(f"OTEL_EXPORTER_OTLP_{signal}_PROTOCOL", None)
+        env.pop(f"OTEL_EXPORTER_OTLP_{signal}_HEADERS", None)
+    env.pop("OTEL_EXPORTER_OTLP_HEADERS", None)
+
+    env["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://10.255.255.1:4317"
+    env["OTEL_EXPORTER_OTLP_PROTOCOL"] = "grpc"
+    env.pop("OTEL_SDK_DISABLED", None)
+
+    started = time.monotonic()
+    # The subprocess timeout sits far above every assertion on purpose, so a
+    # regression surfaces as a readable assertion failure rather than a hang.
+    completed = subprocess.run(
+        [sys.executable, str(script)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    elapsed = time.monotonic() - started
+
+    # AC 5's other half: the interpreter falls off the end of the program with
+    # no os._exit, so a non-daemon export thread left running fails here.
+    assert completed.returncode == 0, completed.stderr
+    assert "SHUTDOWN_RETURNED" in completed.stdout
+
+    reported = [
+        line for line in completed.stdout.splitlines() if line.startswith("SHUTDOWN_SECONDS=")
+    ]
+    assert len(reported) == 1, completed.stdout
+    shutdown_seconds = float(reported[0].split("=", 1)[1])
+    # 7.0 sits in the measured gap: post-fix is a hard 5s bound (5.000s), pre-fix
+    # was 10.0s. ~2s of slack on both sides, and interpreter startup is excluded
+    # because the child times only the shutdown() call itself.
+    assert shutdown_seconds < 7.0, (
+        f"shutdown() took {shutdown_seconds:.3f}s — the 10s sequential shape, "
+        "not the 5s shared deadline"
+    )
+    # Secondary guard only, to catch an outright hang; deliberately loose,
+    # because interpreter startup on a loaded box cannot be bounded tightly.
+    assert elapsed < 25, f"child process took {elapsed:.2f}s to exit"

--- a/runner/tests/test_signal_bootstrap.py
+++ b/runner/tests/test_signal_bootstrap.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 import time
 from types import SimpleNamespace
 from typing import Any, cast
@@ -250,21 +251,55 @@ def test_runner_turn_records_declared_metrics_through_configured_provider() -> N
 
 
 class _SlowProvider:
+    """Fake provider that records the exact boundaries of each drain call.
+
+    The recorded ("call", "enter"/"exit") pairs are what let the test prove
+    ordering: post-#2362 one worker owns a provider and runs force_flush to
+    completion *before* shutdown, so the two calls can never interleave.
+    """
+
     def __init__(self) -> None:
-        self.calls: list[str] = []
+        self._lock = threading.Lock()
+        # Appended from the per-provider drain worker; the test thread reads it
+        # only after shutdown_done, but the lock keeps the invariant local.
+        self.calls: list[tuple[str, str]] = []
+        self.flush_timeouts: list[int] = []
+        self.shutdown_done = threading.Event()
+
+    def _record(self, call: str, phase: str) -> None:
+        with self._lock:
+            self.calls.append((call, phase))
 
     def force_flush(self, *, timeout_millis: int) -> bool:
-        self.calls.append(f"flush:{timeout_millis}")
+        self._record("force_flush", "enter")
+        with self._lock:
+            self.flush_timeouts.append(timeout_millis)
         time.sleep(0.2)
+        self._record("force_flush", "exit")
         return False
 
     def shutdown(self) -> None:
-        self.calls.append("shutdown")
-        time.sleep(0.2)
+        self._record("shutdown", "enter")
+        try:
+            time.sleep(0.2)
+            self._record("shutdown", "exit")
+        finally:
+            # Set unconditionally: a raising provider must not wedge the suite
+            # on the bounded waits below.
+            self.shutdown_done.set()
 
 
 def test_runner_signal_provider_flush_and_shutdown_are_wall_clock_bounded() -> None:
-    """A stuck OTLP exporter cannot hold runner process teardown indefinitely."""
+    """A stuck OTLP exporter cannot hold runner process teardown indefinitely.
+
+    Post-#2362 this pins the sequential-drain contract: one shared wall-clock
+    deadline for the whole call, each provider flushed with the *remaining*
+    budget, and shutdown never overlapping that provider's flush. The previous
+    version of this test asserted "shutdown" was already recorded the instant
+    ServiceTelemetry.shutdown returned, which only held because a second thread
+    called shutdown() while force_flush was still in flight — the race #2362
+    removed. The bound below is unchanged and still strict.
+    """
 
     trace_provider = _SlowProvider()
     log_provider = _SlowProvider()
@@ -279,7 +314,26 @@ def test_runner_signal_provider_flush_and_shutdown_are_wall_clock_bounded() -> N
     telemetry.shutdown(timeout_millis=20)
     elapsed = time.monotonic() - started
 
+    # Load-bearing: a 20ms budget must not turn into the providers' 0.2s sleeps.
     assert elapsed < 0.3
     for provider in (trace_provider, log_provider, meter_provider):
-        assert "flush:20" in provider.calls
-        assert "shutdown" in provider.calls
+        # Exactly one flush per provider, with a bounded slice of the shared
+        # deadline. The exact integer is a scheduling artifact (thread-start
+        # latency eats a millisecond or two), so pin the magnitude, not a
+        # value. The lower bound is inclusive of 0: under load, thread-start
+        # latency can consume the entire 20ms budget before the worker
+        # computes its remaining share, legitimately flooring it at 0 -- a
+        # strict `0 <` would assert scheduler luck rather than the contract.
+        assert len(provider.flush_timeouts) == 1
+        assert 0 <= provider.flush_timeouts[0] <= 20
+    # The workers are daemons that outlive the bounded join, so wait for each to
+    # finish its own flush-then-shutdown sequence before judging ordering.
+    for provider in (trace_provider, log_provider, meter_provider):
+        assert provider.shutdown_done.wait(2.0)
+    for provider in (trace_provider, log_provider, meter_provider):
+        assert provider.calls == [
+            ("force_flush", "enter"),
+            ("force_flush", "exit"),
+            ("shutdown", "enter"),
+            ("shutdown", "exit"),
+        ]


### PR DESCRIPTION
## Summary

`ServiceTelemetry.shutdown()` force-flushed every provider sequentially, then shut every provider
down sequentially, with each of the six calls independently bounded at `_EXPORT_TIMEOUT_MILLIS`
(5s). The worst case therefore scaled with provider count — the arithmetic upper bound is
`2 x 3 x 5s = 30s`, exactly the default `terminationGracePeriodSeconds`, leaving no margin for the
process to exit before SIGKILL.

This replaces the two sequential loops with **one shared wall-clock deadline** and **one daemon
worker thread per provider**. Each worker owns one provider's whole teardown and does
`force_flush(remaining_budget)` then `shutdown()` on it, in that order, in that thread — so
flush-before-shutdown ordering is preserved per provider and the two calls are never raced against
the same provider (the SDK gives no evidence that racing them is safe). Independent providers drain
concurrently, and the join loop waits against the shared deadline, so total teardown is bounded by
`timeout_millis` however many providers exist.

Fixed in `packages/telemetry`, so every instrumented workload gets it at once. No chart
`terminationGracePeriodSeconds` was added.

Closes #2362

## Severity, measured rather than assumed

The ticket's 30s is a correct *theoretical* bound but is not what is reachable on
opentelemetry-sdk 1.44.0. Measured against an unreachable gRPC endpoint with all three signals
carrying data, only the `LoggerProvider` actually blocks, and it blocks on both of its calls:

```
CALL tracer  force_flush 0.000s     CALL tracer  shutdown 0.000s
CALL logger  force_flush 5.003s     CALL logger  shutdown 4.999s
CALL meter   force_flush 0.000s     CALL meter   shutdown 0.000s
TOTAL 10.004s
```

So the honest claim for this PR is **~10.6s to ~5.4s**, not 30s to 5s. The structural point stands
independently: the old shape was unbounded in principle and grew with the number of blocking
providers, and one shared deadline bounds it regardless of which providers block on a given SDK.

Two ticket premises are also corrected: `charts/curie/templates/worker.yaml:155` *does* set
`terminationGracePeriodSeconds` (default 1860 via `values.yaml:1477`), so "none of the workload
templates override it" is false for the worker. Genuinely at the 30s default: api, dispatcher,
mail-adapter, runner/sandbox.

## Live proof (AC 5)

Real pods on an owned k3s cluster, task-owned namespace `curie-2362-proof`, **default** grace
period, `OTEL_EXPORTER_OTLP_ENDPOINT=http://10.255.255.1:4317` (routable-looking, nothing
listening — the state a NetworkPolicy produces). Identical pod spec in both arms; only the mounted
`curie_telemetry` source differs.

| arm | in-process `shutdown()` | container terminated state | SIGTERM-to-pod-gone |
|---|---|---|---|
| control (`origin/main`) | 10.003s / 8.668s | `exitCode 0, reason Completed` | **10.64s** |
| candidate (this branch) | **5.000s** (exactly the deadline) | `exitCode 0, reason Completed` | **5.45s** |

The kubelet-recorded `exitCode 0 / Completed` on both arms is the part that matters for AC 5: the
process genuinely exited on its own rather than being SIGKILLed at grace expiry, which is what a
non-daemon export thread holding the interpreter open would have caused. A helper timeout alone
would not have shown this.

## Sibling paths

All seven `telemetry.shutdown()` call sites (mail-adapter, api, dispatcher, dispatcher
`enqueue_once`, worker, worker eval, and runner `__main__`) call it with no arguments and inherit
the new bound with zero caller edits.

`runner/src/curie_runner/otel.py` carries an independent near-copy, `_bounded_provider_call`. It is
deliberately **not** changed: `RunTracer` wraps a single `TracerProvider`, so its worst case is one
bounded 5s wait and it never exhibited this additive shape.

## Done-check

- [x] **Failing tests committed before implementation** — the pre-squash history was `51ce41352` (failing tests, negative control red) then `53777bd58` (fix).
- [x] **All production edits delegated** — driver ran only git, tests and bookkeeping.
- [x] **Broadened return types** — none. `shutdown() -> None` and `_drain_provider(...) -> None` unchanged; the Protocol only narrows a parameter annotation.
- [x] **agent-router Code Reviewer** — review 410, changes requested, all findings resolved (see below).
- [x] **agent-router Scope Reviewer** — review 413, no blocking scope findings; every hunk maps to an AC.
- [x] **Sibling-path parity** — all seven `telemetry.shutdown()` call sites inherit the fix with no caller edits. The runner's separate `_bounded_provider_call` is enumerated and deliberately unchanged (single provider, never additive); follow-up filed as #2533.
- [x] **Guard demonstration** — N/A, no gate/validator/denylist introduced.
- [x] **Consolidation pass** — applied (two simplifications), revalidated, and re-reviewed by agent-router review 418: behaviour-preserving, not blocking.
- [ ] **Security Reviewer** — N/A, `security` scale-up did not fire.
- [x] **Observable verification** — N/A for user-facing UI; the deployed-surface proof above covers the observable behaviour.
- [x] **E2E / deployed surface** — the two-arm cluster proof above.
- [x] **Train check** — general bug fix in a shared library → `main`, matching the ticket's stated target.
- [x] **Discovery-surface proof** — discovery was `cluster`; proven at cluster tier on a real pod.
- [x] **Re-fix mechanism** — N/A. `git log --follow` shows one prior commit on this file (`acf922a05`, PR #1849); no prior fix ever claimed this symptom.
- [x] **Full affected suite, typecheck, lint** — 142 passed (telemetry + runner signal bootstrap), 426 passed including mail-adapter and dispatcher; `ruff` clean, `mypy Success: no issues found in 248 source files`, `lint-imports` 4 kept / 0 broken.

`apps/worker` and `apps/api` suites need the dev-stack postgres on `127.0.0.1:25432` and were not runnable in this environment; CI covers them. They are unaffected beyond calling `telemetry.shutdown()` from a `finally`.

## Review findings and how they were resolved

The code reviewer caught that the AC 5 test was a **false green** — it asserted `elapsed < 20s` over `http/protobuf`, but the measured pre-fix cost is 10.6s over gRPC, so the old implementation would have passed it. Fixed and then demonstrated: the same child program reports `SHUTDOWN_SECONDS=10.032` against `origin/main` (fails the new `< 7.0`) and `5.000` here.

It also caught that the AC 3 overlap guard **could not fail pytest**, because the fake raised an `AssertionError` that `_drain_provider` swallows along with every other provider exception. Fakes now record violations into the recorder and the tests assert on that list.

Knowingly not fixed: the `_closed` flag is a plain bool with no lock. Two concurrent `shutdown()` calls could both pass the guard. Every production caller is a single-threaded `finally:` or FastAPI lifespan on process teardown, so there is no second caller; the reviewer independently assessed it as not a real defect for these callers.
