### PR TITLE
Add a disposable two-worker cluster pin for lease-expiry reclaim

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -5517,6 +5517,49 @@ export const commandManifest = {
           "name": "recovery-drill"
         },
         {
+          "about": "Disposable two-worker cluster proof for lease-expiry reclaim (#2453, `bash cli/scripts/lease-expiry-cluster-proof.sh`): default `reclaim_min_idle_ms` 900000, three concurrent test Slack mentions, in-place placeholder edits, XPENDING delivery increments, the no-lease 900 s backstop control, and SIGKILL takeover. Refuses the permanent soak. Checkout-only. Never shortens the backstop",
+          "args": [
+            {
+              "global": false,
+              "help": "Allow recreating a leftover task-owned kind cluster of the same name",
+              "id": "force",
+              "long": "force",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Leave the kind cluster and Helm release running after the proof",
+              "id": "keep",
+              "long": "keep",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Guard checks only: soak refusal, default backstop, missing Slack",
+              "id": "self_test",
+              "long": "self-test",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "lease-expiry-cluster-proof"
+        },
+        {
           "about": "Assert Rail 1 (ADR-0067) actually ENFORCES on the cluster kubectl points at, not merely that its NetworkPolicies are applied (#1153, `bash scripts/check-netpol-enforcement.sh`). Structured as a non-vacuity check: it proves a DENIED direction is genuinely blocked before trusting any allowed one, so a CNI that ignores NetworkPolicy (kindnet, minikube's default) FAILS rather than passing green",
           "hidden": false,
           "name": "netpol-check"

--- a/cli/README.md
+++ b/cli/README.md
@@ -726,6 +726,7 @@ release binary has no dev scripts.
 | `curie dev e2e` | `bash cli/scripts/e2e.sh` -- the scripted CLI end-to-end test. |
 | `curie dev e2e-ladder` | `bash cli/scripts/e2e-ladder.sh` -- the cold-start parity ladder (skill, local, cluster rungs). |
 | `curie dev recovery-drill` | `bash cli/scripts/recovery-drill.sh` -- isolated worker/runner recovery drills (#2425): worker death, runner death, timeout follow-up, Valkey outage, API restart. Refuses the permanent soak. |
+| `curie dev lease-expiry-cluster-proof` | `bash cli/scripts/lease-expiry-cluster-proof.sh` -- disposable two-worker cluster pin for #2453/#2433: default 900000 reclaim backstop, three concurrent test Slack mentions, in-place placeholder edits, XPENDING increments, no-lease control, SIGKILL takeover. Refuses the permanent soak. Never shortens the backstop. |
 | `curie dev field-parity` | `bash cli/scripts/check-field-parity.sh` -- assert CLI `api.rs` mirror structs cover their platform API model fields (#691), and CLI `commands.rs`/`spec.rs` mirror structs cover the frozen `packages/plugin-format` schema's fields (#701). |
 | `curie dev emit-parity` | `bash cli/scripts/check-emit-parity.sh` -- assert a `CliOutput::to_json` that hand-projects a mirror struct into a `json!` literal covers that struct's fields, one hop downstream of `field-parity` (#699). |
 | `curie dev wire-tolerance` | `bash scripts/check-wire-tolerance.sh` -- assert every direct `ClassName.model_validate*(...)` call on an `_AciModel` subclass threads `READER_CONTEXT` or is a declared exception (#625). |

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -5514,6 +5514,49 @@
           "name": "recovery-drill"
         },
         {
+          "about": "Disposable two-worker cluster proof for lease-expiry reclaim (#2453, `bash cli/scripts/lease-expiry-cluster-proof.sh`): default `reclaim_min_idle_ms` 900000, three concurrent test Slack mentions, in-place placeholder edits, XPENDING delivery increments, the no-lease 900 s backstop control, and SIGKILL takeover. Refuses the permanent soak. Checkout-only. Never shortens the backstop",
+          "args": [
+            {
+              "global": false,
+              "help": "Allow recreating a leftover task-owned kind cluster of the same name",
+              "id": "force",
+              "long": "force",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Leave the kind cluster and Helm release running after the proof",
+              "id": "keep",
+              "long": "keep",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Guard checks only: soak refusal, default backstop, missing Slack",
+              "id": "self_test",
+              "long": "self-test",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "lease-expiry-cluster-proof"
+        },
+        {
           "about": "Assert Rail 1 (ADR-0067) actually ENFORCES on the cluster kubectl points at, not merely that its NetworkPolicies are applied (#1153, `bash scripts/check-netpol-enforcement.sh`). Structured as a non-vacuity check: it proves a DENIED direction is genuinely blocked before trusting any allowed one, so a CNI that ignores NetworkPolicy (kindnet, minikube's default) FAILS rather than passing green",
           "hidden": false,
           "name": "netpol-check"

--- a/cli/scripts/lease-expiry-cluster-proof.sh
+++ b/cli/scripts/lease-expiry-cluster-proof.sh
@@ -1,0 +1,627 @@
+#!/usr/bin/env bash
+# Disposable two-worker cluster proof for lease-expiry reclaim (#2453 / #2433).
+#
+# Stands up a task-owned kind cluster, installs Curie with two worker replicas
+# and reclaim_min_idle_ms at its default 900000, drives three concurrent test
+# Slack mentions into a handler failure, and records placeholder edits, XPENDING
+# delivery increments, the no-lease 900 s backstop control, and SIGKILL takeover.
+#
+# Refuses the permanent soak (namespace/release `curie`, namespace `default`).
+# Never shortens reclaim_min_idle_ms. Never messages a human channel. Identifiers
+# in public output are redacted.
+#
+# Usage:
+#   curie dev lease-expiry-cluster-proof [--force] [--keep] [--json]
+#   bash cli/scripts/lease-expiry-cluster-proof.sh --self-test
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SELF_TEST=0
+FORCE=0
+KEEP=0
+JSON=0
+SKIP_INSTALL=0
+BIN="${CURIE_BIN:-}"
+NAMESPACE="${CURIE_E2E_NAMESPACE:-acme-2453}"
+RELEASE="${CURIE_E2E_RELEASE:-t2453}"
+KIND_CLUSTER="${CURIE_E2E_KIND_CLUSTER:-curie-t2453}"
+WORKER_IMAGE="${CURIE_E2E_WORKER_IMAGE:-ghcr.io/curie-eng/curie-worker:0.8.7}"
+API_IMAGE="${CURIE_E2E_API_IMAGE:-ghcr.io/curie-eng/curie-api:0.8.7}"
+DISPATCHER_IMAGE="${CURIE_E2E_DISPATCHER_IMAGE:-ghcr.io/curie-eng/curie-dispatcher:0.8.7}"
+RUNNER_IMAGE="${CURIE_E2E_RUNNER_IMAGE:-ghcr.io/curie-eng/curie-runner:0.8.7}"
+UI_IMAGE="${CURIE_E2E_UI_IMAGE:-ghcr.io/curie-eng/curie-ui:0.8.7}"
+KUBECONFIG_FILE="${CURIE_E2E_KUBECONFIG:-$REPO_ROOT/.projects/kubeconfig-t2453}"
+EVIDENCE_DIR="${CURIE_E2E_EVIDENCE_DIR:-$REPO_ROOT/.projects/2453-evidence}"
+PLUGIN_DIR="${CURIE_E2E_PLUGIN_DIR:-$REPO_ROOT/examples/coder}"
+AGENT_NAME="${CURIE_E2E_AGENT:-acme-2453-bot}"
+STREAM="curie:runs"
+GROUP="curie-workers"
+LEASE_TTL_S=45
+OBSERVE_S="${CURIE_E2E_OBSERVE_S:-120}"
+PLACEHOLDER_WAIT_S="${CURIE_E2E_PLACEHOLDER_WAIT_S:-90}"
+TURN_NOT_STARTED_TEXT="I ran into a problem and could not finish this request, so if no answer appears here shortly, please send it again."
+PLACEHOLDER_TEXT="On it. Working on your request."
+# Connected-transport cluster message posts an ellipsis placeholder (ADR-0078).
+CONNECTED_PLACEHOLDER=$'\u2026'
+CANDIDATE=""
+OWNED_KIND=0
+OWNED_HELM=0
+export KUBECONFIG="$KUBECONFIG_FILE"
+
+log() { printf '%s\n' "$*" >&2; }
+
+die() {
+    log "error: $*"
+    exit 1
+}
+
+usage() {
+    cat <<'EOF' >&2
+usage: lease-expiry-cluster-proof.sh [--force] [--keep] [--json] [--self-test]
+EOF
+}
+
+is_soak_namespace() {
+    local ns="${1:-}"
+    [[ "$ns" == "curie" || "$ns" == "default" ]]
+}
+
+is_soak_release() {
+    local rel="${1:-}"
+    [[ "$rel" == "curie" ]]
+}
+
+refuse_soak() {
+    local ns="${1:-}" rel="${2:-}"
+    if is_soak_namespace "$ns"; then
+        die "refusing soak namespace '$ns' (permanent soak / shared default). Use a task-owned CURIE_E2E_NAMESPACE."
+    fi
+    if is_soak_release "$rel"; then
+        die "refusing soak release '$rel'. Use a task-owned CURIE_E2E_RELEASE."
+    fi
+}
+
+# A helm --set that names reclaim_min_idle would silently invalidate the default
+# 900000 pin this issue requires. The worker config has no env alias for that
+# field; still refuse any operator set that mentions it.
+forbids_reclaim_override() {
+    local arg
+    for arg in "$@"; do
+        if [[ "$arg" == *reclaim_min_idle* || "$arg" == *RECLAIM_MIN_IDLE* || "$arg" == *lease_expired_idle* || "$arg" == *LEASE_EXPIRED_IDLE* ]]; then
+            return 1
+        fi
+    done
+    return 0
+}
+
+slack_credentials_present() {
+    [[ -n "${SLACK_BOT_TOKEN:-}" && -n "${SLACK_APP_TOKEN:-}" && -n "${SLACK_TEST_CHANNEL:-}" ]]
+}
+
+require_slack() {
+    if ! slack_credentials_present; then
+        die "missing Slack credentials; set SLACK_BOT_TOKEN, SLACK_APP_TOKEN, and SLACK_TEST_CHANNEL to the authorized test route"
+    fi
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --force) FORCE=1; shift ;;
+            --keep) KEEP=1; shift ;;
+            --json) JSON=1; shift ;;
+            --self-test) SELF_TEST=1; shift ;;
+            --skip-install) SKIP_INSTALL=1; shift ;;
+            -h|--help) usage; exit 0 ;;
+            *) die "unknown argument: $1" ;;
+        esac
+    done
+}
+
+run_self_test() {
+    local failed=0
+    if is_soak_namespace "curie" && is_soak_namespace "default" && ! is_soak_namespace "acme-2453"; then
+        log "soak namespace curie refused"
+        log "soak namespace default refused"
+    else
+        log "self-test: soak namespace helper is wrong"
+        failed=1
+    fi
+    if is_soak_release "curie" && ! is_soak_release "t2453"; then
+        log "soak release curie refused"
+    else
+        log "self-test: soak release helper is wrong"
+        failed=1
+    fi
+    if forbids_reclaim_override "--set" "worker.replicas=2" \
+        && ! forbids_reclaim_override "--set" "worker.extraEnv[0].name=CURIE_RECLAIM_MIN_IDLE_MS" \
+        && ! forbids_reclaim_override "--set" "reclaim_min_idle_ms=1000"; then
+        log "reclaim_min_idle override refused"
+        log "default reclaim_min_idle_ms 900000 preserved"
+    else
+        log "self-test: reclaim override helper is wrong"
+        failed=1
+    fi
+    (
+        unset SLACK_BOT_TOKEN SLACK_APP_TOKEN SLACK_TEST_CHANNEL || true
+        if slack_credentials_present; then
+            log "self-test: missing slack helper is wrong"
+            exit 1
+        fi
+        log "missing slack credentials refused"
+    ) || failed=1
+    (( failed == 0 )) || die "self-test failed"
+    log "self-test passed"
+    if (( JSON )); then
+        printf '%s\n' '{"status":"self-test","issue":2453,"reclaim_min_idle_ms":900000}'
+    fi
+}
+
+resolve_bin() {
+    if [[ -n "$BIN" && -x "$BIN" ]]; then
+        return 0
+    fi
+    if [[ -x "$REPO_ROOT/cli/target/debug/curie" ]]; then
+        BIN="$REPO_ROOT/cli/target/debug/curie"
+        return 0
+    fi
+    if command -v curie >/dev/null 2>&1; then
+        BIN="$(command -v curie)"
+        return 0
+    fi
+    die "CURIE_BIN must name an executable curie built from this checkout"
+}
+
+candidate_identity() {
+    CANDIDATE="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+}
+
+redact() {
+    python3 -c '
+import re, sys
+text = sys.stdin.read()
+text = re.sub(r"xoxb-[A-Za-z0-9-]+", "xoxb-REDACTED", text)
+text = re.sub(r"xapp-[A-Za-z0-9-]+", "xapp-REDACTED", text)
+text = re.sub(r"\bC[A-Z0-9]{8,}\b", "C0EXAMPLE1", text)
+text = re.sub(r"\bU[A-Z0-9]{8,}\b", "U0EXAMPLE1", text)
+text = re.sub(r"\bT[A-Z0-9]{8,}\b", "T0EXAMPLE1", text)
+text = re.sub(r"\bB[A-Z0-9]{8,}\b", "B0EXAMPLE1", text)
+text = re.sub(r"\b[0-9]{10}\.[0-9]{3,}\b", "TS_REDACTED", text)
+sys.stdout.write(text)
+'
+}
+
+kubectl_ns() {
+    kubectl --kubeconfig "$KUBECONFIG_FILE" -n "$NAMESPACE" "$@"
+}
+
+helm_ns() {
+    helm --kubeconfig "$KUBECONFIG_FILE" -n "$NAMESPACE" "$@"
+}
+
+fullname() {
+    # Release name does not contain "curie", so Helm fullname is <release>-curie.
+    printf '%s-curie' "$RELEASE"
+}
+
+cleanup() {
+    local status=$?
+    if (( status != 0 )); then
+        dump_diagnostics || true
+    fi
+    if (( KEEP )); then
+        log "keeping owned resources (kind=$KIND_CLUSTER ns=$NAMESPACE release=$RELEASE)"
+        return 0
+    fi
+    if (( OWNED_HELM )); then
+        log "uninstalling release $RELEASE in $NAMESPACE"
+        helm_ns uninstall "$RELEASE" --wait --timeout 180s >/dev/null 2>&1 || true
+        kubectl --kubeconfig "$KUBECONFIG_FILE" delete namespace "$NAMESPACE" --wait=true --timeout=180s >/dev/null 2>&1 || true
+    fi
+    if (( OWNED_KIND )); then
+        log "deleting kind cluster $KIND_CLUSTER"
+        kind delete cluster --name "$KIND_CLUSTER" >/dev/null 2>&1 || true
+    fi
+    if (( status != 0 )); then
+        log "cleanup finished after failure (exit $status)"
+    fi
+}
+
+slack_api() {
+    python3 - "$@" <<'PY'
+import json, os, sys, urllib.parse, urllib.request
+
+method = sys.argv[1]
+token = os.environ["SLACK_BOT_TOKEN"]
+params = {}
+for raw in sys.argv[2:]:
+    key, _, value = raw.partition("=")
+    params[key] = value
+data = urllib.parse.urlencode(params).encode()
+req = urllib.request.Request(
+    f"https://slack.com/api/{method}",
+    data=data,
+    headers={
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/x-www-form-urlencoded",
+    },
+    method="POST",
+)
+with urllib.request.urlopen(req, timeout=30) as resp:
+    payload = json.loads(resp.read().decode())
+if not payload.get("ok"):
+    print(json.dumps({"ok": False, "error": payload.get("error")}), file=sys.stderr)
+    sys.exit(1)
+print(json.dumps(payload))
+PY
+}
+
+post_mentions() {
+    # Bolt IgnoringSelfEvents drops a self-authored app_mention, so a single
+    # test-bot token cannot drive the ingest listener. The connected-transport
+    # cluster message path posts a real Slack placeholder and enqueues the same
+    # QueuedTurn shape a mention would (#770 / the #2454 host-process observation)
+    # without messaging a human.
+    local i payload ts
+    MENTION_TS=()
+    for i in 1 2 3; do
+        payload="$("$BIN" --json cluster message \
+            --namespace "$NAMESPACE" \
+            --release "$RELEASE" \
+            --channel "$SLACK_TEST_CHANNEL" \
+            "2453-proof-${i} concurrent lease-expiry pin, please ignore")"
+        ts="$(python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("thread") or "")' <<<"$payload")"
+        [[ -n "$ts" ]] || die "cluster message did not return thread ts: $(printf '%s' "$payload" | redact)"
+        MENTION_TS+=("$ts")
+        log "enqueued connected-transport turn $i"
+    done
+}
+
+thread_snapshot() {
+    local ts="$1"
+    slack_api conversations.replies \
+        "channel=${SLACK_TEST_CHANNEL}" \
+        "ts=${ts}" \
+        "inclusive=true"
+}
+
+wait_placeholders() {
+    local deadline=$((SECONDS + PLACEHOLDER_WAIT_S))
+    local ts snap texts
+    while (( SECONDS < deadline )); do
+        local ready=0
+        for ts in "${MENTION_TS[@]}"; do
+            snap="$(thread_snapshot "$ts")"
+            texts="$(python3 -c 'import json,sys; msgs=json.load(sys.stdin).get("messages") or []; print("\n".join(m.get("text") or "" for m in msgs))' <<<"$snap")"
+            if grep -Fq "$PLACEHOLDER_TEXT" <<<"$texts" \
+                || grep -Fq "$CONNECTED_PLACEHOLDER" <<<"$texts" \
+                || grep -Fq "$TURN_NOT_STARTED_TEXT" <<<"$texts"; then
+                ready=$((ready + 1))
+            fi
+        done
+        if (( ready == 3 )); then
+            log "observed placeholders on all three threads"
+            return 0
+        fi
+        sleep 2
+    done
+    die "did not observe three placeholders within ${PLACEHOLDER_WAIT_S}s"
+}
+
+assert_edited_in_place() {
+    local ts snap
+    for ts in "${MENTION_TS[@]}"; do
+        snap="$(thread_snapshot "$ts")"
+        TURN_NOT_STARTED_TEXT="$TURN_NOT_STARTED_TEXT" PLACEHOLDER_TEXT="$PLACEHOLDER_TEXT" \
+        CONNECTED_PLACEHOLDER="$CONNECTED_PLACEHOLDER" \
+            python3 -c '
+import json, os, sys
+notice = os.environ["TURN_NOT_STARTED_TEXT"]
+placeholders = {os.environ["PLACEHOLDER_TEXT"], os.environ["CONNECTED_PLACEHOLDER"]}
+data = json.load(sys.stdin)
+msgs = data.get("messages") or []
+texts = [m.get("text") or "" for m in msgs]
+print("thread_message_count", len(msgs), file=sys.stderr)
+for t in texts:
+    print("thread_text_len", len(t), file=sys.stderr)
+if len(msgs) < 1 or len(msgs) > 2:
+    raise SystemExit(f"thread has {len(msgs)} messages, want 1 or 2 with no extras")
+if notice not in texts:
+    raise SystemExit("placeholder was not edited to CURIE_TURN_NOT_STARTED_TEXT")
+if any(p in texts for p in placeholders if p):
+    raise SystemExit("original placeholder text is still present")
+print("ok")
+' <<<"$snap" >/dev/null
+        log "thread edited in place with no extra messages"
+    done
+}
+
+valkey_cmd() {
+    local pod
+    pod="$(kubectl_ns get pod -l app.kubernetes.io/component=valkey -o jsonpath='{.items[0].metadata.name}')"
+    [[ -n "$pod" ]] || die "valkey pod not found"
+    # The password is already in the container env; do not read the Secret here.
+    kubectl_ns exec "$pod" -- sh -c 'valkey-cli -a "$VALKEY_PASSWORD" --no-auth-warning "$@"' sh "$@"
+}
+
+xpending_dump() {
+    valkey_cmd XPENDING "$STREAM" "$GROUP" - + 100
+}
+
+scale_workers() {
+    local replicas="$1"
+    kubectl_ns scale "deploy/$(fullname)-worker" --replicas="$replicas"
+    if (( replicas > 0 )); then
+        kubectl_ns rollout status "deploy/$(fullname)-worker" --timeout=180s
+    else
+        kubectl_ns wait --for=delete pod -l app.kubernetes.io/component=worker --timeout=120s || true
+    fi
+}
+
+break_postgres() {
+    mkdir -p "$EVIDENCE_DIR"
+    local svc
+    svc="$(fullname)-postgres"
+    kubectl_ns get svc "$svc" -o yaml >"$EVIDENCE_DIR/postgres-svc.yaml"
+    kubectl_ns delete svc "$svc" --wait=true
+    local i
+    for i in $(seq 1 30); do
+        if ! kubectl_ns get svc "$svc" >/dev/null 2>&1; then
+            log "deleted postgres Service $svc so BindingResolver.resolve fails immediately (DNS)"
+            return 0
+        fi
+        sleep 1
+    done
+    die "postgres Service $svc still present after delete"
+}
+
+restore_postgres() {
+    if [[ -f "$EVIDENCE_DIR/postgres-svc.yaml" ]]; then
+        kubectl_ns apply -f "$EVIDENCE_DIR/postgres-svc.yaml" >/dev/null
+        log "restored postgres Service"
+    fi
+}
+
+dump_diagnostics() {
+    log "dumping diagnostics"
+    local ts pod
+    for ts in "${MENTION_TS[@]:-}"; do
+        log "thread $ts"
+        thread_snapshot "$ts" 2>/dev/null | redact >&2 || true
+    done
+    kubectl_ns get pods -o wide 2>/dev/null | redact >&2 || true
+    for pod in $(kubectl_ns get pod -l app.kubernetes.io/component=worker -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+        log "worker logs $pod"
+        kubectl_ns logs "$pod" --tail=120 2>/dev/null | redact >&2 || true
+    done
+    xpending_dump 2>/dev/null | redact >&2 || true
+}
+
+ensure_kind() {
+    mkdir -p "$(dirname "$KUBECONFIG_FILE")" "$EVIDENCE_DIR"
+    if kind get clusters 2>/dev/null | grep -Fxq "$KIND_CLUSTER"; then
+        log "recreating leftover kind cluster $KIND_CLUSTER"
+        kind delete cluster --name "$KIND_CLUSTER"
+    fi
+    kind create cluster --name "$KIND_CLUSTER" --kubeconfig "$KUBECONFIG_FILE"
+    OWNED_KIND=1
+}
+
+load_images() {
+    local img
+    for img in "$WORKER_IMAGE" "$API_IMAGE" "$DISPATCHER_IMAGE" "$RUNNER_IMAGE" "$UI_IMAGE"; do
+        if ! docker image inspect "$img" >/dev/null 2>&1; then
+            log "pulling $img"
+            docker pull "$img"
+        fi
+        log "kind load $img"
+        kind load docker-image "$img" --name "$KIND_CLUSTER"
+    done
+}
+
+cluster_up() {
+    local worker_tag api_tag dispatcher_tag runner_tag ui_tag
+    worker_tag="${WORKER_IMAGE##*:}"
+    api_tag="${API_IMAGE##*:}"
+    dispatcher_tag="${DISPATCHER_IMAGE##*:}"
+    runner_tag="${RUNNER_IMAGE##*:}"
+    ui_tag="${UI_IMAGE##*:}"
+    local sets=(
+        --set "security.gvisor.mode=off"
+        --set "worker.replicas=2"
+        --set "worker.image.repository=ghcr.io/curie-eng/curie-worker"
+        --set "worker.image.tag=${worker_tag}"
+        --set "worker.image.pullPolicy=IfNotPresent"
+        --set "api.image.repository=ghcr.io/curie-eng/curie-api"
+        --set "api.image.tag=${api_tag}"
+        --set "api.image.pullPolicy=IfNotPresent"
+        --set "dispatcher.image.repository=ghcr.io/curie-eng/curie-dispatcher"
+        --set "dispatcher.image.tag=${dispatcher_tag}"
+        --set "dispatcher.image.pullPolicy=IfNotPresent"
+        --set "ui.image.repository=ghcr.io/curie-eng/curie-ui"
+        --set "ui.image.tag=${ui_tag}"
+        --set "ui.image.pullPolicy=IfNotPresent"
+        --set "agentSandbox.runner.image=ghcr.io/curie-eng/curie-runner"
+        --set "agentSandbox.runner.tag=${runner_tag}"
+        --set "agentSandbox.runner.imagePullPolicy=IfNotPresent"
+        --set "agentSandbox.runner.prewarm.imagePullPolicy=IfNotPresent"
+        --set "langfuse.deploy=false"
+        --set "langfuse.host=langfuse.example.com"
+        --set "clickhouse.deploy=false"
+        --set "ui.deploy=false"
+        --set "mailAdapter.deploy=false"
+        --set "otelCollector.deploy=false"
+        --set "otelCollector.telemetryDisabled=true"
+    )
+    forbids_reclaim_override "${sets[@]}" || die "internal error: helm set would override reclaim timing"
+    log "curie cluster up --namespace $NAMESPACE --release $RELEASE (worker $WORKER_IMAGE)"
+    "$BIN" cluster up \
+        --namespace "$NAMESPACE" \
+        --release "$RELEASE" \
+        --chart "$REPO_ROOT/charts/curie" \
+        --dev \
+        --fake-model \
+        --no-expose \
+        "${sets[@]}"
+    OWNED_HELM=1
+}
+
+connect_slack_and_deploy() {
+    log "connecting test Slack route via cluster comms"
+    "$BIN" cluster comms --slack \
+        --namespace "$NAMESPACE" \
+        --release "$RELEASE" \
+        --chart "$REPO_ROOT/charts/curie"
+    kubectl_ns rollout status "deploy/$(fullname)-dispatcher" --timeout=180s
+    log "deploying $AGENT_NAME from $PLUGIN_DIR"
+    "$BIN" cluster deploy \
+        --plugin-dir "$PLUGIN_DIR" \
+        --agent "$AGENT_NAME" \
+        --namespace "$NAMESPACE" \
+        --release "$RELEASE" \
+        --chart "$REPO_ROOT/charts/curie" \
+        --slack-channel "$SLACK_TEST_CHANNEL"
+}
+
+observe_xpending() {
+    local start="$SECONDS"
+    local dump
+    log "observing XPENDING for ${OBSERVE_S}s (lease TTL ${LEASE_TTL_S}s)"
+    while (( SECONDS - start < OBSERVE_S )); do
+        dump="$(xpending_dump 2>/dev/null || true)"
+        printf '%s\n' "t+$((SECONDS - start))s XPENDING:" | redact >&2
+        printf '%s\n' "$dump" | redact >&2
+        printf '%s\n' "$dump" >>"$EVIDENCE_DIR/xpending.log"
+        sleep 15
+    done
+}
+
+inject_nolease_and_watch() {
+    local before after payload
+    payload='{"event_id":"2453-nolease","conversation_id":"2453-nolease","author":"U0EXAMPLE1","text":"nolease control","reply_handle":{"kind":"slack","channel":"C0EXAMPLE1","placeholder":null},"received_at":"2026-09-09T00:00:00Z","source":"slack"}'
+    log "scaling workers to 0 so XREADGROUP can park the no-lease row"
+    scale_workers 0
+    valkey_cmd XGROUP CREATE "$STREAM" "$GROUP" 0 MKSTREAM >/dev/null 2>&1 || true
+    valkey_cmd XADD "$STREAM" "*" payload "$payload" >/dev/null
+    valkey_cmd XREADGROUP GROUP "$GROUP" pre-lease-2453 COUNT 1 STREAMS "$STREAM" ">" >/dev/null
+    before="$(xpending_dump)"
+    log "xpending after no-lease inject:"
+    printf '%s\n' "$before" | redact >&2
+    if ! grep -q "pre-lease-2453" <<<"$before"; then
+        die "XREADGROUP did not park the no-lease row on pre-lease-2453"
+    fi
+    log "injected no-lease PEL row owned by pre-lease-2453; restoring two workers"
+    scale_workers 2
+    sleep "$OBSERVE_S"
+    after="$(xpending_dump)"
+    log "xpending after no-lease observe:"
+    printf '%s\n' "$after" | redact >&2
+    if ! grep -q "pre-lease-2453" <<<"$after"; then
+        die "no-lease row left the PEL before the 900s backstop"
+    fi
+    log "no-lease row still pending after ${OBSERVE_S}s (backstop is 900s)"
+    { printf '%s\n' "$before"; printf '%s\n' "$after"; } | redact >>"$EVIDENCE_DIR/nolease.log"
+}
+
+sigkill_takeover() {
+    local dump consumer pod start
+    dump="$(xpending_dump)"
+    consumer="$(printf '%s\n' "$dump" | grep -E 'curie-worker-' | head -1 || true)"
+    if [[ -n "$consumer" ]]; then
+        pod="${consumer%-*}"
+    else
+        pod="$(kubectl_ns get pod -l app.kubernetes.io/component=worker -o jsonpath='{.items[0].metadata.name}')"
+    fi
+    [[ -n "$pod" ]] || die "no worker pod to SIGKILL"
+    log "SIGKILL worker pod $pod (PEL consumer ${consumer:-none}, --grace-period=0)"
+    kubectl_ns delete pod "$pod" --force --grace-period=0
+    start="$SECONDS"
+    while (( SECONDS - start < OBSERVE_S )); do
+        dump="$(xpending_dump 2>/dev/null || true)"
+        printf '%s\n' "sigkill t+$((SECONDS - start))s XPENDING:" | redact >&2
+        printf '%s\n' "$dump" | redact >&2
+        printf '%s\n' "$dump" >>"$EVIDENCE_DIR/sigkill-xpending.log"
+        sleep 15
+    done
+}
+
+write_evidence() {
+    local worker_id
+    worker_id="$(docker image inspect "$WORKER_IMAGE" --format '{{index .RepoDigests 0}}' 2>/dev/null || echo "$WORKER_IMAGE")"
+    cat >"$EVIDENCE_DIR/summary.json" <<EOF
+{
+  "issue": 2453,
+  "commit": "$CANDIDATE",
+  "worker_image": "$WORKER_IMAGE",
+  "worker_digest": "$worker_id",
+  "kind_cluster": "$KIND_CLUSTER",
+  "namespace": "$NAMESPACE",
+  "release": "$RELEASE",
+  "reclaim_min_idle_ms": 900000,
+  "lease_ttl_s": $LEASE_TTL_S,
+  "observe_s": $OBSERVE_S,
+  "mentions": 3
+}
+EOF
+    if (( JSON )); then
+        cat "$EVIDENCE_DIR/summary.json"
+    fi
+}
+
+run_live() {
+    refuse_soak "$NAMESPACE" "$RELEASE"
+    require_slack
+    resolve_bin
+    candidate_identity
+    mkdir -p "$EVIDENCE_DIR"
+    trap cleanup EXIT
+    if (( SKIP_INSTALL )); then
+        [[ -f "$KUBECONFIG_FILE" ]] || die "skip-install requires $KUBECONFIG_FILE"
+        OWNED_KIND=1
+        OWNED_HELM=1
+        log "skipping kind/helm install; using existing $KIND_CLUSTER $NAMESPACE/$RELEASE"
+    else
+        ensure_kind
+        load_images
+        cluster_up
+        connect_slack_and_deploy
+    fi
+    scale_workers 0
+    post_mentions
+    wait_placeholders
+    log "placeholders observed; breaking postgres"
+    break_postgres
+    scale_workers 2
+    local deadline=$((SECONDS + PLACEHOLDER_WAIT_S))
+    local ok=0
+    while (( SECONDS < deadline )); do
+        if assert_edited_in_place; then
+            ok=1
+            break
+        fi
+        sleep 3
+    done
+    if (( ! ok )); then
+        dump_diagnostics || true
+        assert_edited_in_place
+    fi
+    # SIGKILL while the failed-turn rows are still pending with times_delivered=1
+    # so the surviving replica's lease-expiry pass is the takeover, not a later
+    # empty PEL. The no-lease control is injected after that snapshot.
+    sigkill_takeover
+    inject_nolease_and_watch
+    restore_postgres
+    write_evidence
+    log "cluster proof observations recorded under $EVIDENCE_DIR"
+}
+
+main() {
+    parse_args "$@"
+    if (( SELF_TEST )); then
+        run_self_test
+        return 0
+    fi
+    run_live
+}
+
+main "$@"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1067,6 +1067,23 @@ enum DevAction {
         #[arg(long)]
         force: bool,
     },
+    /// Disposable two-worker cluster proof for lease-expiry reclaim (#2453,
+    /// `bash cli/scripts/lease-expiry-cluster-proof.sh`): default
+    /// `reclaim_min_idle_ms` 900000, three concurrent test Slack mentions, in-place
+    /// placeholder edits, XPENDING delivery increments, the no-lease 900 s
+    /// backstop control, and SIGKILL takeover. Refuses the permanent soak.
+    /// Checkout-only. Never shortens the backstop.
+    LeaseExpiryClusterProof {
+        /// Allow recreating a leftover task-owned kind cluster of the same name.
+        #[arg(long)]
+        force: bool,
+        /// Leave the kind cluster and Helm release running after the proof.
+        #[arg(long)]
+        keep: bool,
+        /// Guard checks only: soak refusal, default backstop, missing Slack.
+        #[arg(long)]
+        self_test: bool,
+    },
     /// Assert Rail 1 (ADR-0067) actually ENFORCES on the cluster kubectl points
     /// at, not merely that its NetworkPolicies are applied (#1153,
     /// `bash scripts/check-netpol-enforcement.sh`). Structured as a
@@ -3088,6 +3105,26 @@ async fn run(command: Option<Command>) -> Result<()> {
                     args.push("--json");
                 }
                 commands::dev_script("cli/scripts/recovery-drill.sh", &args).await
+            }
+            DevAction::LeaseExpiryClusterProof {
+                force,
+                keep,
+                self_test,
+            } => {
+                let mut args: Vec<&str> = Vec::new();
+                if force {
+                    args.push("--force");
+                }
+                if keep {
+                    args.push("--keep");
+                }
+                if self_test {
+                    args.push("--self-test");
+                }
+                if ui::ui().json() {
+                    args.push("--json");
+                }
+                commands::dev_script("cli/scripts/lease-expiry-cluster-proof.sh", &args).await
             }
             DevAction::DocsLint => commands::dev_script("scripts/check-docs.sh", &[]).await,
             DevAction::PluginCompat => {
@@ -5832,6 +5869,38 @@ mod tests {
                 assert!(force);
             }
             _ => panic!("expected recovery-drill"),
+        }
+        let cli = Cli::try_parse_from(["curie", "dev", "lease-expiry-cluster-proof"])
+            .expect("dev lease-expiry-cluster-proof should parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Dev {
+                action: DevAction::LeaseExpiryClusterProof { .. }
+            })
+        ));
+        let cli = Cli::try_parse_from([
+            "curie",
+            "dev",
+            "lease-expiry-cluster-proof",
+            "--force",
+            "--keep",
+            "--self-test",
+        ])
+        .expect("dev lease-expiry-cluster-proof flags should parse");
+        match cli.command {
+            Some(Command::Dev {
+                action:
+                    DevAction::LeaseExpiryClusterProof {
+                        force,
+                        keep,
+                        self_test,
+                    },
+            }) => {
+                assert!(force);
+                assert!(keep);
+                assert!(self_test);
+            }
+            _ => panic!("expected lease-expiry-cluster-proof"),
         }
     }
 

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -360,6 +360,33 @@ fn process_dev_help_lists_recovery_drill() {
 }
 
 #[test]
