### PR TITLE
Expose the bot-thread allowlist as a validated first-class Helm value

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -26,6 +26,13 @@ on:
       - "apps/api/src/curie_api/storage.py"
       - "apps/worker/src/curie_worker/config.py"
       - "apps/worker/src/curie_worker/bundle_store.py"
+      # Same obligation, second gate: the threaded bot allowlist gate (#2437)
+      # executes this file to prove the rendered value survives the REAL
+      # ThreadedBotAdmission parser. Without it here, a PR that reverts or
+      # loosens that model matches nothing in this filter, the helm job is
+      # skipped, and the gate that exists to catch exactly that revert
+      # never runs.
+      - "apps/dispatcher/src/curie_dispatcher/config.py"
       - "uv.lock"
       - "pyproject.toml"
       # The unpinned-image gate (#2319) and the Langfuse image-pin gate
@@ -584,6 +591,17 @@ jobs:
         run: |
           set -euo pipefail
           bash charts/curie/ci/object-store-web-identity-assertions.sh
+
+      # Prove the first-class bot-thread allowlist (#2437) renders a value the
+      # REAL dispatcher parser accepts, not a hand-copied regex: the rendered
+      # env string is fed through curie_dispatcher.config.DispatcherConfig, so a
+      # future drift in ThreadedBotAdmission breaks this chart gate. Needs the
+      # uv workspace above, which is why it sits here rather than beside the
+      # other reserved-env assertions earlier in this job.
+      - name: helm render assertions (threaded bot allowlist)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/threaded-bot-allowlist-assertions.sh
 
       # Prove a BYO object store gets a runner egress allow for S3 (and STS on
       # the key-free path). Rail 1 is fail-closed and the in-chart rustfs pod

--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -87,10 +87,10 @@ for that pair. All unlisted bot/channel pairs retain the default refusal.
 Remove the pair and restart the dispatcher to revoke threaded admission.
 
 Compose forwards this variable in both dev and generated release stacks. Helm
-operators can set the same variable with `dispatcher.extraEnv`; no new chart
-value is required. Runtime Slack proof requires an installed sender app and
-live delivery; the Bolt/Valkey tests alone do not establish that Slack delivered
-or that the worker answered.
+operators should prefer the first-class `dispatcher.threadedBotAllowlist` chart
+value; `dispatcher.extraEnv` still works as well. Runtime Slack proof requires
+an installed sender app and live delivery; the Bolt/Valkey tests alone do not
+establish that Slack delivered or that the worker answered.
 
 ## The queue seam (what the worker consumes)
 

