### PR TITLE
Compact terminal mail completion_events and add offline recover (#2509)

### DIFF
--- a/apps/mail-adapter/CLAUDE.md
+++ b/apps/mail-adapter/CLAUDE.md
@@ -50,6 +50,9 @@ the enforceable-rule summary.
 - **Admission is bounded before state or body allocation.** At the pending or
   state-byte cap, leave provider mail unclaimed and unmodified so later capacity
   can recover it. Never evict an unresolved delivery merely to admit a newer one.
+  Terminal `completion_events` (`delivered=1` or `deleted=1`) are compacted
+  oldest-first under the derived cap; unresolved and leased completion rows are
+  never evicted to make room.
 - **Logs carry no raw mail PII.** Do not log sender addresses, subjects, bodies,
   provider message/thread ids, or reply text. Use a one-way correlation token
   and a reason/state label so operators can join retries without copying mail

--- a/apps/mail-adapter/README.md
+++ b/apps/mail-adapter/README.md
@@ -133,7 +133,7 @@ stray generic `PORT` or `POLL_INTERVAL` in the pod environment cannot reach one.
 | `CURIE_MAIL_MAX_PENDING_DELIVERIES` | `1000` | maximum unresolved inbound deliveries admitted to SQLite; capacity refusal leaves provider mail recoverable |
 | `CURIE_MAIL_MAX_BODY_BYTES` | `1048576` | maximum provider message body read or stored, in bytes |
 | `CURIE_MAIL_MAX_REPLY_BYTES` | `1048576` | maximum accumulated outbound reply, in bytes |
-| `CURIE_MAIL_MAX_STATE_BYTES` | `268435456` | maximum SQLite page budget; size the volume above this for the WAL and filesystem overhead |
+| `CURIE_MAIL_MAX_STATE_BYTES` | `268435456` | maximum SQLite page budget; size the volume above this for the WAL and filesystem overhead. Terminal `completion_events` rows (`delivered=1` or `deleted=1`, not both-required) are compacted oldest-first under the same derived ceiling as terminal receipts (at most 4096, and at most one quarter of the page budget). Unresolved and leased completion rows are never evicted to admit newer mail. A late duplicate whose row was evicted and whose provider marker is gone resends; keep the cap above the worker's 7-day completion retention if that duplicate must not fire |
 | `CURIE_MAIL_ALLOWED_SENDERS` | "" | the allow-list above. Required while ingress is enabled |
 
 ### Boot gates
@@ -248,6 +248,19 @@ instead of deleting state to make an old image boot.
 There is no selective erase command. For complete erasure, stop the adapter,
 delete its PVC and every snapshot/backup, and start with a new claim, accepting
 that the next start is a first boot and primes the current inbox.
+
+A file already larger than `CURIE_MAIL_MAX_STATE_BYTES` (typically after
+lowering the cap; `PRAGMA max_page_count` already clamps organic growth) refuses
+to boot. Deleting rows does not shrink `st_size`. Recover an offline copy with
+no manual SQL, then swap it in while the adapter is stopped:
+
+```bash
+python -m curie_mail_adapter recover --state /path/to/copy.sqlite3
+```
+
+Do not point recover at a live writer. The command compacts terminal
+completions, VACUUMs the copy, and exits 0 only when the file is under the byte
+budget.
 
 ## Run it
 

--- a/apps/mail-adapter/src/curie_mail_adapter/__main__.py
+++ b/apps/mail-adapter/src/curie_mail_adapter/__main__.py
@@ -1,4 +1,17 @@
-from .run import main
+from __future__ import annotations
+
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) > 1 and sys.argv[1] == "recover":
+        from .recover import main as recover_main
+
+        raise SystemExit(recover_main(sys.argv[2:]))
+    from .run import main as run_main
+
+    run_main()
+
 
 if __name__ == "__main__":
     main()