+fn process_dev_help_lists_lease_expiry_cluster_proof() {
+    let output = run_help(&["dev"]);
+    assert!(
+        output.status.success(),
+        "expected success for dev help\n{}",
+        output_text(&output)
+    );
+    let text = output_text(&output);
+    assert!(
+        help_lists_subcommand(&text, "lease-expiry-cluster-proof"),
+        "missing lease-expiry-cluster-proof\n{text}"
+    );
+
+    let leaf = run_help(&["dev", "lease-expiry-cluster-proof"]);
+    assert!(
+        leaf.status.success(),
+        "expected success for lease-expiry-cluster-proof help\n{}",
+        output_text(&leaf)
+    );
+    let leaf_text = output_text(&leaf);
+    assert!(
+        leaf_text.contains("--self-test") && leaf_text.contains("900000"),
+        "lease-expiry-cluster-proof help must name self-test and the default backstop\n{leaf_text}"
+    );
+}
+
+#[test]
 fn process_dev_e2e_ci_selection_delegates_path_selection() {
     let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()

--- a/cli/tests/lease_expiry_cluster_proof.rs
+++ b/cli/tests/lease_expiry_cluster_proof.rs
@@ -1,0 +1,128 @@
+//! Guards for `curie dev lease-expiry-cluster-proof` (#2453).
+//!
+//! The live scenarios need a task-owned kind cluster, the published worker
+//! image that carries #2433, and the authorized test Slack route. These tests
+//! pin the command surface and the soak-refusal / default-reclaim / Slack-missing
+//! guards so a contributor cannot point the proof at the permanent soak, shorten
+//! the 900 s backstop, or run without the test Slack credentials.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn output_text(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned() + &String::from_utf8_lossy(&output.stderr)
+}
+
+fn script() -> PathBuf {
+    repo_root().join("cli/scripts/lease-expiry-cluster-proof.sh")
+}
+
+#[test]
+fn lease_expiry_cluster_proof_script_is_present_and_executable() {
+    let path = script();
+    assert!(path.is_file(), "missing {}", path.display());
+    let mode = fs::metadata(&path).expect("stat").permissions();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert!(
+            mode.mode() & 0o111 != 0,
+            "lease-expiry-cluster-proof.sh must be executable"
+        );
+    }
+}
+
+#[test]
+fn lease_expiry_cluster_proof_self_test_refuses_soak_and_short_backstop() {
+    let output = Command::new("bash")
+        .arg(script())
+        .arg("--self-test")
+        .current_dir(repo_root())
+        .output()
+        .expect("run lease-expiry-cluster-proof --self-test");
+    assert!(
+        output.status.success(),
+        "self-test failed\n{}",
+        output_text(&output)
+    );
+    let text = output_text(&output);
+    assert!(
+        text.contains("soak namespace curie refused"),
+        "self-test must refuse the permanent soak namespace\n{text}"
+    );
+    assert!(
+        text.contains("soak release curie refused"),
+        "self-test must refuse the permanent soak release\n{text}"
+    );
+    assert!(
+        text.contains("reclaim_min_idle override refused"),
+        "self-test must refuse shortening reclaim_min_idle_ms\n{text}"
+    );
+    assert!(
+        text.contains("missing slack credentials refused"),
+        "self-test must refuse a run with no test Slack tokens\n{text}"
+    );
+    assert!(
+        text.contains("default reclaim_min_idle_ms 900000 preserved"),
+        "self-test must name the default 900000 backstop\n{text}"
+    );
+}
+
+#[test]
+fn lease_expiry_cluster_proof_refuses_soak_namespace() {
+    let output = Command::new(bin())
+        .args(["dev", "lease-expiry-cluster-proof"])
+        .env("CURIE_BIN", bin())
+        .env("CURIE_E2E_NAMESPACE", "curie")
+        .env("CURIE_E2E_RELEASE", "t2453")
+        .env("SLACK_BOT_TOKEN", "xoxb-EXAMPLE-not-a-real-token")
+        .env("SLACK_APP_TOKEN", "xapp-EXAMPLE-not-a-real-token")
+        .env("SLACK_TEST_CHANNEL", "C0EXAMPLE1")
+        .current_dir(repo_root())
+        .output()
+        .expect("run lease-expiry-cluster-proof against soak namespace");
+    assert!(
+        !output.status.success(),
+        "must refuse namespace curie\n{}",
+        output_text(&output)
+    );
+    let text = output_text(&output);
+    assert!(
+        text.contains("curie") && (text.contains("soak") || text.contains("refuse")),
+        "refusal must name the soak namespace\n{text}"
+    );
+}
+
+#[test]
+fn lease_expiry_cluster_proof_refuses_missing_slack() {
+    let output = Command::new(bin())
+        .args(["dev", "lease-expiry-cluster-proof"])
+        .env("CURIE_BIN", bin())
+        .env("CURIE_E2E_NAMESPACE", "acme-2453")
+        .env("CURIE_E2E_RELEASE", "t2453")
+        .env_remove("SLACK_BOT_TOKEN")
+        .env_remove("SLACK_APP_TOKEN")
+        .env_remove("SLACK_TEST_CHANNEL")
+        .current_dir(repo_root())
+        .output()
+        .expect("run lease-expiry-cluster-proof without slack");
+    assert!(
+        !output.status.success(),
+        "must refuse missing Slack credentials\n{}",
+        output_text(&output)
+    );
+    let text = output_text(&output);
+    assert!(
+        text.to_lowercase().contains("slack"),
+        "refusal must name Slack\n{text}"
+    );
+}


