### PR TITLE
Document the connector endpoint contract

### DIFF
--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -146,6 +146,9 @@ const MCP_JSON: &str = "{\n  \"mcpServers\": {}\n}\n";
 const CONNECTORS_YAML: &str = r#"# What this agent needs running. Curie derives the Deployment, Service,
 # container hardening, host allowlist, sandbox-to-connector NetworkPolicy,
 # secret wiring, and the URL the agent dials -- so none of that lives here.
+# The container must listen on port 8000.
+# HTTP MCP is served at /mcp where applicable.
+# Connector args are passed through verbatim.
 #
 # Uncomment and edit to declare one:
 #
@@ -601,6 +604,31 @@ mod tests {
                 "{name} must explain itself; it is the only place an author learns it exists"
             );
         }
+
+        let connectors = std::fs::read_to_string(dir.path().join("connectors.yaml")).unwrap();
+        assert!(
+            connectors.contains("The container must listen on port 8000."),
+            "connectors.yaml must name Curie's fixed connector listen port: {connectors}"
+        );
+        assert!(
+            connectors.contains("HTTP MCP is served at /mcp where applicable."),
+            "connectors.yaml must name the HTTP MCP path when the connector serves it: {connectors}"
+        );
+        assert!(
+            connectors.contains("Connector args are passed through verbatim."),
+            "connectors.yaml must warn authors that args control the connector itself: {connectors}"
+        );
+        assert!(
+            connectors.ends_with("connectors: {}\n"),
+            "connectors.yaml must remain an empty valid map until an author opts in: {connectors}"
+        );
+        assert!(
+            connectors.lines().all(|line| {
+                let trimmed = line.trim_start();
+                trimmed.starts_with('#') || !trimmed.starts_with("port:")
+            }),
+            "connectors.yaml must not advertise an active port: key: {connectors}"
+        );
 
         let mcp: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(dir.path().join(".mcp.json")).unwrap())

--- a/docs/guides/deciding-what-belongs-in-a-connector.md
+++ b/docs/guides/deciding-what-belongs-in-a-connector.md
@@ -141,6 +141,11 @@ when it stops being true rather than after.
 
 Each of these has cost somebody a day.
 
+**Expose the fixed endpoint.** Connector containers must listen on port `8000`.
+HTTP MCP connectors serve `/mcp` where applicable. The `args` in
+`connectors.yaml` pass through verbatim, so configure the image to listen on
+that port and serve that path.
+
 **Fail closed on missing configuration.** An empty allowlist means refuse to
 start, never "everything permitted". A connector that comes up with no ceiling
 looks healthy and is wrong.


### PR DESCRIPTION
## Summary

Document the fixed connector endpoint where connector authors look: the generated `connectors.yaml` comments and the connector-boundary guide now state port `8000`, `/mcp` for HTTP MCP where applicable, and verbatim argument forwarding. The scaffold shape remains unchanged and no `port:` schema field was added.

Closes #2351

Fix pin: n/a - the regression assertion is an inline Rust unit test in `cli/src/scaffold.rs`, which `verify-fix-pin` deliberately does not support.

## End-to-end verification

This change affects generated documentation, not connector runtime behavior. The observable author-facing surface was exercised with the CLI built from commit `c6336add3`.

| Tier | Required / n/a | Reason | Command and observed outcome |
| --- | --- | --- | --- |
| Unit | Required | Pins the exact generated comments and absence of an active `port:` key. | `cargo test --locked scaffold::tests::scaffolds_the_frozen_bundle_shape -- --exact` passed, 1 test. |
| Local integration | n/a | No service, persistence, API, or connector runtime path changed. | Not run. |
| Local E2E | Required | The changed surface is a freshly generated scaffold. | Built `curie`, ran `curie init acme-bot --dir <temp>`, and inspected `connectors.yaml`; all three statements were present and no active `port:` key existed. |
| Cluster E2E | n/a | No chart, renderer, deployment, service, or runtime behavior changed; #2350 owns runtime rollout proof. | Not run. |
| External provider | n/a | No provider API or authentication surface changed. | Not run. |
| Production | n/a | This task does not authorize release or deployment. | Not run. |

Scoped checks: `cargo fmt --check`; `cargo clippy --locked --all-targets -- -D warnings`; `bash scripts/check-docs.sh`; `git diff --check`.

## Done check

- [x] Failing tests committed before implementation: `09ac10454` precedes `4615effd3` in the pre-squash history.
- [x] All scaffold, test, and guide edits were performed by delegated native Codex workers.
- [x] Broadened return types: N/A; no type or behavior signature changed.
- [x] Agent-router Code review completed; its image-specific argument concern was reconciled against the bounded issue wording and round two approved the candidate.
- [x] Agent-router Scope review approved every hunk and found no passengers.
- [x] Sibling-path parity: N/A; only author-facing prose and its exact regression assertion changed.
- [x] Guard demonstration: N/A; no gate, validator, denylist, or preflight changed.
- [x] Consolidation completed; the simplification-only pass found no material cleanup and made no edits.
- [x] Security review: N/A; no auth, permission, secret, PII, payment, or tenant boundary changed.
- [x] Observable verification completed with a freshly built CLI and inspected scaffold output.
- [x] Deployed E2E: N/A; correctness does not depend on deployed behavior for this documentation-only task.
- [x] Train check: the isolated worktree was cut from fresh `origin/main`, matching the v0.8.8 target.
- [x] Discovery waiver: the plan records that documentation-only scope excludes cluster reproduction; #2350 owns the higher-tier runtime proof.
- [x] Re-fix mechanism: N/A; no prior fix of this symptom exists on the fresh base.
- [x] Full affected verification passed: exact scaffold test, Rust formatting and Clippy, docs checks, built-CLI scaffold inspection, and diff checks.

## Scope boundaries

No port schema field, frozen package, schema, ADR, chart, connector runtime, release, deployment, or #2350 rollout implementation changes are included.
