### PR TITLE
Refuse broad BYO egress peers on the shared validator

### DIFF
--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -861,8 +861,10 @@ turn. The chart now refuses that shape at render: `rustfs.egress` must cover
 the object-store endpoint, and on this key-free path `rustfs.stsEgress` must
 cover STS (`AssumeRoleWithWebIdentity`). Both are `{cidr, ports}` entries like
 `allowedEgress`. Do not put a DNS name here; NetworkPolicy has no hostname
-peer. A default route or a CIDR that reaches `169.254.169.254` is refused:
-these lists are store endpoints, not a second model allowlist.
+peer. A default route, an IPv4 prefix shorter than `/8`, an IPv6 prefix
+shorter than `/32`, a ports item with only `protocol` or with `endPort`, or a
+CIDR that reaches `169.254.169.254` or `fd00:ec2::254` is refused: these lists
+are store endpoints, not a second model allowlist.
 
 On EKS, create VPC **interface** endpoints for `s3` and `sts` in the cluster
 VPC with private DNS enabled, then put each endpoint's ENI address in as a

--- a/charts/curie/ci/byo-endpoint-egress-assertions.sh
+++ b/charts/curie/ci/byo-endpoint-egress-assertions.sh
@@ -41,8 +41,11 @@
 #   6. Opting out of Rail 1 (`security.networkPolicy.enabled=false`) does not
 #      require either key: there is no fail-closed runner policy to satisfy.
 #   7. Both new keys reuse the shared `curie.objectStore.egressEntry`
-#      validator, so a default route, a metadata-covering CIDR, and a
-#      ports-less entry are each refused.
+#      validator, so a default route, a metadata-covering CIDR, a
+#      ports-less entry, a quarter-route prefix, IPv6 ULA metadata
+#      containment (including uncompressed spelling), a protocol-only
+#      ports item, and an endPort range are each refused, while a /32,
+#      /24, /128, /48, and named-port peer still render (#2368).
 #   8. Neither key is a silent no-op on the in-chart path. Setting
 #      otelCollector.egress with otelCollector.deploy=true, or api.egress with
 #      api.deploy=true, is refused at render naming the key -- the key is only
@@ -143,6 +146,7 @@ must_fail_naming() {
 
 CHECKER="$TMP/check.py"
 cat > "$CHECKER" <<'PY'
+import json
 import pathlib
 import sys
 
@@ -385,6 +389,29 @@ elif ACTION == "no-collector-policy":
         )
     print("ok: telemetry-off BYO renders with no collector egress policy of either kind")
 
+elif ACTION == "has-block":
+    policy_name, cidr, ports_json = sys.argv[3], sys.argv[4], sys.argv[5]
+    expected_ports = json.loads(ports_json)
+    policy = named(docs, policy_name)
+    if policy is None:
+        die(f"missing NetworkPolicy/{policy_name}")
+    matches = [
+        (block_cidr, ports, excepts)
+        for block_cidr, ports, excepts in ip_blocks(policy)
+        if block_cidr == cidr
+    ]
+    if not matches:
+        die(
+            f"{policy_name} has no ipBlock {cidr}; "
+            f"blocks={ip_blocks(policy)!r}"
+        )
+    for block_cidr, ports, excepts in matches:
+        if ports != expected_ports:
+            die(f"{cidr} ports are {ports!r}, expected {expected_ports!r}")
+        if excepts:
+            die(f"{cidr} must not except anything on a narrow allow; got {excepts}")
+    print(f"ok: {policy_name} allows {cidr} with {expected_ports}")
+
 else:
     die(f"unknown action {ACTION!r}")
 PY
@@ -560,7 +587,26 @@ EOF
   fi
 }
 