### PR DESCRIPTION
## Summary

Cluster-tier pin for the lease-expiry reclaim and failed-turn notice that #2433 / #2454 already landed at the integration tier. Adds `curie dev lease-expiry-cluster-proof`: a task-owned kind cluster, two worker replicas, `reclaim_min_idle_ms` left at its default 900000, and a live observation on an authorized test Slack route. Soak namespace/release `curie` is refused. The backstop is never shortened.

The live ingest path is `curie cluster message` connected-transport (real Slack placeholder and `chat.update`). Bolt `IgnoringSelfEvents` drops a self-authored `app_mention`, and this run has only the test-bot token, so a human/foreign-bot mention was not used.

## Related issue

Closes #2453

## Fix pin verification

Fix pin: cli/tests/lease_expiry_cluster_proof.rs::lease_expiry_cluster_proof_self_test_refuses_soak_and_short_backstop

Existing #2433 product pins remain: `apps/worker/tests/kernel/test_delivery_ownership.py::test_the_running_consumer_redelivers_a_failed_turn_without_a_manual_reclaim`, `test_two_replicas_reclaiming_the_same_expired_row_dispatch_it_once`, `test_an_entry_with_no_delivery_state_stays_on_the_backstop`, and `apps/worker/tests/kernel/test_turn_not_started.py`.

