### PR TITLE
Bring the Discord adapter under shared telemetry and log redaction

### DIFF
--- a/adapters/discord/README.md
+++ b/adapters/discord/README.md
@@ -55,8 +55,11 @@ Those remain in the environment or mounted bindings file.
 `main()` calls `bootstrap_service_telemetry` on the `curie_discord_adapter`
 package logger, so every module beneath it — including ones added later —
 writes single-line JSON that has passed
-`curie_telemetry.redact.RedactingLogFilter`, and its logs, traces and metrics
-export over OTLP when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. The three
+`curie_telemetry.redact.RedactingLogFilter`, and those logs export over OTLP
+when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. The bootstrap also installs the
+trace and metric exporters, but the adapter authors no spans and records no
+instruments yet, so those two signals carry nothing until someone
+instruments a call path. The three
 third-party namespaces the process runs under (`discord`, `uvicorn`, `httpx`)
 are bootstrapped alongside it, because they lost their handler when
 `logging.basicConfig` was removed and would otherwise print unredacted text via

--- a/adapters/discord/README.md
+++ b/adapters/discord/README.md
@@ -49,3 +49,28 @@ failure never falls back to Slack or another surface.
 
 SQLite stores thread routing and delivery ids but not scoped channel tokens.
 Those remain in the environment or mounted bindings file.
+
+## Telemetry
+
+`main()` calls `bootstrap_service_telemetry` on the `curie_discord_adapter`
+package logger, so every module beneath it — including ones added later —
+writes single-line JSON that has passed
+`curie_telemetry.redact.RedactingLogFilter`, and its logs, traces and metrics
+export over OTLP when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. The three
+third-party namespaces the process runs under (`discord`, `uvicorn`, `httpx`)
+are bootstrapped alongside it, because they lost their handler when
+`logging.basicConfig` was removed and would otherwise print unredacted text via
+`logging.lastResort`. No endpoint set is a supported no-op, not a boot failure:
+that is what every local, offline and CI install runs.
+
+The adapter is a first-party workload that instruments itself, and it stays
+**outside** the instrumented-set enumeration in `charts/curie/CLAUDE.md`. That
+rule defines membership as exactly the workloads whose container `env` block
+includes the `curie.env.otel` helper, with
+`grep -n 'curie.env.otel' charts/curie/templates/` as the authoritative answer
+at any commit. This adapter has no chart template at all, and no compose
+service, so it renders no container `env` block and cannot be a member of a set
+defined by a template include; writing it in as prose would recreate exactly the
+stale hand-maintained list that rule exists to abolish. Whoever later adds a
+chart template for this adapter must add the `curie.env.otel` include, and that
+is the moment it joins the enumerated set.