--- a/charts/curie/ci/threaded-bot-allowlist-assertions.sh
+++ b/charts/curie/ci/threaded-bot-allowlist-assertions.sh
@@ -1,0 +1,471 @@
+#!/usr/bin/env bash
+# Exercise the first-class dispatcher.threadedBotAllowlist value (#2437):
+# render controls, render-time refusals, a removed-guard duplicate control, the
+# fresh and --is-upgrade paths, and a round trip of the EXACT rendered string
+# through the real dispatcher parser.
+set -euo pipefail
+CHART="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$CHART/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+python3 - "$CHART" "$WORK" <<'PY'
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+
+import yaml
+
+chart = pathlib.Path(sys.argv[1])
+work = pathlib.Path(sys.argv[2])
+
+NAME = "CURIE_SLACK_THREADED_BOT_ALLOWLIST"
+# Fixture ids use the sanctioned placeholder shape (apps/dispatcher/README.md:72).
+# This repo's gitleaks configuration flags realistic-looking Slack ids, so never
+# substitute a plausible one here or in a comment.
+CHANNEL, CHANNEL_2 = "C0EXAMPLE1", "C0EXAMPLE2"
+BOT, BOT_2 = "B0EXAMPLE1", "B0EXAMPLE2"
+GROUP = "G0EXAMPLE1"
+DM = "D0EXAMPLE1"
+
+# A bare `helm template charts/curie` renders almost nothing: the dispatcher is
+# gated behind curie.dispatcher.enabled. Same base shape as
+# ci/reserved-env-assertions.sh.
+base = {
+    "dispatcher": {"slack": {"appToken": "xapp-example", "botToken": "xoxb-example"}},
+    "agentSandbox": {"runner": {"credentials": "example", "workspace": {"enabled": True}}},
+}
+values = work / "values.yaml"
+values.write_text(yaml.safe_dump(base))
+
+
+def dispatcher_values(**overrides):
+    """base values with extra dispatcher keys merged in, without mutating base."""
+    return {**base, "dispatcher": {**base["dispatcher"], **overrides}}
+
+
+def helm_escape(value):
+    """helm's --set/--set-string data parser splits on unescaped commas."""
+    return value.replace(",", "\\,")
+
+
+# An operator already on the OLD shape: dispatcher.extraEnv carries the variable
+# and there is NO threadedBotAllowlist key at all. This is what `helm get values`
+# returns for such a release, and it is the input for the --is-upgrade path.
+OPERATOR_VALUE = json.dumps([{"channel_id": CHANNEL, "bot_id": BOT}], separators=(",", ":"))
+# helm's --set/--set-string parser splits its data on UNESCAPED commas, so a
+# JSON value like OPERATOR_VALUE (which contains one) blows up argument
+# parsing before the chart ever renders. Escape the comma(s) ONLY in what we
+# hand to helm on the command line; the expected/asserted value stays the
+# real, unescaped JSON string, since the whole point of these cases is that
+# the operator's string reaches the rendered env verbatim.
+OPERATOR_SET = helm_escape(OPERATOR_VALUE)
+legacy = dispatcher_values(extraEnv=[{"name": NAME, "value": OPERATOR_VALUE}])
+legacy_values = work / "legacy-retained.yaml"
+legacy_values.write_text(yaml.safe_dump(legacy))
+
+count = 0
+
+
+def render(*args, source=None, values_file=None, ok=True):
+    """One `helm template` into its own output dir. Mirrors reserved-env-assertions.sh."""
+    global count
+    count += 1
+    output = work / str(count)
+    result = subprocess.run(
+        [
+            "helm", "template", "acme", str(source or chart),
+            "-f", str(values_file or values),
+            "--output-dir", str(output),
+            *args,
+        ],
+        text=True,
+        capture_output=True,
+    )
+    if ok:
+        assert result.returncode == 0, f"expected a successful render, got:\n{result.stderr}"
+    return result, output
+
+
+def envs(output):
+    """The dispatcher container's env list out of the rendered Deployment."""
+    docs = yaml.safe_load_all((output / "curie/templates/dispatcher.yaml").read_text())
+
+    def walk(value):
+        if isinstance(value, dict):
+            if value.get("name") == "dispatcher" and "env" in value:
+                yield value["env"]
+            for child in value.values():
+                yield from walk(child)
+        elif isinstance(value, list):
+            for child in value:
+                yield from walk(child)
+
+    return next(env for doc in docs for env in walk(doc))
+
+
+def allowlist_entries(output):
+    return [entry for entry in envs(output) if entry["name"] == NAME]
+
+
+def others(output):
+    """Every env entry that is NOT the allowlist, for byte-identity comparisons."""
+    return [entry for entry in envs(output) if entry["name"] != NAME]
+
+
+def refuse(label, *args, expected, values_file=None):
+    """A render that must FAIL, and must fail with the plan's message text.
+
+    Asserting the message, not just the exit code, is what keeps these controls
+    non-vacuous: against a chart with no validation the render SUCCEEDS and the
+    first assertion fires with the entries it wrongly produced.
+    """
+    result, output = render(*args, values_file=values_file, ok=False)
+    if result.returncode == 0:
+        rendered = allowlist_entries(output)
+        raise AssertionError(
+            f"{label}: helm template SUCCEEDED but the entry is malformed and must be "
+            f"refused at render. Rendered {NAME} entries: {rendered!r}"
+        )
+    for text in expected:
+        assert text in result.stderr, (
+            f"{label}: expected stderr to contain {text!r}\n--- actual stderr ---\n{result.stderr}"
+        )
+    return result
+
+
+# --- T1: empty default omits everything (AC 1, D1) --------------------------
+_, baseline = render()
+baseline_env = envs(baseline)
+assert allowlist_entries(baseline) == [], (
+    f"T1: default render must emit no {NAME} entry; got {allowlist_entries(baseline)!r}"
+)
+baseline_names = [entry["name"] for entry in baseline_env]
+assert NAME not in baseline_names, f"T1: {NAME} present in {baseline_names!r}"
+
+# --- D2: an explicit null takes the same omit branch (nil-safety) -----------
+_, nil_render = render("--set", "dispatcher.threadedBotAllowlist=null")
+assert envs(nil_render) == baseline_env, (
+    "D2: --set dispatcher.threadedBotAllowlist=null must render byte-identically to the "
+    f"default.\nexpected: {baseline_env!r}\nrendered: {envs(nil_render)!r}"
+)
+
+# --- T2: a configured pair renders parseable JSON (AC 2, D3) ----------------
+_, configured = render(
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].channel_id={CHANNEL}",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].bot_id={BOT}",
+)
+entries = allowlist_entries(configured)
+assert len(entries) == 1, f"T2: expected exactly one {NAME} entry, got {entries!r}"
+rendered_value = entries[0]["value"]
+# Compare DECODED objects: the template's toJson emits Go's alphabetical key
+# order, which the parser does not care about and a string compare would.
+assert json.loads(rendered_value) == [{"channel_id": CHANNEL, "bot_id": BOT}], (
+    f"T2: expected [{{'channel_id': {CHANNEL!r}, 'bot_id': {BOT!r}}}], "
+    f"rendered {rendered_value!r}"
+)
+assert others(configured) == baseline_env, (
+    "T2: configuring the allowlist must not disturb any other dispatcher env entry.\n"
+    f"expected: {baseline_env!r}\nrendered: {others(configured)!r}"
+)
+# Hand the EXACT rendered string, never a reconstruction, to the bash half for
+# the real-parser round trip (D4).
+(work / "rendered-value.txt").write_text(rendered_value)
+(work / "expected-pairs.json").write_text(json.dumps([{"channel_id": CHANNEL, "bot_id": BOT}]))
+
+# --- T2b: two pairs, order preserved ----------------------------------------
+_, two = render(
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].channel_id={CHANNEL}",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].bot_id={BOT}",
+    "--set-string", f"dispatcher.threadedBotAllowlist[1].channel_id={CHANNEL_2}",
+    "--set-string", f"dispatcher.threadedBotAllowlist[1].bot_id={BOT_2}",
+)
+two_entries = allowlist_entries(two)
+assert len(two_entries) == 1, f"T2b: expected exactly one {NAME} entry, got {two_entries!r}"
+assert json.loads(two_entries[0]["value"]) == [
+    {"channel_id": CHANNEL, "bot_id": BOT},
+    {"channel_id": CHANNEL_2, "bot_id": BOT_2},
+], f"T2b: both pairs must survive in values order; rendered {two_entries[0]['value']!r}"
+
+# --- T2c: a G-prefixed (group/MPIM) channel_id is accepted (regex `[CG]`) ---
+_, grouped = render(
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].channel_id={GROUP}",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].bot_id={BOT}",
+)
+grouped_entries = allowlist_entries(grouped)
+assert len(grouped_entries) == 1, f"T2c: expected exactly one {NAME} entry, got {grouped_entries!r}"
+assert json.loads(grouped_entries[0]["value"]) == [{"channel_id": GROUP, "bot_id": BOT}], (
+    f"T2c: a G-prefixed channel_id must render and decode; rendered {grouped_entries[0]['value']!r}"
+)
+
+# --- T3: extraEnv-only still works, verbatim (AC 4, D8) ---------------------
+_, passthrough = render(
+    "--set", f"dispatcher.extraEnv[0].name={NAME}",
+    "--set-string", f"dispatcher.extraEnv[0].value={OPERATOR_SET}",
+)
+assert allowlist_entries(passthrough) == [{"name": NAME, "value": OPERATOR_VALUE}], (
+    "T3: an existing dispatcher.extraEnv entry must pass through verbatim while the "
+    f"typed value is empty; got {allowlist_entries(passthrough)!r}"
+)
+assert others(passthrough) == baseline_env, "T3: extraEnv must not disturb the rest of env"
+
+# --- T3b: extraEnv passthrough is not retroactively validated ---------------
+_, unvalidated = render(
+    "--set", f"dispatcher.extraEnv[0].name={NAME}",
+    "--set-string", "dispatcher.extraEnv[0].value=not-json",
+)
+assert allowlist_entries(unvalidated) == [{"name": NAME, "value": "not-json"}], (
+    "T3b: the chart must not police a value it does not own; got "
+    f"{allowlist_entries(unvalidated)!r}"
+)
+
+# --- N1..N9: every malformed shape fails the RENDER (AC 3, D6) --------------
+WHERE = "dispatcher.threadedBotAllowlist[0]"
+refuse(
+    "N1 missing key",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].channel_id={CHANNEL}",
+    expected=[WHERE, "must have exactly the keys channel_id and bot_id"],
+)
+refuse(
+    "N2 extra key",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].channel_id={CHANNEL}",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].bot_id={BOT}",
+    "--set-string", "dispatcher.threadedBotAllowlist[0].note=x",
+    expected=[WHERE, "must have exactly the keys channel_id and bot_id", "note"],
+)
+refuse(
+    "N3 channel_id regex miss",
+    "--set-string", "dispatcher.threadedBotAllowlist[0].channel_id=lowercase",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].bot_id={BOT}",
+    expected=[f"{WHERE}.channel_id", "does not match ^[CG][A-Z0-9]+$"],
+)
+refuse(
+    "N4 bot_id regex miss",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].channel_id={CHANNEL}",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].bot_id={CHANNEL}",
+    expected=[f"{WHERE}.bot_id", "does not match ^B[A-Z0-9]+$"],
+)
+refuse(
+    "N5 non-mapping entry",
+    "--set-string", "dispatcher.threadedBotAllowlist[0]=oops",
+    expected=[WHERE, "must be a mapping"],
+)
+# N6: a non-string scalar. This is why the kindIs "string" checks exist and are
+# not redundant with the regexes -- regexMatch on a non-string is not safe.
+refuse(
+    "N6 non-string scalar",
+    "--set", "dispatcher.threadedBotAllowlist[0].channel_id=123",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].bot_id={BOT}",
+    expected=[f"{WHERE}.channel_id", "must be a string"],
+)
+refuse(
+    "N7 empty-string value (CLI form lands on the exactly-keys branch, not the "
+    "regex branch -- helm drops a key --set-string'd to empty, per the comment "
+    "in the template)",
+    "--set-string", "dispatcher.threadedBotAllowlist[0].channel_id=",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].bot_id={BOT}",
+    expected=[WHERE, "must have exactly the keys channel_id and bot_id", "got [bot_id]"],
+)
+# N7b: the SAME empty channel_id, but supplied through a values file, where
+# helm does NOT drop the key -- this is the case that actually pins the regex
+# branch against an empty string, rather than re-landing on N7's exactly-keys
+# branch by accident.
+empty_channel_values = work / "empty-channel.yaml"
+empty_channel_values.write_text(
+    yaml.safe_dump(
+        dispatcher_values(threadedBotAllowlist=[{"channel_id": "", "bot_id": BOT}])
+    )
+)
+refuse(
+    "N7b empty-string channel_id via values file reaches the regex branch",
+    values_file=empty_channel_values,
+    expected=[f'{WHERE}.channel_id ""', "does not match ^[CG][A-Z0-9]+$"],
+)
+# N8: both paths naming the variable -> refusal, for an extraEnv value both
+# EQUAL to and DIFFERENT from the rendered JSON. The #2297 lesson is that equal
+# values also break strategic merge patches, so equality is not an escape hatch.
+for label, operator_value in (("equal", OPERATOR_VALUE), ("different", "[]")):
+    # Escape commas the same way as OPERATOR_SET above -- "different" ([]) has
+    # none, so this is a no-op there, but "equal" carries the same comma bug.
+    operator_set = helm_escape(operator_value)
+    refuse(
+        f"N8 both paths set ({label} value)",
+        "--set-string", f"dispatcher.threadedBotAllowlist[0].channel_id={CHANNEL}",
+        "--set-string", f"dispatcher.threadedBotAllowlist[0].bot_id={BOT}",
+        "--set", f"dispatcher.extraEnv[0].name={NAME}",
+        "--set-string", f"dispatcher.extraEnv[0].value={operator_set}",
+        expected=["dispatcher.extraEnv", NAME, "dispatcher.threadedBotAllowlist"],
+    )
+# N9: the malformed entry sits at index [1] behind a valid [0]. Guards against a
+# validator that only ever inspects the first entry.
+refuse(
+    "N9 malformed second index",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].channel_id={CHANNEL}",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].bot_id={BOT}",
+    "--set-string", "dispatcher.threadedBotAllowlist[1].channel_id=lowercase",
+    "--set-string", f"dispatcher.threadedBotAllowlist[1].bot_id={BOT_2}",
+    expected=["dispatcher.threadedBotAllowlist[1].channel_id", "does not match ^[CG][A-Z0-9]+$"],
+)
+# N10/N11: a bare one-character id. Pins `+` (one-or-more) against a `*`
+# (zero-or-more) mutant of either regex -- no other fixture uses a
+# single-character id, so `*` would otherwise still pass every case here.
+refuse(
+    "N10 bare single-character channel_id",
+    "--set-string", "dispatcher.threadedBotAllowlist[0].channel_id=C",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].bot_id={BOT}",
+    expected=[f"{WHERE}.channel_id", "does not match ^[CG][A-Z0-9]+$"],
+)
+refuse(
+    "N11 bare single-character bot_id",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].channel_id={CHANNEL}",
+    "--set-string", "dispatcher.threadedBotAllowlist[0].bot_id=B",
+    expected=[f"{WHERE}.bot_id", "does not match ^B[A-Z0-9]+$"],
+)
+# N12: a D-prefixed id (Slack DM) must be refused. Pins the channel class
+# against a broadened `^[A-Z][A-Z0-9]+$` mutant -- every existing fixture only
+# ever exercises a lowercase failure, which a broadened class still catches,
+# so this is the only case that pins the class down to exactly `[CG]`.
+refuse(
+    "N12 D-prefixed (DM) channel_id",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].channel_id={DM}",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].bot_id={BOT}",
+    expected=[f"{WHERE}.channel_id", "does not match ^[CG][A-Z0-9]+$"],
+)
+# N13: the wrong-type top-level case for a MAP instead of a list. `range`
+# yields the map KEY as the loop index, so this also pins the %v verb fix --
+# a %d verb here mangles the message instead of naming the key cleanly.
+wrong_type_values = work / "wrong-type.yaml"
+wrong_type_values.write_text(
+    yaml.safe_dump(dispatcher_values(threadedBotAllowlist={"oops": "value"}))
+)
+refuse(
+    "N13 threadedBotAllowlist supplied as a map, not a list",
+    values_file=wrong_type_values,
+    expected=["dispatcher.threadedBotAllowlist[oops]", "must be a mapping"],
+)
+
+# --- D9: the upgrade path for an operator still on the old shape (AC 4) -----
+_, upgraded = render("--is-upgrade", values_file=legacy_values)
+assert allowlist_entries(upgraded) == [{"name": NAME, "value": OPERATOR_VALUE}], (
+    "D9: a retained legacy values file with no threadedBotAllowlist key must render the "
+    f"operator's single verbatim entry under --is-upgrade; got {allowlist_entries(upgraded)!r}"
+)
+# D7: the refusals are not fresh-install-only.
+refuse(
+    "D7 upgrade refuses a malformed entry",
+    "--is-upgrade",
+    "--set-string", "dispatcher.threadedBotAllowlist[0].channel_id=lowercase",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].bot_id={BOT}",
+    values_file=legacy_values,
+    expected=[f"{WHERE}.channel_id", "does not match ^[CG][A-Z0-9]+$"],
+)
+refuse(
+    "D7 upgrade refuses both paths set",
+    "--is-upgrade",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].channel_id={CHANNEL}",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].bot_id={BOT}",
+    values_file=legacy_values,
+    expected=["dispatcher.extraEnv", NAME, "dispatcher.threadedBotAllowlist"],
+)
+
+# --- D12: removed-guard mutation control ------------------------------------
+# Force the gate true while leaving the reservation empty. If the reservation is
+# what makes one entry structurally guaranteed -- rather than luck -- the mutant
+# renders TWO entries for the name.
+mutant = work / "mutant"
+shutil.copytree(chart, mutant)
+template = mutant / "templates/dispatcher.yaml"
+text = template.read_text()
+gate = "{{- if .Values.dispatcher.threadedBotAllowlist }}"
+assert text.count(gate) == 1, (
+    "D12: expected exactly one occurrence of the gate\n"
+    f"  {gate}\nin templates/dispatcher.yaml; found {text.count(gate)}"
+)
+template.write_text(text.replace(gate, "{{- if true }}"))
+reservation = '{{- $threadedReserved = dict "CURIE_SLACK_THREADED_BOT_ALLOWLIST" "dispatcher.threadedBotAllowlist" -}}'
+mutant_text = template.read_text()
+assert mutant_text.count(reservation) == 1, (
+    "D12: expected exactly one reservation assignment\n"
+    f"  {reservation}\nin templates/dispatcher.yaml; found {mutant_text.count(reservation)}"
+)
+template.write_text(mutant_text.replace(reservation, ""))
+_, mutant_output = render(
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].channel_id={CHANNEL}",
+    "--set-string", f"dispatcher.threadedBotAllowlist[0].bot_id={BOT}",
+    "--set", f"dispatcher.extraEnv[0].name={NAME}",
+    "--set-string", "dispatcher.extraEnv[0].value=[]",
+    source=mutant,
+)
+duplicates = allowlist_entries(mutant_output)
+assert len(duplicates) == 2 and duplicates[1]["value"] == "[]", (
+    "D12: with the reservation removed the mutant must emit TWO entries for "
+    f"{NAME} (that is what the reservation prevents); got {duplicates!r}"
+)
+
+print(f"OK: {count} Helm renders; empty/null omit, configured pairs encode, extraEnv passes "
+      "through verbatim, every malformed shape and both-paths-set refused on fresh and "
+      "--is-upgrade renders, removed-reservation control reproduced two entries")
+PY
+
+# Round-trip the EXACT rendered string through the REAL dispatcher parser (D4).
+# Re-implementing ThreadedBotAdmission's regexes here and checking the template
+# against our own copy would prove nothing about drift; running the value through
+# curie_dispatcher.config.DispatcherConfig means a change to the model or to the
+# NoDecode/_decode_threaded_bot_allowlist env decoding breaks this chart gate.
+# `uv run` must start from the repo root: apps/dispatcher is a workspace member,
+# while this script's own paths are relative to $CHART.
+(
+  cd "$REPO_ROOT"
+  uv run --python 3.13 python - "$WORK/rendered-value.txt" "$WORK/expected-pairs.json" <<'PY'
+import json
+import os
+import sys
+
+# Any ambient CURIE_* on a developer box or CI runner would otherwise decide
+# this gate instead of the chart.
+for key in [key for key in os.environ if key.startswith("CURIE_")]:
+    del os.environ[key]
+
+NAME = "CURIE_SLACK_THREADED_BOT_ALLOWLIST"
+rendered = open(sys.argv[1]).read()
+expected_pairs = json.load(open(sys.argv[2]))
+
+# DispatcherConfig._require_independent_chat_attester rejects a blank attester
+# secret and one equal to the API key, so without these two distinct non-empty
+# placeholders every run here would fail for a reason unrelated to the allowlist.
+os.environ["CURIE_API_KEY"] = "example-api-key"
+os.environ["CURIE_APPROVAL_CHAT_ATTESTER_SECRET"] = "example-attester-secret"
+
+from pydantic import ValidationError
+
+from curie_dispatcher.config import DispatcherConfig, ThreadedBotAdmission
+
+os.environ[NAME] = rendered
+config = DispatcherConfig()
+expected = tuple(ThreadedBotAdmission(**pair) for pair in expected_pairs)
+assert config.slack_threaded_bot_allowlist == expected, (
+    f"the rendered string {rendered!r} parsed to "
+    f"{config.slack_threaded_bot_allowlist!r}, expected {expected!r}"
+)
+
+# The negative direction: the template's exact-keys rule and the parser's
+# extra="forbid" must be the SAME rule, so a payload the template would never
+# emit has to be rejected here. If someone relaxes extra="forbid", this fails.
+unknown_key = json.dumps([dict(expected_pairs[0], note="x")])
+os.environ[NAME] = unknown_key
+try:
+    DispatcherConfig()
+except ValidationError:
+    pass
+else:
+    raise AssertionError(
+        f"the real parser ACCEPTED {unknown_key!r}; ThreadedBotAdmission must stay "
+        'extra="forbid" or the template\'s exact-keys validation is no longer the same rule'
+    )
+
+print(f"OK: rendered {rendered!r} parsed by the real DispatcherConfig into {expected!r}; "
+      "unknown-key payload rejected by that same parser")
+PY
+)

