### PR TITLE
Explain two-positional cluster message as --channel routing

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2905,6 +2905,27 @@ async fn main() {
         std::process::exit(curie::exit::ExitClass::Usage.code());
     }
 
+    if let Some(err) = curie::message::reject_agent_named_message(&args) {
+        // Clap's default extra-positional error fires before `Ui` exists, so
+        // this intercept has to emit the ADR-0021 `{error, fix}` payload (and
+        // the human Error:/Fix: pair) itself. `--json` is global and may sit
+        // anywhere in argv.
+        let json = args.iter().any(|arg| arg == "--json");
+        let (class, fix) = curie::exit::classify(&err);
+        if json {
+            let payload = curie::exit::error_json(&err);
+            if let Ok(line) = serde_json::to_string(&payload) {
+                println!("{line}");
+            }
+        } else {
+            eprintln!("Error: {err}");
+            if let Some(fix) = fix {
+                eprintln!("Fix: {fix}");
+            }
+        }
+        std::process::exit(class.code());
+    }
+
     let cli = Cli::parse();
     ui::init(Ui::from_process(cli.color, cli.debug, cli.quiet, cli.json));
     // main never returns Err (which would give anyhow's default exit 1 and skip

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -142,6 +142,142 @@ fn resolve_supplied_credential(raw: &str, env_value: Option<String>) -> String {
         .unwrap_or_default()
 }
 
+/// Flags on `local message` / `cluster message` that consume a following value.
+/// Keep in sync with the clap declarations in `main.rs`; a new value-taking
+/// flag added there must be added here or a `--flag <value>` pair is counted
+/// as a positional and the two-positional trap fires on a valid invocation.
+const MESSAGE_VALUE_FLAGS: &[&str] = &[
+    "--channel",
+    "--thread",
+    "--namespace",
+    "--release",
+    "--chart",
+    "--listen-host",
+    "--listen-port",
+    "--valkey-local-port",
+    "--valkey-password",
+    "--api-local-port",
+    "--api-key",
+    "--user",
+    "--stream",
+    "--timeout-secs",
+    "--api-url",
+    "--color",
+];
+
+/// Boolean flags that may appear on the message verbs, including globals.
+const MESSAGE_BOOL_FLAGS: &[&str] = &[
+    "--continue",
+    "--dry-run",
+    "--json",
+    "--debug",
+    "--quiet",
+    "-q",
+    "--help",
+    "-h",
+    "--version",
+    "-V",
+];
+
+/// Detect the two-positional `local|cluster message <agent> <text>` shape
+/// copied from sibling verbs that take `<AGENT>` first (#2498).
+///
+/// Returns a usage error naming the existing `--channel` routing model. Does
+/// not invent an agent-name routing API.
+pub fn reject_agent_named_message(args: &[String]) -> Option<anyhow::Error> {
+    let rest = skip_global_flags(args);
+    let tier = rest.first().map(String::as_str)?;
+    if tier != "local" && tier != "cluster" {
+        return None;
+    }
+    // Globals (`--json`, `--debug`, ...) may sit between the target and the
+    // verb because they are `global = true` on `Cli`.
+    let after_tier = skip_global_flags(&rest[1..]);
+    if after_tier.first().map(String::as_str) != Some("message") {
+        return None;
+    }
+    if message_positional_count(&after_tier[1..]) < 2 {
+        return None;
+    }
+    let verb = format!("{tier} message");
+    let siblings = format!("`{tier} versions`, `{tier} kill`, and `{tier} delete`");
+    Some(anyhow::Error::from(
+        crate::exit::CliError::usage(format!(
+            "`curie {verb}` does not take an agent name. The two-positional form \
+             <AGENT> <TEXT> is the shape of {siblings}, not this verb."
+        ))
+        .with_fix(format!(
+            "Pass only the message text. Route with `--channel <CHANNEL>`, or omit \
+             `--channel` when exactly one channel is bound. Example: `curie {verb} \
+             'Who are you?'`"
+        )),
+    ))
+}
+
+/// Skip the `global = true` flags on `Cli` (debug, quiet, color, json) so the
+/// subcommand token is the first remaining argument. Keep in sync with
+/// `retired::retired_hint` plus `--json`.
+fn skip_global_flags(args: &[String]) -> &[String] {
+    let mut index = 0usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--debug" | "-q" | "--quiet" | "--json" => {
+                index += 1;
+            }
+            "--color" => {
+                index += 1;
+                if index < args.len() && !args[index].starts_with('-') {
+                    index += 1;
+                }
+            }
+            token if token.starts_with("--color=") => {
+                index += 1;
+            }
+            _ => break,
+        }
+    }
+    &args[index..]
+}
+
+fn message_positional_count(args: &[String]) -> usize {
+    let mut count = 0usize;
+    let mut index = 0usize;
+    while index < args.len() {
+        let token = args[index].as_str();
+        if token == "--" {
+            return count + args.len().saturating_sub(index + 1);
+        }
+        if let Some(rest) = token.strip_prefix("--") {
+            if rest.contains('=') {
+                index += 1;
+                continue;
+            }
+            if MESSAGE_VALUE_FLAGS.contains(&token) {
+                index += 1;
+                if index < args.len() && !args[index].starts_with('-') {
+                    index += 1;
+                }
+                continue;
+            }
+            if MESSAGE_BOOL_FLAGS.contains(&token) {
+                index += 1;
+                continue;
+            }
+            // Unknown long option: leave it as a flag so clap still owns
+            // unknown-flag errors when only one text token remains.
+            index += 1;
+            continue;
+        }
+        if matches!(token, "-q" | "-h" | "-V") {
+            index += 1;
+            continue;
+        }
+        count += 1;
+        index += 1;
+    }
+    count
+}
+
 /// Resolve one cluster-tier credential: an explicit flag/env value wins,
 /// otherwise read it from the release (issue #786).
 ///