+must_render_block() {
+  local label="$1"
+  local policy_name="$2"
+  local cidr="$3"
+  local ports_json="$4"
+  local values="$5"
+  local out
+  out="$(render_dir "${label// /_}" --values "$values")" \
+    || fail "${label} must render"
+  python3 "$CHECKER" "$out" has-block "$policy_name" "$cidr" "$ports_json" \
+    || fail "${label} did not render ipBlock ${cidr} with ports ${ports_json}"
+}
+
 for KEY in otelCollector.egress api.egress; do
+  if [[ "$KEY" == "otelCollector.egress" ]]; then
+    POLICY_NAME="$COLLECTOR_BYO_POLICY"
+  else
+    POLICY_NAME="$API_BYO_POLICY"
+  fi
+
   DEFAULT_ROUTE_ENTRY=$'    - cidr: 0.0.0.0/0\n      ports: [{ protocol: TCP, port: 443 }]'
   IMDS_ENTRY=$'    - cidr: 169.254.0.0/16\n      ports: [{ protocol: TCP, port: 443 }]'
   NO_PORTS_ENTRY=$'    - cidr: 192.0.2.30/32'
@@ -573,6 +619,55 @@ for KEY in otelCollector.egress api.egress; do
 
   write_entry_values "$TMP/entry-no-ports.yaml" "$KEY" "$NO_PORTS_ENTRY"
   must_fail_naming "ports-missing ${KEY}" "ports" "$TMP/entry-no-ports.yaml"
+
+  write_entry_values "$TMP/entry-quarter-route.yaml" "$KEY" \
+    $'    - cidr: 64.0.0.0/2\n      ports: [{ protocol: TCP, port: 443 }]'
+  must_fail_naming "quarter-route ${KEY}" "IPv4 /8, IPv6 /32" "$TMP/entry-quarter-route.yaml"
+
+  write_entry_values "$TMP/entry-ula8.yaml" "$KEY" \
+    $'    - cidr: fd00::/8\n      ports: [{ protocol: TCP, port: 443 }]'
+  must_fail_naming "ipv6-ula-8 ${KEY}" "169.254.169.254" "$TMP/entry-ula8.yaml"
+
+  write_entry_values "$TMP/entry-ula7.yaml" "$KEY" \
+    $'    - cidr: fc00::/7\n      ports: [{ protocol: TCP, port: 443 }]'
+  must_fail_naming "ipv6-ula-7 ${KEY}" "169.254.169.254" "$TMP/entry-ula7.yaml"
+
+  write_entry_values "$TMP/entry-ula-uncompressed.yaml" "$KEY" \
+    $'    - cidr: fd00:0ec2::/48\n      ports: [{ protocol: TCP, port: 443 }]'
+  must_fail_naming "ipv6-ula-uncompressed ${KEY}" "169.254.169.254" "$TMP/entry-ula-uncompressed.yaml"
+
+  write_entry_values "$TMP/entry-protocol-only.yaml" "$KEY" \
+    $'    - cidr: 192.0.2.30/32\n      ports: [{ protocol: TCP }]'
+  must_fail_naming "protocol-only ${KEY}" "each ports item must set port" "$TMP/entry-protocol-only.yaml"
+
+  write_entry_values "$TMP/entry-endport.yaml" "$KEY" \
+    $'    - cidr: 192.0.2.30/32\n      ports: [{ protocol: TCP, port: 1, endPort: 65535 }]'
+  must_fail_naming "endport ${KEY}" "endPort" "$TMP/entry-endport.yaml"
+
+  write_entry_values "$TMP/entry-p1.yaml" "$KEY" \
+    $'    - cidr: 192.0.2.30/32\n      ports: [{ protocol: TCP, port: 443 }]'
+  must_render_block "narrow-v4-32 ${KEY}" "$POLICY_NAME" "192.0.2.30/32" \
+    '[{"protocol": "TCP", "port": 443}]' "$TMP/entry-p1.yaml"
+
+  write_entry_values "$TMP/entry-p2.yaml" "$KEY" \
+    $'    - cidr: 192.0.2.0/24\n      ports: [{ protocol: TCP, port: 443 }]'
+  must_render_block "narrow-v4-24 ${KEY}" "$POLICY_NAME" "192.0.2.0/24" \
+    '[{"protocol": "TCP", "port": 443}]' "$TMP/entry-p2.yaml"
+
+  write_entry_values "$TMP/entry-p3.yaml" "$KEY" \
+    $'    - cidr: 2001:db8::10/128\n      ports: [{ protocol: TCP, port: 4318 }]'
+  must_render_block "narrow-v6-128 ${KEY}" "$POLICY_NAME" "2001:db8::10/128" \
+    '[{"protocol": "TCP", "port": 4318}]' "$TMP/entry-p3.yaml"
+
+  write_entry_values "$TMP/entry-p4.yaml" "$KEY" \
+    $'    - cidr: 2001:db8::/48\n      ports: [{ protocol: TCP, port: 443 }]'
+  must_render_block "narrow-v6-48 ${KEY}" "$POLICY_NAME" "2001:db8::/48" \
+    '[{"protocol": "TCP", "port": 443}]' "$TMP/entry-p4.yaml"
+
+  write_entry_values "$TMP/entry-p5.yaml" "$KEY" \
+    $'    - cidr: 192.0.2.30/32\n      ports: [{ protocol: TCP, port: https }]'
+  must_render_block "named-port ${KEY}" "$POLICY_NAME" "192.0.2.30/32" \
+    '[{"protocol": "TCP", "port": "https"}]' "$TMP/entry-p5.yaml"
 done
 
 echo "=== Assertion 10: otelCollector.egress with deploy=true is refused at render, naming the key ==="

--- a/charts/curie/ci/object-store-byo-egress-assertions.sh
+++ b/charts/curie/ci/object-store-byo-egress-assertions.sh
@@ -21,6 +21,11 @@
 #      different endpoint than S3). Static credentials do not.
 #   5. Opting out of Rail 1 (`security.networkPolicy.enabled=false`) does not
 #      require the BYO CIDRs: there is no fail-closed runner policy to satisfy.
+#   6. #2368: rustfs.egress and rustfs.stsEgress share curie.objectStore.egressEntry
+#      with the collector/API keys. A quarter-route prefix, an IPv6 ULA that
+#      contains fd00:ec2::254 (including uncompressed spelling), a protocol-only
+#      ports item, and an endPort range are refused; a /32, /24, /128, /48, and
+#      named-port peer still render.
 #
 # NetworkPolicy speaks CIDRs, not DNS names, so the chart cannot derive an
 # allow from rustfs.host. The values-level CIDR lists are the mechanism; the
@@ -62,6 +67,7 @@ render_dir() {
 
 CHECKER="$TMP/check.py"
 cat > "$CHECKER" <<'PY'
+import json
 import pathlib
 import sys
 
@@ -216,6 +222,29 @@ elif ACTION == "byo-static":
     if sts_cidr in cidrs:
         die("static-key BYO must not require or emit an STS allow")
     print("ok: static-key BYO render allows only the object-store CIDR")
+
+elif ACTION == "has-block":
+    policy_name, cidr, ports_json = sys.argv[3], sys.argv[4], sys.argv[5]
+    expected_ports = json.loads(ports_json)
+    policy = named(docs, policy_name)
+    if policy is None:
+        die(f"missing NetworkPolicy/{policy_name}")
+    matches = [
+        (block_cidr, ports, excepts)
+        for block_cidr, ports, excepts in ip_blocks(policy)
+        if block_cidr == cidr
+    ]
+    if not matches:
+        die(
+            f"{policy_name} has no ipBlock {cidr}; "
+            f"blocks={ip_blocks(policy)!r}"
+        )
+    for block_cidr, ports, excepts in matches:
+        if ports != expected_ports:
+            die(f"{cidr} ports are {ports!r}, expected {expected_ports!r}")
+        if excepts:
+            die(f"{cidr} must not except anything on a narrow allow; got {excepts}")
+    print(f"ok: {policy_name} allows {cidr} with {expected_ports}")
 
 else:
     die(f"unknown action {ACTION!r}")
@@ -398,6 +427,125 @@ rustfs:
     - cidr: 192.0.2.10/32
 EOF
 must_fail_naming "ports-missing rustfs.egress" "ports" "$NO_PORTS_VALUES"
+
+write_rustfs_entry_values() {
+  local path="$1"
+  local key="$2"
+  local entry="$3"
+  if [[ "$key" == "rustfs.egress" ]]; then
+    cat > "$path" <<EOF
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+  egress:
+${entry}
+EOF
+  else
+    cat > "$path" <<EOF
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+  auth:
+    accessKey: ""
+  egress:
+    - cidr: ${S3_CIDR}
+      ports: [{ protocol: TCP, port: 443 }]
+  stsEgress:
+${entry}
+api:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-api
+worker:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-worker
+agentSandbox:
+  runner:
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-runner
+EOF
+  fi
+}
+
+must_render_block() {
+  local label="$1"
+  local cidr="$2"
+  local ports_json="$3"
+  local values="$4"
+  local out
+  out="$(render_dir "${label// /_}" --values "$values")" \
+    || fail "${label} must render"
+  python3 "$CHECKER" "$out" has-block "$OBJECT_STORE_POLICY" "$cidr" "$ports_json" \
+    || fail "${label} did not render ipBlock ${cidr} with ports ${ports_json}"
+}
+
+echo "=== Assertion 10: shared validator enforces one-peer floor, IPv6 metadata, and explicit ports on both rustfs keys ==="
+for KEY in rustfs.egress rustfs.stsEgress; do
+  write_rustfs_entry_values "$TMP/${KEY}-default-route.yaml" "$KEY" \
+    $'    - cidr: 0.0.0.0/0\n      ports: [{ protocol: TCP, port: 443 }]'
+  must_fail_naming "default-route ${KEY}" "$KEY" "$TMP/${KEY}-default-route.yaml"
+
+  write_rustfs_entry_values "$TMP/${KEY}-imds-v4.yaml" "$KEY" \
+    $'    - cidr: 169.254.0.0/16\n      ports: [{ protocol: TCP, port: 443 }]'
+  must_fail_naming "metadata-covering ${KEY}" "169.254.169.254" "$TMP/${KEY}-imds-v4.yaml"
+
+  write_rustfs_entry_values "$TMP/${KEY}-no-ports.yaml" "$KEY" \
+    $'    - cidr: 192.0.2.30/32'
+  must_fail_naming "ports-missing ${KEY}" "ports" "$TMP/${KEY}-no-ports.yaml"
+
+  write_rustfs_entry_values "$TMP/${KEY}-quarter-route.yaml" "$KEY" \
+    $'    - cidr: 64.0.0.0/2\n      ports: [{ protocol: TCP, port: 443 }]'
+  must_fail_naming "quarter-route ${KEY}" "IPv4 /8, IPv6 /32" "$TMP/${KEY}-quarter-route.yaml"
+
+  write_rustfs_entry_values "$TMP/${KEY}-ula8.yaml" "$KEY" \
+    $'    - cidr: fd00::/8\n      ports: [{ protocol: TCP, port: 443 }]'
+  must_fail_naming "ipv6-ula-8 ${KEY}" "169.254.169.254" "$TMP/${KEY}-ula8.yaml"
+
+  write_rustfs_entry_values "$TMP/${KEY}-ula7.yaml" "$KEY" \
+    $'    - cidr: fc00::/7\n      ports: [{ protocol: TCP, port: 443 }]'
+  must_fail_naming "ipv6-ula-7 ${KEY}" "169.254.169.254" "$TMP/${KEY}-ula7.yaml"
+
+  write_rustfs_entry_values "$TMP/${KEY}-ula-uncompressed.yaml" "$KEY" \
+    $'    - cidr: fd00:0ec2::/48\n      ports: [{ protocol: TCP, port: 443 }]'
+  must_fail_naming "ipv6-ula-uncompressed ${KEY}" "169.254.169.254" "$TMP/${KEY}-ula-uncompressed.yaml"
+
+  write_rustfs_entry_values "$TMP/${KEY}-protocol-only.yaml" "$KEY" \
+    $'    - cidr: 192.0.2.30/32\n      ports: [{ protocol: TCP }]'
+  must_fail_naming "protocol-only ${KEY}" "each ports item must set port" "$TMP/${KEY}-protocol-only.yaml"
+
+  write_rustfs_entry_values "$TMP/${KEY}-endport.yaml" "$KEY" \
+    $'    - cidr: 192.0.2.30/32\n      ports: [{ protocol: TCP, port: 1, endPort: 65535 }]'
+  must_fail_naming "endport ${KEY}" "endPort" "$TMP/${KEY}-endport.yaml"
+
+  write_rustfs_entry_values "$TMP/${KEY}-p1.yaml" "$KEY" \
+    $'    - cidr: 192.0.2.30/32\n      ports: [{ protocol: TCP, port: 443 }]'
+  must_render_block "narrow-v4-32 ${KEY}" "192.0.2.30/32" \
+    '[{"protocol": "TCP", "port": 443}]' "$TMP/${KEY}-p1.yaml"
+
+  write_rustfs_entry_values "$TMP/${KEY}-p2.yaml" "$KEY" \
+    $'    - cidr: 192.0.2.0/24\n      ports: [{ protocol: TCP, port: 443 }]'
+  must_render_block "narrow-v4-24 ${KEY}" "192.0.2.0/24" \
+    '[{"protocol": "TCP", "port": 443}]' "$TMP/${KEY}-p2.yaml"
+
+  write_rustfs_entry_values "$TMP/${KEY}-p3.yaml" "$KEY" \
+    $'    - cidr: 2001:db8::10/128\n      ports: [{ protocol: TCP, port: 4318 }]'
+  must_render_block "narrow-v6-128 ${KEY}" "2001:db8::10/128" \
+    '[{"protocol": "TCP", "port": 4318}]' "$TMP/${KEY}-p3.yaml"
+
+  write_rustfs_entry_values "$TMP/${KEY}-p4.yaml" "$KEY" \
+    $'    - cidr: 2001:db8::/48\n      ports: [{ protocol: TCP, port: 443 }]'
+  must_render_block "narrow-v6-48 ${KEY}" "2001:db8::/48" \
+    '[{"protocol": "TCP", "port": 443}]' "$TMP/${KEY}-p4.yaml"
+
+  write_rustfs_entry_values "$TMP/${KEY}-p5.yaml" "$KEY" \
+    $'    - cidr: 192.0.2.30/32\n      ports: [{ protocol: TCP, port: https }]'
+  must_render_block "named-port ${KEY}" "192.0.2.30/32" \
+    '[{"protocol": "TCP", "port": "https"}]' "$TMP/${KEY}-p5.yaml"
+done
 
 echo
 echo "PASS: BYO object-store egress is required and rendered as a runner NetworkPolicy; the default in-chart rustfs allow is unchanged."

--- a/charts/curie/templates/security-networkpolicy.yaml
+++ b/charts/curie/templates/security-networkpolicy.yaml
@@ -7,6 +7,136 @@ Pack an IPv4 dotted-quad into a 32-bit integer, e.g. "169.254.169.254" ->
 {{- add (mul (int64 (index $o 0)) 16777216) (mul (int64 (index $o 1)) 65536) (mul (int64 (index $o 2)) 256) (int64 (index $o 3)) -}}
 {{- end -}}
 {{- /*
+Parse one IPv6 hextet (1-4 hex digits) to an integer. Empty on invalid input
+so callers can skip rather than fail: syntax validation is a separate slice.
+*/ -}}
+{{- define "curie.hexToInt" -}}
+{{- $s := lower (trim .) -}}
+{{- $n := 0 -}}
+{{- $ok := true -}}
+{{- $digits := dict "0" 0 "1" 1 "2" 2 "3" 3 "4" 4 "5" 5 "6" 6 "7" 7 "8" 8 "9" 9 "a" 10 "b" 11 "c" 12 "d" 13 "e" 14 "f" 15 -}}
+{{- if or (eq $s "") (gt (len $s) 4) -}}
+{{- $ok = false -}}
+{{- end -}}
+{{- range $c := regexFindAll "." $s -1 -}}
+  {{- if hasKey $digits $c -}}
+    {{- $n = add (mul $n 16) (index $digits $c) -}}
+  {{- else -}}
+    {{- $ok = false -}}
+  {{- end -}}
+{{- end -}}
+{{- if $ok -}}{{- $n -}}{{- end -}}
+{{- end -}}
+{{- /*
+Expand an IPv6 address to eight decimal hextets joined by commas, or "" when
+the address cannot be expanded. Accepts one `::` compression and leading-zero
+hextets so fd00:0ec2:: and fd00:ec2:: compare equal.
+*/ -}}
+{{- define "curie.ipv6Hextets" -}}
+{{- $ip := trim . -}}
+{{- $compressed := splitList "::" $ip -}}
+{{- if le (len $compressed) 2 -}}
+  {{- $left := list -}}
+  {{- $right := list -}}
+  {{- $leftSide := index $compressed 0 -}}
+  {{- if ne $leftSide "" -}}
+    {{- range splitList ":" $leftSide -}}
+      {{- $left = append $left . -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if eq (len $compressed) 2 -}}
+    {{- $rightSide := index $compressed 1 -}}
+    {{- if ne $rightSide "" -}}
+      {{- range splitList ":" $rightSide -}}
+        {{- $right = append $right . -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $total := add (len $left) (len $right) -}}
+  {{- $ok := true -}}
+  {{- if and (eq (len $compressed) 1) (ne $total 8) -}}{{- $ok = false -}}{{- end -}}
+  {{- if and (eq (len $compressed) 2) (gt $total 7) -}}{{- $ok = false -}}{{- end -}}
+  {{- if $ok -}}
+    {{- $zeros := 0 -}}
+    {{- if eq (len $compressed) 2 -}}
+      {{- $zeros = sub 8 $total -}}
+    {{- end -}}
+    {{- $all := $left -}}
+    {{- range until ($zeros | int) -}}
+      {{- $all = append $all "0" -}}
+    {{- end -}}
+    {{- range $right -}}
+      {{- $all = append $all . -}}
+    {{- end -}}
+    {{- if eq (len $all) 8 -}}
+      {{- $nums := list -}}
+      {{- $valid := true -}}
+      {{- range $all -}}
+        {{- $n := include "curie.hexToInt" . | trim -}}
+        {{- if eq $n "" -}}
+          {{- $valid = false -}}
+        {{- else -}}
+          {{- $nums = append $nums $n -}}
+        {{- end -}}
+      {{- end -}}
+      {{- if $valid -}}
+        {{- join "," $nums -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+{{- /*
+Return "true" when the CIDR contains 169.254.169.254 or fd00:ec2::254,
+including the exact host and IPv6 spellings such as fd00:0ec2::/48.
+IPv6 comparison is hextet-normalised; unparseable addresses return "".
+*/ -}}
+{{- define "curie.cidrContainsMetadata" -}}
+{{- $parts := splitList "/" . -}}
+{{- if eq (len $parts) 2 -}}
+{{- $ip := index $parts 0 -}}
+{{- $prefixText := index $parts 1 -}}
+{{- if regexMatch "^(0|[1-9][0-9]{0,2})$" $prefixText -}}
+{{- $prefix := int $prefixText -}}
+{{- if contains ":" $ip -}}
+  {{- if le $prefix 128 -}}
+    {{- $hextets := include "curie.ipv6Hextets" $ip | trim -}}
+    {{- if $hextets -}}
+      {{- $got := splitList "," $hextets -}}
+      {{- $imds := list 64768 3778 0 0 0 0 0 596 -}}
+      {{- $contained := true -}}
+      {{- range $i, $h := $got -}}
+        {{- $bitsBefore := mul $i 16 -}}
+        {{- if and $contained (lt $bitsBefore $prefix) -}}
+          {{- $bitsThis := sub $prefix $bitsBefore -}}
+          {{- if gt $bitsThis 16 -}}{{- $bitsThis = 16 -}}{{- end -}}
+          {{- $shift := sub 16 $bitsThis -}}
+          {{- $div := 1 -}}
+          {{- range until ($shift | int) -}}{{- $div = mul $div 2 -}}{{- end -}}
+          {{- $a := div (int $h) $div -}}
+          {{- $b := div (int (index $imds $i)) $div -}}
+          {{- if ne $a $b -}}{{- $contained = false -}}{{- end -}}
+        {{- end -}}
+      {{- end -}}
+      {{- if $contained -}}true{{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- else -}}
+  {{- if and (ge $prefix 0) (le $prefix 32) (regexMatch "^[0-9.]+$" $ip) -}}
+    {{- $octets := splitList "." $ip -}}
+    {{- if eq (len $octets) 4 -}}
+      {{- $meta := include "curie.ipv4ToInt" "169.254.169.254" | int64 -}}
+      {{- $net := include "curie.ipv4ToInt" $ip | int64 -}}
+      {{- $block := int64 1 -}}
+      {{- range until (sub 32 $prefix | int) -}}{{- $block = mul $block 2 -}}{{- end -}}
+      {{- if eq (div $meta $block) (div $net $block) -}}true{{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- /*
 Given an allowedEgress CIDR string, return the metadata/link-local `except`
 entry that must be carved back out of it, or "" when the CIDR cannot reach the
 cloud metadata endpoint. NetworkPolicy allows are additive, so a broad allow
@@ -20,17 +150,21 @@ stay a STRICT subset (169.254.0.0/16 for prefix <16, the /32 host for 16..<32,
 and nothing for an exact /32 host allow, which is a deliberate operator choice).
 
 IPv4 containment is computed exactly (top `prefix` bits of 169.254.169.254 vs the
-network). IPv6 covers the realistic broad cases -- ::/0 and the AWS IMDS ULA
-prefix fd00:ec2::/nn -- and carves out fd00:ec2::254; full IPv6 range math is not
-attempted (documented assumption). Operators can always override with an explicit
-per-entry `except:` list, which wins over this auto carve-out.
+network). IPv6 containment is hextet-normalised against fd00:ec2::254, so
+::/0, fc00::/7, fd00::/8, and fd00:0ec2::/48 all carve out fd00:ec2::254/128.
+An exact /128 of that host emits nothing (any except would equal cidr). This
+carve-out is live for security.networkPolicy.allowedEgress; the four BYO
+one-peer lists refuse the same CIDRs in curie.objectStore.egressEntry before
+render, so the auto-except branch is not a second defence on those keys.
+Operators can always override with an explicit per-entry `except:` list, which
+wins over this auto carve-out.
 */ -}}
 {{- define "curie.metadataExcept" -}}
 {{- $parts := splitList "/" . -}}
 {{- $ip := index $parts 0 -}}
 {{- $prefix := index $parts 1 | int -}}
 {{- if contains ":" $ip -}}
-  {{- if or (eq $prefix 0) (and (hasPrefix "fd00:ec2:" $ip) (le $prefix 32)) -}}fd00:ec2::254/128{{- end -}}
+  {{- if and (lt $prefix 128) (eq (include "curie.cidrContainsMetadata" . | trim) "true") -}}fd00:ec2::254/128{{- end -}}
 {{- else -}}
   {{- $meta := include "curie.ipv4ToInt" "169.254.169.254" | int64 -}}
   {{- $net := include "curie.ipv4ToInt" $ip | int64 -}}
@@ -49,10 +183,14 @@ per-entry `except:` list, which wins over this auto carve-out.
 {{/*
 Validate one BYO endpoint egress entry (rustfs.egress, rustfs.stsEgress,
 otelCollector.egress, api.egress). Each of those lists names ONE external peer
-the runner must reach, not the model allowlist: a default route or a CIDR that
-reaches the cloud metadata address would additively re-open the prompt-injectable
-runner. Require cidr + ports, refuse prefix 0/1, and refuse any CIDR that
-contains 169.254.169.254 or fd00:ec2::254.
+the runner must reach, not the model allowlist. Require cidr + a ports list,
+refuse prefix 0/1 as a default route, refuse any CIDR that contains
+169.254.169.254 or fd00:ec2::254 (IPv6 hextet-normalised), refuse IPv4 prefixes
+shorter than /8 and IPv6 prefixes shorter than /32 (a floor against a
+route-shaped entry, not a claim of one-host narrowness), and require each
+ports item to set a concrete port with no endPort. The auto-except branch in
+curie.egress.ipBlockRules remains live for allowedEgress; these four lists
+never reach it because this validator refuses the CIDRs that would populate it.
 */}}
 {{- define "curie.objectStore.egressEntry" -}}
 {{- $key := .key -}}
@@ -76,9 +214,38 @@ contains 169.254.169.254 or fd00:ec2::254.
 {{- if le $prefix 1 -}}
 {{- fail (printf "%s entry %q is a default or equivalently broad route; use a VPC interface endpoint /32 or the narrowest prefix that reaches this one endpoint, not a default route" $key $cidr) -}}
 {{- end -}}
-{{- $auto := include "curie.metadataExcept" $cidr | trim -}}
-{{- if or $auto (eq $ip "169.254.169.254") (hasPrefix "fd00:ec2:" $ip) -}}
-{{- fail (printf "%s entry %q must not cover the cloud metadata endpoint 169.254.169.254" $key $cidr) -}}
+{{- if eq (include "curie.cidrContainsMetadata" $cidr | trim) "true" -}}
+{{- fail (printf "%s entry %q must not cover the cloud metadata endpoint 169.254.169.254 or fd00:ec2::254" $key $cidr) -}}
+{{- end -}}
+{{- if contains ":" $ip -}}
+  {{- if lt $prefix 32 -}}
+  {{- fail (printf "%s entry %q is broader than the per-family floor (IPv4 /8, IPv6 /32); use a VPC interface endpoint /32 or the narrowest prefix that reaches this one endpoint, not a route-shaped range" $key $cidr) -}}
+  {{- end -}}
+{{- else -}}
+  {{- if lt $prefix 8 -}}
+  {{- fail (printf "%s entry %q is broader than the per-family floor (IPv4 /8, IPv6 /32); use a VPC interface endpoint /32 or the narrowest prefix that reaches this one endpoint, not a route-shaped range" $key $cidr) -}}
+  {{- end -}}
+{{- end -}}
+{{- range $item := .entry.ports -}}
+  {{- if not (kindIs "map" $item) -}}
+  {{- fail (printf "%s entry %q each ports item must set port; a protocol without port matches every port on the CIDR" $key $cidr) -}}
+  {{- end -}}
+  {{- if hasKey $item "endPort" -}}
+  {{- fail (printf "%s entry %q ports items must not set endPort; name one port, not a range" $key $cidr) -}}
+  {{- end -}}
+  {{- if not (hasKey $item "port") -}}
+  {{- fail (printf "%s entry %q each ports item must set port; a protocol without port matches every port on the CIDR" $key $cidr) -}}
+  {{- end -}}
+  {{- $portText := trim (printf "%v" $item.port) -}}
+  {{- if or (eq $portText "") (eq $portText "<nil>") -}}
+  {{- fail (printf "%s entry %q each ports item must set port; a protocol without port matches every port on the CIDR" $key $cidr) -}}
+  {{- end -}}
+  {{- if regexMatch "^[0-9]+$" $portText -}}
+    {{- $portNum := int $portText -}}
+    {{- if or (lt $portNum 1) (gt $portNum 65535) -}}
+    {{- fail (printf "%s entry %q port must be an integer from 1 through 65535 or a named port" $key $cidr) -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 {{- end -}}
 {{- if and .Values.agentSandbox.deploy .Values.security.networkPolicy.enabled }}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -678,9 +678,11 @@ rustfs:
   # NetworkPolicy cannot target a DNS name, so rustfs.host is not enough.
   # Empty (the default) keeps fail-closed: a BYO install with Rail 1 on and
   # bundle-fetch or workspace enabled is refused at render until these CIDRs
-  # are set. Each entry must set cidr and ports. Default routes and CIDRs that
-  # reach 169.254.169.254 are refused: this is a store-endpoint list, not a
-  # second model allowlist. On EKS the tight form is VPC interface endpoints
+  # are set. Each entry must set cidr and a concrete port (not protocol-only,
+  # not endPort). Default routes, IPv4 prefixes shorter than /8, IPv6 prefixes
+  # shorter than /32, and CIDRs that reach 169.254.169.254 or fd00:ec2::254
+  # are refused: this is a store-endpoint list, not a second model allowlist.
+  # On EKS the tight form is VPC interface endpoints
   # for s3 (and sts on the key-free path) with private DNS enabled, which
   # turns each requirement into a /32 rather than an AWS public service CIDR
   # range. See the chart README, "Key-free object store auth".
@@ -831,9 +833,10 @@ otelCollector:
   # render rather than silently ignored. Empty (the
   # default) keeps fail-closed: otherwise the install is green, every other
   # workload's traces flow, and only the sandbox's spans are silently dropped.
-  # Each entry must set cidr and ports. Default routes and CIDRs that reach
-  # 169.254.169.254 are refused: this is one collector endpoint, not a second
-  # model allowlist.
+  # Each entry must set cidr and a concrete port (not protocol-only, not
+  # endPort). Default routes, IPv4 prefixes shorter than /8, IPv6 prefixes
+  # shorter than /32, and CIDRs that reach 169.254.169.254 or fd00:ec2::254
+  # are refused: this is one collector endpoint, not a second model allowlist.
   egress: []
   #  - cidr: 192.0.2.10/32
   #    ports: [{ protocol: TCP, port: 4318 }]
@@ -1005,9 +1008,11 @@ api:
   # still deployed stays governed by security.networkPolicy.allowedEgress.
   # Empty (the default) keeps fail-closed: otherwise the install is green and
   # agents boot with no memory and no thread history, with only a warning line
-  # inside the sandbox to show for it. Each entry must set cidr and ports.
-  # Default routes and CIDRs that reach 169.254.169.254 are refused: this is
-  # one API endpoint, not a second model allowlist.
+  # inside the sandbox to show for it. Each entry must set cidr and a concrete
+  # port (not protocol-only, not endPort). Default routes, IPv4 prefixes
+  # shorter than /8, IPv6 prefixes shorter than /32, and CIDRs that reach
+  # 169.254.169.254 or fd00:ec2::254 are refused: this is one API endpoint,
+  # not a second model allowlist.
   # mailAdapter.apiEgress.httpsCidrs is the same idea for the mail adapter pod.
   egress: []
   #  - cidr: 192.0.2.11/32


### PR DESCRIPTION
## Summary

The shared BYO egress validator (`curie.objectStore.egressEntry`) now enforces the one-peer contract its comments claimed. A `/2` route, an IPv6 ULA that contains `fd00:ec2::254` (including `fd00:0ec2::` spelling), a protocol-only ports item, and an `endPort` range fail Helm render on all four consumer lists. Narrow `/32`, `/24`, `/128`, `/48`, and named-port peers still render. `allowedEgress` stays the documented model allowlist, including `0.0.0.0/0` with the IMDS except.

The IPv4 `/8` and IPv6 `/32` floors are a route-shaped bound, not a one-host `/32` claim. They come from the #2368 policy spike as the conservative default that refuses `/2` while keeping the existing `/24` and `/48` positives.

## Related issue

Closes #2368

## Fix pin verification

Fix pin: charts/curie/ci/object-store-byo-egress-assertions.sh

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Render-time Helm validator; does not reach plugin packaging, the runner turn loop, or skill eval | | |
| local | n/a | Does not reach compose services, dispatcher/worker/API wiring, or a curie verb | | |
| local-release | n/a | Does not change released binary or image identity | | |
| cluster | required | Chart templates and runner NetworkPolicy BYO ipBlock validation. The operator-facing consumer is `helm template` failing closed on a violating entry and rendering a narrow peer. | fake | Commit `0f2f9b8a6`. `bash charts/curie/ci/object-store-byo-egress-assertions.sh` PASS (quarter-route / ULA / protocol-only / endPort refused on rustfs.egress and rustfs.stsEgress; `192.0.2.30/32` TCP 443 rendered). Second path: `bash charts/curie/ci/byo-endpoint-egress-assertions.sh` PASS on otelCollector.egress and api.egress. Negative: `bash cli/scripts/verify-fix-pin.sh HEAD charts/curie/ci/object-store-byo-egress-assertions.sh` PINNED (`quarter-route rustfs.egress must fail Helm rendering` after reversing the validator). Sibling: `allowedEgress: 0.0.0.0/0` still renders `except: ['169.254.0.0/16']`; `::/0` still excepts `fd00:ec2::254/128`. |
| live provider | n/a | Does not reach model routing, credential resolution, or the MCP/workspace/coding-tool path set | | |
| external integration | n/a | Does not reach Slack, git webhooks, or connector OAuth | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