--- a/adapters/discord/pyproject.toml
+++ b/adapters/discord/pyproject.toml
@@ -5,6 +5,7 @@ description = "Discord Gateway and REST adapter for Curie channel-neutral turns"
 requires-python = ">=3.13"
 dependencies = [
     "curie-channel-protocol",
+    "curie-telemetry",
     "discord.py>=2.6,<3",
     "fastapi>=0.135",
     "httpx>=0.28",

--- a/adapters/discord/src/curie_discord_adapter/__init__.py
+++ b/adapters/discord/src/curie_discord_adapter/__init__.py
@@ -1,1 +1,5 @@
 """Discord surface adapter for Curie."""
+
+__version__ = "0.0.0"
+
+__all__ = ["__version__"]

--- a/adapters/discord/src/curie_discord_adapter/main.py
+++ b/adapters/discord/src/curie_discord_adapter/main.py
@@ -198,12 +198,12 @@ async def run() -> None:
     adapter = DiscordAdapter(config, state)
     reply_service = DiscordReplyService(adapter, state)
     app = create_reply_app(reply_service, config.adapter_secret)
-    # serve() applies uvicorn's own LOGGING_CONFIG via dictConfig, which hands uvicorn.access
-    # a plain-text stdout handler and sets propagate=False, detaching it from the uvicorn
-    # namespace handler set up above. Access lines carry method, path and query string, exactly
-    # what url_secret_param redacts, so log_config=None skips uvicorn's config: uvicorn.access
-    # gets no handler and propagate=True, so it reaches the redacting JSON handler like every
-    # other logger here.
+    # uvicorn.Config(...)'s own constructor applies uvicorn's own LOGGING_CONFIG via dictConfig,
+    # which hands uvicorn.access a plain-text stdout handler and sets propagate=False, detaching
+    # it from the uvicorn namespace handler set up above. Access lines carry method, path and
+    # query string, exactly what url_secret_param redacts, so log_config=None skips uvicorn's
+    # config: uvicorn.access gets no handler and propagate=True, so it reaches the redacting
+    # JSON handler like every other logger here.
     server = uvicorn.Server(
         uvicorn.Config(
             app,

--- a/adapters/discord/src/curie_discord_adapter/main.py
+++ b/adapters/discord/src/curie_discord_adapter/main.py
@@ -2,12 +2,15 @@
 
 import asyncio
 import logging
+import os
 from typing import Any
 
 import discord
 import httpx
 import uvicorn
+from curie_telemetry import bootstrap_service_telemetry, configure_service_logging
 
+from . import __version__
 from .config import DiscordConfig
 from .egress import DiscordReplyService
 from .http import create_reply_app
@@ -15,6 +18,20 @@ from .ingress import DiscordBinding, DiscordMessage, build_turn
 from .state import DiscordState
 
 logger = logging.getLogger(__name__)
+
+SERVICE_NAME = "curie-discord-adapter"
+
+# The third-party libraries this process actually runs under: discord.py owns
+# the Gateway, uvicorn serves the reply wire, and httpx makes every outbound
+# call. Each name is a namespace *root*, so one bootstrap apiece covers
+# `discord.gateway`, `uvicorn.error`, `httpx._client` and every sibling by
+# propagation. They are enumerated here because dropping `basicConfig` took the
+# root handler with it: with no handler anywhere on their chain their WARNING+
+# records fall to `logging.lastResort`, which writes them to stderr as plain
+# unredacted text -- the exact defect #2358 closes, merely moved out of our
+# package and into our dependencies. discord.py emits such a warning on every
+# start, so this is observed rather than hypothetical.
+_THIRD_PARTY_LOG_NAMESPACES = ("discord", "uvicorn", "httpx")
 
 
 class DiscordAdapter(discord.Client):
@@ -181,8 +198,20 @@ async def run() -> None:
     adapter = DiscordAdapter(config, state)
     reply_service = DiscordReplyService(adapter, state)
     app = create_reply_app(reply_service, config.adapter_secret)
+    # serve() applies uvicorn's own LOGGING_CONFIG via dictConfig, which hands uvicorn.access
+    # a plain-text stdout handler and sets propagate=False, detaching it from the uvicorn
+    # namespace handler set up above. Access lines carry method, path and query string, exactly
+    # what url_secret_param redacts, so log_config=None skips uvicorn's config: uvicorn.access
+    # gets no handler and propagate=True, so it reaches the redacting JSON handler like every
+    # other logger here.
     server = uvicorn.Server(
-        uvicorn.Config(app, host=config.reply_host, port=config.reply_port, log_level="info")
+        uvicorn.Config(
+            app,
+            host=config.reply_host,
+            port=config.reply_port,
+            log_level="info",
+            log_config=None,
+        )
     )
     try:
         await asyncio.gather(server.serve(), adapter.start(config.discord_bot_token))
@@ -192,5 +221,35 @@ async def run() -> None:
 
 
 def main() -> None:
-    logging.basicConfig(level=logging.INFO)
-    asyncio.run(run())
+    # The *package* logger is handed over, not this module's.
+    # `configure_service_logging` sets `propagate=False` on exactly the logger
+    # it is given, and `main`, `config`, `egress`, `http`, `ingress` and `state`
+    # each hold their own `getLogger(__name__)` child of it -- so one bootstrap
+    # installs the redacting JSON handler for all six, and for every module
+    # added later, by propagation. Bootstrapping the module loggers one at a
+    # time passes for today's six and silently leaves the seventh outside the
+    # filter.
+    telemetry = bootstrap_service_telemetry(
+        SERVICE_NAME,
+        service_version=__version__,
+        logger=logging.getLogger("curie_discord_adapter"),
+        environ=os.environ,
+    )
+    for namespace in _THIRD_PARTY_LOG_NAMESPACES:
+        configure_service_logging(
+            logging.getLogger(namespace),
+            service_name=SERVICE_NAME,
+            logger_provider=telemetry.logger_provider,
+            level=logging.INFO,
+        )
+    try:
+        asyncio.run(run())
+    finally:
+        # After the body, not a context manager around a narrower region:
+        # `shutdown` force-flushes the batch processors, whose schedule delay is
+        # 1000 ms, so a process that exits sooner delivers nothing at all. Placing
+        # the flush here is what makes both the last records of a graceful stop
+        # and the records immediately preceding a crash actually reach the
+        # collector -- the ones an operator most needs and the ones an unflushed
+        # `BatchLogRecordProcessor` takes down with the process.
+        telemetry.shutdown()

--- a/adapters/discord/tests/_telemetry_process.py
+++ b/adapters/discord/tests/_telemetry_process.py
@@ -59,6 +59,19 @@ PLANTED_CARRIER = "planted telemetry probe record for the discord adapter"
 # this one on the root handler, and the `descendant` scenario would expose it.
 FUTURE_MODULE_LOGGER = "curie_discord_adapter.a_module_added_later"
 
+# One CHILD logger per namespace `main._THIRD_PARTY_LOG_NAMESPACES` claims, minus
+# `uvicorn`, which the `access_log` scenario already pins through
+# `uvicorn.access` under the harsher condition of uvicorn's own `dictConfig`
+# having run. Duplicating it here would add a weaker second copy of that
+# coverage, so its absence from this tuple is deliberate rather than forgotten.
+#
+# Children, not the namespace roots: the bootstrap is handed the roots, so
+# coverage is a claim about propagation, and an implementation that configured
+# exactly one logger by name would still leave every real library logger --
+# `discord.gateway`, `httpx._client` -- on `lastResort`. One entry per namespace
+# is what makes deleting a namespace from that constant turn a test red.
+THIRD_PARTY_CHILD_LOGGERS = ("discord.client", "httpx._client")
+
 
 def _emit_planted_record(logger_name: str) -> None:
     """Log the planted credential as a ``%s`` ARG, never baked into the template.
@@ -115,19 +128,27 @@ def _install_fake_peers(scenario: str) -> None:
             )
             return
         if scenario == "third_party":
-            # A CHILD of `discord`, not `discord` itself. The adapter runs under
-            # third-party loggers it does not own, and `main()` must hand the
-            # bootstrap the parent names — so proving coverage means proving
-            # propagation from a child, the same way the package logger covers
-            # `curie_discord_adapter.*`. Hardcoding `discord` would pass against
-            # an implementation that configured exactly one logger by name and
-            # still left `discord.client`, `discord.gateway` and the rest on
-            # `lastResort`.
+            # A CHILD of each namespace, never the namespace itself. The adapter
+            # runs under third-party loggers it does not own, and `main()` must
+            # hand the bootstrap the parent names — so proving coverage means
+            # proving propagation from a child, the same way the package logger
+            # covers `curie_discord_adapter.*`. Hardcoding `discord` would pass
+            # against an implementation that configured exactly one logger by
+            # name and still left `discord.client`, `discord.gateway` and the
+            # rest on `lastResort`.
+            #
+            # Every namespace gets its own record, at WARNING so `lastResort`
+            # would fire on an uncovered one. Emitting through only one of them
+            # is what let `httpx` be deleted from `_THIRD_PARTY_LOG_NAMESPACES`
+            # with the suite still green: httpx logs at DEBUG in practice, so a
+            # quiet boot stays all-JSON and nothing goes red.
+            #
             # Carrier in the template, credential as the sole arg — see
             # `_emit_planted_record` for why `_otlp_body` forces that split.
-            logging.getLogger("discord.client").warning(
-                PLANTED_CARRIER + ": credential=%s", os.environ[PLANTED_SECRET_ENV]
-            )
+            for logger_name in THIRD_PARTY_CHILD_LOGGERS:
+                logging.getLogger(logger_name).warning(
+                    PLANTED_CARRIER + ": credential=%s", os.environ[PLANTED_SECRET_ENV]
+                )
             return
         if scenario == "descendant":
             _emit_planted_record("curie_discord_adapter.main")
@@ -135,6 +156,24 @@ def _install_fake_peers(scenario: str) -> None:
                 "a module added after the bootstrap was written also logs"
             )
             return
+        if scenario == "base_exception_exit":
+            _emit_planted_record("curie_discord_adapter.main")
+            # `SystemExit` is a `BaseException` and NOT an `Exception`, which is
+            # the whole point: `main()` uses `try/finally`, so it flushes here
+            # too, while the reviewer's mutation
+            #
+            #     try: asyncio.run(run())
+            #     except Exception: telemetry.shutdown(); raise
+            #     telemetry.shutdown()
+            #
+            # keeps `error_exit` and the normal path green and silently stops
+            # flushing on exactly this one. A boot refusal and a signal-driven
+            # stop both leave this process as a `SystemExit`, so it is the
+            # likeliest real exit of the three. The code is a distinctive value
+            # so the test can prove the exception was not swallowed and
+            # re-raised as something else. No credential in the message, for the
+            # same reason as `error_exit` below.
+            raise SystemExit(3)
         if scenario == "error_exit":
             _emit_planted_record("curie_discord_adapter.main")
             # The message carries NO secret on purpose. Python prints an

--- a/adapters/discord/tests/_telemetry_process.py
+++ b/adapters/discord/tests/_telemetry_process.py
@@ -68,14 +68,32 @@ def _emit_planted_record(logger_name: str) -> None:
     while `_otlp_body` walks ``record.args`` against the percent-format template
     on the OTLP side. A secret pre-interpolated into the template would silently
     skip the second one and the OTLP assertions would prove less than they claim.
+
+    The carrier, conversely, MUST be part of the template. `_otlp_body` keeps
+    dynamic args out of the exported body: it substitutes an arg's rendered value
+    only when redacting it *changed* it, so a secret contributes its bounded
+    marker while a safe arg is left as the bare ``%s`` placeholder. A carrier
+    passed as an arg therefore never reaches the collector, and the OTLP negative
+    controls could not hold by construction. Concatenation, not an f-string, so
+    ``record.msg`` is literal text and the credential stays the only arg.
     """
     logging.getLogger(logger_name).info(
-        "%s: credential=%s", PLANTED_CARRIER, os.environ[PLANTED_SECRET_ENV]
+        PLANTED_CARRIER + ": credential=%s", os.environ[PLANTED_SECRET_ENV]
     )
 
 
 def _install_fake_peers(scenario: str) -> None:
     async def fake_serve(self: uvicorn.Server, *args: Any, **kwargs: Any) -> None:
+        # `Server.serve()` calls `self.config.load()` first, so this fake does
+        # too. It is not ceremony: `load()` is where uvicorn applies its own
+        # `LOGGING_CONFIG` through `dictConfig`, attaching a plain-text stdout
+        # handler to `uvicorn.access` and setting `propagate=False` on it — which
+        # detaches the access log, and therefore every request path and query
+        # string, from whatever handler `main()` installed on the `uvicorn`
+        # namespace. Skipping `load()` would make this fake a *less* faithful
+        # peer in exactly the place a real leak lives, and the suite would be
+        # green over it. Only the socket-owning part of `serve()` is omitted.
+        self.config.load()
         # Return promptly rather than immediately: `run()` gathers this with the
         # Gateway coroutine, and yielding to the loop keeps the ordering closer
         # to the real one without making any test depend on the delay.
@@ -87,6 +105,15 @@ def _install_fake_peers(scenario: str) -> None:
         if scenario == "planted_secret":
             _emit_planted_record("curie_discord_adapter.main")
             return
+        if scenario == "access_log":
+            # Emitted from the Gateway coroutine, which `run()` gathers *after*
+            # the server coroutine has already called `config.load()`, so this
+            # record is written under whatever logging state uvicorn left behind
+            # — which is the whole point of the scenario.
+            logging.getLogger("uvicorn.access").warning(
+                PLANTED_CARRIER + ": credential=%s", os.environ[PLANTED_SECRET_ENV]
+            )
+            return
         if scenario == "third_party":
             # A CHILD of `discord`, not `discord` itself. The adapter runs under
             # third-party loggers it does not own, and `main()` must hand the
@@ -96,8 +123,10 @@ def _install_fake_peers(scenario: str) -> None:
             # an implementation that configured exactly one logger by name and
             # still left `discord.client`, `discord.gateway` and the rest on
             # `lastResort`.
+            # Carrier in the template, credential as the sole arg — see
+            # `_emit_planted_record` for why `_otlp_body` forces that split.
             logging.getLogger("discord.client").warning(
-                "%s: credential=%s", PLANTED_CARRIER, os.environ[PLANTED_SECRET_ENV]
+                PLANTED_CARRIER + ": credential=%s", os.environ[PLANTED_SECRET_ENV]
             )
             return
         if scenario == "descendant":

--- a/adapters/discord/tests/_telemetry_process.py
+++ b/adapters/discord/tests/_telemetry_process.py
@@ -1,0 +1,125 @@
+"""Subprocess driver that runs the REAL Discord adapter entrypoint.
+
+This is not a test module; pytest must not collect it. `test_telemetry.py`
+spawns it as ``[sys.executable, str(DRIVER_PATH)]`` because "the process's logs
+are JSON, redacted, and exported" is a property of a *process*, and the only
+honest way to observe it is to start one and read what it actually wrote.
+
+**What is real.** `curie_discord_adapter.main.main()` itself — including the
+telemetry bootstrap this ticket adds and its ``finally`` — plus `DiscordConfig`,
+`DiscordState`, `DiscordAdapter`, `DiscordReplyService`, `create_reply_app` and
+`run()`'s own ``asyncio.gather`` / ``finally`` teardown. Nothing inside the
+package is patched, and in particular nothing about logging is touched here: if
+a test in this suite passes, it passes because the shipped entrypoint behaves.
+
+**What is faked, and why only this.** Exactly two coroutines, both of which are
+*external network peers* rather than code under test:
+
+- ``discord.Client.start`` — Discord's Gateway is an unauthorized external
+  service for this run. Logging into it would require a real bot token and would
+  put traffic on a third party's servers, which this repo's tests never do.
+- ``uvicorn.Server.serve`` — it otherwise blocks forever, so ``asyncio.gather``
+  in `run()` could never return and the process could never reach the
+  ``finally`` whose flush is the very thing under test. Binding a real port adds
+  nothing: no test here speaks HTTP to the adapter.
+
+Faking a peer is not faking the code under test. The substitution is at the
+socket-owning boundary, one call deep, and every statement whose behavior any
+assertion depends on still executes for real.
+
+The scenario is chosen by ``CURIE_DISCORD_TEST_SCENARIO``; the planted synthetic
+credential is supplied by ``CURIE_DISCORD_TEST_PLANTED_SECRET`` so the test file
+owns the constant and this driver never hardcodes anything secret-shaped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+import discord
+import uvicorn
+from curie_discord_adapter.main import main
+
+SCENARIO_ENV = "CURIE_DISCORD_TEST_SCENARIO"
+PLANTED_SECRET_ENV = "CURIE_DISCORD_TEST_PLANTED_SECRET"
+
+# The carrier text of the planted record. It contains no secret, so a test can
+# assert it survived into the output as a negative control *before* asserting
+# that the secret did not — otherwise "the secret is absent" is also satisfied by
+# output that never carried the record at all.
+PLANTED_CARRIER = "planted telemetry probe record for the discord adapter"
+
+# A logger for a module that does not exist. The point is precisely that it does
+# not: `configure_service_logging` is handed the *package* logger, so every
+# descendant is covered by `Logger.callHandlers` walking up — including modules
+# nobody has written yet. Bootstrapping module loggers one at a time would leave
+# this one on the root handler, and the `descendant` scenario would expose it.
+FUTURE_MODULE_LOGGER = "curie_discord_adapter.a_module_added_later"
+
+
+def _emit_planted_record(logger_name: str) -> None:
+    """Log the planted credential as a ``%s`` ARG, never baked into the template.
+
+    Two different code paths must both scrub it, and only an arg exercises both:
+    `RedactingLogFilter` sees it via ``record.getMessage()`` on the stderr side,
+    while `_otlp_body` walks ``record.args`` against the percent-format template
+    on the OTLP side. A secret pre-interpolated into the template would silently
+    skip the second one and the OTLP assertions would prove less than they claim.
+    """
+    logging.getLogger(logger_name).info(
+        "%s: credential=%s", PLANTED_CARRIER, os.environ[PLANTED_SECRET_ENV]
+    )
+
+
+def _install_fake_peers(scenario: str) -> None:
+    async def fake_serve(self: uvicorn.Server, *args: Any, **kwargs: Any) -> None:
+        # Return promptly rather than immediately: `run()` gathers this with the
+        # Gateway coroutine, and yielding to the loop keeps the ordering closer
+        # to the real one without making any test depend on the delay.
+        await asyncio.sleep(0.01)
+
+    async def fake_start(self: discord.Client, token: str, *, reconnect: bool = True) -> None:
+        if scenario == "quiet":
+            return
+        if scenario == "planted_secret":
+            _emit_planted_record("curie_discord_adapter.main")
+            return
+        if scenario == "third_party":
+            # A CHILD of `discord`, not `discord` itself. The adapter runs under
+            # third-party loggers it does not own, and `main()` must hand the
+            # bootstrap the parent names — so proving coverage means proving
+            # propagation from a child, the same way the package logger covers
+            # `curie_discord_adapter.*`. Hardcoding `discord` would pass against
+            # an implementation that configured exactly one logger by name and
+            # still left `discord.client`, `discord.gateway` and the rest on
+            # `lastResort`.
+            logging.getLogger("discord.client").warning(
+                "%s: credential=%s", PLANTED_CARRIER, os.environ[PLANTED_SECRET_ENV]
+            )
+            return
+        if scenario == "descendant":
+            _emit_planted_record("curie_discord_adapter.main")
+            logging.getLogger(FUTURE_MODULE_LOGGER).info(
+                "a module added after the bootstrap was written also logs"
+            )
+            return
+        if scenario == "error_exit":
+            _emit_planted_record("curie_discord_adapter.main")
+            # The message carries NO secret on purpose. Python prints an
+            # uncaught traceback itself, outside the logging package and
+            # therefore outside the redaction filter, so a secret in the
+            # exception text would leak legitimately — and a test asserting its
+            # absence would then be asserting something false about the design.
+            raise RuntimeError("synthetic gateway failure with no credential in its message")
+        raise SystemExit(f"unknown scenario {scenario!r}")
+
+    uvicorn.Server.serve = fake_serve  # type: ignore[method-assign]
+    discord.Client.start = fake_start  # type: ignore[method-assign]
+
+
+if __name__ == "__main__":
+    _install_fake_peers(os.environ[SCENARIO_ENV])
+    main()

--- a/adapters/discord/tests/test_telemetry.py
+++ b/adapters/discord/tests/test_telemetry.py
@@ -25,6 +25,16 @@ output as `[REDACTED:home_path]`. `pytest`'s `tmp_path` lives under the
 `tempfile` root (`/tmp` on this project's Linux images and CI), which is why the
 state path is built from it rather than from a home-relative directory.
 
+**A negative control on the export path must live in the message template.**
+`_otlp_body` builds the exported body from `record.msg` with *safe* formatting
+args elided back to a bare `%s`, substituting an arg's value only when redaction
+changed it — so a secret contributes its bounded marker and nothing else dynamic
+travels. The planted records therefore carry `PLANTED_CARRIER` as literal
+template text and the credential as the lone `%s` arg. Folding the credential
+into the template too would look like a simplification and would silently stop
+exercising `_otlp_body`'s arg-redaction path; moving the carrier into an arg
+would break the OTLP negative controls by construction rather than by regression.
+
 **Removing `basicConfig` is what makes third-party coverage load-bearing.** That
 call had one accidental virtue: it gave `discord`, `uvicorn` and `httpx` a root
 handler. Delete it and configure only the `curie_discord_adapter` package logger,
@@ -543,4 +553,52 @@ def test_a_third_party_library_warning_also_leaves_as_redacted_json(tmp_path: Pa
     )
     assert REDACTION_MARKER in output, (
         f"the third-party record never passed RedactingLogFilter; output:\n{output}"
+    )
+
+
+def test_the_uvicorn_access_log_is_redacted_json_too(tmp_path: Path) -> None:
+    """uvicorn must not be allowed to steal its own access logger back.
+
+    `uvicorn.Config.load()` — the first thing `Server.serve()` does — applies
+    uvicorn's default `LOGGING_CONFIG` through `dictConfig`, which attaches a
+    plain-text stdout handler to `uvicorn.access` and sets `propagate=False` on
+    it. That detaches the access log from the `uvicorn` namespace handler
+    `main()` installs, and the access log is precisely where request paths and
+    query strings go — the payload the `url_secret_param` redaction rule exists
+    for. So bootstrapping the `uvicorn` logger is necessary and not sufficient.
+
+    The mechanism that makes it sufficient is `log_config=None` on the
+    `uvicorn.Config` built in `run()`: uvicorn then leaves logging alone and
+    `uvicorn.access` stays `handlers=[] propagate=True`, reaching the redacting
+    JSON handler like every other logger here. A future author who drops that
+    kwarg as redundant will see this test go red, and this docstring is the
+    explanation of why.
+
+    Cannot pass vacuously: the fake `serve()` really does call `config.load()`,
+    `json_records` is strict so a stolen logger's stdout line is an error naming
+    it, and the carrier is asserted present before the token is asserted absent.
+    """
+    code, output = run_driver(driver_env(tmp_path, "access_log"))
+
+    assert code == 0, f"the driver did not exit cleanly; output:\n{output}"
+    records = json_records(output)
+    access = [record for record in records if record.get("logger") == "uvicorn.access"]
+    assert access, (
+        f"no uvicorn.access record was emitted as service JSON, so uvicorn's "
+        f"LOGGING_CONFIG kept ownership of it; saw "
+        f"{sorted({str(record.get('logger')) for record in records})}"
+    )
+    for record in access:
+        assert record.get("service.name") == SERVICE_NAME, (
+            f"an access record carries no service identity: {record}"
+        )
+    assert PLANTED_CARRIER in output, (
+        f"the planted access record was never emitted, so the redaction "
+        f"assertions below would pass vacuously; output:\n{output}"
+    )
+    assert PLANTED_CHANNEL_TOKEN not in output, (
+        f"the access log wrote the planted channel token verbatim:\n{output}"
+    )
+    assert REDACTION_MARKER in output, (
+        f"the access record never passed RedactingLogFilter; output:\n{output}"
     )

--- a/adapters/discord/tests/test_telemetry.py
+++ b/adapters/discord/tests/test_telemetry.py
@@ -1,0 +1,546 @@
+"""Shared telemetry: the Discord adapter's process logs are JSON, redacted, exported.
+
+Until #2358 `main()` called `logging.basicConfig(level=logging.INFO)`, which
+puts the adapter outside `curie_telemetry` entirely: no `RedactingLogFilter`, no
+JSON envelope carrying `service.name`, and no OTLP export of a single log line,
+span or metric. It was the last first-party Python entrypoint in this repo in
+that state.
+
+"The process's logs are redacted and exported" is a property of the *process*,
+not of a function, so every test here drives the real entrypoint through
+`_telemetry_process.py` in a subprocess and reads its actual merged
+stdout+stderr, or reads a real OTLP collector listening on 127.0.0.1. Calling
+`configure_service_logging` directly, or asserting on `caplog`, would prove
+nothing about the shipped image — the regression this file exists to catch lives
+in `main()`, in the one statement those approaches skip.
+
+Only synthetic credentials appear here. No real Discord token exists in this
+suite, no Discord surface is contacted, and no socket leaves 127.0.0.1.
+
+Two environment facts a later author needs.
+
+**`/tmp`, not `$HOME`.** `REDACTION_RULES`' `home_path` rule rewrites
+`/(?:home|Users)/[^/\\s]+`, so any adapter path under `$HOME` would arrive in
+output as `[REDACTED:home_path]`. `pytest`'s `tmp_path` lives under the
+`tempfile` root (`/tmp` on this project's Linux images and CI), which is why the
+state path is built from it rather than from a home-relative directory.
+
+**Removing `basicConfig` is what makes third-party coverage load-bearing.** That
+call had one accidental virtue: it gave `discord`, `uvicorn` and `httpx` a root
+handler. Delete it and configure only the `curie_discord_adapter` package logger,
+and those libraries have no handler at all — so `logging.lastResort` prints their
+WARNING+ records to stderr as plain, unredacted text. That is the exact condition
+#2358 exists to end, merely relocated from our package into our dependencies, and
+discord.py's own "davey is not installed" warning fires it on every boot. So
+`main()` must bootstrap those three logger names too, and the last test here pins
+it. A future author whose instinct is to mute the dependency to make that test
+pass would be re-creating the leak in the shipped process while turning the suite
+green; the fix belongs in `main()`.
+
+**The adapter logs no operator-supplied credential today.** Its call sites pass
+ids, status codes and fixed labels — that is the design working. So the planted
+record below is what a *future* call site would look like, and the regression
+actually guarded is "the shared filter is installed on the package logger by the
+real entrypoint", which is exactly what `basicConfig` fails to do.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceRequest
+
+SERVICE_NAME = "curie-discord-adapter"
+DRIVER_PATH = Path(__file__).with_name("_telemetry_process.py")
+
+# A synthetic Curie-minted channel token in the exact `chn.{payload}.{signature}`
+# shape `redact.py`'s `channel_token` rule matches. That rule landed in #2359,
+# the prerequisite this ticket is deliberately sequenced after, so planting this
+# specific shape is what proves the Discord adapter joins the *strengthened*
+# common policy rather than some weaker local one. Payload and signature are
+# obviously fake and decode to nothing.
+PLANTED_CHANNEL_TOKEN = "chn.not-a-real-payload-2358.not-a-real-signature-2358"
+REDACTION_MARKER = "[REDACTED:channel_token]"
+
+# Duplicated from `_telemetry_process.PLANTED_CARRIER` rather than imported: this
+# suite has no `conftest.py` putting its own directory on `sys.path`, and the root
+# run uses `--import-mode=importlib`, under which a sibling test-directory module
+# is not importable by bare name. The constant is a plain literal with no logic
+# behind it, and if a copy ever drifted the negative controls below would fail
+# loudly rather than start passing vacuously.
+PLANTED_CARRIER = "planted telemetry probe record for the discord adapter"
+
+
+def free_port() -> int:
+    """A port the OS has just confirmed free, released immediately.
+
+    Racy in principle and fine in practice: the window is microseconds and the
+    alternative — a fixed port — collides for real whenever this suite runs
+    beside another.
+    """
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+def wait_until(predicate: object, timeout: float, message: str) -> None:
+    """Poll instead of sleeping a fixed interval, and fail loudly on timeout.
+
+    A fixed sleep either wastes time or flakes under load; a bare `assert` after
+    a sleep loses the reason. Every wait here names what it was waiting for.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():  # type: ignore[operator]
+            return
+        time.sleep(0.02)
+    raise AssertionError(f"timed out after {timeout}s waiting for: {message}")
+
+
+# --- the local OTLP collector -------------------------------------------------
+
+
+class OtlpReceiver:
+    """A real HTTP OTLP endpoint on 127.0.0.1 that keeps every request verbatim.
+
+    Verbatim matters: the strongest assertion available is "the planted secret's
+    bytes appear nowhere in anything the process put on the wire", and that can
+    only be made against the raw bodies, not against a parsed view that might
+    quietly drop the field carrying it.
+    """
+
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, bytes, dict[str, str]]] = []
+        self._lock = threading.Lock()
+
+    def record(self, path: str, body: bytes, headers: dict[str, str]) -> None:
+        with self._lock:
+            self.requests.append((path, body, headers))
+
+    def paths(self) -> list[str]:
+        with self._lock:
+            return [path for path, _, _ in self.requests]
+
+    def bodies(self, path: str) -> list[bytes]:
+        with self._lock:
+            return [body for request_path, body, _ in self.requests if request_path == path]
+
+    def all_bytes(self) -> bytes:
+        with self._lock:
+            return b"".join(body for _, body, _ in self.requests)
+
+    def log_requests(self) -> list[ExportLogsServiceRequest]:
+        """The `/v1/logs` payloads decoded as real protobuf.
+
+        Decoding is the point of this helper. "A POST arrived" is satisfied by
+        an empty or malformed body; only a parsed `ExportLogsServiceRequest`
+        shows that the SDK actually built and exported log records.
+        """
+        decoded = []
+        for body in self.bodies("/v1/logs"):
+            request = ExportLogsServiceRequest()
+            request.ParseFromString(body)
+            decoded.append(request)
+        return decoded
+
+    def log_record_count(self) -> int:
+        return sum(
+            len(scope.log_records)
+            for request in self.log_requests()
+            for resource in request.resource_logs
+            for scope in resource.scope_logs
+        )
+
+    def service_names(self) -> set[str]:
+        return {
+            attribute.value.string_value
+            for request in self.log_requests()
+            for resource in request.resource_logs
+            for attribute in resource.resource.attributes
+            if attribute.key == "service.name"
+        }
+
+
+class _Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self) -> None:  # noqa: N802  (BaseHTTPRequestHandler's naming)
+        length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(length)
+        # The SDK's HTTP exporter gzips by default. Store the decompressed bytes
+        # so a raw-substring assertion is looking at plaintext rather than at a
+        # deflate stream in which any string is trivially "absent".
+        if (self.headers.get("Content-Encoding") or "").lower() == "gzip":
+            body = gzip.decompress(body)
+        self.server.receiver.record(  # type: ignore[attr-defined]
+            self.path, body, {key.lower(): value for key, value in self.headers.items()}
+        )
+        self.send_response(200)
+        self.send_header("Content-Type", "application/x-protobuf")
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, *args: object) -> None:
+        """Silence the default per-request stderr line; it is pytest noise only."""
+
+
+@pytest.fixture
+def otlp() -> Iterator[tuple[OtlpReceiver, str]]:
+    receiver = OtlpReceiver()
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    server.receiver = receiver  # type: ignore[attr-defined]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield receiver, f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+# --- driving the real entrypoint ----------------------------------------------
+
+
+def driver_env(tmp_path: Path, scenario: str, **extra: str) -> dict[str, str]:
+    """A CLOSED environment for the adapter process.
+
+    Built explicitly rather than copied from `os.environ`, because inheriting
+    would let an `OTEL_*` variable set on the developer's box, or by the outer
+    pytest run, decide which code path the "no endpoint configured" test
+    exercises — and that test would then pass while proving the opposite of what
+    it claims. `PATH` is the one inherited key: it is what makes the interpreter
+    and its venv resolvable, and it carries no telemetry meaning.
+    """
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "CURIE_DISCORD_TEST_SCENARIO": scenario,
+        "CURIE_DISCORD_TEST_PLANTED_SECRET": PLANTED_CHANNEL_TOKEN,
+        # `DiscordConfig` refuses an empty token and an empty secret, so both are
+        # required for the process to reach `run()` at all. Synthetic values: the
+        # Gateway peer is faked and no HTTP request is ever authenticated.
+        "DISCORD_BOT_TOKEN": "synthetic-bot-token-not-a-real-discord-credential",
+        # Deliberately short and non-credential-shaped. The repo's pre-commit
+        # credential scanner flags a long quoted literal assigned to any
+        # secret-named key, and a test placeholder that trips that gate trains
+        # people to bypass it. The adapter only requires a non-empty value here.
+        "CURIE_DISCORD_ADAPTER_SECRET": "unused",
+        # Under `tmp_path` (the `tempfile` root, i.e. `/tmp`) rather than `$HOME`:
+        # the `home_path` redaction rule would rewrite a home-relative path in
+        # any output assertion, and the test would then be reading a placeholder.
+        "CURIE_DISCORD_STATE_PATH": str(tmp_path / "discord-state.sqlite3"),
+        "CURIE_DISCORD_REPLY_PORT": str(free_port()),
+    }
+    env.update(extra)
+    return env
+
+
+def run_driver(env: dict[str, str], *, timeout: float = 60.0) -> tuple[int, str]:
+    """Run the entrypoint to completion; return its exit code and merged output.
+
+    Merged stdout+stderr on purpose: the claim under test is that *nothing* the
+    process writes escapes the service logger, and splitting the streams would
+    let an escapee hide in the one nobody asserted on.
+    """
+    process = subprocess.run(
+        [sys.executable, str(DRIVER_PATH)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=timeout,
+    )
+    return process.returncode, process.stdout
+
+
+def json_records(output: str) -> list[dict[str, object]]:
+    """Every non-blank output line, parsed as a service log record.
+
+    Strict on purpose: `bootstrap_service_telemetry` is the first statement in
+    `main()`, so no line of this process's output may legitimately predate the
+    JSON handler. A plain-text line here means a logger escaped the
+    `curie_discord_adapter` package — precisely the `basicConfig` regression —
+    so it is an assertion failure naming the escapee, not something to skip.
+    """
+    records: list[dict[str, object]] = []
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except ValueError:
+            raise AssertionError(
+                f"a line of adapter output was not JSON, so it bypassed the "
+                f"service logger:\n{line!r}\n\nfull output:\n{output}"
+            ) from None
+        assert isinstance(record, dict), f"a log line was not a JSON object: {line!r}"
+        records.append(record)
+    return records
+
+
+# --- the tests ----------------------------------------------------------------
+
+
+def test_a_planted_secret_in_a_package_log_line_is_redacted_in_process_output(
+    tmp_path: Path,
+) -> None:
+    """A credential that reaches a log line leaves the process redacted.
+
+    With `basicConfig` there is no `RedactingLogFilter` anywhere in this process,
+    so whatever a call site passes goes verbatim into the cluster's log
+    retention. The planted `chn.` token stands in for a future call site; what is
+    actually pinned is that the shared filter is installed on the *package*
+    logger by the real entrypoint.
+
+    Cannot pass vacuously: the negative control asserts the record's own
+    non-secret carrier text is present first, so "the raw token is absent" is
+    never satisfied by output that simply never contained the record.
+    """
+    code, output = run_driver(driver_env(tmp_path, "planted_secret"))
+
+    assert code == 0, f"the driver did not exit cleanly; output:\n{output}"
+    assert PLANTED_CARRIER in output, (
+        f"the log record carrying the planted secret was never emitted, so the "
+        f"redaction assertions below would pass vacuously; output:\n{output}"
+    )
+    assert PLANTED_CHANNEL_TOKEN not in output, (
+        f"the planted channel token survived into process output:\n{output}"
+    )
+    assert REDACTION_MARKER in output, (
+        f"the record was emitted but carries no channel_token placeholder, so it "
+        f"never passed RedactingLogFilter; output:\n{output}"
+    )
+
+
+def test_log_records_actually_reach_a_local_otlp_collector_redacted(
+    tmp_path: Path, otlp: tuple[OtlpReceiver, str]
+) -> None:
+    """Records really are exported, and really are redacted on the wire.
+
+    The AC that matters most, and the one no in-process assertion can make:
+    `basicConfig` installs no `LoggerProvider` at all, so nothing is exported no
+    matter how the handler is inspected. Only `OTEL_EXPORTER_OTLP_ENDPOINT` is
+    set — the bootstrap appends `/v1/logs` itself (verified against
+    `bootstrap._exporter_endpoint`), so pointing at the bare base URL is what a
+    real deployment does.
+
+    This is simultaneously the proof of normal-exit cleanup. The
+    `BatchLogRecordProcessor` runs on a 1000 ms schedule delay and this process
+    exits well inside it, so the only way a record can arrive at all is
+    `finally: telemetry.shutdown()` force-flushing it. If the flush is dropped,
+    this test fails with zero requests received rather than with a wrong value.
+    """
+    receiver, base_url = otlp
+    env = driver_env(tmp_path, "planted_secret", OTEL_EXPORTER_OTLP_ENDPOINT=base_url)
+
+    code, output = run_driver(env)
+    assert code == 0, f"the driver did not exit cleanly; output:\n{output}"
+
+    wait_until(
+        lambda: receiver.log_record_count() > 0,
+        10.0,
+        "an ExportLogsServiceRequest carrying at least one log record on /v1/logs — "
+        "none arrived, which is what a missing bootstrap or a dropped "
+        f"telemetry.shutdown() force-flush looks like. Process output:\n{output}",
+    )
+
+    assert "/v1/logs" in receiver.paths()
+    assert SERVICE_NAME in receiver.service_names(), (
+        f"no exported resource identified itself as {SERVICE_NAME}; saw "
+        f"{sorted(receiver.service_names())}"
+    )
+
+    exported = receiver.all_bytes()
+    # Negative control, exactly as in the stderr test: the carrier text must be
+    # on the wire before "the secret is not on the wire" means anything.
+    assert PLANTED_CARRIER.encode() in exported, (
+        "the planted record reached the collector's socket in no recognizable "
+        "form, so the redaction assertion below would pass vacuously"
+    )
+    assert PLANTED_CHANNEL_TOKEN.encode() not in exported, (
+        "the planted channel token was exported verbatim to the collector"
+    )
+    assert REDACTION_MARKER.encode() in exported, (
+        "the exported body carries no channel_token placeholder, so `_otlp_body` "
+        "never saw the record"
+    )
+
+
+def test_no_otlp_endpoint_configured_is_a_no_op_not_a_boot_failure(
+    tmp_path: Path, otlp: tuple[OtlpReceiver, str]
+) -> None:
+    """No endpoint means no export — and emphatically not a crash.
+
+    The negative control for the test above: it shows the collector assertions
+    there are caused by the configuration, not by the receiver observing traffic
+    it would have seen anyway. It is also the property every local, offline and
+    CI install depends on. The bootstrap runs before `DiscordConfig()`, so a
+    raise inside it would replace a precise config error with an opaque OTel
+    traceback on every developer's machine.
+
+    The receiver is running and its address is deliberately never given to the
+    process, so "received nothing" is a real observation rather than the absence
+    of a listener.
+    """
+    receiver, _ = otlp
+    env = driver_env(tmp_path, "quiet")
+    assert not [name for name in env if name.startswith("OTEL_")], (
+        "driver_env is a closed world; an OTEL_* key here would mean this test "
+        "is exercising the configured path instead of the unconfigured one"
+    )
+
+    code, output = run_driver(env)
+
+    assert code == 0, f"the adapter failed to boot without an OTLP endpoint:\n{output}"
+    assert json_records(output), (
+        f"the adapter emitted no log records at all, so this proves nothing "
+        f"about the unconfigured path still logging; output:\n{output}"
+    )
+    assert receiver.requests == [], (
+        f"the process contacted a collector it was never pointed at: "
+        f"{receiver.paths()}"
+    )
+
+
+def test_the_package_logger_owns_module_loggers_including_ones_added_later(
+    tmp_path: Path,
+) -> None:
+    """One bootstrap on the package logger has to cover every module beneath it.
+
+    `main`, `egress`, `http`, `ingress`, `state` and `config` each hold their own
+    `logging.getLogger(__name__)`, reached only because `Logger.callHandlers`
+    walks up to the `curie_discord_adapter` package logger, on which
+    `configure_service_logging` sets `propagate=False`. The driver logs through a
+    module name that does not exist in the tree at all, which is the property
+    that separates bootstrapping the package from bootstrapping modules one by
+    one: the latter passes for today's six modules and silently leaves the
+    seventh unredacted.
+
+    A stray `basicConfig` restoring a plain-text root handler shows up here as a
+    non-JSON line (`json_records` raises naming it); a per-module bootstrap shows
+    up as a missing logger name.
+    """
+    code, output = run_driver(driver_env(tmp_path, "descendant"))
+
+    assert code == 0, f"the driver did not exit cleanly; output:\n{output}"
+    records = json_records(output)
+    assert records, f"the adapter emitted no log records at all:\n{output}"
+    for record in records:
+        assert record.get("service.name") == SERVICE_NAME, (
+            f"a record escaped the service logger: {record}"
+        )
+    loggers = {str(record.get("logger")) for record in records}
+    assert {
+        "curie_discord_adapter.main",
+        "curie_discord_adapter.a_module_added_later",
+    } <= loggers, (
+        f"an existing module logger and a not-yet-written one were both expected "
+        f"under the package logger; saw {sorted(loggers)}"
+    )
+
+
+def test_telemetry_is_flushed_on_an_error_exit_too(
+    tmp_path: Path, otlp: tuple[OtlpReceiver, str]
+) -> None:
+    """The `finally` runs when `run()` raises, and the failure still surfaces.
+
+    Both halves are load-bearing together. A non-zero exit alone would also be
+    produced by a `main()` with no cleanup at all; a delivered record alone would
+    also be produced by swallowing the exception and returning normally. Only the
+    pair proves `finally: telemetry.shutdown()` ran *on the error path* — the
+    process is dying at that moment, and an unflushed `BatchLogRecordProcessor`
+    dies with it, taking the last record before a crash, the one an operator most
+    needs, along with it.
+
+    Paired with the normal-exit delivery proved above, this covers both exits.
+    """
+    receiver, base_url = otlp
+    env = driver_env(tmp_path, "error_exit", OTEL_EXPORTER_OTLP_ENDPOINT=base_url)
+
+    code, output = run_driver(env)
+
+    assert code != 0, (
+        f"the synthetic gateway failure was swallowed; an adapter that exits 0 on "
+        f"a Gateway crash never restarts. Output:\n{output}"
+    )
+    wait_until(
+        lambda: receiver.log_record_count() > 0,
+        10.0,
+        "a log record exported on the error path — none arrived, so "
+        f"telemetry.shutdown() did not run in main()'s finally. Output:\n{output}",
+    )
+
+    exported = receiver.all_bytes()
+    assert PLANTED_CARRIER.encode() in exported, (
+        "records were exported but not the planted one, so the redaction "
+        "assertion below would pass vacuously"
+    )
+    assert PLANTED_CHANNEL_TOKEN.encode() not in exported, (
+        "the planted channel token was exported verbatim on the error path"
+    )
+    assert REDACTION_MARKER.encode() in exported
+    # The traceback Python prints for the uncaught RuntimeError is written by the
+    # interpreter, outside logging, so it is not asserted to be JSON here. Its
+    # message is credential-free by construction (see the driver) precisely so
+    # that this test never has to pretend otherwise.
+    assert PLANTED_CHANNEL_TOKEN not in output, (
+        f"the planted token leaked into process output on the error path:\n{output}"
+    )
+
+
+def test_a_third_party_library_warning_also_leaves_as_redacted_json(tmp_path: Path) -> None:
+    """`discord`, `uvicorn` and `httpx` records go through the same handler.
+
+    The regression this catches is created by the fix itself. `basicConfig`'s one
+    accidental virtue was a root handler that caught every library the adapter
+    runs under; removing it without bootstrapping those loggers sends their
+    WARNING+ records to `logging.lastResort`, which writes plain unredacted text
+    to the very stderr an operator ships to log retention. discord.py fires that
+    path unprompted on every boot with its optional-voice warning.
+
+    Driven through `discord.client`, a *child* of `discord`, so what is pinned is
+    propagation coverage: an implementation that configured one logger by exact
+    name would still leave `discord.gateway`, `discord.http` and every sibling
+    uncovered, and this test fails on it.
+
+    Cannot pass vacuously: `json_records` is strict, so a `lastResort` line is an
+    error naming the escapee rather than a skipped line, and the carrier text is
+    asserted present before the raw token is asserted absent.
+    """
+    code, output = run_driver(driver_env(tmp_path, "third_party"))
+
+    assert code == 0, f"the driver did not exit cleanly; output:\n{output}"
+    records = json_records(output)
+    third_party = [
+        record for record in records if str(record.get("logger", "")).startswith("discord")
+    ]
+    assert third_party, (
+        f"no record from a discord.py logger was emitted as service JSON, so it "
+        f"either never fired or escaped to lastResort; saw "
+        f"{sorted({str(record.get('logger')) for record in records})}"
+    )
+    for record in third_party:
+        assert record.get("service.name") == SERVICE_NAME, (
+            f"a third-party record carries no service identity: {record}"
+        )
+    assert PLANTED_CARRIER in output, (
+        f"the planted third-party record was never emitted, so the redaction "
+        f"assertions below would pass vacuously; output:\n{output}"
+    )
+    assert PLANTED_CHANNEL_TOKEN not in output, (
+        f"a third-party logger wrote the planted channel token verbatim:\n{output}"
+    )
+    assert REDACTION_MARKER in output, (
+        f"the third-party record never passed RedactingLogFilter; output:\n{output}"
+    )

--- a/adapters/discord/tests/test_telemetry.py
+++ b/adapters/discord/tests/test_telemetry.py
@@ -91,6 +91,15 @@ REDACTION_MARKER = "[REDACTED:channel_token]"
 # loudly rather than start passing vacuously.
 PLANTED_CARRIER = "planted telemetry probe record for the discord adapter"
 
+# Duplicated from `_telemetry_process.THIRD_PARTY_CHILD_LOGGERS` for the same
+# `sys.path` reason as the carrier above. One child per namespace listed in
+# `main._THIRD_PARTY_LOG_NAMESPACES`, except `uvicorn`, which is pinned by
+# `test_the_uvicorn_access_log_is_redacted_json_too` under a strictly harder
+# condition (uvicorn's own `dictConfig` has run by then). Its omission here is
+# deliberate, not an oversight: a second, weaker copy of that coverage would add
+# no mutation the access-log test does not already kill.
+THIRD_PARTY_CHILD_LOGGERS = ("discord.client", "httpx._client")
+
 
 def free_port() -> int:
     """A port the OS has just confirmed free, released immediately.
@@ -171,6 +180,22 @@ class OtlpReceiver:
             for resource in request.resource_logs
             for scope in resource.scope_logs
         )
+
+    def logger_names(self) -> set[str]:
+        """The logger name of every exported record.
+
+        The SDK's `LoggingHandler` calls `get_logger(record.name)`, so a record's
+        originating logger arrives as its instrumentation *scope* name. That is
+        the only place the name survives export, and reading it is what lets a
+        test say "a record from THIS logger reached the collector" rather than
+        the much weaker "some record did".
+        """
+        return {
+            scope.scope.name
+            for request in self.log_requests()
+            for resource in request.resource_logs
+            for scope in resource.scope_logs
+        }
 
     def service_names(self) -> set[str]:
         return {
@@ -274,6 +299,48 @@ def run_driver(env: dict[str, str], *, timeout: float = 60.0) -> tuple[int, str]
     return process.returncode, process.stdout
 
 
+def assert_carrier_survived_and_secret_did_not(text: str, *, where: str) -> None:
+    """The shared redaction triplet, asserted against one surface: `where`.
+
+    Three assertions, in this exact order, repeat verbatim across the tests
+    below regardless of whether `text` is the process's decoded stderr or the
+    decoded bytes a local OTLP collector received: the non-secret carrier text
+    IS present, the raw planted token is NOT present, and the
+    `[REDACTED:channel_token]` marker IS present.
+
+    The carrier assertion runs FIRST, deliberately: without it, the two secret
+    assertions that follow are satisfied just as well by output that never
+    contained the planted record at all, so a caller could not tell "redacted"
+    apart from "never emitted" — the carrier check is what keeps the negative
+    controls from passing vacuously.
+    """
+    assert PLANTED_CARRIER in text, (
+        f"the planted record was never emitted to {where}, so the redaction "
+        f"assertions below would pass vacuously"
+    )
+    assert PLANTED_CHANNEL_TOKEN not in text, (
+        f"the planted channel token survived into {where}"
+    )
+    assert REDACTION_MARKER in text, (
+        f"{where} carries no channel_token placeholder, so the record never "
+        f"passed RedactingLogFilter"
+    )
+
+
+def wait_for_export(receiver: OtlpReceiver, *, where: str) -> None:
+    """Poll until the collector has received at least one log record.
+
+    Centralizes the polling shape shared by every exporting test — only the
+    `BatchLogRecordProcessor`'s force-flush on exit ever makes a record arrive
+    at all, since its 1000 ms schedule delay outlives these short-lived
+    processes — so a dropped `telemetry.shutdown()` call on any exit path shows
+    up here as a timeout rather than as a wrong value. `where` names what this
+    call site expected to see arrive, so a timeout still identifies which path
+    is missing its flush.
+    """
+    wait_until(lambda: receiver.log_record_count() > 0, 10.0, where)
+
+
 def json_records(output: str) -> list[dict[str, object]]:
     """Every non-blank output line, parsed as a service log record.
 
@@ -320,16 +387,8 @@ def test_a_planted_secret_in_a_package_log_line_is_redacted_in_process_output(
     code, output = run_driver(driver_env(tmp_path, "planted_secret"))
 
     assert code == 0, f"the driver did not exit cleanly; output:\n{output}"
-    assert PLANTED_CARRIER in output, (
-        f"the log record carrying the planted secret was never emitted, so the "
-        f"redaction assertions below would pass vacuously; output:\n{output}"
-    )
-    assert PLANTED_CHANNEL_TOKEN not in output, (
-        f"the planted channel token survived into process output:\n{output}"
-    )
-    assert REDACTION_MARKER in output, (
-        f"the record was emitted but carries no channel_token placeholder, so it "
-        f"never passed RedactingLogFilter; output:\n{output}"
+    assert_carrier_survived_and_secret_did_not(
+        output, where=f"process output:\n{output}"
     )
 
 
@@ -357,11 +416,10 @@ def test_log_records_actually_reach_a_local_otlp_collector_redacted(
     code, output = run_driver(env)
     assert code == 0, f"the driver did not exit cleanly; output:\n{output}"
 
-    wait_until(
-        lambda: receiver.log_record_count() > 0,
-        10.0,
-        "an ExportLogsServiceRequest carrying at least one log record on /v1/logs — "
-        "none arrived, which is what a missing bootstrap or a dropped "
+    wait_for_export(
+        receiver,
+        where="an ExportLogsServiceRequest carrying at least one log record on "
+        "/v1/logs — none arrived, which is what a missing bootstrap or a dropped "
         f"telemetry.shutdown() force-flush looks like. Process output:\n{output}",
     )
 
@@ -371,19 +429,11 @@ def test_log_records_actually_reach_a_local_otlp_collector_redacted(
         f"{sorted(receiver.service_names())}"
     )
 
-    exported = receiver.all_bytes()
     # Negative control, exactly as in the stderr test: the carrier text must be
     # on the wire before "the secret is not on the wire" means anything.
-    assert PLANTED_CARRIER.encode() in exported, (
-        "the planted record reached the collector's socket in no recognizable "
-        "form, so the redaction assertion below would pass vacuously"
-    )
-    assert PLANTED_CHANNEL_TOKEN.encode() not in exported, (
-        "the planted channel token was exported verbatim to the collector"
-    )
-    assert REDACTION_MARKER.encode() in exported, (
-        "the exported body carries no channel_token placeholder, so `_otlp_body` "
-        "never saw the record"
+    exported = receiver.all_bytes()
+    assert_carrier_survived_and_secret_did_not(
+        exported.decode("utf-8", errors="replace"), where="the collector's socket"
     )
 
 
@@ -484,22 +534,16 @@ def test_telemetry_is_flushed_on_an_error_exit_too(
         f"the synthetic gateway failure was swallowed; an adapter that exits 0 on "
         f"a Gateway crash never restarts. Output:\n{output}"
     )
-    wait_until(
-        lambda: receiver.log_record_count() > 0,
-        10.0,
-        "a log record exported on the error path — none arrived, so "
+    wait_for_export(
+        receiver,
+        where="a log record exported on the error path — none arrived, so "
         f"telemetry.shutdown() did not run in main()'s finally. Output:\n{output}",
     )
 
     exported = receiver.all_bytes()
-    assert PLANTED_CARRIER.encode() in exported, (
-        "records were exported but not the planted one, so the redaction "
-        "assertion below would pass vacuously"
+    assert_carrier_survived_and_secret_did_not(
+        exported.decode("utf-8", errors="replace"), where="the error path's export"
     )
-    assert PLANTED_CHANNEL_TOKEN.encode() not in exported, (
-        "the planted channel token was exported verbatim on the error path"
-    )
-    assert REDACTION_MARKER.encode() in exported
     # The traceback Python prints for the uncaught RuntimeError is written by the
     # interpreter, outside logging, so it is not asserted to be JSON here. Its
     # message is credential-free by construction (see the driver) precisely so
@@ -509,7 +553,9 @@ def test_telemetry_is_flushed_on_an_error_exit_too(
     )
 
 
-def test_a_third_party_library_warning_also_leaves_as_redacted_json(tmp_path: Path) -> None:
+def test_a_third_party_library_warning_also_leaves_as_redacted_json(
+    tmp_path: Path, otlp: tuple[OtlpReceiver, str]
+) -> None:
     """`discord`, `uvicorn` and `httpx` records go through the same handler.
 
     The regression this catches is created by the fix itself. `basicConfig`'s one
@@ -519,40 +565,72 @@ def test_a_third_party_library_warning_also_leaves_as_redacted_json(tmp_path: Pa
     to the very stderr an operator ships to log retention. discord.py fires that
     path unprompted on every boot with its optional-voice warning.
 
-    Driven through `discord.client`, a *child* of `discord`, so what is pinned is
-    propagation coverage: an implementation that configured one logger by exact
-    name would still leave `discord.gateway`, `discord.http` and every sibling
-    uncovered, and this test fails on it.
+    Driven through a *child* of each namespace — `discord.client`, `httpx._client`
+    — so what is pinned is propagation coverage: an implementation that
+    configured one logger by exact name would still leave `discord.gateway`,
+    `discord.http` and every sibling uncovered, and this test fails on it.
+
+    One record per namespace, and one assertion per namespace, is what makes the
+    constant load-bearing entry by entry. Emitting only through `discord.client`
+    left `httpx` deletable from `_THIRD_PARTY_LOG_NAMESPACES` with the suite
+    green: httpx logs at DEBUG in practice and `logging.lastResort` fires only at
+    WARNING+, so an uncovered httpx never printed a plain-text line for
+    `json_records` to catch. `uvicorn` is not re-emitted here; it is pinned by
+    the access-log test under a harder condition, and duplicating it would add no
+    coverage.
+
+    The collector half additionally pins `logger_provider=telemetry.logger_provider`
+    in the bootstrap loop: drop it and third-party records still reach the
+    redacting JSON handler on stderr — every stderr assertion here stays green —
+    while nothing from those namespaces is ever exported. Only an OTLP assertion
+    naming those loggers kills that mutation.
 
     Cannot pass vacuously: `json_records` is strict, so a `lastResort` line is an
     error naming the escapee rather than a skipped line, and the carrier text is
-    asserted present before the raw token is asserted absent.
+    asserted present before the raw token is asserted absent, on stderr and on
+    the wire alike.
     """
-    code, output = run_driver(driver_env(tmp_path, "third_party"))
+    receiver, base_url = otlp
+    code, output = run_driver(
+        driver_env(tmp_path, "third_party", OTEL_EXPORTER_OTLP_ENDPOINT=base_url)
+    )
 
     assert code == 0, f"the driver did not exit cleanly; output:\n{output}"
     records = json_records(output)
+    emitted = {str(record.get("logger")) for record in records}
+    for logger_name in THIRD_PARTY_CHILD_LOGGERS:
+        assert logger_name in emitted, (
+            f"no record from {logger_name} was emitted as service JSON, so its "
+            f"namespace either never fired or escaped to lastResort; saw "
+            f"{sorted(emitted)}"
+        )
     third_party = [
-        record for record in records if str(record.get("logger", "")).startswith("discord")
+        record for record in records if str(record.get("logger")) in THIRD_PARTY_CHILD_LOGGERS
     ]
-    assert third_party, (
-        f"no record from a discord.py logger was emitted as service JSON, so it "
-        f"either never fired or escaped to lastResort; saw "
-        f"{sorted({str(record.get('logger')) for record in records})}"
-    )
     for record in third_party:
         assert record.get("service.name") == SERVICE_NAME, (
             f"a third-party record carries no service identity: {record}"
         )
-    assert PLANTED_CARRIER in output, (
-        f"the planted third-party record was never emitted, so the redaction "
-        f"assertions below would pass vacuously; output:\n{output}"
+    assert_carrier_survived_and_secret_did_not(
+        output, where=f"third-party process output:\n{output}"
     )
-    assert PLANTED_CHANNEL_TOKEN not in output, (
-        f"a third-party logger wrote the planted channel token verbatim:\n{output}"
+
+    wait_for_export(
+        receiver,
+        where="an exported log record from a third-party logger — none arrived, "
+        "which is what dropping logger_provider from main()'s third-party "
+        f"bootstrap loop looks like while stderr stays green. Output:\n{output}",
     )
-    assert REDACTION_MARKER in output, (
-        f"the third-party record never passed RedactingLogFilter; output:\n{output}"
+    exported_loggers = receiver.logger_names()
+    for logger_name in THIRD_PARTY_CHILD_LOGGERS:
+        assert logger_name in exported_loggers, (
+            f"{logger_name} reached stderr but never the collector, so its "
+            f"bootstrap was given no logger_provider; exported "
+            f"{sorted(exported_loggers)}"
+        )
+    exported = receiver.all_bytes()
+    assert_carrier_survived_and_secret_did_not(
+        exported.decode("utf-8", errors="replace"), where="the third-party export"
     )
 
 
@@ -592,13 +670,60 @@ def test_the_uvicorn_access_log_is_redacted_json_too(tmp_path: Path) -> None:
         assert record.get("service.name") == SERVICE_NAME, (
             f"an access record carries no service identity: {record}"
         )
-    assert PLANTED_CARRIER in output, (
-        f"the planted access record was never emitted, so the redaction "
-        f"assertions below would pass vacuously; output:\n{output}"
+    assert_carrier_survived_and_secret_did_not(
+        output, where=f"uvicorn access-log output:\n{output}"
+    )
+
+
+def test_telemetry_is_flushed_when_the_process_exits_on_a_base_exception(
+    tmp_path: Path, otlp: tuple[OtlpReceiver, str]
+) -> None:
+    """`SystemExit` is not an `Exception`, and the flush must survive it anyway.
+
+    `main()` is written as `try: asyncio.run(run()) finally: telemetry.shutdown()`,
+    which flushes on every exit. A reviewer named the mutation that today's tests
+    do not kill:
+
+        try:
+            asyncio.run(run())
+        except Exception:
+            telemetry.shutdown()
+            raise
+        telemetry.shutdown()
+
+    Normal exit still delivers, and `test_telemetry_is_flushed_on_an_error_exit_too`
+    still passes because its scenario raises `RuntimeError` — but every
+    `BaseException` exit silently stops flushing. That is not an exotic path:
+    `SystemExit` is exactly how a boot refusal and a signal-driven stop leave this
+    process, so the mutation would drop the records of the two shutdowns an
+    operator is most likely to be reading afterwards.
+
+    Both halves are load-bearing, as in the error-exit test. The exit code proves
+    the `BaseException` propagated rather than being swallowed or re-raised as
+    something else; the delivered record proves `shutdown()` ran on that path,
+    since the `BatchLogRecordProcessor`'s 1000 ms schedule delay outlives this
+    process by far and nothing arrives without the force-flush.
+    """
+    receiver, base_url = otlp
+    env = driver_env(tmp_path, "base_exception_exit", OTEL_EXPORTER_OTLP_ENDPOINT=base_url)
+
+    code, output = run_driver(env)
+
+    assert code == 3, (
+        f"the driver did not exit with the scenario's SystemExit code, so the "
+        f"BaseException was swallowed or replaced; got {code}. Output:\n{output}"
+    )
+    wait_for_export(
+        receiver,
+        where="a log record exported on the SystemExit path — none arrived, so "
+        "the flush is guarded by `except Exception` rather than `finally`. "
+        f"Output:\n{output}",
+    )
+
+    exported = receiver.all_bytes()
+    assert_carrier_survived_and_secret_did_not(
+        exported.decode("utf-8", errors="replace"), where="the SystemExit path's export"
     )
     assert PLANTED_CHANNEL_TOKEN not in output, (
-        f"the access log wrote the planted channel token verbatim:\n{output}"
-    )
-    assert REDACTION_MARKER in output, (
-        f"the access record never passed RedactingLogFilter; output:\n{output}"
+        f"the planted token leaked into process output on the SystemExit path:\n{output}"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,11 @@ testpaths = [
     "apps/api/tests",
     "apps/dispatcher/tests",
     "apps/mail-adapter/tests",
+    # The Discord adapter's tests sat in no collection root above, and the
+    # string "discord" appears in no .github/workflows file, so they ran
+    # nowhere in CI (#2358). A telemetry test in a suite CI never collects is
+    # a falsely-claimed proof, so the listing is part of the fix, not tidying.
+    "adapters/discord/tests",
     "apps/worker/tests",
     "runner/tests",
     "compose/tests",

--- a/uv.lock
+++ b/uv.lock
@@ -751,6 +751,7 @@ version = "0.1.0"
 source = { editable = "adapters/discord" }
 dependencies = [
     { name = "curie-channel-protocol" },
+    { name = "curie-telemetry" },
     { name = "discord-py" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -761,6 +762,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "curie-channel-protocol", editable = "packages/channel-protocol" },
+    { name = "curie-telemetry", editable = "packages/telemetry" },
     { name = "discord-py", specifier = ">=2.6,<3" },
     { name = "fastapi", specifier = ">=0.135" },
     { name = "httpx", specifier = ">=0.28" },


### PR DESCRIPTION
Closes #2358.

The Discord adapter called `logging.basicConfig`, so its records never passed `curie_telemetry.redact.RedactingLogFilter` and it exported no logs, traces or metrics. It is the last first-party Python entrypoint outside the shared bootstrap; `apps/api`, `apps/dispatcher`, `apps/worker`, `runner` and `apps/mail-adapter` (#2331) were already inside it.

Sequenced after #2359 (merged as #2523) on purpose: the planted credential in these tests is a `chn.` channel token, so the adapter proves the strengthened common policy rather than the pre-#2359 one.

## What changed

- `main()` bootstraps shared telemetry on the **package** logger `curie_discord_adapter`. `configure_service_logging` sets `propagate=False` on exactly the logger it is handed, so one bootstrap covers all six module loggers by propagation — and the seventh, whenever someone adds it. Bootstrapping module loggers one at a time passes for today's six and silently leaves the next one outside the filter.
- The body is wrapped in `try` / `finally: telemetry.shutdown()`. The batch processors have a 1000 ms schedule delay, so without the force-flush a process that exits sooner delivers nothing — including the records immediately preceding a crash.
- **Third-party namespaces.** Dropping `basicConfig` also drops the root handler that `discord`, `uvicorn` and `httpx` were riding, after which their WARNING+ records fall to `logging.lastResort` as plain, unredacted stderr text — the same defect, relocated from our package into our dependencies. discord.py emits such a warning on every start, so this was observed, not hypothetical. Each namespace root now goes through the same redacting handler.
- **`log_config=None` on `uvicorn.Config`.** Measured on uvicorn 0.52.4, the constructor applies uvicorn's own `LOGGING_CONFIG`, which gives `uvicorn.access` a plain stdout handler and `propagate=False`. Access lines carry the request path and query string — exactly what the `url_secret_param` rule exists to strip.
- **`adapters/discord/tests` added to `testpaths`.** It was in no collection root and the string `discord` appears in no `.github/workflows` file, so these tests ran nowhere. A telemetry test in a suite CI never collects is a falsely-claimed proof, so the listing is part of the fix rather than tidying.

## The boundary question the issue asks to decide

**The adapter is a first-party workload that instruments itself, and it stays outside the instrumented-set enumeration in `charts/curie/CLAUDE.md`.** That rule defines membership as exactly the workloads whose container `env` block includes the `curie.env.otel` helper, with `grep -n 'curie.env.otel' charts/curie/templates/` as the authoritative answer at any commit. This adapter has no chart template and no compose service, so it renders no container `env` block and cannot belong to a set defined by a template include; adding it as prose would recreate the stale hand-maintained list that rule exists to abolish. Recorded in `adapters/discord/README.md`, next to the adapter. Whoever adds a chart template later must add the include, and that is when it joins the set. No chart file is touched here.

## Verification

23 tests in `adapters/discord/tests`, 8 of them new and all process-level: each drives the real entrypoint as a subprocess and reads its actual output, because "this process's logs are redacted" is a property of the process, not of a function. Only the two external network peers are replaced (`discord.Client.start`, `uvicorn.Server.serve`); no real Discord surface is contacted and every credential is synthetic.

Real OTLP receipt is proven against a local collector: the test decodes an actual `ExportLogsServiceRequest`, asserts the `service.name` resource attribute, asserts the carrier text arrived (so the next assertion cannot pass vacuously), then asserts the raw token is absent from the payload bytes and the `[REDACTED:channel_token]` marker is present. Its negative control is a separate test that runs with a closed env containing no `OTEL_*` key and asserts the receiver was never contacted.

Two mutations named by the adversarial reviewer were applied and **demonstrated red**, then re-verified red after the consolidation pass:

- deleting `httpx` from `_THIRD_PARTY_LOG_NAMESPACES` → `test_a_third_party_library_warning_also_leaves_as_redacted_json` fails;
- replacing the `finally` with `except Exception` → `test_telemetry_is_flushed_when_the_process_exits_on_a_base_exception` fails.

`ruff` clean repo-wide, `mypy --strict` clean, `import-linter` 4/4 kept, `uv lock --check` clean, and the sibling suites (`packages/telemetry`, `apps/mail-adapter/tests/test_telemetry.py`) stay green at 158 passed together.

## Reviewed

`agent-router adversarial-review --primary claude` (reviewer: grok) on the full branch diff: **no blocking findings**. Its five advisories were all addressed or filed:

- the uvicorn comment named the wrong call site — corrected against measurement;
- `httpx` untested and the `BaseException` flush unpinned — both now pinned, mutations demonstrated above;
- README overstated traces/metrics — reworded, since the exporters are installed but nothing authors spans or instruments yet;
- no `REDACTION_RULES` entry matches a Discord bot token — **not fixed here**, because changing that file alters behavior for every instrumented workload. Filed as #2532 with the current mitigations recorded.

A second router pass reviewed the applied consolidation diff on its own: no blocking findings, and it independently confirmed no assertion changed meaning, strength or order across the 11 extracted call sites.

## Out of scope, deliberately

No chart template, no NetworkPolicy, no Discord delivery change, no new channel feature. Three adjacent defects this work surfaced are filed rather than folded in: #2532 (Discord token redaction), #2535 (`bootstrap_service_telemetry` should own third-party namespaces for all five services, rather than each service hand-listing them), #2536 (`apps/api`'s `uvicorn.access` has the same detachment by a different mechanism), and #2534 (`packages/telemetry`'s own 131 tests are in no collection root either).