--- a/charts/curie/templates/_threaded-bot-allowlist.tpl
+++ b/charts/curie/templates/_threaded-bot-allowlist.tpl
@@ -1,0 +1,42 @@
+{{/* Validate dispatcher.threadedBotAllowlist against the dispatcher's own
+     ThreadedBotAdmission contract and encode it as the JSON array
+     CURIE_SLACK_THREADED_BOT_ALLOWLIST carries. Fail at RENDER, not pod start.
+     Rebuild each entry rather than re-serializing the operator's map, so an
+     unknown key can never reach the wire even if the shape check is loosened.
+
+     Source of truth for both regexes and for the exactly-two-keys rule:
+     apps/dispatcher/src/curie_dispatcher/config.py::ThreadedBotAdmission
+     (extra="forbid"). They are duplicated here on purpose so a malformed entry
+     is refused by `helm upgrade` instead of crash-looping the dispatcher; the
+     duplication is pinned against drift by
+     charts/curie/ci/threaded-bot-allowlist-assertions.sh, which feeds the
+     rendered string through that real parser. */}}
+{{- define "curie.dispatcher.threadedBotAllowlist" -}}
+{{- $normalized := list -}}
+{{- range $i, $entry := .Values.dispatcher.threadedBotAllowlist -}}
+{{- $where := printf "dispatcher.threadedBotAllowlist[%v]" $i -}}
+{{- if not (kindIs "map" $entry) -}}
+{{- fail (printf "%s must be a mapping with exactly channel_id and bot_id; got %s." $where (kindOf $entry)) -}}
+{{- end -}}
+{{- $names := keys $entry | sortAlpha -}}
+{{- if ne (join "," $names) "bot_id,channel_id" -}}
+{{/* Name both full paths: helm DROPS a key set to an empty value (`--set-string
+     ...channel_id=` on helm 3.20.0 leaves the key absent, not empty), so this
+     branch -- not the regex below -- is where a blanked field lands, and the
+     operator needs to see which field it was. */}}
+{{- fail (printf "%s must have exactly the keys channel_id and bot_id (%s.channel_id and %s.bot_id); got [%s]." $where $where $where (join " " $names)) -}}
+{{- end -}}
+{{- $channel := get $entry "channel_id" -}}
+{{- $bot := get $entry "bot_id" -}}
+{{- if not (kindIs "string" $channel) -}}{{- fail (printf "%s.channel_id must be a string." $where) -}}{{- end -}}
+{{- if not (kindIs "string" $bot) -}}{{- fail (printf "%s.bot_id must be a string." $where) -}}{{- end -}}
+{{- if not (regexMatch "^[CG][A-Z0-9]+$" $channel) -}}
+{{- fail (printf "%s.channel_id %q does not match ^[CG][A-Z0-9]+$ (apps/dispatcher ThreadedBotAdmission)." $where $channel) -}}
+{{- end -}}
+{{- if not (regexMatch "^B[A-Z0-9]+$" $bot) -}}
+{{- fail (printf "%s.bot_id %q does not match ^B[A-Z0-9]+$ (apps/dispatcher ThreadedBotAdmission)." $where $bot) -}}
+{{- end -}}
+{{- $normalized = append $normalized (dict "channel_id" $channel "bot_id" $bot) -}}
+{{- end -}}
+{{- toJson $normalized -}}
+{{- end -}}

