### PR TITLE
Surface declared-connector MCP probe failures to the caller

### DIFF
--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -1182,6 +1182,34 @@ def test_budget_exceeded_escalates_without_retry(make_harness) -> None:
     asyncio.run(go())
 
 
+def test_connector_capability_failed_done_posts_diagnosis_not_escalate(
+    make_harness,
+) -> None:
+    # #2519: the runner short-circuits with ErrorEvent + DONE so the diagnosis
+    # reaches the message caller without a kernel.py change. Classified-failure
+    # would be overwritten by the escalate copy. This pins the DONE fork.
+    async def go() -> None:
+        async with make_harness() as h:
+            diagnosis = (
+                "declared connector 'github' failed MCP capability probe: "
+                "credential GITHUB_TOKEN expanded empty. Connector tools are unavailable."
+            )
+            h.runner.default_script = [
+                ErrorEvent(
+                    message=diagnosis, classification="connector-capability-failed"
+                ),
+                Final(text=diagnosis, status=DONE),
+            ]
+            await h.kernel.process_event(_qevent("go"))
+
+            assert h.runner.opened == ["go"]
+            assert h.sink.last_text == diagnosis
+            assert "Flagging for a human" not in diagnosis
+            assert "human" not in (h.sink.last_text or "").lower()
+
+    asyncio.run(go())
+
+
 def test_retries_are_bounded_then_escalate(make_harness) -> None:
     async def go() -> None:
         async with make_harness(max_attempts=3) as h:

--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -58,7 +58,12 @@ from .history import (
     resolve_history,
 )
 from .hooks import _merge_pre_tool_use_hooks, load_bundle_hooks
-from .mcp_tool_capability import McpToolCapabilityProbe, probe_mcp_tool_capability
+from .mcp_tool_capability import (
+    ConnectorCapabilityFailure,
+    McpToolCapabilityProbe,
+    diagnose_derived_connector_headers,
+    probe_mcp_tool_capability,
+)
 from .memory import MemoryStore, format_memory_preamble, resolve_memory
 from .otel import RunTracer, build_tracer_provider
 from .redact import install_stdout_redaction