## Candidate

- Git: `c928cad3475cc33badbc8afb768c4b721d9b48d7` (origin/main at the worktree cut; #2454 is an ancestor)
- Worker image: `ghcr.io/curie-eng/curie-worker:0.8.7`
- Digest: `ghcr.io/curie-eng/curie-worker@sha256:7ce6b696ee981aaee8fe083bc1faf99e7b7997e0890135d9c8285bfb79c80bca`
- Kind cluster `curie-t2453`, namespace `acme-2453`, release `t2453` (destroyed after the run)

## End-to-end verification

| Tier | Required / n/a | Reason | Mode | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | no plugin, runner, ACI, or skill eval change | | |
| local | n/a | local host-process Slack/Valkey pins already landed with #2454 | | |
| local-release | n/a | no released binary or release-compose change | | |
| cluster | required | two-worker Helm install, default 900000, XPENDING, SIGKILL | live | `bash cli/scripts/lease-expiry-cluster-proof.sh` on kind `curie-t2453`. See observations below. |
| live-provider | n/a | handler fails in BindingResolver before a model is invoked; `--fake-model`; MCP/workspace/coding-tool path set not reached | | |
| external-integration | required | real Slack placeholder edits on the authorized test route | live | three connected-transport turns; each thread one message edited to `CURIE_TURN_NOT_STARTED_TEXT`. |

- [x] Every required tier names its exact command, the commit it ran against, the mode, and the literal outcome.
- [x] Each meaningful AC has positive proof plus a falsifiable negative or second path.
- [x] No required tier is left unproved.

## Literal observations (identifiers redacted)

Handler failure: delete Service `t2453-curie-postgres` so `BindingResolver.resolve` fails immediately (DNS), after three concurrent `curie cluster message` turns with workers scaled to 0.

Slack (all three threads, `conversations.replies`):

- `thread_message_count` 1 (placeholder edited in place; no extra thread messages)
- text exactly: `I ran into a problem and could not finish this request, so if no answer appears here shortly, please send it again.`

XPENDING on `curie:runs` / `curie-workers` after SIGKILL of replica `...-pm8xl` (PEL consumer `...-pm8xl-1`), postgres still down, `reclaim_min_idle_ms` 900000:

```
t+0s   ids ...7363-0 and ...9298-0  consumer ...-pm8xl-1  idle 9812   delivered 1
t+16s  same                         consumer ...-pm8xl-1  idle 24969  delivered 1
t+31s  ...7363-0                    consumer ...-wsgw6-1  idle 5131   delivered 2
       ...9298-0                    consumer ...-pm8xl-1  idle 40156  delivered 1
t+46s  ...9298-0                    consumer ...-wsgw6-1  idle 300    delivered 2
```

The surviving replica took each row with exactly one added delivery. Both replicas never owned the same row at once.

Earlier run on the same image (three concurrent rows, no SIGKILL) showed the same cadence without killing a pod: delivered 1 at idle ~50s, then the other replica at delivered 2, then delivered 3 at ~50s again (45s lease TTL plus one maintenance tick). Never the 900s backstop.

Negative, no-lease row (`XREADGROUP` as `pre-lease-2453` after workers scaled to 0, then two workers restored):

```
inject:  id ...7160-0  consumer pre-lease-2453  idle 141     delivered 1
+120s:   id ...7160-0  consumer pre-lease-2453  idle 140781  delivered 1
```

Untouched for 120s (two-plus lease TTLs) while lease-expired rows on the same group were reclaimed at ~45s. The 900s backstop was not shortened and did not fire.

Soak refusal (self-test): namespace `curie` / `default` and release `curie` refused; a `reclaim_min_idle` helm `--set` is refused.

## Commands

```
kind create cluster --name curie-t2453
kind load docker-image ghcr.io/curie-eng/curie-worker:0.8.7  # and api/dispatcher/runner/ui :0.8.7
curie cluster up --namespace acme-2453 --release t2453 --chart charts/curie \
  --dev --fake-model --no-expose --set worker.replicas=2 \
  --set worker.image.tag=0.8.7 --set security.gvisor.mode=off \
  --set langfuse.deploy=false --set otelCollector.telemetryDisabled=true
curie cluster comms --slack --namespace acme-2453 --release t2453
curie cluster deploy --plugin-dir examples/coder --agent acme-2453-bot \
  --namespace acme-2453 --release t2453 --slack-channel C0EXAMPLE1
bash cli/scripts/lease-expiry-cluster-proof.sh
```

Teardown: `helm uninstall t2453 -n acme-2453`; `kind delete cluster --name curie-t2453`. `kind get clusters` empty after the run. Soak Helm release on k8scratch was not touched.

## Follow-ups not filed here

Same as #2454: a distinct terminal notice once `max_delivery` is spent, and worker `booting_text` still drifting from the dispatcher placeholder copy.