--- a/charts/curie/templates/dispatcher.yaml
+++ b/charts/curie/templates/dispatcher.yaml
@@ -93,7 +93,18 @@ spec:
             # app cannot drift.
             - name: CURIE_HEARTBEAT_FILE
               value: /tmp/curie-dispatcher.heartbeat
-            {{- include "curie.extraEnv" (dict "root" . "workload" "dispatcher" "env" .Values.dispatcher.extraEnv) | nindent 12 }}
+            {{- $threadedReserved := dict -}}
+            {{- if .Values.dispatcher.threadedBotAllowlist }}
+            # First-class allowlist (#2437). Rendered ONLY when the typed value is
+            # non-empty; the chart then owns the name for this render, so the
+            # #2297 guard below refuses a dispatcher.extraEnv entry that also
+            # names it. An empty value renders nothing and reserves nothing, so a
+            # pre-existing extraEnv entry keeps working unchanged.
+            - name: CURIE_SLACK_THREADED_BOT_ALLOWLIST
+              value: {{ include "curie.dispatcher.threadedBotAllowlist" . | quote }}
+            {{- $threadedReserved = dict "CURIE_SLACK_THREADED_BOT_ALLOWLIST" "dispatcher.threadedBotAllowlist" -}}
+            {{- end }}
+            {{- include "curie.extraEnv" (dict "root" . "workload" "dispatcher" "env" .Values.dispatcher.extraEnv "additionalReserved" $threadedReserved) | nindent 12 }}
           # No HTTP port on the dispatcher (Slack Socket Mode is outbound-only),
           # so an exec probe checks a heartbeat file a background daemon thread
           # touches each tick. The dispatcher blocks the main thread in

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -1304,9 +1304,48 @@ dispatcher:
   resources:
     requests: { cpu: 50m, memory: 128Mi }
     limits: { cpu: 500m, memory: 256Mi }