--- a/apps/mail-adapter/src/curie_mail_adapter/recover.py
+++ b/apps/mail-adapter/src/curie_mail_adapter/recover.py
@@ -1,0 +1,143 @@
+"""Offline recovery for a mail-adapter SQLite copy that has crossed the byte budget.
+
+Operate on a copy, never on a live writer. Compaction frees pages; VACUUM is
+what returns them to the filesystem and is what the startup size check sees.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+from .config import MailAdapterConfig
+from .state import MailState
+
+
+def recover_state_file(
+    path: str,
+    *,
+    max_pending: int,
+    max_bytes: int,
+    keep: int | None = None,
+) -> dict[str, Any]:
+    """Compact terminal completion_events on ``path`` and VACUUM it in place."""
+    target = Path(path)
+    if not target.exists():
+        raise FileNotFoundError(f"mail state {target} does not exist")
+    before = target.stat().st_size
+    before_rows = _count_completions(target)
+    state = MailState(
+        str(target),
+        max_pending=max_pending,
+        max_bytes=max_bytes,
+        terminal_completion_max=keep,
+        enforce_size=False,
+    )
+    try:
+        with state.transaction() as connection:
+            state._compact_terminal_completions(connection)
+        survivors = int(
+            state.connection.execute("SELECT count(*) FROM completion_events").fetchone()[0]
+        )
+        state.connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    finally:
+        state.close()
+    _vacuum_file(target)
+    after = target.stat().st_size
+    evicted = max(0, before_rows - survivors)
+    return {
+        "after_bytes": after,
+        "before_bytes": before,
+        "evicted": evicted,
+        "max_bytes": max_bytes,
+        "path": str(target),
+        "survivors": survivors,
+        "under_budget": after <= max_bytes,
+    }
+
+
+def _count_completions(path: Path) -> int:
+    connection = sqlite3.connect(str(path))
+    try:
+        row = connection.execute("SELECT count(*) FROM completion_events").fetchone()
+        return int(row[0]) if row else 0
+    finally:
+        connection.close()
+
+
+def _vacuum_file(target: Path) -> None:
+    """Rebuild the file after the adapter connection has released it."""
+    vacuumed = target.with_name(f"{target.name}.vacuum")
+    if vacuumed.exists():
+        vacuumed.unlink()
+    connection = sqlite3.connect(str(target))
+    try:
+        connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        escaped = str(vacuumed).replace("'", "''")
+        connection.execute(f"VACUUM INTO '{escaped}'")
+    finally:
+        connection.close()
+    os.replace(vacuumed, target)
+    for suffix in ("-wal", "-shm"):
+        companion = Path(f"{target}{suffix}")
+        if companion.exists():
+            companion.unlink()
+    os.chmod(target, 0o600)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m curie_mail_adapter recover",
+        description=(
+            "Compact terminal completion_events and VACUUM an offline copy of "
+            "the mail-adapter SQLite file. Do not point this at a live writer."
+        ),
+    )
+    parser.add_argument("--state", required=True, help="path to the offline copy")
+    parser.add_argument("--max-bytes", type=int, default=None)
+    parser.add_argument("--max-pending", type=int, default=None)
+    parser.add_argument(
+        "--keep",
+        type=int,
+        default=None,
+        help="terminal completion rows to retain; default is the derived cap",
+    )
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    config = MailAdapterConfig()
+    max_bytes = args.max_bytes if args.max_bytes is not None else config.max_state_bytes
+    max_pending = (
+        args.max_pending if args.max_pending is not None else config.max_pending_deliveries
+    )
+    if max_bytes <= 0 or max_pending <= 0:
+        print("max-bytes and max-pending must be greater than zero", file=sys.stderr)
+        return 2
+    try:
+        result = recover_state_file(
+            args.state,
+            max_pending=max_pending,
+            max_bytes=max_bytes,
+            keep=args.keep,
+        )
+    except FileNotFoundError as error:
+        print(str(error), file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(result, separators=(",", ":"), sort_keys=True))
+    else:
+        print(
+            f"recovered {result['path']}: {result['before_bytes']} -> "
+            f"{result['after_bytes']} bytes, evicted {result['evicted']} "
+            "terminal completions"
+        )
+        if not result["under_budget"]:
+            print(
+                f"still larger than {result['max_bytes']} bytes; raise CURIE_MAIL_MAX_STATE_BYTES",
+                file=sys.stderr,
+            )
+    return 0 if result["under_budget"] else 1

--- a/apps/mail-adapter/src/curie_mail_adapter/state.py
+++ b/apps/mail-adapter/src/curie_mail_adapter/state.py
@@ -22,6 +22,8 @@ SCHEMA_VERSION = 2
 LEASE_SECONDS = 300.0
 BODY_FAILURE_BACKOFF_SECONDS = 60.0
 TERMINAL_RECEIPT_MAX = 4096
+TERMINAL_COMPLETION_MAX = 4096
+_TERMINAL_COMPLETION_SQL = "delivered=1 OR deleted=1"
 
 _TERMINAL_STATES = ("accepted", "oversize", "primed", "rejected")
 _COMPACTABLE_TERMINAL_STATES = ("oversize", "rejected")
@@ -43,15 +45,25 @@ EventClaim = Literal["claimed", "busy", "done", "deleted"]
 class MailState:
     """The adapter's serialized SQLite owner."""
 
-    def __init__(self, path: str, *, max_pending: int, max_bytes: int) -> None:
+    def __init__(
+        self,
+        path: str,
+        *,
+        max_pending: int,
+        max_bytes: int,
+        terminal_completion_max: int | None = None,
+        enforce_size: bool = True,
+    ) -> None:
         self.path = Path(path)
         self.max_pending = max_pending
         self.max_bytes = max_bytes
         self.lock = threading.RLock()
         self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-        if self.path.exists() and self.path.stat().st_size > max_bytes:
+        if enforce_size and self.path.exists() and self.path.stat().st_size > max_bytes:
             raise RuntimeError(
-                f"mail state {self.path} is larger than CURIE_MAIL_MAX_STATE_BYTES"
+                f"mail state {self.path} is larger than CURIE_MAIL_MAX_STATE_BYTES; "
+                "recover an offline copy with python -m curie_mail_adapter recover "
+                "--state <copy>"
             )
         self.connection = sqlite3.connect(
             self.path,
@@ -87,14 +99,30 @@ class MailState:
                 8,
                 min(TERMINAL_RECEIPT_MAX, max(1, max_bytes // page_size) // 4),
             )
+            derived_completion_max = max(
+                8,
+                min(TERMINAL_COMPLETION_MAX, max(1, max_bytes // page_size) // 4),
+            )
+            self.terminal_completion_max = (
+                derived_completion_max
+                if terminal_completion_max is None
+                else max(0, int(terminal_completion_max))
+            )
             page_limit = max(page_count, max_bytes // page_size)
             self.connection.execute(f"PRAGMA max_page_count={page_limit}")
             # A replacement is the sole writer. A lease left behind by SIGKILL
             # cannot still have an owner, so reclaim it immediately on open.
             self.connection.execute(
-                "UPDATE completion_events SET lease_owner=NULL, lease_until=NULL "
-                "WHERE delivered=0"
+                "UPDATE completion_events SET lease_owner=NULL, lease_until=NULL WHERE delivered=0"
             )
+            self.connection.execute("BEGIN IMMEDIATE")
+            try:
+                self._compact_terminal_completions(self.connection)
+                self.connection.commit()
+            except BaseException:
+                if self.connection.in_transaction:
+                    self.connection.rollback()
+                raise
 
     def _migrate(self, version: int) -> None:
         if version == 0:
@@ -203,6 +231,7 @@ class MailState:
                 ).fetchone():
                     return "known"
                 self._compact_terminal_receipts(connection)
+                self._compact_terminal_completions(connection)
                 pending = int(
                     connection.execute(
                         "SELECT count(*) FROM deliveries "
@@ -285,6 +314,26 @@ class MailState:
             "ORDER BY updated_at, message_id LIMIT ?)",
             (*_COMPACTABLE_TERMINAL_STATES, excess),
         )
+
+    def _compact_terminal_completions(
+        self, connection: sqlite3.Connection, *, incoming: int = 0
+    ) -> int:
+        """Evict oldest delivered or deleted completion rows; never unresolved or leased."""
+        count = int(
+            connection.execute(
+                f"SELECT count(*) FROM completion_events WHERE {_TERMINAL_COMPLETION_SQL}"
+            ).fetchone()[0]
+        )
+        excess = count + incoming - self.terminal_completion_max
+        if excess <= 0:
+            return 0
+        cursor = connection.execute(
+            "DELETE FROM completion_events WHERE event_id IN ("
+            f"SELECT event_id FROM completion_events WHERE {_TERMINAL_COMPLETION_SQL} "
+            "ORDER BY updated_at, event_id LIMIT ?)",
+            (excess,),
+        )
+        return max(0, int(cursor.rowcount))
 
     def _at_size_limit(self, connection: sqlite3.Connection) -> bool:
         page_size = int(connection.execute("PRAGMA page_size").fetchone()[0])
@@ -402,8 +451,7 @@ class MailState:
     ) -> Literal["ok", "missing", "too_large"]:
         with self.transaction() as connection:
             row = connection.execute(
-                "SELECT text FROM reply_state "
-                "WHERE conversation_id=? AND reply_ref=? AND active=1",
+                "SELECT text FROM reply_state WHERE conversation_id=? AND reply_ref=? AND active=1",
                 (conversation_id, reply_ref),
             ).fetchone()
             if row is None:
@@ -496,6 +544,7 @@ class MailState:
                 "WHERE conversation_id=? AND reply_ref=?",
                 (time.time(), conversation_id, reply_ref),
             )
+            self._compact_terminal_completions(connection)
 
     def finish_event(self, event_id: str) -> None:
         with self.transaction() as connection:
@@ -504,6 +553,7 @@ class MailState:
                 "updated_at=? WHERE event_id=?",
                 (time.time(), event_id),
             )
+            self._compact_terminal_completions(connection)
 
 
 def _receipt_json(message_id: str) -> str:

--- a/apps/mail-adapter/tests/test_completion_compaction.py
+++ b/apps/mail-adapter/tests/test_completion_compaction.py
@@ -1,0 +1,554 @@
+"""Bounded compaction of terminal completion_events, and offline over-budget recovery.
+
+#2509: delivered and deleted completion rows were immortal, so admission returned
+full forever and a lowered CURIE_MAIL_MAX_STATE_BYTES refused to boot. These
+tests drive the real MailState and MailAdapter APIs (and the recover entry
+point). They do not patch internals.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+from curie_mail_adapter.adapter import EMPTY_REPLY_TEXT, EVENT_MARKER, MailAdapter
+from curie_mail_adapter.agentmail import AgentMailClient
+from curie_mail_adapter.state import MailState
+
+SMALL_CAP = 128 * 1024
+TERMINAL_COMPLETION_MAX = 4096
+
+
+def derived_completion_cap(max_bytes: int = SMALL_CAP) -> int:
+    page_size = 4096
+    return max(8, min(TERMINAL_COMPLETION_MAX, max(1, max_bytes // page_size) // 4))
+
+
+def closed_world_env(home: str) -> dict[str, str]:
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": home,
+        "PYTHONUNBUFFERED": "1",
+    }
+    if os.environ.get("PYTHONPATH"):
+        env["PYTHONPATH"] = os.environ["PYTHONPATH"]
+    return env
+
+
+def open_state(
+    path: Path,
+    *,
+    max_bytes: int = SMALL_CAP,
+    max_pending: int = 1000,
+    **kwargs: Any,
+) -> MailState:
+    return MailState(str(path), max_pending=max_pending, max_bytes=max_bytes, **kwargs)
+
+
+def completion_rows(state: MailState) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for row in state.connection.execute(
+        "SELECT event_id, delivered, deleted, lease_owner, lease_until, updated_at "
+        "FROM completion_events ORDER BY updated_at, event_id"
+    ):
+        out[row[0]] = {
+            "delivered": int(row[1]),
+            "deleted": int(row[2]),
+            "lease_owner": row[3],
+            "lease_until": row[4],
+            "updated_at": row[5],
+        }
+    return out
+
+
+def classify(row: dict[str, Any], now: float) -> str:
+    if row["deleted"] == 1 and row["delivered"] == 1:
+        return "delivered+deleted"
+    if row["deleted"] == 1:
+        return "deleted"
+    if row["delivered"] == 1:
+        return "delivered"
+    if row["lease_owner"] and float(row["lease_until"] or 0) > now:
+        return "leased"
+    return "unresolved"
+
+
+def terminal_count(state: MailState) -> int:
+    return int(
+        state.connection.execute(
+            "SELECT count(*) FROM completion_events WHERE delivered=1 OR deleted=1"
+        ).fetchone()[0]
+    )
+
+
+def set_updated_at(state: MailState, event_id: str, when: float) -> None:
+    with state.transaction() as connection:
+        connection.execute(
+            "UPDATE completion_events SET updated_at=? WHERE event_id=?",
+            (when, event_id),
+        )
+
+
+def pages(state: MailState) -> dict[str, int]:
+    connection = state.connection
+    page_size = int(connection.execute("PRAGMA page_size").fetchone()[0])
+    page_count = int(connection.execute("PRAGMA page_count").fetchone()[0])
+    freelist = int(connection.execute("PRAGMA freelist_count").fetchone()[0])
+    return {
+        "page_size": page_size,
+        "page_count": page_count,
+        "freelist": freelist,
+        "used_bytes": page_size * (page_count - freelist),
+        "file_bytes": state.path.stat().st_size,
+    }
+
+
+def fill_delivered_until_full(state: MailState, prefix: str = "a") -> int:
+    """Grow only completion_events until admit returns full. Withdraw each probe."""
+    n = 0
+    while True:
+        probe = f"{prefix}-probe-{n}"
+        if state.admit({"message_id": probe, "thread_id": "t"}) == "full":
+            return n
+        with state.transaction() as connection:
+            connection.execute("DELETE FROM deliveries WHERE message_id=?", (probe,))
+        state.claim_event(
+            f"{prefix}-{n:07d}",
+            "conversation-" + "x" * 40,
+            "reply-" + "y" * 40,
+            "owner",
+        )
+        state.finish_event(f"{prefix}-{n:07d}")
+        n += 1
+        assert n < 200_000
+
+
+def test_real_transitions_identify_each_terminal_class_separately(tmp_path: Path) -> None:
+    """delivered=1 OR deleted=1; the accidental both-flag row is not the only class."""
+    state = open_state(tmp_path / "s.sqlite3")
+    assert state.claim_event("ev-unres", "thr", "msg", "ownerA") == "claimed"
+    state.release_event("ev-unres", "ownerA")
+    assert state.claim_event("ev-leased", "thr", "msg", "ownerA") == "claimed"
+    assert state.claim_event("ev-leased", "thr", "msg", "ownerB") == "busy"
+    assert state.claim_event("ev-deliv", "thr", "msg", "ownerA") == "claimed"
+    state.finish_event("ev-deliv")
+    assert state.claim_event("ev-deliv", "thr", "msg", "ownerB") == "done"
+    assert state.claim_event("ev-del", "thr", "msg", "ownerA") == "claimed"
+    state.delete_event("ev-del", "thr", "msg")
+    assert state.claim_event("ev-del", "thr", "msg", "ownerB") == "deleted"
+    assert state.claim_event("ev-both", "thr", "msg", "ownerA") == "claimed"
+    state.finish_event("ev-both")
+    state.delete_event("ev-both", "thr", "msg")
+    assert state.claim_event("ev-both", "thr", "msg", "ownerB") == "deleted"
+    assert state.claim_event("ev-expired", "thr", "msg", "ownerA") == "claimed"
+    with state.transaction() as connection:
+        connection.execute(
+            "UPDATE completion_events SET lease_until=? WHERE event_id='ev-expired'",
+            (time.time() - 1,),
+        )
+    assert state.claim_event("ev-expired", "thr", "msg", "ownerB") == "claimed"
+
+    table = completion_rows(state)
+    classes = {key: classify(value, time.time()) for key, value in table.items()}
+    assert classes == {
+        "ev-unres": "unresolved",
+        "ev-leased": "leased",
+        "ev-deliv": "delivered",
+        "ev-del": "deleted",
+        "ev-both": "delivered+deleted",
+        "ev-expired": "leased",
+    }
+    assert table["ev-deliv"]["lease_owner"] is None
+    assert table["ev-del"]["lease_owner"] is None
+    state.close()
+
+    reopened = open_state(tmp_path / "s.sqlite3")
+    after = completion_rows(reopened)
+    assert after["ev-leased"]["lease_owner"] is None
+    assert reopened.claim_event("ev-leased", "thr", "msg", "ownerC") == "claimed"
+    reopened.close()
+
+
+def test_oldest_terminal_rows_are_evicted_unresolved_and_leased_survive(
+    tmp_path: Path,
+) -> None:
+    state = open_state(tmp_path / "s.sqlite3", terminal_completion_max=1_000_000)
+    cap = derived_completion_cap()
+    base = 1_000_000.0
+    delivered = cap + 4
+    for index in range(delivered):
+        event_id = f"d{index:02d}"
+        state.claim_event(event_id, "thr", "msg", "o")
+        state.finish_event(event_id)
+        set_updated_at(state, event_id, base + index)
+    for index in range(3):
+        event_id = f"x{index}"
+        state.claim_event(event_id, "thr", "msg", "o")
+        state.delete_event(event_id, "thr", "msg")
+        set_updated_at(state, event_id, base - 10 + index)
+    for index in range(2):
+        event_id = f"u{index}"
+        state.claim_event(event_id, "thr", "msg", "o")
+        state.release_event(event_id, "o")
+        set_updated_at(state, event_id, base - 100)
+    for index in range(2):
+        event_id = f"l{index}"
+        state.claim_event(event_id, "thr", "msg", "leaser")
+        set_updated_at(state, event_id, base - 100)
+    state.terminal_completion_max = cap
+    assert state.admit({"message_id": "kick", "thread_id": "t"}) == "admitted"
+
+    after = completion_rows(state)
+    assert {key for key in after if key[0] in "ul"} == {"u0", "u1", "l0", "l1"}
+    terminals = [key for key in after if key[0] in "dx"]
+    assert len(terminals) == cap
+    assert terminals == [f"d{index:02d}" for index in range(delivered - cap, delivered)]
+    assert "x0" not in after
+    assert terminal_count(state) == cap
+    state.close()
+
+
+def test_equal_updated_at_breaks_ties_on_event_id(tmp_path: Path) -> None:
+    state = open_state(tmp_path / "s.sqlite3", terminal_completion_max=1_000_000)
+    for name in ("b", "a", "c"):
+        state.claim_event(name, "thr", "msg", "o")
+        state.finish_event(name)
+        set_updated_at(state, name, 5.0)
+    state.terminal_completion_max = 1
+    assert state.admit({"message_id": "kick", "thread_id": "t"}) == "admitted"
+    assert list(completion_rows(state)) == ["c"]
+    state.close()
+
+
+def test_literal_and_predicate_would_leave_delivered_only_rows(
+    tmp_path: Path,
+) -> None:
+    """Negative: requiring both flags would not bound the table the issue named."""
+    state = open_state(tmp_path / "s.sqlite3")
+    cap = state.terminal_completion_max
+    for index in range(cap + 5):
+        event_id = f"d{index:02d}"
+        state.claim_event(event_id, "thr", "msg", "o")
+        state.finish_event(event_id)
+    both = int(
+        state.connection.execute(
+            "SELECT count(*) FROM completion_events WHERE delivered=1 AND deleted=1"
+        ).fetchone()[0]
+    )
+    assert both == 0
+    assert terminal_count(state) == cap
+    state.close()
+
+
+def test_filling_delivered_completions_does_not_permanently_refuse_ingress(
+    tmp_path: Path,
+) -> None:
+    state = open_state(tmp_path / "s.sqlite3")
+    cap = state.terminal_completion_max
+    for index in range(cap + 50):
+        state.claim_event(f"e{index:05d}", "thr", "msg", "o")
+        state.finish_event(f"e{index:05d}")
+    assert terminal_count(state) <= cap
+    assert state.admit({"message_id": "late", "thread_id": "t"}) == "admitted"
+    state.close()
+
+
+def test_reverting_the_compact_leaves_a_full_file_refusing_ingress(tmp_path: Path) -> None:
+    """Falsifiable negative: without a bound, delivered rows fill the page budget."""
+    path = tmp_path / "s.sqlite3"
+    state = open_state(path, terminal_completion_max=1_000_000)
+    fill_delivered_until_full(state)
+    assert state.admit({"message_id": "late", "thread_id": "t"}) == "full"
+    assert terminal_count(state) > state.terminal_receipt_max
+    state.close()
+
+
+def test_a_file_already_full_of_delivered_rows_recovers_on_reopen(tmp_path: Path) -> None:
+    path = tmp_path / "s.sqlite3"
+    fat = open_state(path, terminal_completion_max=1_000_000)
+    fill_delivered_until_full(fat)
+    assert fat.admit({"message_id": "blocked", "thread_id": "t"}) == "full"
+    fat.close()
+    recovered = open_state(path)
+    assert recovered.admit({"message_id": "late", "thread_id": "t"}) == "admitted"
+    assert terminal_count(recovered) <= recovered.terminal_completion_max
+    recovered.close()
+
+
+def test_unresolved_and_leased_rows_are_not_evicted_to_admit(tmp_path: Path) -> None:
+    state = open_state(tmp_path / "s.sqlite3")
+    n = 0
+    while True:
+        probe = f"probe-{n}"
+        if state.admit({"message_id": probe, "thread_id": "t"}) == "full":
+            break
+        with state.transaction() as connection:
+            connection.execute("DELETE FROM deliveries WHERE message_id=?", (probe,))
+        event_id = f"u{n:07d}"
+        state.claim_event(event_id, "c" + "x" * 40, "r" + "y" * 40, "owner")
+        if n % 2 == 0:
+            state.release_event(event_id, "owner")
+        n += 1
+        assert n < 200_000
+    remaining = completion_rows(state)
+    assert remaining
+    assert all(classify(row, time.time()) in {"unresolved", "leased"} for row in remaining.values())
+    assert state.admit({"message_id": "newer", "thread_id": "t"}) == "full"
+    assert set(completion_rows(state)) == set(remaining)
+    state.close()
+
+
+def test_delete_frees_pages_for_reuse_but_does_not_shrink_the_file(tmp_path: Path) -> None:
+    path = tmp_path / "s.sqlite3"
+    fat = open_state(path, terminal_completion_max=1_000_000)
+    n = fill_delivered_until_full(fat)
+    fat.connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    full = pages(fat)
+    assert full["used_bytes"] >= SMALL_CAP or full["page_count"] * full["page_size"] >= SMALL_CAP
+    fat.close()
+
+    recovered = open_state(path)
+    recovered.connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    freed = pages(recovered)
+    assert freed["freelist"] > 0
+    assert freed["file_bytes"] == full["file_bytes"]
+    assert freed["used_bytes"] < full["used_bytes"]
+    assert recovered.admit({"message_id": "late", "thread_id": "t"}) == "admitted"
+    before_refill = pages(recovered)
+    for index in range(min(n // 4, recovered.terminal_completion_max)):
+        recovered.claim_event(f"b-{index:07d}", "c" + "x" * 40, "r" + "y" * 40, "owner")
+        recovered.finish_event(f"b-{index:07d}")
+    recovered.connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    refilled = pages(recovered)
+    assert refilled["page_count"] == before_refill["page_count"]
+    recovered.close()
+
+
+class _StubClient(AgentMailClient):
+    def __init__(self, config: Any) -> None:
+        super().__init__(config)
+        self.thread_status = 200
+        self.thread_messages: list[dict[str, Any]] = []
+        self.thread_body: Any = None
+        self.get_thread_calls = 0
+        self.replies: list[tuple[str, str]] = []
+
+    def get_thread(self, thread_id: str) -> tuple[int, Any]:
+        self.get_thread_calls += 1
+        if self.thread_status == 200:
+            return 200, {"thread_id": thread_id, "messages": list(self.thread_messages)}
+        return self.thread_status, self.thread_body
+
+    def reply(self, message_id: str, text: str) -> tuple[int, Any]:
+        self.replies.append((message_id, text))
+        return 200, {"message_id": "sent-1"}
+
+
+def _adapter(make_config: Any, tmp_path: Path, name: str) -> tuple[MailAdapter, _StubClient]:
+    config = make_config(
+        max_state_bytes=SMALL_CAP,
+        state_path=str(tmp_path / f"{name}.sqlite3"),
+    )
+    client = _StubClient(config)
+    return MailAdapter(config, client=client), client
+
+
+def _admit_turn(adapter: MailAdapter, conversation_id: str, reply_ref: str) -> None:
+    adapter.state.admit({"message_id": reply_ref, "thread_id": conversation_id})
+    adapter.state.store_turn(
+        reply_ref, {"conversation_id": conversation_id, "reply_ref": reply_ref, "text": "hi"}
+    )
+    adapter.state.record_text(conversation_id, reply_ref, "answer", append=False, max_bytes=1 << 20)
+
+
+def _overflow_terminal_cap(adapter: MailAdapter) -> str:
+    """Send one more completion than the cap; return the oldest event id."""
+    cap = adapter.state.terminal_completion_max
+    oldest = "ev-000"
+    for index in range(cap + 1):
+        event_id = f"ev-{index:03d}"
+        conversation_id = f"thr-{index:03d}"
+        reply_ref = f"msg-{index:03d}"
+        if index == 0:
+            oldest = event_id
+        _admit_turn(adapter, conversation_id, reply_ref)
+        assert adapter.send_reply(event_id, conversation_id, reply_ref) == 200
+    return oldest
+
+
+def test_retained_delivered_row_short_circuits_without_provider(
+    make_config: Any, tmp_path: Path
+) -> None:
+    adapter, client = _adapter(make_config, tmp_path, "retain")
+    _admit_turn(adapter, "thr", "msg")
+    assert adapter.send_reply("ev1", "thr", "msg") == 200
+    assert len(client.replies) == 1 and EVENT_MARKER in client.replies[0][1]
+    calls = client.get_thread_calls
+    assert adapter.send_reply("ev1", "thr", "msg") == 200
+    assert client.get_thread_calls == calls and len(client.replies) == 1
+    adapter.close()
+
+
+def test_evicted_delivered_row_recovers_from_provider_witness(
+    make_config: Any, tmp_path: Path
+) -> None:
+    adapter, client = _adapter(make_config, tmp_path, "witness")
+    oldest = _overflow_terminal_cap(adapter)
+    assert oldest not in completion_rows(adapter.state)
+    sent = next(text for message_id, text in client.replies if oldest in text)
+    client.thread_messages = [{"text": sent}]
+    calls = client.get_thread_calls
+    replies = len(client.replies)
+    assert adapter.send_reply(oldest, "thr-000", "msg-000") == 200
+    assert client.get_thread_calls == calls + 1
+    assert len(client.replies) == replies
+    assert classify(completion_rows(adapter.state)[oldest], time.time()) == "delivered"
+    adapter.close()
+
+
+def test_evicted_delivered_row_without_witness_sends_an_empty_duplicate(
+    make_config: Any, tmp_path: Path
+) -> None:
+    """Replay horizon is the provider marker: eviction plus a lost witness resends."""
+    adapter, client = _adapter(make_config, tmp_path, "nowitness")
+    oldest = _overflow_terminal_cap(adapter)
+    replies = len(client.replies)
+    client.thread_messages = []
+    status = adapter.send_reply(oldest, "thr-000", "msg-000")
+    assert status == 200
+    assert len(client.replies) == replies + 1
+    assert client.replies[-1][1].startswith(EMPTY_REPLY_TEXT)
+    adapter.close()
+
+
+def test_retained_row_still_blocks_resend_when_the_witness_is_gone(
+    make_config: Any, tmp_path: Path
+) -> None:
+    adapter, client = _adapter(make_config, tmp_path, "control")
+    _admit_turn(adapter, "thr", "msg")
+    assert adapter.send_reply("ev1", "thr", "msg") == 200
+    client.thread_messages = []
+    assert adapter.send_reply("ev1", "thr", "msg") == 200
+    assert len(client.replies) == 1
+    adapter.close()
+
+
+def test_evicted_tombstone_replays_confirmed_404_and_refuses_ambiguous(
+    make_config: Any, tmp_path: Path
+) -> None:
+    adapter, client = _adapter(make_config, tmp_path, "tomb")
+    cap = adapter.state.terminal_completion_max
+    client.thread_status, client.thread_body = 404, {"error": "not found"}
+    for index in range(cap + 1):
+        event_id = f"ev-{index:03d}"
+        _admit_turn(adapter, f"thr-{index:03d}", f"msg-{index:03d}")
+        assert adapter.send_reply(event_id, f"thr-{index:03d}", f"msg-{index:03d}") == 410
+    assert "ev-000" not in completion_rows(adapter.state)
+    assert adapter.send_reply("ev-000", "thr-000", "msg-000") == 410
+    assert client.replies == []
+    adapter.state.terminal_completion_max = 0
+    assert adapter.state.admit({"message_id": "evict-kick", "thread_id": "t"}) == "admitted"
+    assert "ev-000" not in completion_rows(adapter.state)
+    client.thread_status, client.thread_body = 404, "<html>edge</html>"
+    assert adapter.send_reply("ev-000", "thr-000", "msg-000") == 502
+    client.thread_status, client.thread_body = 500, None
+    assert adapter.send_reply("ev-000", "thr-000", "msg-000") == 502
+    client.thread_status, client.thread_messages = 200, []
+    assert adapter.send_reply("ev-000", "thr-000", "msg-000") == 200
+    assert len(client.replies) == 1
+    assert client.replies[0][1].startswith(EMPTY_REPLY_TEXT)
+    adapter.close()
+
+
+def test_boot_refusal_survives_delete_alone_and_recover_shrinks_a_copy(
+    tmp_path: Path,
+) -> None:
+    from curie_mail_adapter.recover import recover_state_file
+
+    path = tmp_path / "s.sqlite3"
+    state = open_state(path, terminal_completion_max=1_000_000)
+    fill_delivered_until_full(state)
+    state.connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    state.close()
+    lowered = SMALL_CAP // 2
+    with pytest.raises(RuntimeError, match="CURIE_MAIL_MAX_STATE_BYTES"):
+        open_state(path, max_bytes=lowered)
+
+    live_bytes = path.read_bytes()
+    copy = tmp_path / "copy.sqlite3"
+    shutil.copy2(path, copy)
+    with pytest.raises(RuntimeError, match="CURIE_MAIL_MAX_STATE_BYTES"):
+        open_state(copy, max_bytes=lowered)
+
+    result = recover_state_file(str(copy), max_pending=1000, max_bytes=lowered)
+    assert path.read_bytes() == live_bytes
+    assert copy.stat().st_size < lowered
+    assert result["under_budget"] is True
+    assert result["evicted"] > 0
+    recovered = open_state(copy, max_bytes=lowered)
+    assert recovered.admit({"message_id": "after", "thread_id": "t"}) == "admitted"
+    recovered.close()
+    with pytest.raises(RuntimeError, match="CURIE_MAIL_MAX_STATE_BYTES"):
+        open_state(path, max_bytes=lowered)
+
+
+def test_recover_entry_point_compacts_a_copy_without_credentials(
+    tmp_path: Path,
+) -> None:
+    live = tmp_path / "live.sqlite3"
+    state = open_state(live, terminal_completion_max=1_000_000)
+    fill_delivered_until_full(state)
+    state.claim_event("keep-unresolved", "c", "r", "o")
+    state.release_event("keep-unresolved", "o")
+    state.claim_event("keep-leased", "c", "r", "o")
+    state.connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    state.close()
+    live_bytes = live.read_bytes()
+    copy = tmp_path / "copy.sqlite3"
+    shutil.copy2(live, copy)
+    lowered = SMALL_CAP // 2
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "curie_mail_adapter",
+            "recover",
+            "--state",
+            str(copy),
+            "--max-bytes",
+            str(lowered),
+            "--json",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=closed_world_env(str(tmp_path)),
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    payload = json.loads(proc.stdout)
+    assert payload["under_budget"] is True
+    assert live.read_bytes() == live_bytes
+    check = open_state(copy, max_bytes=lowered)
+    survivors = completion_rows(check)
+    assert "keep-unresolved" in survivors
+    assert "keep-leased" in survivors
+    assert classify(survivors["keep-leased"], time.time()) in {"leased", "unresolved"}
+    check.close()
+
+
+def test_recover_usage_error_is_exit_2() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-m", "curie_mail_adapter", "recover"],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=closed_world_env("/tmp"),
+    )
+    assert proc.returncode == 2


### PR DESCRIPTION
## Summary

Terminal `completion_events` rows were immortal: `finish_event` and `delete_event` only flipped flags, so a table of delivered completions could fill the SQLite page budget and leave admission returning `full` forever. A lowered `CURIE_MAIL_MAX_STATE_BYTES` then refused to boot, with no operator path short of hand-edited SQL.

This adds a `_compact_terminal_receipts` analogue for `completion_events`. The compactable set is `delivered=1 OR deleted=1` (not AND): those classes are identified through real claim/finish/delete/lease transitions. Eviction is oldest-first by `updated_at, event_id` under the same derived ceiling as terminal receipts (at most 4096, and at most one quarter of the page budget). Unresolved and leased rows are never evicted to admit newer mail.

`python -m curie_mail_adapter recover --state <copy>` compact-then-VACUUMs an offline copy (no credentials, no live writer). Deleting rows alone does not shrink `st_size`; recover does. Restart against the recovered copy comes up.

Replay after eviction is pinned, not hidden: a late duplicate whose row is gone and whose provider marker is gone resends. The worker's 7-day completion retention is the horizon for worker-originated retries; the README states the trade.

## Related issue

Closes #2509

## Fix pin verification

Fix pin: apps/mail-adapter/tests/test_completion_compaction.py::test_filling_delivered_completions_does_not_permanently_refuse_ingress

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | required | Mail-adapter admission, boot size check, and the recover entry point are process runtime. compose.dev.yaml does not start this adapter. | fake | Commit `9fb4416bf`. `uv run pytest apps/mail-adapter/tests -q` - 170 passed. Recover CLI test observed `returncode == 0`, `under_budget: true`, live file byte-identical. Fix pin: reversing the commit fails `test_filling_delivered_completions_does_not_permanently_refuse_ingress` (`AttributeError: terminal_completion_max`). |
| local-release | n/a | Does not change released binary identity, install path, version pins, or release compose. | | |
| cluster | n/a | Does not change chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, or init containers. | | |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, token/cost accounting, or the MCP/workspace/coding-tool path set. | | |
| external integration | n/a | Does not change Slack, git webhooks, connector OAuth, or the AgentMail API shape. Live mailbox use is out of contract; tests drive the package fake provider servers. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Acceptance criteria

- Terminal `completion_events` compacted under a documented cap, analogue to `_compact_terminal_receipts`. Predicate is OR, not AND.
- Admission still returns `full` at the pending or byte cap for unresolved work; unresolved and leased rows survive.
- Over-budget file: `python -m curie_mail_adapter recover --state <copy>` then restart. No manual SQL. Live file untouched in the copy procedure.
- Filling delivered completions no longer permanently refuses ingress. Huge-cap revert (`terminal_completion_max=1_000_000`) still fills and returns `full`.

## Sibling paths

Deliveries compact (`_compact_terminal_receipts`) is unchanged and still skips primed/accepted receipts. Completions get a sibling helper rather than a shared DELETE, because the tables and predicates differ. `send_reply` is unchanged so a new event_id after a finished reply still sends.

## Checklist

- [x] Tests cover the change
- [x] Docs updated (README cap and recover procedure; mail-adapter CLAUDE.md admission invariant)