@@ -7499,5 +7635,83 @@ mod tests {
             "{err:#}"
         );
         assert!(format!("{err:#}").contains("greets-the-usr"), "{err:#}");
+    }
+
+    fn argv(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|part| (*part).to_string()).collect()
+    }
+
+    #[test]
+    fn reject_agent_named_message_fires_on_the_issue_2498_argv() {
+        let err = reject_agent_named_message(&argv(&[
+            "cluster",
+            "message",
+            "acme-bot",
+            "Who are you? Reply with the plugin name.",
+            "--namespace",
+            "curie",
+            "--release",
+            "curie",
+        ]))
+        .expect("two positionals must be a usage error");
+        let (class, fix) = crate::exit::classify(&err);
+        assert_eq!(class, crate::exit::ExitClass::Usage);
+        let shown = format!("{err:#}");
+        assert!(shown.contains("does not take an agent name"), "{shown}");
+        assert!(shown.contains("<AGENT>"), "{shown}");
+        let fix = fix.expect("fix must name --channel");
+        assert!(fix.contains("--channel"), "{fix}");
+        assert!(fix.contains("exactly one channel"), "{fix}");
+    }
+
+    #[test]
+    fn reject_agent_named_message_ignores_single_text_continue_and_channel() {
+        for parts in [
+            &["cluster", "message", "Who are you?"][..],
+            &["cluster", "message", "--continue", "what's 2 + 2?"],
+            &[
+                "cluster",
+                "message",
+                "--channel",
+                "C0EXAMPLE1",
+                "Who are you?",
+            ],
+            &["local", "message", "Who are you?", "--dry-run"],
+            &["cluster", "versions", "acme-bot"],
+            &["cluster", "versions", "acme-bot", "extra"],
+            &["skill", "message", "acme-bot", "Who are you?"],
+        ] {
+            assert_eq!(
+                reject_agent_named_message(&argv(parts)).map(|err| format!("{err:#}")),
+                None,
+                "must not reject {parts:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn reject_agent_named_message_sees_json_before_the_verb() {
+        let err = reject_agent_named_message(&argv(&[
+            "--json",
+            "local",
+            "message",
+            "acme-bot",
+            "Who are you?",
+        ]))
+        .expect("global --json must not hide the two-positional trap");
+        assert!(format!("{err:#}").contains("local message"), "{err:#}");
+    }
+
+    #[test]
+    fn reject_agent_named_message_sees_json_between_target_and_verb() {
+        let err = reject_agent_named_message(&argv(&[
+            "cluster",
+            "--json",
+            "message",
+            "acme-bot",
+            "Who are you?",
+        ]))
+        .expect("global --json between target and verb must not hide the trap");
+        assert!(format!("{err:#}").contains("cluster message"), "{err:#}");
     }
 }

--- a/cli/tests/message_argv.rs
+++ b/cli/tests/message_argv.rs
@@ -1,0 +1,335 @@
+//! Drive the built CLI for the two-positional `cluster message <agent> <text>`
+//! trap (#2498). Sibling verbs such as `cluster versions` take `<AGENT>` first;
+//! this verb routes by `--channel` (omit it when exactly one channel is bound).
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+fn repo_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cli crate lives in the repository")
+}
+
+fn run(args: &[&str]) -> Output {
+    run_in(repo_root(), args)
+}
+
+fn run_in(dir: &Path, args: &[&str]) -> Output {
+    Command::new(bin())
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|err| panic!("run curie {}: {err}", args.join(" ")))
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn combined(output: &Output) -> String {
+    stdout(output) + &stderr(output)
+}
+
+const ISSUE_TEXT: &str = "Who are you? Reply with the plugin name.";
+const ISSUE_AGENT: &str = "acme-bot";
+
+fn two_positional_cluster_argv() -> Vec<&'static str> {
+    vec![
+        "cluster",
+        "message",
+        ISSUE_AGENT,
+        ISSUE_TEXT,
+        "--namespace",
+        "curie",
+        "--release",
+        "curie",
+    ]
+}
+
+fn assert_two_positional_usage(output: &Output, verb: &str) {
+    let text = combined(output);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{verb} two-positional form must exit 2 (usage)\n{text}"
+    );
+    assert!(
+        !text.contains("unexpected argument"),
+        "{verb} must not leave the operator on clap's generic unexpected-argument error\n{text}"
+    );
+    assert!(
+        text.contains("--channel"),
+        "{verb} must name the --channel routing model\n{text}"
+    );
+    assert!(
+        text.to_ascii_lowercase().contains("agent")
+            && (text.contains("does not take")
+                || text.contains("not by agent")
+                || text.contains("not an agent")),
+        "{verb} must explain that this verb does not route by agent name\n{text}"
+    );
+}
+
+fn assert_json_usage(output: &Output, verb: &str) {
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{verb} --json two-positional form must exit 2\n{}",
+        combined(output)
+    );
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|err| {
+        panic!(
+            "{verb} --json must emit one JSON object on stdout: {err}; stdout: {}; stderr: {}",
+            stdout(output),
+            stderr(output)
+        )
+    });
+    let obj = payload
+        .as_object()
+        .unwrap_or_else(|| panic!("{verb} --json payload must be an object: {payload}"));
+    assert_eq!(
+        obj.keys().collect::<Vec<_>>(),
+        vec!["error", "fix"],
+        "{verb} --json must be exactly error and fix: {payload}"
+    );
+    let error = payload["error"]
+        .as_str()
+        .unwrap_or_else(|| panic!("error must be a string: {payload}"));
+    let fix = payload["fix"]
+        .as_str()
+        .unwrap_or_else(|| panic!("fix must be a string, not null: {payload}"));
+    assert!(
+        error.contains("--channel") || fix.contains("--channel"),
+        "{verb} --json must name --channel in error or fix: {payload}"
+    );
+    assert!(
+        !fix.is_empty(),
+        "{verb} --json fix must be actionable: {payload}"
+    );
+    assert!(
+        error.contains("does not take an agent name")
+            || error.contains("two-positional")
+            || error.contains("<AGENT>"),
+        "{verb} --json error must name the rejected two-positional / agent-name form: {payload}"
+    );
+}
+
+/// The exact argv from #2498: `cluster message <agent> "<text>"` plus the
+/// namespace/release flags used after deploy.
+#[test]
+fn cluster_message_two_positionals_explains_channel_routing() {
+    let output = run(&two_positional_cluster_argv());
+    assert_two_positional_usage(&output, "cluster message");
+    let text = combined(&output);
+    assert!(
+        text.contains("cluster versions")
+            || text.contains("cluster kill")
+            || text.contains("<AGENT>"),
+        "must name the sibling verbs that do take <AGENT> first\n{text}"
+    );
+}
+
+#[test]
+fn cluster_message_two_positionals_json_has_error_and_fix() {
+    let mut args = vec!["--json"];
+    args.extend(two_positional_cluster_argv());
+    let output = run(&args);
+    assert_json_usage(&output, "cluster message");
+}
+
+#[test]
+fn cluster_message_json_after_verb_still_emits_error_and_fix() {
+    let output = run(&[
+        "cluster",
+        "message",
+        "--json",
+        ISSUE_AGENT,
+        ISSUE_TEXT,
+        "--namespace",
+        "curie",
+        "--release",
+        "curie",
+    ]);
+    assert_json_usage(&output, "cluster message");
+}
+
+#[test]
+fn cluster_message_json_between_target_and_verb_still_emits_error_and_fix() {
+    let output = run(&[
+        "cluster",
+        "--json",
+        "message",
+        ISSUE_AGENT,
+        ISSUE_TEXT,
+        "--namespace",
+        "curie",
+        "--release",
+        "curie",
+    ]);
+    assert_json_usage(&output, "cluster message");
+}
+
+#[test]
+fn local_message_two_positionals_explains_channel_routing() {
+    let output = run(&["local", "message", ISSUE_AGENT, ISSUE_TEXT]);
+    assert_two_positional_usage(&output, "local message");
+}
+
+#[test]
+fn local_message_two_positionals_json_has_error_and_fix() {
+    let output = run(&["--json", "local", "message", ISSUE_AGENT, ISSUE_TEXT]);
+    assert_json_usage(&output, "local message");
+}
+
+/// Single-text form from #2498 must still parse and plan, not hit the usage
+/// trap. `--dry-run` stays offline.
+#[test]
+fn cluster_message_single_text_dry_run_is_not_usage() {
+    let output = run(&[
+        "cluster",
+        "message",
+        ISSUE_TEXT,
+        "--namespace",
+        "curie",
+        "--release",
+        "curie",
+        "--dry-run",
+    ]);
+    let text = combined(&output);
+    assert_ne!(
+        output.status.code(),
+        Some(2),
+        "single-text cluster message must not be a usage error\n{text}"
+    );
+    assert!(
+        output.status.success(),
+        "single-text --dry-run must succeed\n{text}"
+    );
+    assert!(
+        !text.contains("does not take an agent name"),
+        "single-text must not trip the two-positional explanation\n{text}"
+    );
+}
+
+#[test]
+fn cluster_message_explicit_channel_dry_run_is_not_usage() {
+    let output = run(&[
+        "cluster",
+        "message",
+        "--channel",
+        "C0EXAMPLE1",
+        ISSUE_TEXT,
+        "--namespace",
+        "curie",
+        "--release",
+        "curie",
+        "--dry-run",
+    ]);
+    let text = combined(&output);
+    assert!(
+        output.status.success(),
+        "explicit --channel single-text --dry-run must succeed\n{text}"
+    );
+}
+
+/// `--continue` with one text token is valid argv. With no last-turn file it
+/// fails later; it must not be classified as the two-positional usage trap.
+/// Run in an empty tempdir so a leftover `.curie/last-turn.json` in the
+/// checkout cannot turn this into a live cluster message.
+#[test]
+fn cluster_message_continue_is_not_two_positional_usage() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let output = run_in(
+        dir.path(),
+        &[
+            "cluster",
+            "message",
+            "--continue",
+            "what's 2 + 2?",
+            "--namespace",
+            "curie",
+            "--release",
+            "curie",
+        ],
+    );
+    let text = combined(&output);
+    assert_ne!(
+        output.status.code(),
+        Some(2),
+        "--continue with one text token must not be usage\n{text}"
+    );
+    assert!(
+        text.contains("last-turn.json") || text.contains("no previous turn"),
+        "--continue without a recorded turn must say so, not invent a clap usage error\n{text}"
+    );
+}
+
+#[test]
+fn local_message_single_text_dry_run_is_not_usage() {
+    let output = run(&["local", "message", ISSUE_TEXT, "--dry-run"]);
+    let text = combined(&output);
+    assert!(
+        output.status.success(),
+        "local message single-text --dry-run must succeed\n{text}"
+    );
+}
+
+#[test]
+fn cluster_message_help_still_takes_text_not_agent() {
+    let output = run(&["cluster", "message", "--help"]);
+    let text = combined(&output);
+    assert!(output.status.success(), "help must exit 0\n{text}");
+    assert!(
+        text.contains("<TEXT>") || text.contains("<text>"),
+        "help must keep the single TEXT positional\n{text}"
+    );
+    assert!(
+        text.contains("--channel"),
+        "help must still document --channel\n{text}"
+    );
+    assert!(
+        !text.contains("<AGENT>") && !text.contains("<agent>"),
+        "help must not grow an agent-name positional\n{text}"
+    );
+}
+
+/// Sibling that does take `<AGENT>` first: two extra tokens stay clap's
+/// unexpected-argument error, not the message-verb channel explanation.
+#[test]
+fn cluster_versions_two_positionals_is_not_channel_routing_error() {
+    let output = run(&["cluster", "versions", ISSUE_AGENT, ISSUE_TEXT]);
+    let text = combined(&output);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "cluster versions extra positional is still usage\n{text}"
+    );
+    assert!(
+        text.contains("unexpected argument"),
+        "cluster versions must keep clap's extra-argument error\n{text}"
+    );
+    assert!(
+        !text.contains("--channel"),
+        "cluster versions must not inherit the message-verb channel explanation\n{text}"
+    );
+}
+
+#[test]
+fn cluster_versions_help_still_takes_agent() {
+    let output = run(&["cluster", "versions", "--help"]);
+    let text = combined(&output);
+    assert!(output.status.success(), "help must exit 0\n{text}");
+    assert!(
+        text.contains("<AGENT>") || text.contains("<agent>"),
+        "cluster versions help must keep the AGENT positional\n{text}"
+    );
+}


