### PR TITLE
Fail closed when the runner dials an external API or OTLP endpoint

### DIFF
--- a/charts/curie/.helmignore
+++ b/charts/curie/.helmignore
@@ -8,3 +8,7 @@
 *.swp
 .idea/
 .vscode/
+# Test scripts are not part of the installable chart. Shipping them in the
+# release Secret is what blew the 1MiB Kubernetes Secret cap on
+# `curie cluster up` once the BYO egress assertions grew (#2367).
+ci/

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -227,9 +227,9 @@ failure it prevents is silent: agents boot with no
 prior memory and no thread transcript, `remember` writes never persist, and the
 only symptom is a warning line inside the sandbox.
 `security.networkPolicy.allowedEgress` remains the documented legacy allow for
-the inverse (`deploy: true` + external URL) so an install that already listed
-that host on the model allowlist keeps rendering; `api.egress` is the dedicated
-one-peer key. The same effective-endpoint rule applies to the collector:
+the inverse (`deploy: true` + external URL) so an install that already has a
+non-empty model allowlist keeps rendering. The chart cannot prove those CIDRs
+cover the hostname; `api.egress` is the dedicated one-peer key. The same effective-endpoint rule applies to the collector:
 `otelCollector.egress` is required when the runner's OTLP URL is external,
 including an `agentSandbox.runner.extraEnv` `OTEL_EXPORTER_OTLP_ENDPOINT`
 override while the in-chart collector is still deployed.

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -220,10 +220,19 @@ egress. The in-chart `runner-allow-api` policy selects this release's API pods,
 so it does not render, and NetworkPolicy has no hostname peer to derive from
 `dispatcher.apiBaseUrl`. Set `api.egress` to the endpoint's CIDRs (`{cidr,
 ports}` entries, same shape as the allowlist); the chart requires it at render
-whenever `dispatcher.apiBaseUrl` names an external API, because the failure it
-prevents is silent — agents boot with no
+whenever the URL the runner actually dials is external -- `api.deploy: false`,
+or `api.deploy: true` with `dispatcher.apiBaseUrl` / worker `extraEnv`
+`CURIE_API_URL` / `CURIE_RUNNER_API_URL` pointing off-cluster -- because the
+failure it prevents is silent: agents boot with no
 prior memory and no thread transcript, `remember` writes never persist, and the
 only symptom is a warning line inside the sandbox.
+`security.networkPolicy.allowedEgress` remains the documented legacy allow for
+the inverse (`deploy: true` + external URL) so an install that already listed
+that host on the model allowlist keeps rendering; `api.egress` is the dedicated
+one-peer key. The same effective-endpoint rule applies to the collector:
+`otelCollector.egress` is required when the runner's OTLP URL is external,
+including an `agentSandbox.runner.extraEnv` `OTEL_EXPORTER_OTLP_ENDPOINT`
+override while the in-chart collector is still deployed.
 `mailAdapter.apiEgress.httpsCidrs` above is the same idea for the mail adapter
 pod: one BYO peer, declared explicitly, per pod that has an egress policy.
 
@@ -1070,11 +1079,13 @@ where the model API and MCP endpoints live (`{cidr, ports}` entries). An unset
 allowlist never means allow-all. The BYO in-chart peers are not on that list
 either, because each names one endpoint rather than a class of destinations: set
 `rustfs.egress` (and `rustfs.stsEgress` on the key-free path) so the sandbox
-bundle-fetch can reach S3 and STS, `otelCollector.egress` when
-`otelCollector.deploy: false` points the runner at an external collector, and
-`api.egress` when `api.deploy: false` points it at an external API. Each is
-required at render on its BYO path, so the install fails loudly instead of
-shipping a sandbox holding an address it can never reach. See **Key-free object
+bundle-fetch can reach S3 and STS, `otelCollector.egress` when the runner's
+OTLP URL is external, and `api.egress` when the runner's API URL is external.
+Each is required at render on that effective-endpoint path, so the install
+fails loudly instead of shipping a sandbox holding an address it can never
+reach. `deploy: false` is the common BYO shape; the same requirement fires
+when the in-chart pod is still deployed but `dispatcher.apiBaseUrl` or a
+supported extraEnv override points the runner elsewhere. See **Key-free object
 store auth** above.
 
 **The controller does not get a second vote on egress (#765, ADR-0067).**

--- a/charts/curie/ci/byo-endpoint-egress-assertions.sh
+++ b/charts/curie/ci/byo-endpoint-egress-assertions.sh
@@ -1246,5 +1246,16 @@ if ! helm template "$RELEASE" "$CHART" --namespace "$NAMESPACE" \
 fi
 echo "ok: opting out of Rail 1 does not require api.egress for an external apiBaseUrl"
 
+echo "=== Assertion 28: helm package does not ship ci/ test scripts into the release Secret ==="
+PKG_DIR="$TMP/helm-pkg"
+mkdir -p "$PKG_DIR"
+helm package "$CHART" -d "$PKG_DIR" >/dev/null
+PKG_TGZ="$(find "$PKG_DIR" -maxdepth 1 -name '*.tgz' -print)"
+[ -n "$PKG_TGZ" ] || fail "helm package wrote no tgz"
+if tar -tzf "$PKG_TGZ" | grep -q '/ci/'; then
+  fail "helm package still contains ci/ test scripts; add ci/ to charts/curie/.helmignore so the release Secret stays under 1MiB"
+fi
+echo "ok: helm package excludes ci/"
+
 echo
 echo "PASS: BYO collector and API egress are required and rendered as runner NetworkPolicies; the in-chart carve-outs are unchanged; the effective runner-facing endpoint fails closed without a declared peer; and no .deploy carve-out lacks a BYO branch."

--- a/charts/curie/ci/byo-endpoint-egress-assertions.sh
+++ b/charts/curie/ci/byo-endpoint-egress-assertions.sh
@@ -1187,7 +1187,49 @@ python3 "$CHECKER" "$EXTRAENV_OTLP_OUT" inverse-collector-dedicated \
   "$COLLECTOR_CIDR" "$GRPC_PORT" "$HTTP_PORT" \
   || fail "runner extraEnv OTEL + otelCollector.egress must render ${COLLECTOR_BYO_POLICY} beside the in-chart collector allow"
 
-echo "=== Assertion 24: Rail 1 off does not require a peer for an external apiBaseUrl with api.deploy=true ==="
+echo "=== Assertion 24: api.deploy=false with dispatcher.apiBaseUrl set to this release's Service DNS still requires api.egress ==="
+INCHART_BYO_API="$TMP/inchart-byo-api.yaml"
+cat > "$INCHART_BYO_API" <<'EOF'
+api:
+  deploy: false
+dispatcher:
+  apiBaseUrl: http://curie-api:8000
+ui:
+  apiBaseUrl: http://curie-api:8000
+EOF
+must_fail_naming "deploy-false in-chart apiBaseUrl missing peer" "api.egress" "$INCHART_BYO_API"
+
+echo "=== Assertion 25: runner extraEnv OTEL_EXPORTER_OTLP_TRACES_ENDPOINT with no peer fails, naming otelCollector.egress ==="
+EXTRAENV_OTLP_TRACES="$TMP/extraenv-otlp-traces.yaml"
+cat > "$EXTRAENV_OTLP_TRACES" <<EOF
+agentSandbox:
+  runner:
+    extraEnv:
+      - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+        value: ${OTLP_ENDPOINT}
+EOF
+must_fail_naming "extraEnv OTEL_EXPORTER_OTLP_TRACES_ENDPOINT missing peer" "otelCollector.egress" "$EXTRAENV_OTLP_TRACES"
+
+echo "=== Assertion 26: runner extraEnv OTEL + allowedEgress is the documented collector legacy allow ==="
+INVERSE_OTLP_LEGACY="$TMP/inverse-otlp-legacy.yaml"
+cat > "$INVERSE_OTLP_LEGACY" <<EOF
+agentSandbox:
+  runner:
+    extraEnv:
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: ${OTLP_ENDPOINT}
+security:
+  networkPolicy:
+    allowedEgress:
+      - cidr: ${COLLECTOR_CIDR}
+        ports: [{ protocol: TCP, port: 4318 }]
+EOF
+INVERSE_OTLP_LEGACY_OUT="$(render_dir inverse-otlp-legacy --values "$INVERSE_OTLP_LEGACY")"
+python3 "$CHECKER" "$INVERSE_OTLP_LEGACY_OUT" inverse-api-legacy \
+  "$COLLECTOR_POLICY" "$COLLECTOR_BYO_POLICY" "$DEFAULT_DENY_EGRESS" "$ALLOW_EGRESS" \
+  || fail "inverse OTEL extraEnv + allowedEgress must keep runner-allow-collector and runner-allow-egress without a dedicated endpoint policy"
+
+echo "=== Assertion 27: Rail 1 off does not require a peer for an external apiBaseUrl with api.deploy=true ==="
 INVERSE_RAIL_OFF="$TMP/inverse-rail-off.yaml"
 cat > "$INVERSE_RAIL_OFF" <<EOF
 security:

--- a/charts/curie/ci/byo-endpoint-egress-assertions.sh
+++ b/charts/curie/ci/byo-endpoint-egress-assertions.sh
@@ -51,7 +51,10 @@
 #      api.deploy=true, is refused at render naming the key -- the key is only
 #      read on the BYO branch, and quietly ignoring it there is how an operator
 #      ends up believing egress is declared when the pod selector is what
-#      actually governs.
+#      actually governs. That unused-key refusal is scoped to the runner still
+#      dialing the in-chart Service. When the effective runner-facing endpoint
+#      is external (#2367), the dedicated key is the peer for that host even
+#      while the in-chart pod remains deployed.
 #   9. CLASS GUARD. The point of #2317 is that this was a class, not two bugs.
 #      Assertion 12 parses EVERY template under charts/curie/templates that
 #      renders a `kind: NetworkPolicy` -- discovered by grep, never a hardcoded
@@ -63,6 +66,19 @@
 #      (keyed by file AND component) with a written reason. A future author adding a
 #      fourth in-chart carve-out is caught at CI time rather than by a customer
 #      whose telemetry silently stops.
+#  13. #2367 inverse: api.deploy=true with an external dispatcher.apiBaseUrl and
+#      no declared peer fails at render naming api.egress. The same render with
+#      api.egress emits runner-allow-api-endpoint (in-chart runner-allow-api
+#      stays). The same render with only allowedEgress still succeeds -- that
+#      is the documented legacy allow, including 0.0.0.0/0.
+#  14. #2367 extraEnv siblings: worker.extraEnv CURIE_API_URL,
+#      worker.extraEnv CURIE_RUNNER_API_URL, and agentSandbox.runner.extraEnv
+#      OTEL_EXPORTER_OTLP_ENDPOINT each fail closed when they point the runner
+#      at an external host with no peer, and render the dedicated endpoint
+#      policy when the matching egress key is set. A valueFrom extraEnv is
+#      treated as external because the chart cannot prove it is in-cluster.
+#  15. An in-chart dispatcher.apiBaseUrl (this release's API Service) is not
+#      external: api.deploy=true does not require api.egress.
 #
 # NetworkPolicy speaks CIDRs, not DNS names, so the chart cannot derive an
 # allow from otelCollector.endpoint or dispatcher.apiBaseUrl. Values-level CIDR
@@ -411,6 +427,86 @@ elif ACTION == "has-block":
         if excepts:
             die(f"{cidr} must not except anything on a narrow allow; got {excepts}")
     print(f"ok: {policy_name} allows {cidr} with {expected_ports}")
+
+elif ACTION == "inverse-api-legacy":
+    (api_name, api_byo_name, deny_name, allow_name) = ARGS
+    if named(docs, api_name) is None:
+        die(f"inverse legacy render dropped in-chart {api_name}")
+    if named(docs, api_byo_name) is not None:
+        die(
+            f"inverse legacy render emitted {api_byo_name}; allowedEgress is the "
+            "peer on this path, so the dedicated endpoint policy must stay off"
+        )
+    if named(docs, deny_name) is None:
+        die("inverse legacy render dropped runner-default-deny-egress")
+    if named(docs, allow_name) is None:
+        die(f"inverse legacy render dropped {allow_name}")
+    print(
+        "ok: api.deploy=true + external API + allowedEgress keeps the in-chart "
+        "api allow and the legacy runner-allow-egress; no dedicated endpoint policy"
+    )
+
+elif ACTION == "inverse-api-dedicated":
+    (api_name, api_byo_name, deny_name, allow_name, cidr) = ARGS
+    if named(docs, api_name) is None:
+        die(f"inverse dedicated render dropped in-chart {api_name}")
+    if named(docs, deny_name) is None:
+        die("inverse dedicated render dropped runner-default-deny-egress")
+    if named(docs, allow_name) is not None:
+        die(
+            f"inverse dedicated render emitted {allow_name}; allowedEgress is "
+            "empty on this path"
+        )
+    assert_byo(
+        named(docs, api_byo_name),
+        api_byo_name,
+        cidr,
+        [{"protocol": "TCP", "port": 443}],
+    )
+    print(
+        "ok: api.deploy=true + external API + api.egress renders "
+        "runner-allow-api-endpoint beside the in-chart api allow"
+    )
+
+elif ACTION == "inverse-collector-dedicated":
+    (
+        collector_name,
+        collector_byo_name,
+        deny_name,
+        allow_name,
+        cidr,
+        grpc_port,
+        http_port,
+    ) = ARGS
+    if named(docs, collector_name) is None:
+        die(f"inverse collector render dropped in-chart {collector_name}")
+    if named(docs, deny_name) is None:
+        die("inverse collector render dropped runner-default-deny-egress")
+    if named(docs, allow_name) is not None:
+        die(
+            f"inverse collector render emitted {allow_name}; allowedEgress is "
+            "empty on this path"
+        )
+    assert_in_chart(
+        named(docs, collector_name),
+        collector_name,
+        "otel-collector",
+        [
+            {"protocol": "TCP", "port": int(grpc_port)},
+            {"protocol": "TCP", "port": int(http_port)},
+        ],
+    )
+    assert_byo(
+        named(docs, collector_byo_name),
+        collector_byo_name,
+        cidr,
+        [{"protocol": "TCP", "port": 4318}],
+    )
+    print(
+        "ok: otelCollector.deploy=true + runner extraEnv OTLP + "
+        "otelCollector.egress renders runner-allow-collector-endpoint beside "
+        "the in-chart collector allow"
+    )
 
 else:
     die(f"unknown action {ACTION!r}")
@@ -932,5 +1028,181 @@ else
   fail "class guard: an in-chart .deploy carve-out has no BYO else branch and no exemption"
 fi
 
+echo "=== Assertion 13: api.deploy=true + external apiBaseUrl with no peer fails at render, naming api.egress ==="
+INVERSE_API_MISSING="$TMP/inverse-api-missing.yaml"
+cat > "$INVERSE_API_MISSING" <<EOF
+dispatcher:
+  apiBaseUrl: ${API_BASE_URL}
+ui:
+  apiBaseUrl: ${API_BASE_URL}
+EOF
+must_fail_naming "inverse apiBaseUrl missing peer" "api.egress" "$INVERSE_API_MISSING"
+
+echo "=== Assertion 14: api.deploy=true + external apiBaseUrl + allowedEgress is the documented legacy allow ==="
+INVERSE_API_LEGACY="$TMP/inverse-api-legacy.yaml"
+cat > "$INVERSE_API_LEGACY" <<EOF
+dispatcher:
+  apiBaseUrl: ${API_BASE_URL}
+ui:
+  apiBaseUrl: ${API_BASE_URL}
+security:
+  networkPolicy:
+    allowedEgress:
+      - cidr: ${API_CIDR}
+        ports: [{ protocol: TCP, port: 443 }]
+EOF
+INVERSE_API_LEGACY_OUT="$(render_dir inverse-api-legacy --values "$INVERSE_API_LEGACY")"
+python3 "$CHECKER" "$INVERSE_API_LEGACY_OUT" inverse-api-legacy \
+  "$API_POLICY" "$API_BYO_POLICY" "$DEFAULT_DENY_EGRESS" "$ALLOW_EGRESS" \
+  || fail "inverse apiBaseUrl + allowedEgress must keep runner-allow-api and runner-allow-egress without a dedicated endpoint policy"
+
+echo "=== Assertion 15: api.deploy=true + external apiBaseUrl + allowedEgress 0.0.0.0/0 still renders (documented web egress) ==="
+INVERSE_API_WEB="$TMP/inverse-api-web.yaml"
+cat > "$INVERSE_API_WEB" <<EOF
+dispatcher:
+  apiBaseUrl: ${API_BASE_URL}
+ui:
+  apiBaseUrl: ${API_BASE_URL}
+security:
+  networkPolicy:
+    allowedEgress:
+      - cidr: 0.0.0.0/0
+        ports: [{ protocol: TCP, port: 443 }]
+EOF
+INVERSE_API_WEB_OUT="$(render_dir inverse-api-web --values "$INVERSE_API_WEB")" \
+  || fail "inverse apiBaseUrl + allowedEgress 0.0.0.0/0 must still render"
+python3 "$CHECKER" "$INVERSE_API_WEB_OUT" inverse-api-legacy \
+  "$API_POLICY" "$API_BYO_POLICY" "$DEFAULT_DENY_EGRESS" "$ALLOW_EGRESS" \
+  || fail "inverse apiBaseUrl + 0.0.0.0/0 must keep the legacy runner-allow-egress path"
+
+echo "=== Assertion 16: api.deploy=true + external apiBaseUrl + api.egress renders the dedicated endpoint policy ==="
+INVERSE_API_DEDICATED="$TMP/inverse-api-dedicated.yaml"
+cat > "$INVERSE_API_DEDICATED" <<EOF
+api:
+  egress:
+    - cidr: ${API_CIDR}
+      ports: [{ protocol: TCP, port: 443 }]
+dispatcher:
+  apiBaseUrl: ${API_BASE_URL}
+ui:
+  apiBaseUrl: ${API_BASE_URL}
+EOF
+INVERSE_API_DEDICATED_OUT="$(render_dir inverse-api-dedicated --values "$INVERSE_API_DEDICATED")"
+python3 "$CHECKER" "$INVERSE_API_DEDICATED_OUT" inverse-api-dedicated \
+  "$API_POLICY" "$API_BYO_POLICY" "$DEFAULT_DENY_EGRESS" "$ALLOW_EGRESS" "$API_CIDR" \
+  || fail "inverse apiBaseUrl + api.egress must render ${API_BYO_POLICY} covering api.egress"
+
+echo "=== Assertion 17: in-chart apiBaseUrl is not external and does not require api.egress ==="
+IN_CHART_API_BASE="$TMP/in-chart-api-base.yaml"
+cat > "$IN_CHART_API_BASE" <<'EOF'
+dispatcher:
+  apiBaseUrl: http://curie-api:8000
+ui:
+  apiBaseUrl: http://curie-api:8000
+EOF
+IN_CHART_API_BASE_OUT="$(render_dir in-chart-api-base --values "$IN_CHART_API_BASE")" \
+  || fail "dispatcher.apiBaseUrl pointing at this release's API Service must still render without api.egress"
+python3 "$CHECKER" "$IN_CHART_API_BASE_OUT" default \
+  "$COLLECTOR_POLICY" "$COLLECTOR_BYO_POLICY" "$API_POLICY" "$API_BYO_POLICY" \
+  "$DEFAULT_DENY_EGRESS" "$ALLOW_EGRESS" "$GRPC_PORT" "$HTTP_PORT" \
+  || fail "in-chart apiBaseUrl must keep the default in-chart collector/api carve-outs"
+
+echo "=== Assertion 18: worker.extraEnv CURIE_API_URL external with no peer fails, naming api.egress ==="
+EXTRAENV_API_MISSING="$TMP/extraenv-api-missing.yaml"
+cat > "$EXTRAENV_API_MISSING" <<EOF
+worker:
+  extraEnv:
+    - name: CURIE_API_URL
+      value: ${API_BASE_URL}
+EOF
+must_fail_naming "extraEnv CURIE_API_URL missing peer" "api.egress" "$EXTRAENV_API_MISSING"
+
+echo "=== Assertion 19: worker.extraEnv CURIE_API_URL + api.egress renders the dedicated endpoint policy ==="
+EXTRAENV_API_DEDICATED="$TMP/extraenv-api-dedicated.yaml"
+cat > "$EXTRAENV_API_DEDICATED" <<EOF
+api:
+  egress:
+    - cidr: ${API_CIDR}
+      ports: [{ protocol: TCP, port: 443 }]
+worker:
+  extraEnv:
+    - name: CURIE_API_URL
+      value: ${API_BASE_URL}
+EOF
+EXTRAENV_API_OUT="$(render_dir extraenv-api-dedicated --values "$EXTRAENV_API_DEDICATED")"
+python3 "$CHECKER" "$EXTRAENV_API_OUT" inverse-api-dedicated \
+  "$API_POLICY" "$API_BYO_POLICY" "$DEFAULT_DENY_EGRESS" "$ALLOW_EGRESS" "$API_CIDR" \
+  || fail "extraEnv CURIE_API_URL + api.egress must render ${API_BYO_POLICY}"
+
+echo "=== Assertion 20: worker.extraEnv CURIE_RUNNER_API_URL external with no peer fails, naming api.egress ==="
+EXTRAENV_RUNNER_API_MISSING="$TMP/extraenv-runner-api-missing.yaml"
+cat > "$EXTRAENV_RUNNER_API_MISSING" <<EOF
+worker:
+  extraEnv:
+    - name: CURIE_RUNNER_API_URL
+      value: ${API_BASE_URL}
+EOF
+must_fail_naming "extraEnv CURIE_RUNNER_API_URL missing peer" "api.egress" "$EXTRAENV_RUNNER_API_MISSING"
+
+echo "=== Assertion 21: worker.extraEnv CURIE_API_URL valueFrom with no peer fails, naming api.egress ==="
+EXTRAENV_API_VALUEFROM="$TMP/extraenv-api-valuefrom.yaml"
+cat > "$EXTRAENV_API_VALUEFROM" <<'EOF'
+worker:
+  extraEnv:
+    - name: CURIE_API_URL
+      valueFrom:
+        secretKeyRef:
+          name: acme-api-url
+          key: url
+EOF
+must_fail_naming "extraEnv CURIE_API_URL valueFrom missing peer" "api.egress" "$EXTRAENV_API_VALUEFROM"
+
+echo "=== Assertion 22: runner extraEnv OTEL_EXPORTER_OTLP_ENDPOINT with collector in-chart and no peer fails, naming otelCollector.egress ==="
+EXTRAENV_OTLP_MISSING="$TMP/extraenv-otlp-missing.yaml"
+cat > "$EXTRAENV_OTLP_MISSING" <<EOF
+agentSandbox:
+  runner:
+    extraEnv:
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: ${OTLP_ENDPOINT}
+EOF
+must_fail_naming "extraEnv OTEL_EXPORTER_OTLP_ENDPOINT missing peer" "otelCollector.egress" "$EXTRAENV_OTLP_MISSING"
+
+echo "=== Assertion 23: runner extraEnv OTEL + otelCollector.egress with deploy=true renders the dedicated endpoint policy ==="
+EXTRAENV_OTLP_DEDICATED="$TMP/extraenv-otlp-dedicated.yaml"
+cat > "$EXTRAENV_OTLP_DEDICATED" <<EOF
+otelCollector:
+  egress:
+    - cidr: ${COLLECTOR_CIDR}
+      ports: [{ protocol: TCP, port: 4318 }]
+agentSandbox:
+  runner:
+    extraEnv:
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: ${OTLP_ENDPOINT}
+EOF
+EXTRAENV_OTLP_OUT="$(render_dir extraenv-otlp-dedicated --values "$EXTRAENV_OTLP_DEDICATED")"
+python3 "$CHECKER" "$EXTRAENV_OTLP_OUT" inverse-collector-dedicated \
+  "$COLLECTOR_POLICY" "$COLLECTOR_BYO_POLICY" "$DEFAULT_DENY_EGRESS" "$ALLOW_EGRESS" \
+  "$COLLECTOR_CIDR" "$GRPC_PORT" "$HTTP_PORT" \
+  || fail "runner extraEnv OTEL + otelCollector.egress must render ${COLLECTOR_BYO_POLICY} beside the in-chart collector allow"
+
+echo "=== Assertion 24: Rail 1 off does not require a peer for an external apiBaseUrl with api.deploy=true ==="
+INVERSE_RAIL_OFF="$TMP/inverse-rail-off.yaml"
+cat > "$INVERSE_RAIL_OFF" <<EOF
+security:
+  networkPolicy:
+    enabled: false
+dispatcher:
+  apiBaseUrl: ${API_BASE_URL}
+ui:
+  apiBaseUrl: ${API_BASE_URL}
+EOF
+if ! helm template "$RELEASE" "$CHART" --namespace "$NAMESPACE" \
+  --values "$INVERSE_RAIL_OFF" > /dev/null; then
+  fail "networkPolicy.enabled=false must render an external apiBaseUrl without api.egress"
+fi
+echo "ok: opting out of Rail 1 does not require api.egress for an external apiBaseUrl"
+
 echo
-echo "PASS: BYO collector and API egress are required and rendered as runner NetworkPolicies; the in-chart carve-outs are unchanged; and no .deploy carve-out lacks a BYO branch."
+echo "PASS: BYO collector and API egress are required and rendered as runner NetworkPolicies; the in-chart carve-outs are unchanged; the effective runner-facing endpoint fails closed without a declared peer; and no .deploy carve-out lacks a BYO branch."

--- a/charts/curie/ci/dispatcher-api-wiring-assertions.sh
+++ b/charts/curie/ci/dispatcher-api-wiring-assertions.sh
@@ -257,8 +257,15 @@ actual="$(env_value "$manifest" CURIE_API_URL)"
 [ "$actual" = "http://curie-api:9999" ] \
   || fail "api.service.port=9999: CURIE_API_URL is '$actual', expected 'http://curie-api:9999' (the port is hardcoded in the template instead of read from .Values.api.service.port)"
 
-# 3: BYO override renders verbatim (the api.deploy=false answer).
-manifest="$(render_dispatcher byo --set dispatcher.apiBaseUrl=http://byo-api.example:8080 "${TOKENS[@]}")"
+# 3: BYO override renders verbatim (the api.deploy=false answer). Rail 1
+# requires a declared peer when the runner-facing URL is external and the
+# in-chart API is still deployed (#2367); this fixture is about the env value.
+manifest="$(render_dispatcher byo \
+  --set dispatcher.apiBaseUrl=http://byo-api.example:8080 \
+  --set 'api.egress[0].cidr=192.0.2.21/32' \
+  --set 'api.egress[0].ports[0].protocol=TCP' \
+  --set 'api.egress[0].ports[0].port=8080' \
+  "${TOKENS[@]}")"
 actual="$(env_value "$manifest" CURIE_API_URL)"
 [ "$actual" = "http://byo-api.example:8080" ] \
   || fail "dispatcher.apiBaseUrl override: CURIE_API_URL is '$actual', expected the verbatim override 'http://byo-api.example:8080'"

--- a/charts/curie/ci/otel-collector-durability-assertions.sh
+++ b/charts/curie/ci/otel-collector-durability-assertions.sh
@@ -119,6 +119,11 @@ YAML
 cat > "$TMP/external-otel-workload-env.yaml" <<'YAML'
 otelCollector:
   deploy: false
+  # Rail 1 keys on the effective runner OTLP URL (#2367); extraEnv below is
+  # external, so the dedicated peer is required even with no chart-owned endpoint.
+  egress:
+    - cidr: 192.0.2.40/32
+      ports: [{ protocol: TCP, port: 4318 }]
 dispatcher:
   deploy: true
   slack:
@@ -144,6 +149,12 @@ agentSandbox:
 YAML
 
 cat > "$TMP/internal-runner-otel-override.yaml" <<'YAML'
+otelCollector:
+  # In-chart collector stays deployed; runner extraEnv points OTLP elsewhere.
+  # Rail 1 requires the dedicated peer (#2367).
+  egress:
+    - cidr: 192.0.2.40/32
+      ports: [{ protocol: TCP, port: 4318 }]
 dispatcher:
   deploy: true
   slack:

--- a/charts/curie/ci/render-assertions.sh
+++ b/charts/curie/ci/render-assertions.sh
@@ -1501,6 +1501,11 @@ assert_worker_api byo curie https://byo-api.example chart -f "$WORKER_API_BYO"
 
 WORKER_API_OVERRIDE="$TMP/worker_api_override.yaml"
 cat > "$WORKER_API_OVERRIDE" <<'EOF'
+api:
+  # Rail 1 keys on the effective runner API URL (#2367); extraEnv below is external.
+  egress:
+    - cidr: 192.0.2.41/32
+      ports: [{ protocol: TCP, port: 9000 }]
 dispatcher:
   apiBaseUrl: https://byo-api.example
 worker:

--- a/charts/curie/ci/reserved-env-assertions.sh
+++ b/charts/curie/ci/reserved-env-assertions.sh
@@ -104,7 +104,24 @@ with tempfile.TemporaryDirectory() as tmp:
         assert result.returncode != 0, "accepted exact or conflicting timeout duplicate"
         assert "worker.runnerTotalTimeoutSeconds" in result.stderr, result.stderr
     # Ordinary extension envs and the existing single-entry override contract survive.
-    _, output = render(chart, "--set", "worker.extraEnv[0].name=ACME_EXTENSION", "--set-string", "worker.extraEnv[0].value=preserved", "--set", "worker.extraEnv[1].name=CURIE_API_URL", "--set-string", "worker.extraEnv[1].value=https://api.example.com")
+    # Rail 1 requires a declared peer when CURIE_API_URL is external (#2367).
+    _, output = render(
+        chart,
+        "--set",
+        "worker.extraEnv[0].name=ACME_EXTENSION",
+        "--set-string",
+        "worker.extraEnv[0].value=preserved",
+        "--set",
+        "worker.extraEnv[1].name=CURIE_API_URL",
+        "--set-string",
+        "worker.extraEnv[1].value=https://api.example.com",
+        "--set",
+        "api.egress[0].cidr=192.0.2.21/32",
+        "--set",
+        "api.egress[0].ports[0].protocol=TCP",
+        "--set",
+        "api.egress[0].ports[0].port=443",
+    )
     env = envs(output, "worker.yaml", "worker")
     assert [e for e in env if e["name"] == "ACME_EXTENSION"] == [{"name": "ACME_EXTENSION", "value": "preserved"}]
     assert [e for e in env if e["name"] == "CURIE_API_URL"] == [{"name": "CURIE_API_URL", "value": "https://api.example.com"}]

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -1064,14 +1064,19 @@ before contacting Valkey.
 
 {{/* Literal extraEnv value for one name, or the sentinel __valueFrom__ when
      the entry exists without a string value. Empty when the name is absent.
-     Used by the runner-facing endpoint helpers: a valueFrom destination cannot
-     be proven in-cluster at render, so Rail 1 treats it as external. */}}
+     A present empty value is the sentinel __empty__: worker.yaml treats name
+     presence as an override, so Rail 1 must not fall through to the in-chart
+     URL. valueFrom cannot be proven in-cluster at render. */}}
 {{- define "curie.extraEnv.lookup" -}}
 {{- $found := "" -}}
 {{- range (.env | default list) -}}
 {{- if eq .name $.name -}}
 {{- if and (hasKey . "value") (kindIs "string" .value) -}}
+{{- if eq (trim .value) "" -}}
+{{- $found = "__empty__" -}}
+{{- else -}}
 {{- $found = .value -}}
+{{- end -}}
 {{- else if hasKey . "value" -}}
 {{- $found = printf "%v" .value -}}
 {{- else -}}
@@ -1083,12 +1088,17 @@ before contacting Valkey.
 {{- end -}}
 
 {{/* Hostname of a URL, port stripped for host:port. Bracketed IPv6 is left
-     intact; those hosts are never this chart's in-cluster Service DNS. */}}
+     intact; those hosts are never this chart's in-cluster Service DNS. A
+     host:port with no scheme (sprig urlParse leaves host empty) is treated
+     as the raw string so curie-api:8000 still matches the in-chart Service. */}}
 {{- define "curie.endpoint.host" -}}
 {{- $raw := trim . -}}
 {{- if $raw -}}
 {{- $parsed := urlParse $raw -}}
 {{- $host := $parsed.host | default "" -}}
+{{- if not $host -}}
+{{- $host = $raw -}}
+{{- end -}}
 {{- if contains "[" $host -}}
 {{- $host -}}
 {{- else -}}
@@ -1140,28 +1150,62 @@ the in-chart API Service
 
 {{- define "curie.runner.apiIsExternal" -}}
 {{- $url := include "curie.runner.effectiveApiUrl" . | trim -}}
-{{- if or (empty $url) (eq $url "__valueFrom__") -}}
-{{- if eq $url "__valueFrom__" -}}true{{- end -}}
+{{- if or (eq $url "__valueFrom__") (eq $url "__empty__") -}}
+true
+{{- else if empty $url -}}
 {{- else if include "curie.host.inChartService" (dict "root" . "host" (include "curie.endpoint.host" $url) "component" "api") -}}
 {{- else -}}
 true
 {{- end -}}
 {{- end -}}
 
-{{/* OTLP URL the runner sandbox actually dials (#2367). runner extraEnv wins
-     over the chart-owned curie.otel.endpoint. */}}
+{{/* True when the operator overrode the runner-facing API URL, including an
+     in-chart Service DNS leftover. The deploy-false BYO gate uses this so
+     api.deploy false plus dispatcher.apiBaseUrl=http://<release>-api still
+     requires api.egress (#2317), while empty apiBaseUrl with no extraEnv
+     still dead-ends at dispatcher boot. */}}
+{{- define "curie.runner.apiOverrideSet" -}}
+{{- $base := trim (printf "%v" (.Values.dispatcher.apiBaseUrl | default "")) -}}
+{{- $runner := include "curie.extraEnv.lookup" (dict "env" .Values.worker.extraEnv "name" "CURIE_RUNNER_API_URL") | trim -}}
+{{- $api := include "curie.extraEnv.lookup" (dict "env" .Values.worker.extraEnv "name" "CURIE_API_URL") | trim -}}
+{{- if or $base $runner $api -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/* OTLP URL the runner sandbox actually dials (#2367). Signal-specific
+     extraEnv (traces, then metrics, then logs) wins over the generic
+     OTEL_EXPORTER_OTLP_ENDPOINT, then the chart-owned curie.otel.endpoint. */}}
 {{- define "curie.runner.effectiveOtlpEndpoint" -}}
-{{- $extra := include "curie.extraEnv.lookup" (dict "env" .Values.agentSandbox.runner.extraEnv "name" "OTEL_EXPORTER_OTLP_ENDPOINT") | trim -}}
-{{- if $extra -}}
-{{- $extra -}}
+{{- $traces := include "curie.extraEnv.lookup" (dict "env" .Values.agentSandbox.runner.extraEnv "name" "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") | trim -}}
+{{- $metrics := include "curie.extraEnv.lookup" (dict "env" .Values.agentSandbox.runner.extraEnv "name" "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT") | trim -}}
+{{- $logs := include "curie.extraEnv.lookup" (dict "env" .Values.agentSandbox.runner.extraEnv "name" "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT") | trim -}}
+{{- $generic := include "curie.extraEnv.lookup" (dict "env" .Values.agentSandbox.runner.extraEnv "name" "OTEL_EXPORTER_OTLP_ENDPOINT") | trim -}}
+{{- if $traces -}}
+{{- $traces -}}
+{{- else if $metrics -}}
+{{- $metrics -}}
+{{- else if $logs -}}
+{{- $logs -}}
+{{- else if $generic -}}
+{{- $generic -}}
 {{- else -}}
 {{- include "curie.otel.endpoint" . | trim -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "curie.runner.effectiveOtlpSource" -}}
-{{- $extra := include "curie.extraEnv.lookup" (dict "env" .Values.agentSandbox.runner.extraEnv "name" "OTEL_EXPORTER_OTLP_ENDPOINT") | trim -}}
-{{- if $extra -}}
+{{- $traces := include "curie.extraEnv.lookup" (dict "env" .Values.agentSandbox.runner.extraEnv "name" "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") | trim -}}
+{{- $metrics := include "curie.extraEnv.lookup" (dict "env" .Values.agentSandbox.runner.extraEnv "name" "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT") | trim -}}
+{{- $logs := include "curie.extraEnv.lookup" (dict "env" .Values.agentSandbox.runner.extraEnv "name" "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT") | trim -}}
+{{- $generic := include "curie.extraEnv.lookup" (dict "env" .Values.agentSandbox.runner.extraEnv "name" "OTEL_EXPORTER_OTLP_ENDPOINT") | trim -}}
+{{- if $traces -}}
+agentSandbox.runner.extraEnv OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+{{- else if $metrics -}}
+agentSandbox.runner.extraEnv OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+{{- else if $logs -}}
+agentSandbox.runner.extraEnv OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
+{{- else if $generic -}}
 agentSandbox.runner.extraEnv OTEL_EXPORTER_OTLP_ENDPOINT
 {{- else -}}
 curie.otel.endpoint
@@ -1170,8 +1214,9 @@ curie.otel.endpoint
 
 {{- define "curie.runner.otlpIsExternal" -}}
 {{- $url := include "curie.runner.effectiveOtlpEndpoint" . | trim -}}
-{{- if or (empty $url) (eq $url "__valueFrom__") -}}
-{{- if eq $url "__valueFrom__" -}}true{{- end -}}
+{{- if or (eq $url "__valueFrom__") (eq $url "__empty__") -}}
+true
+{{- else if empty $url -}}
 {{- else if include "curie.host.inChartService" (dict "root" . "host" (include "curie.endpoint.host" $url) "component" "otel-collector") -}}
 {{- else -}}
 true

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -1062,6 +1062,122 @@ before contacting Valkey.
 {{ include "curie.env.apiKey" . }}
 {{- end -}}
 
+{{/* Literal extraEnv value for one name, or the sentinel __valueFrom__ when
+     the entry exists without a string value. Empty when the name is absent.
+     Used by the runner-facing endpoint helpers: a valueFrom destination cannot
+     be proven in-cluster at render, so Rail 1 treats it as external. */}}
+{{- define "curie.extraEnv.lookup" -}}
+{{- $found := "" -}}
+{{- range (.env | default list) -}}
+{{- if eq .name $.name -}}
+{{- if and (hasKey . "value") (kindIs "string" .value) -}}
+{{- $found = .value -}}
+{{- else if hasKey . "value" -}}
+{{- $found = printf "%v" .value -}}
+{{- else -}}
+{{- $found = "__valueFrom__" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $found -}}
+{{- end -}}
+
+{{/* Hostname of a URL, port stripped for host:port. Bracketed IPv6 is left
+     intact; those hosts are never this chart's in-cluster Service DNS. */}}
+{{- define "curie.endpoint.host" -}}
+{{- $raw := trim . -}}
+{{- if $raw -}}
+{{- $parsed := urlParse $raw -}}
+{{- $host := $parsed.host | default "" -}}
+{{- if contains "[" $host -}}
+{{- $host -}}
+{{- else -}}
+{{- regexReplaceAll ":[0-9]+$" $host "" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* True when host is this release's Service DNS for component (api or
+     otel-collector), including the usual cluster.local FQDNs. */}}
+{{- define "curie.host.inChartService" -}}
+{{- $fullname := include "curie.fullname" .root -}}
+{{- $ns := .root.Release.Namespace -}}
+{{- $svc := printf "%s-%s" $fullname .component -}}
+{{- $h := lower (trim .host) -}}
+{{- if or (eq $h $svc) (eq $h (printf "%s.%s" $svc $ns)) (eq $h (printf "%s.%s.svc" $svc $ns)) (eq $h (printf "%s.%s.svc.cluster.local" $svc $ns)) -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/* API URL a spawned runner actually dials (#2367). worker.extraEnv
+     CURIE_RUNNER_API_URL wins, then CURIE_API_URL, then dispatcher.apiBaseUrl
+     / the in-chart API Service. Matches apps/worker runner_facing_api_base_url. */}}
+{{- define "curie.runner.effectiveApiUrl" -}}
+{{- $runner := include "curie.extraEnv.lookup" (dict "env" .Values.worker.extraEnv "name" "CURIE_RUNNER_API_URL") | trim -}}
+{{- $api := include "curie.extraEnv.lookup" (dict "env" .Values.worker.extraEnv "name" "CURIE_API_URL") | trim -}}
+{{- if $runner -}}
+{{- $runner -}}
+{{- else if $api -}}
+{{- $api -}}
+{{- else -}}
+{{- include "curie.api.url" (dict "root" . "baseUrl" .Values.dispatcher.apiBaseUrl) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "curie.runner.effectiveApiSource" -}}
+{{- $runner := include "curie.extraEnv.lookup" (dict "env" .Values.worker.extraEnv "name" "CURIE_RUNNER_API_URL") | trim -}}
+{{- $api := include "curie.extraEnv.lookup" (dict "env" .Values.worker.extraEnv "name" "CURIE_API_URL") | trim -}}
+{{- if $runner -}}
+worker.extraEnv CURIE_RUNNER_API_URL
+{{- else if $api -}}
+worker.extraEnv CURIE_API_URL
+{{- else if trim (printf "%v" (.Values.dispatcher.apiBaseUrl | default "")) -}}
+dispatcher.apiBaseUrl
+{{- else -}}
+the in-chart API Service
+{{- end -}}
+{{- end -}}
+
+{{- define "curie.runner.apiIsExternal" -}}
+{{- $url := include "curie.runner.effectiveApiUrl" . | trim -}}
+{{- if or (empty $url) (eq $url "__valueFrom__") -}}
+{{- if eq $url "__valueFrom__" -}}true{{- end -}}
+{{- else if include "curie.host.inChartService" (dict "root" . "host" (include "curie.endpoint.host" $url) "component" "api") -}}
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/* OTLP URL the runner sandbox actually dials (#2367). runner extraEnv wins
+     over the chart-owned curie.otel.endpoint. */}}
+{{- define "curie.runner.effectiveOtlpEndpoint" -}}
+{{- $extra := include "curie.extraEnv.lookup" (dict "env" .Values.agentSandbox.runner.extraEnv "name" "OTEL_EXPORTER_OTLP_ENDPOINT") | trim -}}
+{{- if $extra -}}
+{{- $extra -}}
+{{- else -}}
+{{- include "curie.otel.endpoint" . | trim -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "curie.runner.effectiveOtlpSource" -}}
+{{- $extra := include "curie.extraEnv.lookup" (dict "env" .Values.agentSandbox.runner.extraEnv "name" "OTEL_EXPORTER_OTLP_ENDPOINT") | trim -}}
+{{- if $extra -}}
+agentSandbox.runner.extraEnv OTEL_EXPORTER_OTLP_ENDPOINT
+{{- else -}}
+curie.otel.endpoint
+{{- end -}}
+{{- end -}}
+
+{{- define "curie.runner.otlpIsExternal" -}}
+{{- $url := include "curie.runner.effectiveOtlpEndpoint" . | trim -}}
+{{- if or (empty $url) (eq $url "__valueFrom__") -}}
+{{- if eq $url "__valueFrom__" -}}true{{- end -}}
+{{- else if include "curie.host.inChartService" (dict "root" . "host" (include "curie.endpoint.host" $url) "component" "otel-collector") -}}
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+
 {{/* Coalesce the worker's chart-managed egress credentials and the first-party
      mail adapter's chart-managed paired credential. The chart Secret and the
      worker rollout checksum must use this same rendered JSON so a rotation

--- a/charts/curie/templates/security-networkpolicy.yaml
+++ b/charts/curie/templates/security-networkpolicy.yaml
@@ -347,7 +347,7 @@ spec:
      legacy allow; never invent a CIDR from the hostname. */}}
 {{- if not .Values.otelCollector.egress }}
 {{- if not $np.allowedEgress }}
-{{- fail (printf "%s points the runner at an external OTLP endpoint while Rail 1 is on: set otelCollector.egress to the collector endpoint CIDRs the runner sandbox must reach. The in-chart runner-allow-collector pod selector does not cover that host. NetworkPolicy cannot target a DNS name. Without a declared peer every runner, agent.run, llm.generation and execute_tool span is silently dropped. security.networkPolicy.allowedEgress is the documented legacy allow for this inverse shape; this refusal fires only when that list is also empty." (include "curie.runner.effectiveOtlpSource" .)) }}
+{{- fail (printf "%s points the runner at an external OTLP endpoint while Rail 1 is on: set otelCollector.egress to the collector endpoint CIDRs the runner sandbox must reach. The in-chart runner-allow-collector pod selector does not cover that host. NetworkPolicy cannot target a DNS name. Without a declared peer every runner, agent.run, llm.generation and execute_tool span is silently dropped. security.networkPolicy.allowedEgress is the documented legacy allow for this inverse shape; this refusal fires only when that list is also empty. The chart cannot prove a CIDR in allowedEgress covers this hostname." (include "curie.runner.effectiveOtlpSource" .)) }}
 {{- end }}
 {{- else }}
 {{- range .Values.otelCollector.egress }}
@@ -447,7 +447,7 @@ spec:
      allowedEgress legacy allow; never invent a CIDR from the hostname. */}}
 {{- if not .Values.api.egress }}
 {{- if not $np.allowedEgress }}
-{{- fail (printf "%s points the runner at an external API while Rail 1 is on: set api.egress to the external API endpoint CIDRs the runner sandbox must reach for memory, history and state. The in-chart runner-allow-api pod selector does not cover that host. NetworkPolicy cannot target a DNS name. Without a declared peer agents boot with no memory and no history, remember writes never persist, and the only symptom is a warning line inside the sandbox. security.networkPolicy.allowedEgress is the documented legacy allow for this inverse shape; this refusal fires only when that list is also empty." (include "curie.runner.effectiveApiSource" .)) }}
+{{- fail (printf "%s points the runner at an external API while Rail 1 is on: set api.egress to the external API endpoint CIDRs the runner sandbox must reach for memory, history and state. The in-chart runner-allow-api pod selector does not cover that host. NetworkPolicy cannot target a DNS name. Without a declared peer agents boot with no memory and no history, remember writes never persist, and the only symptom is a warning line inside the sandbox. security.networkPolicy.allowedEgress is the documented legacy allow for this inverse shape; this refusal fires only when that list is also empty. The chart cannot prove a CIDR in allowedEgress covers this hostname." (include "curie.runner.effectiveApiSource" .)) }}
 {{- end }}
 {{- else }}
 {{- range .Values.api.egress }}
@@ -471,8 +471,7 @@ spec:
 {{- end }}
 {{- end }}
 {{- else }}
-{{- $apiExternalByo := include "curie.runner.apiIsExternal" . | trim }}
-{{- if $apiExternalByo }}
+{{- if include "curie.runner.apiOverrideSet" . }}
 {{/* BYO API (#2317). There is no in-chart api pod to select, and NetworkPolicy
      cannot target the effective API URL (a DNS name), so the operator must
      declare CIDRs. Empty keeps fail-closed: without this the install is green
@@ -482,11 +481,13 @@ spec:
      timeout latency inside the worker's claim-bind window. The only trace is a
      `memory load failed` warning inside the sandbox. Mirrors the BYO object
      store branch below; mailAdapter.apiEgress.httpsCidrs is the same idea for
-     the mail adapter pod. Gated on the effective runner-facing URL, not only
-     dispatcher.apiBaseUrl, so a worker.extraEnv override cannot skip this
-     gate. api.deploy false with no external URL at all names no API for the
-     runner to reach -- that install already dead-ends loudly at dispatcher
-     boot (see curie.env.apiUrl), and the trimming overlays render on it. */}}
+     the mail adapter pod. Gated on dispatcher.apiBaseUrl or a worker extraEnv
+     API override, including an in-chart Service DNS leftover, so extraEnv
+     cannot skip this gate and api.deploy false plus apiBaseUrl=http://<release>-api
+     still requires api.egress. api.deploy false with no override at all names
+     no API for the runner to reach -- that install already dead-ends loudly at
+     dispatcher boot (see curie.env.apiUrl), and the trimming overlays render
+     on it. */}}
 {{- if not .Values.api.egress }}
 {{- fail "api.deploy is false: set api.egress to the external API endpoint CIDRs the runner sandbox must reach for memory, history and state. Rail 1 is fail-closed and the in-chart runner-allow-api policy does not render without an in-cluster api pod. NetworkPolicy cannot target a DNS name, so dispatcher.apiBaseUrl alone is not enough -- without this key agents boot with no memory and no history, remember writes never persist, and the only symptom is a warning line inside the sandbox. If a CIDR for this endpoint already sits in security.networkPolicy.allowedEgress, move it to (or duplicate it into) api.egress: allowedEgress is the model/MCP allowlist, and rail 1 renders no runner peer for this endpoint without the dedicated key." }}
 {{- end }}

--- a/charts/curie/templates/security-networkpolicy.yaml
+++ b/charts/curie/templates/security-networkpolicy.yaml
@@ -250,6 +250,8 @@ never reach it because this validator refuses the CIDRs that would populate it.
 {{- end -}}
 {{- if and .Values.agentSandbox.deploy .Values.security.networkPolicy.enabled }}
 {{- $np := .Values.security.networkPolicy }}
+{{- $apiExternal := include "curie.runner.apiIsExternal" . | trim }}
+{{- $otlpExternal := include "curie.runner.otlpIsExternal" . | trim }}
 {{/*
 Rail 1: default-deny egress on runner sandboxes, with explicit allows.
 
@@ -307,8 +309,8 @@ spec:
         - { protocol: TCP, port: 53 }
 {{- end }}
 {{- if .Values.otelCollector.deploy }}
-{{- if .Values.otelCollector.egress }}
-{{- fail "otelCollector.egress is set while otelCollector.deploy is true, where the chart never reads it: it is only read on the BYO branch (otelCollector.deploy false). With the collector in-chart, runner egress to it is governed by the rendered runner-allow-collector policy's in-chart pod selector, so either clear otelCollector.egress or set otelCollector.deploy: false. If a CIDR for this endpoint already sits in security.networkPolicy.allowedEgress, move it to (or duplicate it into) otelCollector.egress when you flip deploy off: allowedEgress is the model/MCP allowlist, and rail 1 renders no runner peer for this endpoint without the dedicated key." }}
+{{- if and .Values.otelCollector.egress (not $otlpExternal) }}
+{{- fail "otelCollector.egress is set while the runner still dials this release's in-chart collector: the key is only read when the effective runner-facing OTLP endpoint is external. With the collector in-chart and no extraEnv override, runner egress to it is governed by the rendered runner-allow-collector policy's in-chart pod selector, so either clear otelCollector.egress or point the runner at an external collector. If a CIDR for this endpoint already sits in security.networkPolicy.allowedEgress, move it to (or duplicate it into) otelCollector.egress when the runner's destination leaves the in-chart Service: allowedEgress is the model/MCP allowlist, and rail 1 renders no dedicated runner peer for an external collector without the dedicated key." }}
 {{- end }}
 ---
 {{/* Allow the runner to ship OTLP traces to THIS release's in-chart collector.
@@ -337,17 +339,49 @@ spec:
       ports:
         - { protocol: TCP, port: {{ .Values.otelCollector.service.grpcPort }} }
         - { protocol: TCP, port: {{ .Values.otelCollector.service.httpPort }} }
+{{- if $otlpExternal }}
+{{/* Inverse of #2317 (#2367): the in-chart collector is still deployed, but
+     the runner actually dials an external OTLP endpoint (runner extraEnv
+     OTEL_EXPORTER_OTLP_ENDPOINT). The pod selector above does not cover that
+     host. Require otelCollector.egress or the documented allowedEgress
+     legacy allow; never invent a CIDR from the hostname. */}}
+{{- if not .Values.otelCollector.egress }}
+{{- if not $np.allowedEgress }}
+{{- fail (printf "%s points the runner at an external OTLP endpoint while Rail 1 is on: set otelCollector.egress to the collector endpoint CIDRs the runner sandbox must reach. The in-chart runner-allow-collector pod selector does not cover that host. NetworkPolicy cannot target a DNS name. Without a declared peer every runner, agent.run, llm.generation and execute_tool span is silently dropped. security.networkPolicy.allowedEgress is the documented legacy allow for this inverse shape; this refusal fires only when that list is also empty." (include "curie.runner.effectiveOtlpSource" .)) }}
+{{- end }}
 {{- else }}
-{{- $otlpEndpoint := include "curie.otel.endpoint" . | trim }}
+{{- range .Values.otelCollector.egress }}
+{{- include "curie.objectStore.egressEntry" (dict "key" "otelCollector.egress" "entry" .) }}
+{{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "curie.fullname" . }}-runner-allow-collector-endpoint
+  labels:
+    {{- include "curie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agent-sandbox
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "curie.selectorLabels" (dict "root" . "component" "runner-sandbox") | nindent 6 }}
+  policyTypes: [Egress]
+  egress:
+    {{- include "curie.egress.ipBlockRules" .Values.otelCollector.egress | trim | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- else }}
+{{- $otlpEndpoint := include "curie.runner.effectiveOtlpEndpoint" . | trim }}
 {{- if $otlpEndpoint }}
 {{/* BYO collector (#2317). There is no in-chart collector pod to select, yet
-     curie.env.otel still hands the sandbox OTEL_EXPORTER_OTLP_ENDPOINT for an
-     external host, and NetworkPolicy cannot target that host (a DNS name). So
-     the operator must declare CIDRs. Empty keeps fail-closed: without this the
-     install is green, api/worker/dispatcher traces flow, and only the runner's
-     spans are silently dropped -- while every turn also pays the exporter's
-     flush stall. An empty resolved endpoint (telemetry off, or no endpoint at
-     all) requires nothing and renders no policy: there is nothing to reach. */}}
+     the runner is handed OTEL_EXPORTER_OTLP_ENDPOINT for an external host, and
+     NetworkPolicy cannot target that host (a DNS name). So the operator must
+     declare CIDRs. Empty keeps fail-closed: without this the install is green,
+     api/worker/dispatcher traces flow, and only the runner's spans are silently
+     dropped -- while every turn also pays the exporter's flush stall. An empty
+     resolved endpoint (telemetry off, or no endpoint at all) requires nothing
+     and renders no policy: there is nothing to reach. Effective URL includes
+     runner extraEnv, so an extraEnv override cannot skip this gate. */}}
 {{- if not .Values.otelCollector.egress }}
 {{- fail "otelCollector.deploy is false with an OTLP endpoint set: set otelCollector.egress to the collector endpoint CIDRs the runner sandbox must reach. Rail 1 is fail-closed and the in-chart runner-allow-collector policy does not render without an in-cluster collector pod. NetworkPolicy cannot target a DNS name, so otelCollector.endpoint alone is not enough -- without this key every runner, agent.run, llm.generation and execute_tool span is silently dropped while every other workload's traces keep flowing. If a CIDR for this endpoint already sits in security.networkPolicy.allowedEgress, move it to (or duplicate it into) otelCollector.egress: allowedEgress is the model/MCP allowlist, and rail 1 renders no runner peer for this endpoint without the dedicated key." }}
 {{- end }}
@@ -372,19 +406,17 @@ spec:
 {{- end }}
 {{- end }}
 {{- if .Values.api.deploy }}
-{{- if .Values.api.egress }}
-{{- fail "api.egress is set while api.deploy is true, where the chart never reads it: it is only read on the BYO branch (api.deploy false). With the API in-chart, runner egress to it is governed by the rendered runner-allow-api policy's in-chart pod selector, and an external destination reached while the in-chart API is still deployed stays governed by security.networkPolicy.allowedEgress -- so either clear api.egress or set api.deploy: false. If a CIDR for this endpoint already sits in allowedEgress, move it to (or duplicate it into) api.egress when you flip deploy off: allowedEgress is the model/MCP allowlist, and rail 1 renders no runner peer for this endpoint without the dedicated key." }}
+{{- if and .Values.api.egress (not $apiExternal) }}
+{{- fail "api.egress is set while the runner still dials this release's in-chart API: the key is only read when the effective runner-facing API URL is external. With the API in-chart and no extraEnv / apiBaseUrl override, runner egress to it is governed by the rendered runner-allow-api policy's in-chart pod selector, so either clear api.egress or point the runner at an external API. If a CIDR for this endpoint already sits in security.networkPolicy.allowedEgress, move it to (or duplicate it into) api.egress when the runner's destination leaves the in-chart Service: allowedEgress is the model/MCP allowlist, and rail 1 renders no dedicated runner peer for an external API without the dedicated key." }}
 {{- end }}
 ---
 {{/* Allow the runner to reach THIS release's in chart API for memory and history calls;
      without this carve out, rail 1 default deny blocks those calls. TCP 8000 is the API
      container port, not the configurable Service port. Two different destinations,
-     two different mechanisms: `api.egress` in the BYO branch below covers the
-     `api.deploy: false` shape, where there is no in-chart api pod to select. It
-     is NOT read here -- with api.deploy true the chart renders this pod selector
-     even when dispatcher.apiBaseUrl points at an external host, and reaching that
-     external destination remains governed by the operator's
-     security.networkPolicy.allowedEgress list. */}}
+     two different mechanisms: `api.egress` covers an external host the runner
+     actually dials (api.deploy false, or api.deploy true with an external
+     effective URL -- #2367). The pod selector here only covers this release's
+     API pods. */}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -407,11 +439,42 @@ spec:
               {{- include "curie.selectorLabels" (dict "root" . "component" "api") | nindent 14 }}
       ports:
         - { protocol: TCP, port: 8000 }
+{{- if $apiExternal }}
+{{/* Inverse of #2317 (#2367): the in-chart API is still deployed, but the
+     runner actually dials an external API (dispatcher.apiBaseUrl, or
+     worker.extraEnv CURIE_API_URL / CURIE_RUNNER_API_URL). The pod selector
+     above does not cover that host. Require api.egress or the documented
+     allowedEgress legacy allow; never invent a CIDR from the hostname. */}}
+{{- if not .Values.api.egress }}
+{{- if not $np.allowedEgress }}
+{{- fail (printf "%s points the runner at an external API while Rail 1 is on: set api.egress to the external API endpoint CIDRs the runner sandbox must reach for memory, history and state. The in-chart runner-allow-api pod selector does not cover that host. NetworkPolicy cannot target a DNS name. Without a declared peer agents boot with no memory and no history, remember writes never persist, and the only symptom is a warning line inside the sandbox. security.networkPolicy.allowedEgress is the documented legacy allow for this inverse shape; this refusal fires only when that list is also empty." (include "curie.runner.effectiveApiSource" .)) }}
+{{- end }}
 {{- else }}
-{{- $apiBaseUrl := trim (printf "%v" (.Values.dispatcher.apiBaseUrl | default "")) }}
-{{- if $apiBaseUrl }}
+{{- range .Values.api.egress }}
+{{- include "curie.objectStore.egressEntry" (dict "key" "api.egress" "entry" .) }}
+{{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "curie.fullname" . }}-runner-allow-api-endpoint
+  labels:
+    {{- include "curie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agent-sandbox
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "curie.selectorLabels" (dict "root" . "component" "runner-sandbox") | nindent 6 }}
+  policyTypes: [Egress]
+  egress:
+    {{- include "curie.egress.ipBlockRules" .Values.api.egress | trim | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- else }}
+{{- $apiExternalByo := include "curie.runner.apiIsExternal" . | trim }}
+{{- if $apiExternalByo }}
 {{/* BYO API (#2317). There is no in-chart api pod to select, and NetworkPolicy
-     cannot target dispatcher.apiBaseUrl (a DNS name), so the operator must
+     cannot target the effective API URL (a DNS name), so the operator must
      declare CIDRs. Empty keeps fail-closed: without this the install is green
      and the failure is silent and agent-shaped -- every turn boots with no
      prior memory and no thread transcript, `remember` writes never persist, the
@@ -419,11 +482,11 @@ spec:
      timeout latency inside the worker's claim-bind window. The only trace is a
      `memory load failed` warning inside the sandbox. Mirrors the BYO object
      store branch below; mailAdapter.apiEgress.httpsCidrs is the same idea for
-     the mail adapter pod. Scoped to a set dispatcher.apiBaseUrl, mirroring the
-     collector branch above: api.deploy false with no base URL at all names no
-     API for the runner to reach -- that install already dead-ends loudly at
-     dispatcher boot (see curie.env.apiUrl), and the trimming overlays render on
-     it. */}}
+     the mail adapter pod. Gated on the effective runner-facing URL, not only
+     dispatcher.apiBaseUrl, so a worker.extraEnv override cannot skip this
+     gate. api.deploy false with no external URL at all names no API for the
+     runner to reach -- that install already dead-ends loudly at dispatcher
+     boot (see curie.env.apiUrl), and the trimming overlays render on it. */}}
 {{- if not .Values.api.egress }}
 {{- fail "api.deploy is false: set api.egress to the external API endpoint CIDRs the runner sandbox must reach for memory, history and state. Rail 1 is fail-closed and the in-chart runner-allow-api policy does not render without an in-cluster api pod. NetworkPolicy cannot target a DNS name, so dispatcher.apiBaseUrl alone is not enough -- without this key agents boot with no memory and no history, remember writes never persist, and the only symptom is a warning line inside the sandbox. If a CIDR for this endpoint already sits in security.networkPolicy.allowedEgress, move it to (or duplicate it into) api.egress: allowedEgress is the model/MCP allowlist, and rail 1 renders no runner peer for this endpoint without the dedicated key." }}
 {{- end }}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -821,22 +821,26 @@ otelCollector:
   # supplied egress policy selecting the adapter, or its exports are dropped
   # while every other workload's succeed.
   endpoint: ""
-  # Runner sandbox egress to a BYO collector endpoint (#2317). Rail 1 is
-  # fail-closed, and the in-chart runner-allow-collector policy selects this
-  # release's collector pod, so it does not render when deploy is false. Each
-  # entry is {cidr, ports, except?} like security.networkPolicy.allowedEgress.
-  # NetworkPolicy cannot target a DNS name, so the `endpoint` above is not
-  # enough. Required only when deploy is false, Rail 1 is on, and the resolved
-  # endpoint is non-empty; a telemetry-disabled or endpoint-less install needs
-  # nothing here because there is nothing for the runner to reach. It is read
-  # ONLY on that BYO branch: setting it while deploy is true is refused at
-  # render rather than silently ignored. Empty (the
-  # default) keeps fail-closed: otherwise the install is green, every other
-  # workload's traces flow, and only the sandbox's spans are silently dropped.
-  # Each entry must set cidr and a concrete port (not protocol-only, not
-  # endPort). Default routes, IPv4 prefixes shorter than /8, IPv6 prefixes
-  # shorter than /32, and CIDRs that reach 169.254.169.254 or fd00:ec2::254
-  # are refused: this is one collector endpoint, not a second model allowlist.
+  # Runner sandbox egress to an external collector endpoint (#2317, #2367).
+  # Rail 1 is fail-closed. The in-chart runner-allow-collector policy selects
+  # this release's collector pod, so it does not cover a host the runner
+  # actually dials. Each entry is {cidr, ports, except?} like
+  # security.networkPolicy.allowedEgress. NetworkPolicy cannot target a DNS
+  # name, so the `endpoint` above (or a runner extraEnv
+  # OTEL_EXPORTER_OTLP_ENDPOINT override) is not enough. Required when Rail 1
+  # is on and the effective runner-facing OTLP URL is external -- including
+  # deploy true with a runner extraEnv override -- unless
+  # security.networkPolicy.allowedEgress already holds a covering CIDR (the
+  # documented legacy allow). A telemetry-disabled or endpoint-less install
+  # needs nothing here because there is nothing for the runner to reach.
+  # Setting it while the runner still dials the in-chart collector is refused
+  # at render rather than silently ignored. Empty (the default) keeps
+  # fail-closed: otherwise the install is green, every other workload's traces
+  # flow, and only the sandbox's spans are silently dropped. Each entry must
+  # set cidr and a concrete port (not protocol-only, not endPort). Default
+  # routes, IPv4 prefixes shorter than /8, IPv6 prefixes shorter than /32, and
+  # CIDRs that reach 169.254.169.254 or fd00:ec2::254 are refused: this is one
+  # collector endpoint, not a second model allowlist.
   egress: []
   #  - cidr: 192.0.2.10/32
   #    ports: [{ protocol: TCP, port: 4318 }]
@@ -994,26 +998,28 @@ grafanaConnector:
 # ---------------------------------------------------------------------------
 api:
   deploy: true
-  # Runner sandbox egress to a BYO API endpoint (#2317). Rail 1 is fail-closed,
-  # and the in-chart runner-allow-api policy selects this release's api pod, so
-  # it does not render when deploy is false. Each entry is
-  # {cidr, ports, except?} like security.networkPolicy.allowedEgress.
-  # NetworkPolicy cannot target a DNS name, so dispatcher.apiBaseUrl is not
-  # enough. Required when deploy is false, Rail 1 is on, and
-  # dispatcher.apiBaseUrl names an external API; deploy false with no base URL
-  # at all names nothing for the runner to reach and that install already
-  # dead-ends loudly at dispatcher boot. It is read ONLY on that BYO branch:
-  # setting it while deploy is true is refused at render rather than silently
-  # ignored, and an external destination reached while the in-chart API is
-  # still deployed stays governed by security.networkPolicy.allowedEgress.
-  # Empty (the default) keeps fail-closed: otherwise the install is green and
-  # agents boot with no memory and no thread history, with only a warning line
-  # inside the sandbox to show for it. Each entry must set cidr and a concrete
-  # port (not protocol-only, not endPort). Default routes, IPv4 prefixes
-  # shorter than /8, IPv6 prefixes shorter than /32, and CIDRs that reach
-  # 169.254.169.254 or fd00:ec2::254 are refused: this is one API endpoint,
-  # not a second model allowlist.
-  # mailAdapter.apiEgress.httpsCidrs is the same idea for the mail adapter pod.
+  # Runner sandbox egress to an external API endpoint (#2317, #2367). Rail 1
+  # is fail-closed. The in-chart runner-allow-api policy selects this
+  # release's api pod, so it does not cover a host the runner actually dials.
+  # Each entry is {cidr, ports, except?} like
+  # security.networkPolicy.allowedEgress. NetworkPolicy cannot target a DNS
+  # name, so dispatcher.apiBaseUrl (or worker.extraEnv CURIE_API_URL /
+  # CURIE_RUNNER_API_URL) is not enough. Required when Rail 1 is on and the
+  # effective runner-facing API URL is external -- including deploy true with
+  # an external apiBaseUrl or extraEnv override -- unless
+  # security.networkPolicy.allowedEgress already holds a covering CIDR (the
+  # documented legacy allow). deploy false with no external URL at all names
+  # nothing for the runner to reach and that install already dead-ends loudly
+  # at dispatcher boot. Setting it while the runner still dials the in-chart
+  # API is refused at render rather than silently ignored. Empty (the default)
+  # keeps fail-closed: otherwise the install is green and agents boot with no
+  # memory and no thread history, with only a warning line inside the sandbox
+  # to show for it. Each entry must set cidr and a concrete port (not
+  # protocol-only, not endPort). Default routes, IPv4 prefixes shorter than
+  # /8, IPv6 prefixes shorter than /32, and CIDRs that reach 169.254.169.254
+  # or fd00:ec2::254 are refused: this is one API endpoint, not a second
+  # model allowlist. mailAdapter.apiEgress.httpsCidrs is the same idea for
+  # the mail adapter pod.
   egress: []
   #  - cidr: 192.0.2.11/32
   #    ports: [{ protocol: TCP, port: 443 }]

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -830,8 +830,9 @@ otelCollector:
   # OTEL_EXPORTER_OTLP_ENDPOINT override) is not enough. Required when Rail 1
   # is on and the effective runner-facing OTLP URL is external -- including
   # deploy true with a runner extraEnv override -- unless
-  # security.networkPolicy.allowedEgress already holds a covering CIDR (the
-  # documented legacy allow). A telemetry-disabled or endpoint-less install
+  # security.networkPolicy.allowedEgress is already non-empty (the documented
+  # legacy allow). The chart cannot prove a CIDR covers the hostname. A
+  # telemetry-disabled or endpoint-less install
   # needs nothing here because there is nothing for the runner to reach.
   # Setting it while the runner still dials the in-chart collector is refused
   # at render rather than silently ignored. Empty (the default) keeps
@@ -1007,8 +1008,9 @@ api:
   # CURIE_RUNNER_API_URL) is not enough. Required when Rail 1 is on and the
   # effective runner-facing API URL is external -- including deploy true with
   # an external apiBaseUrl or extraEnv override -- unless
-  # security.networkPolicy.allowedEgress already holds a covering CIDR (the
-  # documented legacy allow). deploy false with no external URL at all names
+  # security.networkPolicy.allowedEgress is already non-empty (the documented
+  # legacy allow). The chart cannot prove a CIDR covers the hostname. deploy
+  # false with no external URL at all names
   # nothing for the runner to reach and that install already dead-ends loudly
   # at dispatcher boot. Setting it while the runner still dials the in-chart
   # API is refused at render rather than silently ignored. Empty (the default)


### PR DESCRIPTION
## Summary

Rail 1 keyed runner API and collector egress on `api.deploy` / `otelCollector.deploy`. With the in-chart pod still deployed, an external `dispatcher.apiBaseUrl` or a supported extraEnv override pointed the runner at a host no rendered policy permitted. Agents then booted with no memory and no history, or sandbox spans were dropped, with only a warning inside the sandbox.

The chart now resolves the URL the runner actually dials. When that URL is external, render fails closed naming `api.egress` or `otelCollector.egress`, or keeps the documented `allowedEgress` legacy allow when that list is already non-empty. Setting the dedicated key while the runner still dials this release's Service is still refused. The dedicated `*-endpoint` ipBlock policy renders from the operator CIDR even while the in-chart pod remains deployed. No CIDR is derived from a hostname, and default-deny is not widened.

`api.deploy: false` plus `dispatcher.apiBaseUrl` pointing at this release's API Service DNS still requires `api.egress`, matching #2317. Runner extraEnv `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is part of the effective OTLP URL.

