### PR TITLE
Warn when cluster deploy hosts a connector with no MCP declaration

### DIFF
--- a/cli/src/connectors.rs
+++ b/cli/src/connectors.rs
@@ -294,6 +294,111 @@ pub fn as_list_document(manifests: &[Value]) -> Result<String> {
     serde_json::to_string(&doc).context("serializing connector manifests")
 }
 
+/// Whether an mcp_entry URL names this Deployment's Service.
+///
+/// Same host match #2350 uses for rollout wait (`connector_workloads`): the
+/// Service DNS is `<deployment>.<namespace>.svc.cluster.local`. Sibling: share
+/// this helper with #2350 when that PR merges. Do not treat a missing match as
+/// a capability-probe failure (#2519).
+fn url_names_deployment(url: &str, deployment: &str) -> bool {
+    let rest = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
+    let hostport = rest.split('/').next().unwrap_or(rest);
+    let host = hostport.rsplit('@').next().unwrap_or(hostport);
+    let host = host.split(':').next().unwrap_or(host);
+    host == deployment || host.starts_with(&format!("{deployment}."))
+}
+
+fn mcp_join_prefix(release: &str, agent: &str) -> String {
+    format!("{release}-{agent}-mcp-")
+}
+
+/// Hosted Deployments whose Service is not in `mcp_entries` (#2352).
+///
+/// This is the mounted-*declaration* check, not tool-surface discovery: a
+/// matching URL means Curie derived the MCP entry the runner will inject.
+/// Empty Bearer expansion and probe failure stay #2519. Hosted *readiness*
+/// (rollout) stays #2350. A hosted connector with a matching entry must not
+/// warn: that is the shipped 0.8.6+ mount path, not the 0.8.5 silence.
+pub fn hosted_unmounted_connectors(
+    manifests: &[Value],
+    mcp_entries: &BTreeMap<String, Value>,
+    release: &str,
+    agent: &str,
+) -> Vec<String> {
+    let prefix = mcp_join_prefix(release, agent);
+    let mut names = Vec::new();
+    for obj in manifests {
+        if obj.get("kind").and_then(Value::as_str) != Some("Deployment") {
+            continue;
+        }
+        let Some(name) = obj
+            .get("metadata")
+            .and_then(|m| m.get("name"))
+            .and_then(Value::as_str)
+        else {
+            continue;
+        };
+        if name.is_empty() {
+            continue;
+        }
+        if mcp_entries.iter().any(|(_, entry)| {
+            entry
+                .get("url")
+                .and_then(Value::as_str)
+                .is_some_and(|url| url_names_deployment(url, name))
+        }) {
+            continue;
+        }
+        let connector = name.strip_prefix(&prefix).unwrap_or(name);
+        names.push(connector.to_string());
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// Loud warning for connectors that were hosted but not declared mounted.
+pub fn hosted_unmounted_warning(names: &[String]) -> Option<String> {
+    match names {
+        [] => None,
+        [one] => Some(format!(
+            "connector {one} was hosted but not mounted into the agent's MCP declaration"
+        )),
+        many => Some(format!(
+            "connectors {} were hosted but not mounted into the agent's MCP declaration",
+            many.join(", ")
+        )),
+    }
+}
+
+/// Human deploy report: warnings first, then URL notes for mounted entries.
+pub fn connector_report_lines(synced: &ConnectorSync) -> (Vec<String>, Vec<String>) {
+    let mut warnings = Vec::new();
+    let mut notes = Vec::new();
+    if let Some(msg) = hosted_unmounted_warning(&synced.hosted_unmounted) {
+        warnings.push(msg);
+    }
+    for (name, url) in &synced.urls {
+        if synced.hosted_unmounted.iter().any(|n| n == name) {
+            continue;
+        }
+        notes.push(format!("connector {name}: {url}"));
+    }
+    (warnings, notes)
+}
+
+/// Emit the deploy-time hosted vs mounted-declaration report.
+pub fn report_connector_sync(synced: &ConnectorSync) {
+    let ui = crate::ui::ui();
+    let (warnings, notes) = connector_report_lines(synced);
+    for msg in warnings {
+        ui.warn(&msg);
+    }
+    for msg in notes {
+        ui.note(&msg);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -594,6 +699,12 @@ pub struct ConnectorSync {
     pub written_keys: Vec<String>,
     /// Live Secret keys this deploy is replacing. Names only, never values.
     pub replaced_keys: Vec<String>,
+    /// Hosted Deployments with no matching mcp_entry URL (#2352).
+    ///
+    /// Declaration-layer only: not rollout readiness (#2350) and not MCP
+    /// capability discovery (#2519). Empty means every hosted connector was
+    /// declared mounted.
+    pub hosted_unmounted: Vec<String>,
 }
 
 /// Discover the release's rendered app name (the chart's nameOverride).
@@ -727,6 +838,11 @@ impl PreparedConnectorSync {
             .map(|(key, source)| format!("{key}: {source}"))
             .collect()
     }
+
+    /// Hosted connectors with no matching mcp_entry, recorded at prepare.
+    pub fn hosted_unmounted(&self) -> &[String] {
+        &self.result.hosted_unmounted
+    }
 }
 
 /// Discover the current kubeconfig's cluster identity.
@@ -795,6 +911,12 @@ pub fn prepare(
 
     let mut result = ConnectorSync {
         written_keys: secret_keys.clone(),
+        hosted_unmounted: hosted_unmounted_connectors(
+            manifests,
+            mcp_entries,
+            &target.release,
+            agent_name,
+        ),
         ..Default::default()
     };
     for (name, entry) in mcp_entries {
@@ -925,10 +1047,7 @@ pub async fn sync_deployed_version(
     )?
     .bind_target(target)?;
     let synced = sync(prepared).await?;
-    let ui = crate::ui::ui();
-    for (name, url) in &synced.urls {
-        ui.note(&format!("connector {name}: {url}"));
-    }
+    report_connector_sync(&synced);
     Ok(())
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -406,10 +406,7 @@ async fn apply_connectors(
     prepared: curie::connectors::PreparedConnectorSync,
 ) -> anyhow::Result<()> {
     let synced = curie::connectors::sync(prepared).await?;
-    let ui = curie::ui::ui();
-    for (name, url) in &synced.urls {
-        ui.note(&format!("connector {name}: {url}"));
-    }
+    curie::connectors::report_connector_sync(&synced);
     Ok(())
 }
 

--- a/cli/tests/connector_mount_visibility.rs
+++ b/cli/tests/connector_mount_visibility.rs
@@ -1,0 +1,144 @@
+//! Deploy-time hosted vs mounted-declaration check (#2352).
+//!
+//! Hosted readiness is a Deployment in the rendered manifests. Mounted
+//! declaration is an mcp_entries URL that names that Deployment. Capability
+//! discovery, including empty Bearer expansion, is #2519 and must not look
+//! like unmounted. Hosted rollout wait is #2350.
+
+use std::collections::BTreeMap;
+
+use curie::connectors::{
+    connector_report_lines, hosted_unmounted_connectors, hosted_unmounted_warning, prepare,
+    ConnectorSync,
+};
+use curie::secrets::SecretScope;
+use serde_json::{json, Value};
+
+fn hosted_deployment(name: &str) -> Value {
+    json!({"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name": name}})
+}
+
+fn hosted_service(name: &str) -> Value {
+    json!({"apiVersion":"v1","kind":"Service","metadata":{"name": name}})
+}
+
+fn github_mcp_entry() -> BTreeMap<String, Value> {
+    let mut entries = BTreeMap::new();
+    entries.insert(
+        "github".into(),
+        json!({
+            "type": "http",
+            "url": "http://curie-acme-bot-mcp-github.curie.svc.cluster.local:8000/mcp",
+            "headers": {"Authorization": "Bearer ${GITHUB_TOKEN}"}
+        }),
+    );
+    entries
+}
+
+#[test]
+fn hosted_and_declared_is_not_unmounted() {
+    let name = "curie-acme-bot-mcp-github";
+    let manifests = vec![hosted_deployment(name), hosted_service(name)];
+    let unmounted =
+        hosted_unmounted_connectors(&manifests, &github_mcp_entry(), "curie", "acme-bot");
+    assert!(unmounted.is_empty(), "{unmounted:?}");
+    assert_eq!(hosted_unmounted_warning(&unmounted), None);
+    let (warnings, notes) = connector_report_lines(&ConnectorSync {
+        urls: BTreeMap::from([(
+            "github".into(),
+            "http://curie-acme-bot-mcp-github.curie.svc.cluster.local:8000/mcp".into(),
+        )]),
+        hosted_unmounted: unmounted,
+        ..Default::default()
+    });
+    assert!(warnings.is_empty(), "{warnings:?}");
+    assert_eq!(
+        notes,
+        vec![
+            "connector github: http://curie-acme-bot-mcp-github.curie.svc.cluster.local:8000/mcp"
+                .to_string()
+        ]
+    );
+}
+
+#[test]
+fn hosted_without_mcp_entry_is_unmounted() {
+    let name = "curie-acme-bot-mcp-github";
+    let manifests = vec![hosted_deployment(name), hosted_service(name)];
+    let unmounted = hosted_unmounted_connectors(&manifests, &BTreeMap::new(), "curie", "acme-bot");
+    assert_eq!(unmounted, vec!["github".to_string()]);
+    let warning = hosted_unmounted_warning(&unmounted).expect("warning");
+    assert!(warning.contains("hosted but not mounted"), "{warning}");
+    assert!(warning.contains("github"), "{warning}");
+    let (warnings, notes) = connector_report_lines(&ConnectorSync {
+        hosted_unmounted: unmounted,
+        ..Default::default()
+    });
+    assert_eq!(warnings.len(), 1, "{warnings:?}");
+    assert!(warnings[0].contains("hosted but not mounted"));
+    assert!(
+        notes.is_empty(),
+        "unmounted connectors must not print a URL: {notes:?}"
+    );
+}
+
+#[test]
+fn remote_url_without_deployment_is_not_hosted_unmounted() {
+    let mut entries = BTreeMap::new();
+    entries.insert(
+        "internal".into(),
+        json!({"type": "http", "url": "https://mcp.example.com/mcp"}),
+    );
+    let manifests = vec![hosted_service("curie-acme-bot-mcp-internal")];
+    let unmounted = hosted_unmounted_connectors(&manifests, &entries, "curie", "acme-bot");
+    assert!(unmounted.is_empty(), "{unmounted:?}");
+    assert_eq!(hosted_unmounted_warning(&unmounted), None);
+}
+
+#[test]
+fn empty_bearer_header_is_still_mounted_declaration() {
+    // The Authorization placeholder expanding empty is #2519, not an
+    // unmounted connector. Deploy must not emit the #2352 warning for it.
+    let name = "curie-acme-bot-mcp-github";
+    let manifests = vec![hosted_deployment(name)];
+    let unmounted =
+        hosted_unmounted_connectors(&manifests, &github_mcp_entry(), "curie", "acme-bot");
+    assert!(unmounted.is_empty(), "{unmounted:?}");
+}
+
+#[test]
+fn two_hosted_connectors_name_only_the_unmounted_one() {
+    let github = "curie-acme-bot-mcp-github";
+    let slack = "curie-acme-bot-mcp-slack";
+    let manifests = vec![hosted_deployment(github), hosted_deployment(slack)];
+    let unmounted =
+        hosted_unmounted_connectors(&manifests, &github_mcp_entry(), "curie", "acme-bot");
+    assert_eq!(unmounted, vec!["slack".to_string()]);
+    let warning = hosted_unmounted_warning(&unmounted).unwrap();
+    assert!(warning.contains("slack"), "{warning}");
+    assert!(!warning.contains("github"), "{warning}");
+}
+
+#[test]
+fn prepare_records_hosted_unmounted_from_manifests() {
+    let name = "curie-acme-bot-mcp-github";
+    let scope = SecretScope {
+        cluster_identity: "ca:test".into(),
+        release: "curie".into(),
+        namespace: "curie".into(),
+    };
+    let prepared = prepare(
+        &[hosted_deployment(name), hosted_service(name)],
+        &BTreeMap::new(),
+        "",
+        &[],
+        &scope,
+        "acme-bot",
+        &BTreeMap::new(),
+    )
+    .unwrap();
+    assert_eq!(
+        prepared.hosted_unmounted(),
+        &["github".to_string()] as &[String]
+    );
+}


### PR DESCRIPTION
## Summary

`curie cluster deploy` now warns when a hosted connector Deployment has no matching `mcp_entries` URL, instead of only printing a Service URL next to an `active` deployment. A hosted connector whose URL is declared still prints that URL and does not warn: that is the shipped 0.8.6+ mount path, not the 0.8.5 silence. Empty Bearer expansion and MCP capability-probe failure stay #2519. Hosted rollout wait stays #2350.

The 0.8.5 failure (healthy connector objects, no `mcp__github` tools) was runner injection, which shipped in #1118 / 0.8.6, plus hosted Bearer derivation in #2503. This change is the remaining deploy-time hosted-readiness versus mounted-declaration check. It does not re-permit a duplicate `.mcp.json` entry and does not add a second HTTP MCP probe.

## Related issue

Closes #2352
Ref #1118
Ref #2350
Ref #2503
Ref #2519

## Fix pin verification

Fix pin: cli/tests/connector_mount_visibility.rs::hosted_without_mcp_entry_is_unmounted

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not change plugin packaging, the runner turn loop, ACI events, skill eval, or skill check | | |
| local | required | `curie cluster deploy` / `sync_deployed_version` warning and URL notes | fake | Commit `6f49c5fc9`. `cd cli && cargo test --test connector_mount_visibility`: 6 passed. Positive: `hosted_and_declared_is_not_unmounted` warnings empty and prints `connector github: http://curie-acme-bot-mcp-github.curie.svc.cluster.local:8000/mcp`. Negative: `hosted_without_mcp_entry_is_unmounted` warning contains `hosted but not mounted` and `github`, notes empty. Second path: `empty_bearer_header_is_still_mounted_declaration` stays mounted. |
| local-release | n/a | No released-binary identity, install path, or release-compose pin change | | |
| cluster | n/a | Does not reach chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, or init containers. Hosted rollout wait is #2350. | | |
| live provider | n/a | Does not change MCP catalog projection, unscoped PreToolUse, in-process platform MCP tools, workspace publication, or coding-tool capability. Runner mounting already shipped. | | |
| external integration | n/a | Does not change Slack, git push webhooks, connector OAuth, or any third-party API shape | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Checklist

- Declaration-layer warning only; no unconditional hosted-but-unmounted warning on a matching mcp_entry
- No frozen aci-protocol, plugin-format, schema, or ADR changes
- Duplicate `.mcp.json` escape hatch not reopened
- Sibling: #2350 `url_names_deployment` / `connector_workloads`; share after that PR merges
- #2519 keeps empty-expansion / probe diagnosis; this PR does not add a deploy-time HTTP probe