+  # Bots allowed to mention the agent from inside a channel THREAD, as exact
+  # {channel_id, bot_id} pairs -- the same wire contract
+  # CURIE_SLACK_THREADED_BOT_ALLOWLIST has always carried, now typed and
+  # validated by the chart instead of hand-encoded JSON. Example:
+  #   threadedBotAllowlist:
+  #     - channel_id: C0EXAMPLE1
+  #       bot_id: B0EXAMPLE1
+  # There is no wildcard and no cross product: one pair admits one bot in one
+  # channel.
+  #
+  # EMPTY (the default) renders NO env at all, which is byte-identical to the
+  # behavior before this key existed and is the fail-closed production posture:
+  # every bot-authored thread mention is refused as BOT_AUTHORED_THREAD_REPLY.
+  #
+  # Entries are validated AT RENDER, not at pod start, so a typo fails
+  # `helm upgrade` rather than crash-looping the dispatcher: channel_id must
+  # match ^[CG][A-Z0-9]+$, bot_id must match ^B[A-Z0-9]+$, both must be strings,
+  # and exactly those two keys are accepted -- no more and no fewer -- because
+  # the dispatcher's ThreadedBotAdmission model is extra="forbid" and would
+  # reject anything else at boot.
+  #
+  # PRECEDENCE, in both directions. While this list is NON-EMPTY the chart owns
+  # the variable, and a dispatcher.extraEnv entry that also names
+  # CURIE_SLACK_THREADED_BOT_ALLOWLIST FAILS the render with a pointer back
+  # here; the refusal is deliberate, because silently dropping one of two
+  # authorization lists would leave the admitted set different from the one the
+  # operator wrote down. While it is EMPTY the chart owns nothing and reserves
+  # nothing, so an existing extraEnv entry keeps passing through verbatim
+  # exactly as before, across an upgrade included.
+  #
+  # Only ever allowlist a dedicated sender that does not itself respond to
+  # Curie: an allowlisted second Curie installation can loop
+  # (docs/interfaces/channel-ingress/INTERFACE.md).
+  #
+  # Declare this value in curie.yaml so a plain `curie cluster up` keeps it.
+  threadedBotAllowlist: []
   # Extra env for the dispatcher container. Full Kubernetes EnvVar entries are