@@ -134,6 +139,7 @@ def build_runner(
     mcp_capability: McpToolCapabilityProbe | None = None,
     harness: HarnessContribution | None = None,
     workspace_path: Path | None = None,
+    connector_failures: tuple[ConnectorCapabilityFailure, ...] = (),
 ) -> SessionRunner:
     """Wire a SessionRunner backed by the active harness's model session.
 
@@ -266,6 +272,7 @@ def build_runner(
 
     real_options: ClaudeAgentOptions | None = None
     observed_readonly_tools: frozenset[str] = frozenset()
+    capability = mcp_capability
     if not fake_model:
         # The bundle's live MCP ``tools/list`` response is the actual advertised
         # MCP surface. Probe even when an explicit gate already requires the
@@ -274,7 +281,6 @@ def build_runner(
         # and probe failures preserve the historical fail-closed behavior. The
         # annotation remains a non-authoritative hint: it never authorizes or
         # denies tool execution.
-        capability = mcp_capability
         if capability is None:
             capability = anyio.run(
                 probe_mcp_tool_capability,
@@ -393,6 +399,12 @@ def build_runner(
         approval_resumed_kind=config.approval_resumed_kind,
         approval_decision=config.approval_decision,
         false_completion_check=config.false_completion_check,
+        connector_failures=connector_failures
+        or (
+            capability.connector_failures
+            if capability is not None
+            else ()
+        ),
     )
 
 
@@ -469,6 +481,7 @@ class _BootFetches:
     history_store: TranscriptStore
     conversation_preamble: str | None
     mcp_capability: McpToolCapabilityProbe | None
+    connector_failures: tuple[ConnectorCapabilityFailure, ...] = ()
 
 
 async def _load_boot_fetches(
@@ -494,6 +507,19 @@ async def _load_boot_fetches(
     memory: tuple[MemoryStore, str | None] | None = None
     history: tuple[TranscriptStore, str | None] | None = None
     capability: McpToolCapabilityProbe | None = None
+    derived = derive_mcp_servers(
+        config.session.plugin_dir,
+        release=config.connector_release,
+        agent=config.connector_agent,
+        namespace=config.connector_namespace,
+    )
+    expansion_failures = (
+        diagnose_derived_connector_headers(
+            derived, {**os.environ, **dict(sdk_env or {})}
+        )
+        if fake_model
+        else ()
+    )
 
     async def load_memory() -> None:
         nonlocal memory
@@ -505,12 +531,6 @@ async def _load_boot_fetches(
 
     async def probe() -> None:
         nonlocal capability
-        derived = derive_mcp_servers(
-            config.session.plugin_dir,
-            release=config.connector_release,
-            agent=config.connector_agent,
-            namespace=config.connector_namespace,
-        )
         capability = await probe_mcp_tool_capability(
             config.session.plugin_dir,
             derived,
@@ -525,12 +545,16 @@ async def _load_boot_fetches(
 
     assert memory is not None
     assert history is not None
+    connector_failures = (
+        capability.connector_failures if capability is not None else expansion_failures
+    )
     return _BootFetches(
         memory_store=memory[0],
         memory_preamble=memory[1],
         history_store=history[0],
         conversation_preamble=history[1],
         mcp_capability=capability,
+        connector_failures=connector_failures,
     )
 
 
@@ -590,6 +614,7 @@ def _serve() -> None:
         mcp_capability=fetches.mcp_capability,
         harness=harness,
         workspace_path=workspace_path,
+        connector_failures=fetches.connector_failures,
     )
 
     def capture_mounted_workspace() -> WorkspaceSnapshot:

--- a/runner/src/curie_runner/mcp_tool_capability.py
+++ b/runner/src/curie_runner/mcp_tool_capability.py
@@ -48,6 +48,37 @@ _PROBE_TIMEOUT_SECONDS = 15
 
 
 @dataclass(frozen=True)
+class ConnectorCapabilityFailure:
+    """A declared-connector capability/auth failure safe to show a caller (#2519).
+
+    Names the connector and the credential env var. Never carries a secret
+    value: diagnosis keys on placeholder presence versus env emptiness, and
+    probe exceptions are mapped to ``probe_failed`` without ``str(exc)``.
+    """
+
+    connector: str
+    credential_names: tuple[str, ...]
+    reason: str
+
+    def caller_message(self) -> str:
+        """The exact sentence the message caller sees. Values never appear."""
+
+        names = ", ".join(self.credential_names)
+        if self.reason == "empty_expansion":
+            detail = f"credential {names} expanded empty"
+        elif self.reason == "missing_credential":
+            detail = f"credential {names} is not set in the sandbox"
+        elif self.credential_names:
+            detail = f"credential {names}; capability probe failed"
+        else:
+            detail = "capability probe failed"
+        return (
+            f"declared connector '{self.connector}' failed MCP capability probe: "
+            f"{detail}. Connector tools are unavailable."
+        )
+
+
+@dataclass(frozen=True)
 class McpToolCapabilityProbe:
     """The conservative capability conclusion for one session's MCP surface."""
 
@@ -56,6 +87,58 @@ class McpToolCapabilityProbe:
     tool_count: int
     failures: tuple[str, ...] = ()
     readonly_tools: frozenset[str] = frozenset()
+    connector_failures: tuple[ConnectorCapabilityFailure, ...] = ()
+
+
+def _header_placeholders(config: Mapping[str, Any]) -> tuple[str, ...]:
+    """Credential env-var names referenced by ``${NAME}`` in MCP headers."""
+
+    headers = config.get("headers")
+    if not isinstance(headers, Mapping):
+        return ()
+    found: list[str] = []
+    for value in headers.values():
+        if isinstance(value, str):
+            for var in _VARIABLE.findall(value):
+                if var not in found:
+                    found.append(var)
+    return tuple(found)
+
+
+def diagnose_derived_connector_headers(
+    derived_servers: Mapping[str, Mapping[str, Any]],
+    inherited_env: Mapping[str, str] | None = None,
+) -> tuple[ConnectorCapabilityFailure, ...]:
+    """Network-free diagnosis of empty or missing header placeholders (#2519).
+
+    Shared with #2352 via ``tests/vectors/connector-probe-diagnosis.json``.
+    Inspects env presence and emptiness only; it never interpolates values.
+    """
+
+    env = dict(inherited_env or {})
+    failures: list[ConnectorCapabilityFailure] = []
+    for name, config in derived_servers.items():
+        if not isinstance(config, Mapping):
+            continue
+        placeholders = _header_placeholders(config)
+        if not placeholders:
+            continue
+        empty: list[str] = []
+        missing: list[str] = []
+        for var in placeholders:
+            if var not in env:
+                missing.append(var)
+            elif not str(env[var]).strip():
+                empty.append(var)
+        if empty or missing:
+            failures.append(
+                ConnectorCapabilityFailure(
+                    connector=str(name),
+                    credential_names=tuple(empty + missing),
+                    reason="empty_expansion" if empty else "missing_credential",
+                )
+            )
+    return tuple(failures)
 
 
 def _expand(value: str, env: Mapping[str, str]) -> str:
@@ -241,6 +324,9 @@ async def probe_mcp_tool_capability(
     env = {**os.environ, **dict(inherited_env or {})}
     failures: list[str] = []
     observations: list[tuple[int, bool, frozenset[str]]] = []
+    expansion_failures = diagnose_derived_connector_headers(derived_servers, env)
+    skip_http = {failure.connector for failure in expansion_failures}
+    connector_failures: list[ConnectorCapabilityFailure] = list(expansion_failures)
 
     try:
         declared = _bundle_server_configs(root) if root is not None else []
@@ -251,11 +337,13 @@ async def probe_mcp_tool_capability(
             has_potential_write_tool=True,
             tool_count=0,
             failures=("bundle-config",),
+            connector_failures=tuple(expansion_failures),
         )
 
     work: list[tuple[str, Mapping[str, Any], Path | None, str]] = [
         (name, config, root, tool_prefix) for name, config, tool_prefix in declared
     ]
+    derived_names: set[str] = set()
     for name, config in derived_servers.items():
         if not isinstance(config, Mapping):
             failures.append(str(name))
@@ -265,6 +353,7 @@ async def probe_mcp_tool_capability(
             )
             continue
         server_name = str(name)
+        derived_names.add(server_name)
         work.append((server_name, config, None, connector_tool_prefix(server_name)))
 
     async def inspect(
@@ -273,6 +362,12 @@ async def probe_mcp_tool_capability(
         cwd: Path | None,
         tool_prefix: str,
     ) -> None:
+        derived = cwd is None and name in derived_names
+        if derived and name in skip_http:
+            # Empty/missing expansion already diagnosed; do not dial /mcp with
+            # an empty Bearer (the exception text is the leak surface).
+            failures.append(name)
+            return
         try:
             observations.append(
                 await _probe_server(
@@ -289,6 +384,14 @@ async def probe_mcp_tool_capability(
                 name,
                 exc,
             )
+            if derived and name not in skip_http:
+                connector_failures.append(
+                    ConnectorCapabilityFailure(
+                        connector=name,
+                        credential_names=_header_placeholders(config),
+                        reason="probe_failed",
+                    )
+                )
 
     async with anyio.create_task_group() as task_group:
         for name, config, cwd, tool_prefix in work:
@@ -307,4 +410,5 @@ async def probe_mcp_tool_capability(
         tool_count=tool_count,
         failures=tuple(sorted(set(failures))),
         readonly_tools=readonly_tools,
+        connector_failures=tuple(connector_failures),
     )

--- a/runner/src/curie_runner/session.py
+++ b/runner/src/curie_runner/session.py
@@ -44,6 +44,7 @@ from .adapter import ModelSession, PartialMessageBoundary, StreamedToolUseBounda
 from .approval import PUBLISH_TOOL_NAME, ApprovalGate
 from .budget import BUDGET_CLASSIFICATION, BudgetTracker
 from .history import NullTranscriptStore, TranscriptStore, TurnRecord
+from .mcp_tool_capability import ConnectorCapabilityFailure
 from .memory import (
     ConsolidationResult,
     MemoryRecord,
@@ -96,6 +97,11 @@ FALSE_COMPLETION_CLASSIFICATION = "false-completion"
 # error+final pair, because a publication request that produced no approval
 # record must never finalize looking like a clean turn.
 PUBLICATION_UNRECORDED_CLASSIFICATION = "publication-unrecorded"
+# Declared-connector capability/auth failure (#2519). Distinct from a model
+# credential rejection: the session can still boot, but the connector's tools
+# are not available. Rides ErrorEvent.classification; the Final is DONE so the
+# worker posts the diagnosis text instead of overwriting it with escalate copy.
+CONNECTOR_CAPABILITY_FAILED = "connector-capability-failed"
 
 
 def _is_auth_rejection(message: object) -> bool:
@@ -195,6 +201,7 @@ class SessionRunner:
         approval_resumed_kind: str | None = None,
         approval_decision: str | None = None,
         false_completion_check: bool = False,
+        connector_failures: tuple[ConnectorCapabilityFailure, ...] = (),
     ) -> None:
         self._factory = session_factory
         self._ceiling = ceiling
@@ -228,6 +235,10 @@ class SessionRunner:
         # Opt-in, observe-only false-completion check (#517): warn when a turn
         # ends DONE with a substantive answer but zero tool calls. Off by default.
         self._false_completion_check = false_completion_check
+        # Declared-connector probe/expansion failures (#2519). Empty means the
+        # model runs as usual. Non-empty short-circuits every turn before query
+        # so the agent cannot answer from memory with the connector's tools gone.
+        self._connector_failures = connector_failures
 
         self._session: ModelSession | None = None
         # One turn consumes the SDK generator at a time. This MUST be a
@@ -542,13 +553,26 @@ class SessionRunner:
                     parent=parent,
                 ) as gen:
                     try:
-                        async for line in self._drive_turn(event, state, tracker, gen):
-                            if isinstance(parse_ndjson_line(line), Final):
-                                # The terminal decision is authoritative once the
-                                # Final reaches the consumer, even if it closes
-                                # without requesting the generator's next item.
-                                metric_outcome = self._metric_outcome(tracker)
-                            yield line
+                        if self._connector_failures:
+                            message = " ".join(
+                                failure.caller_message()
+                                for failure in self._connector_failures
+                            )
+                            state.final_text = message
+                            for line in self._connector_capability_halt_lines(gen, message):
+                                if isinstance(parse_ndjson_line(line), Final):
+                                    metric_outcome = self._metric_outcome(tracker)
+                                yield line
+                        else:
+                            async for line in self._drive_turn(
+                                event, state, tracker, gen
+                            ):
+                                if isinstance(parse_ndjson_line(line), Final):
+                                    # The terminal decision is authoritative once the
+                                    # Final reaches the consumer, even if it closes
+                                    # without requesting the generator's next item.
+                                    metric_outcome = self._metric_outcome(tracker)
+                                yield line
                         logger.info(
                             "turn end session=%s status=%s duration_ms=%d",
                             self._session_id,
@@ -1297,6 +1321,44 @@ class SessionRunner:
                     status=SessionStatus.CLASSIFIED_FAILURE,
                 )
             ),
+        ]
+
+    def _connector_capability_halt_lines(
+        self, gen: _GenerationSpan, message: str
+    ) -> list[str]:
+        """ErrorEvent + DONE so the diagnosis reaches the message caller (#2519).
+
+        Does not query the model. Final is DONE, not classified-failure: the
+        worker's escalate path would replace the connector and credential names
+        with a generic human-flag. completed_without_result keeps the OTel span
+        from being marked abandoned. Logs names only, never values.
+        """
+
+        logger.error(
+            "declared connector capability failed session=%s connectors=%s credentials=%s",
+            self._session_id,
+            ",".join(failure.connector for failure in self._connector_failures),
+            ",".join(
+                name
+                for failure in self._connector_failures
+                for name in failure.credential_names
+            ),
+        )
+        self._turn_open = False
+        self._status = SessionStatus.DONE
+        gen.finish_turn(
+            interrupt_requested=False,
+            classified_failure=False,
+            completed_without_result=True,
+        )
+        return [
+            to_ndjson_line(
+                ErrorEvent(
+                    message=message,
+                    classification=CONNECTOR_CAPABILITY_FAILED,
+                )
+            ),
+            to_ndjson_line(Final(text=message, status=SessionStatus.DONE)),
         ]
 
     def _auth_halt_lines(self) -> list[str]:

--- a/runner/tests/test_boot_fetches.py
+++ b/runner/tests/test_boot_fetches.py
@@ -295,6 +295,46 @@ def test_boot_fetches_bad_memory_ref_fails_visibly(tmp_path: Path) -> None:
     anyio.run(go)
 
 
+def test_boot_fetches_diagnoses_empty_expansion_on_fake_model_without_probing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin_dir = tmp_path / "bundle"
+    (plugin_dir / ".claude-plugin").mkdir(parents=True)
+    (plugin_dir / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "acme-bot"}), encoding="utf-8"
+    )
+    (plugin_dir / "connectors.yaml").write_text(
+        "connectors:\n"
+        "  github:\n"
+        "    url: http://127.0.0.1:9/mcp\n"
+        "    headers:\n"
+        "      Authorization: Bearer ${GITHUB_TOKEN}\n",
+        encoding="utf-8",
+    )
+
+    async def boom(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("fake-model must not HTTP-probe a connector")
+
+    monkeypatch.setattr(boot, "probe_mcp_tool_capability", boom)
+    app = _state_app(memory_value=[_MEMORY_ITEM], history_value=[_HISTORY_ITEM])
+
+    async def go() -> None:
+        async with TestServer(app) as server:
+            config = _config(
+                plugin_dir,
+                memory_ref=str(server.make_url("/agents/A/state/memory")),
+                history_ref=str(server.make_url("/agents/A/state/transcript/t1")),
+            )
+            fetches = await boot._load_boot_fetches(config, True, {"GITHUB_TOKEN": ""})
+            assert fetches.mcp_capability is None
+            assert fetches.connector_failures
+            assert fetches.connector_failures[0].connector == "github"
+            assert fetches.connector_failures[0].reason == "empty_expansion"
+            assert fetches.connector_failures[0].credential_names == ("GITHUB_TOKEN",)
+
+    anyio.run(go)
+
+
 def test_boot_fetches_skips_probe_on_fake_model(tmp_path: Path) -> None:
     plugin_dir = _bundle(tmp_path / "bundle", mcp_command=[sys.executable, str(_SERVER)])
     app = _state_app(memory_value=[_MEMORY_ITEM], history_value=[_HISTORY_ITEM])

--- a/runner/tests/test_connector_probe_diagnosis.py
+++ b/runner/tests/test_connector_probe_diagnosis.py
@@ -1,0 +1,235 @@
+"""Declared-connector capability diagnosis (#2519).
+
+A SecretRef-form credential never reaches the sandbox under ADR-0090, so
+``Authorization: Bearer ${NAME}`` expands empty and the MCP capability probe
+only logged. This module pins the network-free diagnosis that names the
+connector and the credential, never a value, and the vector #2352 must reuse
+instead of probing HTTP at deploy time.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import anyio
+import pytest
+from curie_runner.mcp_tool_capability import probe_mcp_tool_capability
+
+_VECTOR = (
+    Path(__file__).resolve().parents[2] / "tests" / "vectors" / "connector-probe-diagnosis.json"
+)
+_VECTOR_CASE_KEYS = {
+    "name",
+    "connector",
+    "headers",
+    "env",
+    "expected_reason",
+    "expected_credentials",
+    "expected_message",
+}
+_PLANTED = "must-not-appear-PLACEHOLDER"
+
+
+def _load_vector() -> dict:
+    payload = json.loads(_VECTOR.read_text(encoding="utf-8"))
+    extra = set(payload) - {"comment", "vectors"}
+    assert not extra, extra
+    assert payload["comment"]
+    return payload
+
+
+def test_vector_rejects_unknown_fields() -> None:
+    payload = _load_vector()
+    for case in payload["vectors"]:
+        extra = set(case) - _VECTOR_CASE_KEYS
+        assert not extra, extra
+
+
+def test_vector_cases_match_diagnose_derived_connector_headers() -> None:
+    from curie_runner.mcp_tool_capability import diagnose_derived_connector_headers
+
+    payload = _load_vector()
+    assert payload["vectors"], "the diagnosis vector must not be empty"
+    for case in payload["vectors"]:
+        derived = {
+            case["connector"]: {
+                "type": "http",
+                "url": "http://127.0.0.1:9/mcp",
+                "headers": case["headers"],
+            }
+        }
+        failures = diagnose_derived_connector_headers(derived, case["env"])
+        if case["expected_reason"] is None:
+            assert failures == ()
+            continue
+        assert len(failures) == 1, case["name"]
+        failure = failures[0]
+        assert failure.connector == case["connector"]
+        assert failure.reason == case["expected_reason"]
+        assert list(failure.credential_names) == case["expected_credentials"]
+        assert failure.caller_message() == case["expected_message"]
+        assert _PLANTED not in failure.caller_message()
+        for value in case["env"].values():
+            if value.strip():
+                assert value not in failure.caller_message()
+
+
+def test_empty_expansion_skips_http_probe_for_that_derived_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called: list[str] = []
+
+    async def boom(*_args: object, **_kwargs: object) -> tuple[int, bool, frozenset[str]]:
+        called.append("probed")
+        raise AssertionError("empty expansion must not dial the connector")
+
+    monkeypatch.setattr("curie_runner.mcp_tool_capability._probe_server", boom)
+    derived = {
+        "github": {
+            "type": "http",
+            "url": "http://127.0.0.1:9/mcp",
+            "headers": {"Authorization": "Bearer ${GITHUB_TOKEN}"},
+        }
+    }
+    result = anyio.run(probe_mcp_tool_capability, None, derived, {"GITHUB_TOKEN": ""})
+    # getattr so reversing the product files yields AssertionError, not an
+    # import/attribute ERROR the fix-pin gate refuses to attribute.
+    failures = getattr(result, "connector_failures", ())
+    assert called == []
+    assert result.has_potential_write_tool
+    assert failures
+    assert failures[0].connector == "github"
+    assert failures[0].reason == "empty_expansion"
+    assert failures[0].credential_names == ("GITHUB_TOKEN",)
+
+
+def test_missing_credential_skips_http_probe_for_that_derived_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called: list[str] = []
+
+    async def boom(*_args: object, **_kwargs: object) -> tuple[int, bool, frozenset[str]]:
+        called.append("probed")
+        raise AssertionError("missing credential must not dial the connector")
+
+    monkeypatch.setattr("curie_runner.mcp_tool_capability._probe_server", boom)
+    derived = {
+        "github": {
+            "type": "http",
+            "url": "http://127.0.0.1:9/mcp",
+            "headers": {"Authorization": "Bearer ${CURIE_TEST_CONNECTOR_TOKEN}"},
+        }
+    }
+    result = anyio.run(probe_mcp_tool_capability, None, derived, {})
+    assert called == []
+    assert result.connector_failures[0].reason == "missing_credential"
+    assert result.connector_failures[0].credential_names == ("CURIE_TEST_CONNECTOR_TOKEN",)
+
+
+def test_healthy_nonempty_header_still_probes_the_derived_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called: list[str] = []
+
+    async def ok(*_args: object, **_kwargs: object) -> tuple[int, bool, frozenset[str]]:
+        called.append("probed")
+        return 1, True, frozenset()
+
+    monkeypatch.setattr("curie_runner.mcp_tool_capability._probe_server", ok)
+    derived = {
+        "github": {
+            "type": "http",
+            "url": "http://127.0.0.1:9/mcp",
+            "headers": {"Authorization": "Bearer ${GITHUB_TOKEN}"},
+        }
+    }
+    result = anyio.run(
+        probe_mcp_tool_capability,
+        None,
+        derived,
+        {"GITHUB_TOKEN": "ghp-not-a-real-token-PLACEHOLDER"},
+    )
+    assert called == ["probed"]
+    assert result.connector_failures == ()
+    assert result.complete
+    assert result.has_potential_write_tool
+
+
+def test_probe_exception_on_nonempty_expansion_is_probe_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail(*_args: object, **_kwargs: object) -> tuple[int, bool, frozenset[str]]:
+        raise ConnectionError(
+            "dial http://127.0.0.1:9/mcp with Bearer ghp-not-a-real-token-PLACEHOLDER"
+        )
+
+    monkeypatch.setattr("curie_runner.mcp_tool_capability._probe_server", fail)
+    planted = "ghp-not-a-real-token-PLACEHOLDER"
+    derived = {
+        "github": {
+            "type": "http",
+            "url": "http://127.0.0.1:9/mcp",
+            "headers": {"Authorization": "Bearer ${GITHUB_TOKEN}"},
+        }
+    }
+    result = anyio.run(probe_mcp_tool_capability, None, derived, {"GITHUB_TOKEN": planted})
+    assert result.connector_failures[0].reason == "probe_failed"
+    assert result.has_potential_write_tool
+    message = result.connector_failures[0].caller_message()
+    assert planted not in message
+    assert "github" in message
+    assert "GITHUB_TOKEN" in message
+
+
+def test_bundle_config_abort_still_reports_derived_empty_expansion(tmp_path: Path) -> None:
+    root = tmp_path / "bundle"
+    (root / ".claude-plugin").mkdir(parents=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "acme-bot", "mcpServers": "config/servers.json"}),
+        encoding="utf-8",
+    )
+    derived = {
+        "github": {
+            "type": "http",
+            "url": "http://127.0.0.1:9/mcp",
+            "headers": {"Authorization": "Bearer ${GITHUB_TOKEN}"},
+        }
+    }
+    result = anyio.run(probe_mcp_tool_capability, root, derived, {"GITHUB_TOKEN": ""})
+    assert result.failures == ("bundle-config",)
+    assert result.has_potential_write_tool
+    assert result.connector_failures[0].reason == "empty_expansion"
+    assert result.connector_failures[0].connector == "github"
+
+
+def test_bundle_mcp_json_probe_failure_is_not_a_connector_failure(tmp_path: Path) -> None:
+    root = tmp_path / "bundle"
+    (root / ".claude-plugin").mkdir(parents=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "acme-bot"}), encoding="utf-8"
+    )
+    (root / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"operations": {"command": str(root / "missing-server")}}}),
+        encoding="utf-8",
+    )
+
+    result = anyio.run(probe_mcp_tool_capability, root, {}, {})
+    assert result.failures == ("operations",)
+    assert result.connector_failures == ()
+    assert result.has_potential_write_tool
+
+
+def test_caller_message_never_contains_a_planted_secret() -> None:
+    from curie_runner.mcp_tool_capability import ConnectorCapabilityFailure
+
+    failure = ConnectorCapabilityFailure(
+        connector="github",
+        credential_names=("GITHUB_TOKEN",),
+        reason="empty_expansion",
+    )
+    message = failure.caller_message()
+    assert "GITHUB_TOKEN" in message
+    assert "github" in message
+    assert "ghp-" not in message
+    assert "${" not in message

--- a/runner/tests/test_session.py
+++ b/runner/tests/test_session.py
@@ -10,7 +10,8 @@ from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUse
 from curie_runner import RunTracer, SideEffectClassifier, build_options
 from curie_runner import session as session_module
 from curie_runner.fake import FakeModelSession, default_turn
-from curie_runner.session import SessionRunner
+from curie_runner.mcp_tool_capability import ConnectorCapabilityFailure
+from curie_runner.session import CONNECTOR_CAPABILITY_FAILED, SessionRunner
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -1373,3 +1374,104 @@ def test_steer_reaches_live_session() -> None:
 
     anyio.run(go)
     assert fake.queries == ["first", "steered follow-up"]
+
+
+def _connector_failure() -> ConnectorCapabilityFailure:
+    return ConnectorCapabilityFailure(
+        connector="github",
+        credential_names=("GITHUB_TOKEN",),
+        reason="empty_expansion",
+    )
+
+
+def test_declared_connector_failure_short_circuits_every_turn_before_query(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    planted = "ghp-must-not-appear-PLACEHOLDER"
+    fake = FakeModelSession(default_turn)
+    runner = SessionRunner(
+        session_factory=lambda: fake,
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="t",
+        connector_failures=(_connector_failure(),),
+    )
+
+    async def go() -> tuple[list, list]:
+        await runner.start()
+        first = parse_ndjson(
+            "".join(
+                [
+                    line
+                    async for line in runner.run_inbound(
+                        Event(type="message", text="go", user="U", ts="1")
+                    )
+                ]
+            )
+        )
+        second = parse_ndjson(
+            "".join(
+                [
+                    line
+                    async for line in runner.run_inbound(
+                        Event(type="message", text="again", user="U", ts="2")
+                    )
+                ]
+            )
+        )
+        return first, second
+
+    with caplog.at_level(logging.ERROR, logger="curie_runner.session"):
+        first, second = anyio.run(go)
+
+    assert fake.queries == []
+    for events in (first, second):
+        assert [e.type for e in events] == ["error", "final"]
+        assert events[0].classification == CONNECTOR_CAPABILITY_FAILED
+        assert events[0].message == _connector_failure().caller_message()
+        assert events[-1].status == SessionStatus.DONE
+        assert events[-1].text == _connector_failure().caller_message()
+        assert planted not in events[0].message
+        assert planted not in events[-1].text
+    assert any(
+        record.levelno == logging.ERROR
+        and "github" in record.getMessage()
+        and "GITHUB_TOKEN" in record.getMessage()
+        and planted not in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_declared_connector_failure_does_not_abandon_the_otel_span() -> None:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    fake = FakeModelSession(default_turn)
+    runner = SessionRunner(
+        session_factory=lambda: fake,
+        ceiling=0,
+        tracer=RunTracer(provider),
+        classifier=SideEffectClassifier(),
+        trace_name="t",
+        connector_failures=(_connector_failure(),),
+    )
+
+    async def go() -> None:
+        await runner.start()
+        async for _line in runner.run_inbound(Event(type="message", text="go", user="U", ts="1")):
+            pass
+        await runner.close()
+
+    anyio.run(go)
+    root = _span_named(list(exporter.get_finished_spans()), "agent.run")[0]
+    assert root.attributes["curie.terminal.cause"] == "completed"
+    assert root.attributes["curie.terminal.status"] == "succeeded"
+    assert fake.queries == []
+
+
+def test_healthy_connector_still_queries_the_model() -> None:
+    runner, fake = _runner()
+    events = _drain(runner, Event(type="message", text="go", user="U", ts="1"))
+    assert fake.queries == ["go"]
+    assert events[-1].status == SessionStatus.DONE

--- a/tests/vectors/connector-probe-diagnosis.json
+++ b/tests/vectors/connector-probe-diagnosis.json
@@ -1,0 +1,53 @@
+{
+  "comment": "Expansion diagnosis for a declared connector's MCP header placeholders (#2519). The runner owns diagnose_derived_connector_headers in runner/src/curie_runner/mcp_tool_capability.py. The Rust CLI cannot share that function, so this vector is the seam: header templates plus env presence/emptiness map to a reason enum, credential NAMES, and the exact caller sentence. Changing a rule here without changing the runner fails the Python loop in runner/tests/test_connector_probe_diagnosis.py. #2352 may implement the same expansion diagnosis against this file; it must not add a second HTTP MCP capability probe at deploy time. #2352 still owns deploy-time hosted readiness vs mounted declaration. expected is names and reasons only -- never a secret VALUE. Both the Python loop and any later Rust loop must reject unknown fields so a key one lane cannot see cannot pass vacuously.",
+  "vectors": [
+    {
+      "name": "empty_bearer_expansion",
+      "connector": "github",
+      "headers": {"Authorization": "Bearer ${GITHUB_TOKEN}"},
+      "env": {"GITHUB_TOKEN": ""},
+      "expected_reason": "empty_expansion",
+      "expected_credentials": ["GITHUB_TOKEN"],
+      "expected_message": "declared connector 'github' failed MCP capability probe: credential GITHUB_TOKEN expanded empty. Connector tools are unavailable."
+    },
+    {
+      "name": "whitespace_bearer_expansion",
+      "connector": "github",
+      "headers": {"Authorization": "Bearer ${GITHUB_TOKEN}"},
+      "env": {"GITHUB_TOKEN": "  "},
+      "expected_reason": "empty_expansion",
+      "expected_credentials": ["GITHUB_TOKEN"],
+      "expected_message": "declared connector 'github' failed MCP capability probe: credential GITHUB_TOKEN expanded empty. Connector tools are unavailable."
+    },
+    {
+      "name": "missing_env_var",
+      "connector": "github",
+      "headers": {"Authorization": "Bearer ${GITHUB_TOKEN}"},
+      "env": {},
+      "expected_reason": "missing_credential",
+      "expected_credentials": ["GITHUB_TOKEN"],
+      "expected_message": "declared connector 'github' failed MCP capability probe: credential GITHUB_TOKEN is not set in the sandbox. Connector tools are unavailable."
+    },
+    {
+      "name": "healthy_nonempty",
+      "connector": "github",
+      "headers": {"Authorization": "Bearer ${GITHUB_TOKEN}"},
+      "env": {"GITHUB_TOKEN": "ghp-not-a-real-token-PLACEHOLDER"},
+      "expected_reason": null,
+      "expected_credentials": [],
+      "expected_message": null
+    },
+    {
+      "name": "empty_does_not_echo_other_env",
+      "connector": "github",
+      "headers": {"Authorization": "Bearer ${GITHUB_TOKEN}"},
+      "env": {
+        "GITHUB_TOKEN": "",
+        "PLANTED_SECRET": "must-not-appear-PLACEHOLDER"
+      },
+      "expected_reason": "empty_expansion",
+      "expected_credentials": ["GITHUB_TOKEN"],
+      "expected_message": "declared connector 'github' failed MCP capability probe: credential GITHUB_TOKEN expanded empty. Connector tools are unavailable."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

A declared connector whose `Authorization: Bearer ${NAME}` placeholder expands empty (or whose capability probe fails) no longer stays a log line. The runner diagnoses the connector and credential name, skips dialing `/mcp` with an empty Bearer, and short-circuits every turn before the model runs so the agent cannot answer from memory. The caller sees the diagnosis as the turn text. Secret values never appear in that text or in the new error log.

SecretRef credential delivery and ADR-0090 are unchanged. How a `from_secret` value reaches the sandbox, if at all, remains on #2519.

#2352 should reuse `tests/vectors/connector-probe-diagnosis.json` for expansion diagnosis and must not add a second HTTP MCP capability probe at deploy time. Deploy-time hosted readiness versus mounted declaration stays #2352.

Sibling: worker `kernel.py` is not edited. ErrorEvent plus a DONE final is the path that posts `Final.text` to Slack and `curie cluster message`. Classified-failure would be overwritten by the escalate copy.

## Related issue

Refs #2519
Refs #2503
Refs #2352

## Fix pin verification

Fix pin: runner/tests/test_connector_probe_diagnosis.py::test_empty_expansion_skips_http_probe_for_that_derived_server

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | required | Runner ACI `/v1/event` is the diagnosis surface | fake | Commit `d259e7906`. In-process `create_app` POST `/v1/event` with empty-expansion failure: `FAIL_PROBE_OK declared connector 'github' failed MCP capability probe: credential GITHUB_TOKEN expanded empty. Connector tools are unavailable.` Fake model queries stayed `[]`. Healthy connector: `HEALTHY_OK queries= ['hi'] final_status= done`. Negative: derived server with no headers produced no failure (`NO_HEADER_NEGATIVE_OK`). |
| local | required | Worker DONE path posts `Final.text` | fake | Commit `d259e7906`. `TEST_VALKEY_PORT=36379 uv run pytest apps/worker/tests/kernel/test_kernel.py::test_connector_capability_failed_done_posts_diagnosis_not_escalate` passed. Observed: sink text is the diagnosis, no escalate, one attempt. Negative: existing `test_budget_exceeded_escalates_without_retry` still posts the human-flag copy for classified-failure. |
| local-release | n/a | No released-binary identity, install path, or release-compose pin change | | |
| cluster | n/a | Change does not reach chart templates, RBAC, sandbox claims, or init containers. Empty-expansion diagnosis runs inside the runner from headers plus env on every tier that mounts a derived server. | | |
| live provider | n/a | Does not change MCP catalog projection, tool mounting, model routing, or coding-tool capability. Diagnosis is local header-placeholder versus env inspection. | | |
| external integration | n/a | Does not change Slack, git webhooks, or connector OAuth. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Checklist

- Diagnostic slice only; SecretRef delivery left on #2519
- No frozen aci-protocol, plugin-format, schema, or ADR changes
- `kernel.py` untouched