### PR DESCRIPTION
## Summary

`curie cluster message <agent> "<text>"` copied the `cluster versions <AGENT>` shape and died on clap's generic unexpected-argument error. The only positional is the message text; this verb routes by `--channel` (omit it when exactly one channel is bound).

This change catches the two-positional local/cluster message argv before clap, exits 2, and prints an actionable error/fix (including `--json`) that names that routing model. It does not add an agent-name routing API. Valid single-text, `--continue`, and explicit `--channel` forms are unchanged. Sibling verbs that take `<AGENT>` first still do.

## Related issue

Closes #2498

## Fix pin verification

Fix pin: cli/tests/message_argv.rs::cluster_message_two_positionals_explains_channel_routing

`curie dev verify-fix-pin eb56a8cef cli/tests/message_argv.rs::cluster_message_two_positionals_explains_channel_routing` reported `PINNED`: the selector passed on the candidate and failed after product hunks were reversed (clap's `unexpected argument 'Who are you? Reply with the plugin name.' found` returned).

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | required | Changes a curie verb's usage error, exit code 2, and --json error/fix shape for cluster message and the local message sibling. | fake | Candidate eb56a8cef. Exact invalid argv `curie cluster message acme-bot 'Who are you? Reply with the plugin name.' --namespace curie --release curie` exited 2 with Error/Fix naming --channel routing. --json emitted one object with error "does not take an agent name" and fix "Route with --channel <CHANNEL>, or omit --channel when exactly one channel is bound." |
| local-release | n/a | Does not change released binary identity, the install path, version pins, or release compose. | | |
| cluster | n/a | Does not reach chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, or init containers. The invalid argv is rejected before kubectl. | | |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, token accounting, MCP catalog, PreToolUse, platform MCP tools, workspace publication, or coding-tool session capability. | | |
| external integration | n/a | Does not reach Slack, git webhooks, connector OAuth, or a live third-party API. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive and negative per criterion (all on `eb56a8cef`):

- Two-positional trap: exact #2498 argv exits 2 and names `--channel`, not clap's unexpected-argument error. Negative: valid single-text `--dry-run` exits 0 with a plan; `--continue` with one text token is not usage (exit 1, `no previous turn recorded in .curie/last-turn.json`); `--channel C0EXAMPLE1` single-text `--dry-run` exits 0.
- `--json`: compact `{error, fix}` on stdout, both fields name the routing model. Second path: `--json` before the verb, after `message`, and between `cluster` and `message` all emit the same payload.
- Sibling: `local message acme-bot '<text>'` gets the same usage error for that tier. `cluster versions acme-bot '<text>'` still clap unexpected-argument and does not inherit the channel explanation. `cluster message --help` still documents `<TEXT>` and `--channel`, not `<AGENT>`.

Command manifest was not regenerated: clap surface is unchanged (`command_manifest_matches_committed_artifact` passed).

Unrelated baseline on this checkout: `cargo test --test chart_check` failed `chart_check_passes_on_the_unmodified_chart` (`mail-adapter-wiring-assertions.sh`, collector peer `namespaceSelector`). Not in this diff.

`skill message` two-positionals remain clap's extra-argument error. Skill has no working `<AGENT>`-first versions/kill/delete sibling; out of scope for the local/cluster pair.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision.