-  # accepted, including valueFrom. Per-workload OTEL_EXPORTER_OTLP_* overrides
-  # still win over the chart-owned collector endpoint.
+  # accepted, including valueFrom. For CURIE_SLACK_THREADED_BOT_ALLOWLIST prefer
+  # the first-class threadedBotAllowlist above; use extraEnv for any other
+  # dispatcher override the fixed env block does not cover. Per-workload
+  # OTEL_EXPORTER_OTLP_* overrides still win over the chart-owned collector
+  # endpoint.
   extraEnv: []
   # Container securityContext (issue #67). Image runs as non-root uid 1000 (see
   # apps/dispatcher/Dockerfile). readOnlyRootFilesystem stays false -- the

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -1184,6 +1184,11 @@ class TestHelmCiWorkflowTriggers:
         # compose.dev.yaml is here for the same reason: two chart gates (the
         # unpinned-image gate, #2319, and the Langfuse image-pin gate, #2190)
         # read it, so a compose-only unpin must still trigger this workflow.
+        # apps/dispatcher/src/curie_dispatcher/config.py is here for the same
+        # reason again: the threaded-bot-allowlist chart gate (#2437) feeds
+        # the rendered env value through the real ThreadedBotAdmission
+        # parser, so a PR that only relaxes that parser must still run this
+        # workflow.
         assert triggers["pull_request"]["paths"] == [
             "charts/curie/**",
             "examples/sre-bot/observability/**",
@@ -1193,6 +1198,7 @@ class TestHelmCiWorkflowTriggers:
             "apps/api/src/curie_api/storage.py",
             "apps/worker/src/curie_worker/config.py",
             "apps/worker/src/curie_worker/bundle_store.py",
+            "apps/dispatcher/src/curie_dispatcher/config.py",
             "uv.lock",
             "pyproject.toml",
             "compose.dev.yaml",


### PR DESCRIPTION
Adds a first-class `dispatcher.threadedBotAllowlist` (default `[]`) rendered into
`CURIE_SLACK_THREADED_BOT_ALLOWLIST` as JSON, **alongside** the existing
`dispatcher.extraEnv` route rather than replacing it.

`extraEnv` already reached this variable, so this is a configuration enhancement, not a
missing capability. What it adds is render-time validation, one documented precedence
rule, and discoverability in `values.yaml`.

## Design: conditional first-class precedence

| `dispatcher.threadedBotAllowlist` | Chart behavior |
|---|---|
| empty (default) | renders **no** env and reserves nothing — an operator already using `dispatcher.extraEnv` keeps working byte-for-byte across an upgrade |
| non-empty | chart renders the variable itself **and** reserves the name for that render via the #2297 `additionalReserved` guard, so a colliding `extraEnv` entry fails the render |

The env entry and the reservation are gated on the **same `if`**, so emitting two entries is
structurally impossible. A removed-reservation chart mutant is asserted to produce two
entries, proving the reservation — not luck — is what guarantees one.

Silent-drop of the `extraEnv` duplicate was considered and rejected: this is an
authorization allowlist, and silently discarding an operator-supplied value would make the
effective set differ from what the operator wrote. An **unconditional** reservation (the
`SLACK_API_BASE_URL` idiom) was rejected because it would fail the render for every
operator already on `extraEnv` the moment they upgrade.

## Validation mirrors the real parser

Entries must have exactly the keys `channel_id` and `bot_id`, both strings, matching
`^[CG][A-Z0-9]+$` and `^B[A-Z0-9]+$` — the contract of
`apps/dispatcher/src/curie_dispatcher/config.py::ThreadedBotAdmission` (`extra="forbid"`).
The template rebuilds each entry rather than re-serializing the operator's map, so an
unknown key cannot reach the wire.

Those regexes are duplicated from Python on purpose, and the duplication is pinned against
drift: the new gate feeds the **exact rendered string** through the real `DispatcherConfig`
under `uv run`, and asserts an unknown-key payload is rejected by that same parser. So
relaxing `extra="forbid"` or moving a regex breaks this chart test.

## Honest limit

**No live cluster evidence is claimed.** A cluster deploy was not authorized for this run.
The deployed-surface proof is the render → real-parser round trip plus fresh and
`--is-upgrade` render paths. Every AC as written is a render-level claim.

## Done-check

- [x] **Failing tests committed before implementation** — `0a2e39cbf` (test) preceded `455f7728f` (feat) pre-squash; the gate failed on positive control T2 against the unmodified chart (`expected exactly one CURIE_SLACK_THREADED_BOT_ALLOWLIST entry, got []`).
- [x] **All production edits by delegated executors** — driver ran only git/validation.
- [x] **Broadened return types** — none. `curie.dispatcher.threadedBotAllowlist` is a new template; `curie.extraEnv` gained no new case (`additionalReserved` already existed).
- [x] **agent-router Code Reviewer** — completed (grok, review 423). No blocking findings. Two advisories refuted by execution: empty-map `{}` is falsy in Go and helm coalesce ignores it (AC4 holds); a raw byte diff of the default render before/after is identical except per-render generated secrets.
- [x] **agent-router Scope Reviewer** — completed (grok, review 424), 5 findings. Two fixed (trimmed the CLI-preservation prose, dropped fragile `INTERFACE.md` line numbers). Three declined with reason: the `pull_request.paths` addition, the parser-drift assertion, and the D12 mutant all follow explicit in-repo precedent — the workflow's own comment argues a gate that *executes* a file must run when that file changes, "the difference between a gate and a gate-shaped thing."
- [x] **agent-router Security Reviewer** — completed (grok, review 425). No over-admission, injection, unknown-key, precedence-bypass, fail-open, secret, or wildcard findings.
- [x] **Sibling-path parity** — 17 behavior sites enumerated in the plan; 6 in scope, 4 covered/reference, 7 explicit non-goals (compose already passes the variable through and is untouched; `apps/dispatcher` unchanged).
- [x] **Guard demonstration** — every validation branch was executed rejecting a violating input: N1–N13 across missing key, extra key, both regex misses, non-map entry, non-string scalar, empty string (CLI and values-file forms), second-index, bare `C`/`B`, `D`-prefixed channel, and map-not-list.
- [x] **Consolidation pass** — `/simplify` ran; reuse/efficiency/altitude clean, two test-boilerplate consolidations applied; revalidated and re-reviewed by agent-router (no drift, no state leak, render count verified not held constant by a skipped case).
- [x] **Train check** — milestone v0.8.8, based on `main`.
- [ ] **Observable verification / E2E Tester** — N/A, no user-facing flow and no cluster authorized; see Honest limit.
- [x] **Discovery-surface proof** — N/A, enhancement not a defect.
- [x] **Re-fix mechanism** — N/A, no prior fix of this symptom.
- [x] **Full affected suite + lint** — `threaded-bot-allowlist-assertions.sh` 26 renders exit 0; `reserved-env-assertions.sh` 157 renders exit 0 unmodified; both `helm lint` invocations clean; default render 92 docs, zero allowlist entries.

## Review-driven changes

A mutation review found regexes that survived the original gate: no `G`-prefix case, no
`+`-vs-`*` case, no channel-prefix-class case, and an N7 passing for the wrong reason. Each
now has a control proven non-vacuous by mutating the template and watching the gate fail.
One defect the reviewers missed: `printf "...[%d]"` mangled to `[%!d(string=oops)]` when the
operator supplies a map, because Go's `range` yields the key — now `%v`, pinned by N13.

Closes #2437