## Related issue

Closes #2367

## Fix pin verification

Fix pin: charts/curie/ci/byo-endpoint-egress-assertions.sh

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Render-time Helm NetworkPolicy guard; does not reach plugin packaging, the runner turn loop, or skill eval | | |
| local | n/a | Does not reach compose services, dispatcher/worker/API wiring, or a curie verb | | |
| local-release | n/a | Does not change released binary or image identity | | |
| cluster | required | Chart templates and runner NetworkPolicy. The operator-facing consumer is `helm template` failing closed on a missing peer and rendering a dedicated endpoint policy or preserving allowedEgress. | fake | Commit `8622c156b`. `bash charts/curie/ci/byo-endpoint-egress-assertions.sh` PASS (assertions 13-27: inverse apiBaseUrl fail-closed naming `api.egress`; dedicated `api.egress` renders `runner-allow-api-endpoint`; extraEnv `CURIE_API_URL` / `CURIE_RUNNER_API_URL` / `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` fail-closed; `api.deploy=false` plus in-chart Service DNS still requires `api.egress`). Negative: `bash cli/scripts/verify-fix-pin.sh HEAD charts/curie/ci/byo-endpoint-egress-assertions.sh` PINNED. Sibling: `allowedEgress` including `0.0.0.0/0` still renders; in-chart `apiBaseUrl` does not require `api.egress`; Rail 1 off does not require a peer. |
| live provider | n/a | Does not reach model routing, credential resolution, or the MCP/workspace/coding-tool path set | | |
| external integration | n/a | Does not reach Slack, git webhooks, or connector OAuth | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
