### PR TITLE
docs(adr): dark factory decision set

### DIFF
--- a/docs/adr/0145-a-labelled-issue-is-a-backlog-item-and-the-stream-is-its-queue.md
+++ b/docs/adr/0145-a-labelled-issue-is-a-backlog-item-and-the-stream-is-its-queue.md
@@ -1,0 +1,186 @@
+# 145. A labelled issue is a backlog item and the stream is its queue
+
+Date: 2026-09-10
+
+Status: Draft
+
+Proposed as part of the dark-factory decision set, discussed in
+[discussion #2551](https://github.com/curie-eng/curie/discussions/2551).
+
+Relies on [ADR-0134](0134-a-hook-shares-one-thread-per-partition.md) (a hook
+shares one thread per partition) for its fan-out primitive and on
+[ADR-0079](0079-inbound-triggers-as-a-new-event-kind.md) for the ingress it
+partitions. It supersedes no ADR.
+
+## Context
+
+Headless ticket-to-pull-request execution needs a way for a ticket to become a
+turn without a person sending a message. Curie has two intake surfaces that
+could carry that and one that already almost does.
+
+`POST /github/webhook` is signed, deployed, and deliberately narrow: after the
+ping case it returns `ignored` for every event that is not a push
+(`apps/api/src/curie_api/routers/github.py:44`). It exists to run the
+git-push-is-the-deploy flow of ADR-0014 and it knows nothing about issues.
+
+`POST /hooks/{agent_id}/{hook}` is the general signed ingress. It verifies an
+HMAC over the body, claims an `X-Curie-Delivery-Id` so a redelivery runs at
+most once, returns a receipt naming the conversation it landed on, and — since
+ADR-0134 — mints one thread per partition value drawn from an operator-named
+JSON Pointer into the delivery body (`agents.hook_partitions`,
+`apps/api/src/curie_api/models.py:162`). One hook delivery per issue,
+partitioned on the issue number, is exactly one thread per ticket with
+intra-ticket serialization intact. That is the fan-out the factory needs and it
+is already built.
+
+What is not decided is whether a backlog is a thing Curie stores. ADR-0013
+rejected a durable workflow engine on ADR-0007 grounds, and the `curie:runs`
+Valkey stream is a delivery transport rather than a work store: there is no row
+with a task id, a submitter, a priority, or a `queued → running → done` status
+that survives a restart. An earlier framing of this proposal treated that
+absence as the largest gap in the design and reached for a task table and a
+polling loop over the tracker.
+
+It is the wrong reach. The tracker already is the backlog. A GitHub issue has
+an id, an author, a state, labels, comments, a permalink, and a UI every
+engineer already uses; duplicating a subset of that into Curie creates two
+records of the same fact and a reconciliation problem between them. What the
+platform actually needs is not to *hold* the backlog but to be *told* when an
+item enters it, and to hold the in-flight item long enough to run it.
+
+There is one property of the stream worth naming precisely, because it is
+easy to overstate. The runs consumer group is created at `$`, the stream's
+current tail (`apps/worker/src/curie_worker/consumer.py:225`). That is a
+deliberate first-boot guard: a persistent Valkey that accumulated stale
+mentions while no worker ran must not storm every one of them into a live turn
+the moment a group appears. An *existing* group is left untouched, and
+crash recovery works off the pending list rather than the group's start id, so
+a worker restart does not discard in-flight deliveries. The loss window is
+narrow and specific: entries written to the stream before the group has ever
+been created.
+
+## Decision
+
+**The tracker is the backlog. A labelled issue event is a signed delivery on
+the existing hook ingress, partitioned on the issue number, and the
+`curie:runs` stream is the queue for the items currently in flight. Curie
+stores no task row and polls no tracker.**
+
+### The issue event enters through the ingress that already exists
+
+`issues` and `issue_comment` events are routed into the hook enqueue path — the
+one with the HMAC check, the delivery claim, the receipt, and the partition
+derivation — rather than into a second ingress written beside it. The
+`/github/webhook` route's push handling is unchanged; what changes is that the
+non-push arm stops being a uniform `ignored`.
+
+The operator says which events matter by labelling. A delivery whose event does
+not name a label the operator selected for that agent is acknowledged and not
+enqueued. Label selection is operator state on the agent row, alongside the
+other operator-owned per-agent policy already there (`model`, `thinking`,
+`approval_required_tools`, `approval_routes`, `hook_partitions`). A bundle has
+no surface for it, for the same reason ADR-0134 put the partition pointer on
+the agent row and refused a request header: the sender must not decide how much
+of this install's capacity it can command.
+
+### The partition is the issue number, and it is the thread
+
+Under ADR-0134 the conversation id becomes
+`hook:<agent_id>:<hook>:<issue-number>`. Every artifact that keys on the
+conversation id follows: the sandbox affinity route, the thread lock, the
+transcript, the workspace selection, and the publication lineage are all
+per-issue. Two events about the same issue serialize; two events about
+different issues run concurrently. ADR-0134's stability requirement is
+satisfied by construction, because an issue number is a stable identity of the
+thing the delivery is about and never a per-delivery value.
+
+### There is no polling loop and no task table
+
+The platform does not sweep the tracker for ready work. A push arrives or it
+does not. This is the smallest thing that works, and it is reversible: if the
+narrow group-creation loss window above ever bites in practice, the remedy is a
+reconciliation sweep that asks the tracker which labelled issues have no
+publication — a read against the record that is already authoritative — and not
+a durable task store that would have to be kept in step with it.
+
+### Reading the ticket is the bundle's job
+
+The delivery carries enough to identify the issue; it is not the ticket. The
+factory bundle reads the issue by link through an MCP server holding its own
+credential, which is what makes the same intake shape work for a tracker that
+is not GitHub. The platform does not parse issue bodies, does not model
+acceptance criteria, and does not learn a tracker's schema. A second tracker is
+a different signature scheme at the ingress and a different MCP server in the
+bundle, and nothing else.
+
+## Consequences
+
+An operator labels an issue and a thread exists. That is the whole intake
+story, and it is roughly a day of work against shipped ingress rather than the
+task-store epic the first framing implied.
+
+The backlog is legible where engineers already look. "What is queued" is a
+label filter in the tracker's own UI, and it stays correct without Curie
+writing anything.
+
+Curie gains no ability to answer "what is queued" from its own data. `GET
+/publications` answers what came *out*; nothing answers what is waiting. For a
+push-based design that is honest rather than missing — the queue is somewhere
+else on purpose — but an operator wanting one screen will be looking at two.
+
+A labelled issue commands sandbox capacity, and whoever can label can therefore
+drive load. The agent backlog quota (per agent, per window) still meters
+admission exactly as it does for any hook, and ADR-0134's analysis of
+sender-driven cardinality applies unchanged: what the operator holds is the
+decision to enable this at all, on this agent, for these labels.
+
+An issue that is labelled while the install is at capacity is the subject of a
+separate decision, because the current at-capacity outcome is a reply and an
+ack. See
+[ADR-0146](0146-headless-capacity-is-a-wait-not-a-reply.md).
+
+The `/github/webhook` route stops being a deploy-only surface. Its signature
+check, body bound, and ping handling are unchanged, but the mental model "this
+route deploys agents" becomes "this route carries GitHub", which is a thing a
+later reader has to be told rather than infer.
+
+## Alternatives considered
+
+**A durable task table with a state machine.** Rejected. It duplicates the
+tracker, requires reconciliation with it, and re-opens the ADR-0013 decision
+against a durable workflow engine for a benefit — a backlog view — that the
+tracker already renders better. The `queued → running → done` states would be a
+second, lagging copy of an issue's own state.
+
+**A polling loop over the tracker.** Rejected for v1. It is the natural remedy
+for the stream's narrow first-creation loss window, but paying for a permanent
+sweep to cover a window that opens once per install is the wrong trade. Held as
+the named fallback if the window is ever observed to matter.
+
+**A second, issue-specific ingress route.** Rejected. The hook route's HMAC
+verification, delivery claim, receipt, backlog quota, and partition derivation
+are the parts that are hard to get right, and they are all already correct. A
+parallel route would reimplement them or drift from them.
+
+**Parsing the issue body in the platform.** Rejected. It would make the
+platform learn a tracker's schema and would put the ticket's meaning in a place
+no eval can iterate on. Reading the ticket is bundle behaviour, which is where
+it can be changed without a release.
+
+**Deriving the partition from the delivery id.** Rejected, and it is the
+failure mode ADR-0134 warns about explicitly: a per-delivery partition makes
+every transcript single-use and grows retained per-partition state without
+bound while delivering none of the continuity the split exists for.
+
+## Realizing code path
+
+Unimplemented. The named paths for the eventual work are the non-push arm of
+`apps/api/src/curie_api/routers/github.py`, the enqueue path in
+`apps/api/src/curie_api/routers/hooks.py`, the partition derivation in
+`apps/api/src/curie_api/hook_partition.py`, and a label-selection column
+alongside `agents.hook_partitions` in `apps/api/src/curie_api/models.py`.
+
+This ADR is **Draft** and authorizes nothing by itself. Under
+[ADR-0085](0085-acceptance-not-implementation-authorizes-an-adr.md) as amended
+by [ADR-0102](0102-accepted-alongside-implementation-with-explicit-approval.md),
+acceptance is a maintainer act.

--- a/docs/adr/0146-headless-capacity-is-a-wait-not-a-reply.md
+++ b/docs/adr/0146-headless-capacity-is-a-wait-not-a-reply.md
@@ -1,0 +1,192 @@
+# 146. For a headless lane, at capacity means wait, not reply
+
+Date: 2026-09-10
+
+Status: Draft
+
+Proposed as part of the dark-factory decision set, discussed in
+[discussion #2551](https://github.com/curie-eng/curie/discussions/2551).
+
+Extends [ADR-0109](0109-retention-capacity-and-back-pressure-are-one-policy.md)
+(retention, capacity, and back pressure are one policy) by deciding the
+queue discipline for a lane with no human at the other end. It builds on
+[ADR-0013](0013-concurrency-and-delivery-model.md) (one live session per
+thread) and [ADR-0059](0059-sandbox-is-a-bounded-resource-envelope.md) (the
+sandbox is a bounded resource envelope). It supersedes no ADR.
+
+## Context
+
+A default install can hold eight concurrent sandboxes: the tenant
+`ResourceQuota` allows `limitsCpu: "8"` (`charts/curie/values.yaml:2432`) and
+one sandbox costs one CPU. ADR-0109 wrote the arithmetic down and decided the
+policy at the boundary — admission before creation, a bounded queue, then an
+explicit refusal.
+
+Part of that has since shipped, and it shipped well. A claim whose pod the
+quota refuses is now detected from the claim's own status after a two-poll
+debounce and raised as `CapacityExhaustedError`
+(`apps/worker/src/curie_worker/sandbox/substrate.py:790`), rather than polling
+in silence until `claimTimeoutSeconds` elapses. The failure is fast, and it
+names the quota, the resource axis, and the observed usage in the operator log.
+That closed the "late and misattributed" half of what ADR-0109 set out to fix.
+
+What it did not close — and did not set out to close — is what happens to the
+work. The kernel replies into the thread with "This agent is at capacity right
+now… please try again shortly" and returns `TurnOutcome(terminal_ok=True)`
+(`apps/worker/src/curie_worker/kernel.py:2468`). `terminal_ok` is the input to
+the retry-and-escalate decision (`apps/worker/src/curie_worker/kernel.py:554`),
+so a true value means the delivery is done: it is acked off the stream and
+never retried.
+
+For an interactive turn that is the right answer and a good one. A person read
+a sentence, understands what happened, and will send the message again.
+
+For a headless lane it is the wrong answer, and the reason is precisely that it
+is correct-looking. Nobody reads the reply. Nothing sends the message again. A
+labelled issue that arrives while eight sandboxes are held produces a thread, a
+message into a channel, a green ack, and no pull request — and the operator's
+only signal that a ticket was silently dropped is its continued absence from a
+board that lists what came out rather than what went in. This is an ambiguous
+signal — "at capacity" means "come back later", which is a true statement about
+an interactive user and a false one about a webhook — being resolved into a
+sticky, invisible, work-destroying state.
+
+The obvious fix is to make the outcome retryable rather than terminal, and it
+is not sufficient on its own. The retryable set is bounded: `max_attempts` is 3
+and the delivery deadline
+([ADR-0131](0131-a-delivery-has-one-deadline-and-one-renewable-fenced-owner.md))
+bounds the whole attempt chain. A backlog
+of fifty labelled issues against eight slots does not clear inside three
+attempts, and turning capacity exhaustion into a `runner-error` would spend the
+retry budget on a condition that is neither an error nor the delivery's fault,
+then dead-letter the ticket anyway.
+
+ADR-0109's own queue does not reach this either, and it says so honestly: its
+bound is "the headroom under the ADR-0013 thread lock TTL", which is 120
+seconds. That is the right bound for a claim already holding a thread lock and
+a caller waiting on a reply. It is not a bound in which a fifty-issue backlog
+drains.
+
+## Decision
+
+**A delivery on a headless lane that cannot be admitted is not claimed. It
+waits in the stream, unacked, until capacity exists or its deadline expires,
+and an expiry is a visible failure rather than a reply.**
+
+The distinction this decision turns on is where the wait happens. ADR-0109
+queues *inside the worker*, after the delivery has been claimed and while a
+thread lock is held, which is why its bound must be short. This decision moves
+back-pressure one layer out, to the point before a delivery becomes the
+worker's problem at all.
+
+1. **Admission is checked before the delivery is claimed.** The worker consults
+   the published ceiling from ADR-0109 decision 1 before it takes a headless
+   delivery off the stream. A delivery it cannot serve is left pending, which is
+   what a Valkey stream consumer group is for: an unacked entry stays in the
+   pending list and is redelivered.
+
+2. **Waiting is the normal case, not a failure.** Time spent waiting for a slot
+   does not consume `max_attempts`, is not classified as `runner-error`, and
+   emits no message to any channel. A headless delivery may sit for as long as
+   its deadline allows. The unit of patience is the delivery deadline
+   (ADR-0131), which is already the durable bound on how long the platform will
+   keep trying, and which an operator can raise for a factory lane without
+   changing anything about the interactive one.
+
+3. **A headless delivery never resolves capacity exhaustion into an ack.** The
+   `terminal_ok=True` reply path stays exactly as it is for a turn with a human
+   reply route. For a headless delivery the same condition either waits or, past
+   the deadline, ends in an explicit, recorded failure naming capacity as the
+   cause.
+
+4. **Expiry is visible where the work was.** A delivery that never got a slot is
+   not silently gone. The outcome is written where an operator looking for that
+   ticket will find it — the dead-letter graveyard already carries permanently
+   failed deliveries
+   ([ADR-0039](0039-bounded-delivery-and-a-dead-letter-graveyard.md)), and a capacity
+   expiry belongs there with a
+   classification that distinguishes it from a run that failed.
+
+5. **What tells the two lanes apart is the reply route, not a new flag.** A turn
+   whose delivery carries a human-addressable reply target is interactive; a
+   webhook-sourced delivery whose only audience is an operator log is not. The
+   platform already carries this distinction — `TurnSource`, and the reply
+   handle minted from the channel binding — and this decision reads it rather
+   than adding a parallel one.
+
+**The invariant** (what we test to): a labelled ticket admitted by the ingress
+either runs, or is recorded as failed with a stated cause. It is never
+acknowledged, replied to, and dropped.
+
+## Consequences
+
+The factory becomes throughput-limited instead of loss-limited. Labelling fifty
+issues against eight slots takes longer; it does not lose forty-two of them.
+The demo throttle — "label at most as many issues as the ceiling allows" — stops
+being load-bearing.
+
+Deliveries sitting unacked in the pending list is a new steady state for the
+stream, and the pending list is not free: it is the same structure crash
+recovery reads. A large waiting backlog makes recovery scans longer and makes
+"is this worker stuck or is it waiting?" a question an operator will ask. That
+is the main cost of this decision and the thing to instrument first.
+
+The delivery deadline becomes the factory's real service-level knob. An
+operator who wants a fifty-ticket batch to survive overnight sets it there, and
+the failure mode of setting it too low is now legible rather than silent.
+
+An operator can no longer tell capacity exhaustion from a slow queue by watching
+a channel, because the channel goes quiet on this path. The compensating signal
+has to be the observability ADR-0109 decision 5 already calls for — held
+sandboxes, queue depth, refusals — which this decision makes load-bearing rather
+than nice to have.
+
+Nothing here changes isolation, the ceiling itself, or the interactive path. One
+pod still serves one thread, ADR-0059's envelope stands, and a human at capacity
+still gets the same sentence they get today.
+
+## Alternatives considered
+
+**Classify capacity exhaustion as retryable and let the existing retry ladder
+handle it.** Rejected. `max_attempts` is 3 and the attempt chain is bounded by
+the delivery deadline; a backlog that takes an hour to drain exhausts that in
+minutes and dead-letters work that was never wrong. It also mislabels a
+capacity condition as an error, which pollutes exactly the signal an operator
+uses to find real failures.
+
+**Reuse ADR-0109's in-worker bounded FIFO for the headless lane.** Rejected as
+the whole answer, though it stands unchanged for interactive turns. Its bound is
+headroom under a 120-second thread lock, which is correct for a queue entered
+after the lock is held and far too short for a backlog. Widening that bound
+would mean holding thread locks for hours, which is a different and worse
+decision.
+
+**Raise the ceiling until waiting never happens.** Rejected, and ADR-0109
+already tested this shape: every default has a load that exceeds it, and tuning
+moves the cliff without changing the behaviour at it. The dark factory's whole
+premise is that batch size grows.
+
+**Refuse the delivery at the ingress with a 429 and let GitHub retry.** Rejected.
+It makes the tracker's retry policy the platform's capacity policy, retries
+carry the same delivery id and are deduplicated by design, and the operator
+loses any record that the ticket was ever offered.
+
+**Reclaim an idle route to serve the waiting delivery** (ADR-0109 decision 4).
+Not rejected, and not decided here. Reclamation is the highest-risk part of
+ADR-0109 by its own account, and it is orthogonal: it changes which work gets a
+slot, while this decision changes what happens to work that does not get one.
+Adding it later strictly improves this decision's latency and changes none of
+its guarantees.
+
+## Realizing code path
+
+Unimplemented. The named paths for the eventual work are the admission check
+ahead of the claim in `apps/worker/src/curie_worker/consumer.py` and
+`apps/worker/src/curie_worker/sandbox/substrate.py`, the capacity arm of
+`apps/worker/src/curie_worker/kernel.py`, and the dead-letter classification in
+`apps/api/src/curie_api/graveyardwatcher.py`.
+
+This ADR is **Draft** and authorizes nothing by itself. Under
+[ADR-0085](0085-acceptance-not-implementation-authorizes-an-adr.md) as amended
+by [ADR-0102](0102-accepted-alongside-implementation-with-explicit-approval.md),
+acceptance is a maintainer act.

--- a/docs/adr/0147-publication-approval-is-a-per-agent-operator-policy.md
+++ b/docs/adr/0147-publication-approval-is-a-per-agent-operator-policy.md
@@ -1,0 +1,222 @@
+# 147. Publication approval is a per-agent operator policy, not a platform constant
+
+Date: 2026-09-10
+
+Status: Draft
+
+Proposed as part of the dark-factory decision set, discussed in
+[discussion #2551](https://github.com/curie-eng/curie/discussions/2551).
+
+**Amends [ADR-0125](0125-managed-repository-workspaces-and-approval-gated-publication.md)**
+(managed repository workspaces and approval-gated publication are platform
+capabilities). It supersedes in part exactly one clause of 0125's Decision:
+that `mcp__curie__publish_changes` "is an additive **mandatory** permission gate
+that a bundle or operator policy cannot remove." Everything else in 0125 stands
+unchanged — the worker-owned clone, the credential the sandbox never holds, the
+remote-URL reset and verification, the snapshot validation, the publication Job
+outside the sandbox NetworkPolicy, the repository allowlist checked twice, and
+the audited credential redemption. The gate itself is not removed by this
+decision. What becomes policy is who resolves it.
+
+Under [ADR-0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md),
+the back-link on ADR-0125 is written when this decision is Accepted, not while
+it is Draft.
+
+## Context
+
+ADR-0125 put the most sensitive boundary in the system outside prompt-controlled
+code, and it did so on evidence: a clone URL carrying a write-scoped credential
+persisted in `.git/config`, code inside the sandbox read it, and a pull request
+was opened without passing through the approval plane. Everything 0125 decided
+follows from that incident, and the mandatory gate was the belt to the
+credential boundary's braces.
+
+The gate is unconditional today, structurally rather than by configuration. The
+runner adds `publish_changes` to the gated set whenever a managed workspace is
+mounted (`runner/src/curie_runner/approval.py:1409-1414`), a `Publication` row
+is created only alongside an `Approval` whose `purpose` is publication, and the
+credential endpoint refuses to redeem for a publication that is not approved,
+launching, or running (`apps/api/src/curie_api/routers/publications.py:409`).
+`Publication.approval_id` is `NOT NULL` and unique
+(`apps/api/src/curie_api/models.py:534`). There is no bypass flag anywhere in
+the tree, which is exactly what 0125 intended.
+
+Headless ticket-to-pull-request execution needs a pull request to open without a
+person clicking a card. The existing escape hatch is a scripted operator
+principal: mint one, poll for pending approvals, resolve the publication rows.
+CI already does precisely this in the end-to-end demo script. That works, and it
+is the wrong shape to ship. It moves the decision out of the platform into a
+loop someone runs beside it, and the audit trail then records a principal that
+is really a cron job wearing an operator's name. A dark factory does not need a
+bypass flag; it needs a decision about what replaces the human, made in the open
+and recorded where an auditor will find it.
+
+The premise that has changed since 0125 is not the risk. It is who is exposed to
+it. ADR-0125 was written for an interactive agent steered from a Slack thread by
+whoever happened to be in the channel, where the approving human is the only
+thing standing between a conversational prompt and a push. A headless factory
+agent is deployed by an operator, against a repository the operator allowlisted,
+from tickets the operator's own team filed, running a bundle the operator
+installed. In that configuration the approval card is asking a person to
+re-consent, one pull request at a time, to a thing the operator already
+consented to at install. That is not a safety property; it is a rate limiter on
+a decision already made.
+
+Meanwhile every guardrail that does not depend on a human is untouched by this
+and stays: the sandbox holds no credential and cannot push, the patch is
+validated against a privately-held base, `.github/workflows` edits are refused,
+patches cap at 900 KB, the repository must be on the allowlist at clone *and*
+again at redemption, the Job runs outside the sandbox NetworkPolicy with a
+tokenless ServiceAccount, and every redemption is audited. The output is a pull
+request, which is itself a review object a human must merge.
+
+## Decision
+
+**Whether a publication requires a human decision is per-agent operator policy.
+An agent's `publication` policy is `approve` (the default, and today's
+behaviour) or `auto`. Under `auto` the platform resolves the publication
+approval itself, under a recorded policy, and every other publication guardrail
+applies unchanged.**
+
+### The policy lives on the agent row
+
+`publication` joins the operator-owned per-agent policy already on `agents`:
+`model`, `thinking`, `approval_required_tools`, `approval_routes`,
+`hook_partitions`, `max_usd_per_day`. It is operator state, set at deploy. **A
+bundle has no surface for it at any tier**, which is the part of ADR-0125's
+clause that this decision keeps rather than supersedes: prompt-controlled code
+still cannot reach this, and neither can a bundle author. Only the operator who
+installed Curie and allowlisted the repository can turn it on, for one named
+agent at a time.
+
+The default is `approve`. An install that changes nothing behaves exactly as it
+does today, byte for byte.
+
+### `auto` does not mean "no approval"
+
+`Publication.approval_id` is `NOT NULL`, and this decision does not change that.
+Under `auto` the `Approval` row is still created, and it is still the object the
+credential endpoint checks; what changes is that the platform resolves it
+immediately under the recorded policy instead of posting a card and waiting.
+
+This is deliberate and is the crux of the decision. The approval row is the
+audit trail: it carries the purpose, the conversation, the resolving principal,
+and the timestamp, and the credential redemption audit entry points at it. An
+`auto` publication that skipped the row would be a publication with no record of
+why it was allowed. Instead it records that it was allowed *by policy*, naming
+the agent's policy as the authorizer, and it is distinguishable in the audit
+trail from one a person resolved. An operator reviewing a quarter of
+publications can tell the two apart.
+
+The consequence is stated plainly: **under `auto`, the platform is the
+approver.**
+[ADR-0106](0106-an-approver-is-an-authenticated-principal.md) made an approver an
+authenticated principal, and a policy
+is not a principal. This decision does not pretend otherwise. It says the
+operator's act of setting the policy is the authorization, that it is recorded
+as such, and that it is scoped to one agent and one allowlisted repository set.
+
+### Every other guardrail is unchanged, and the gate still runs
+
+The runner still registers `publish_changes` as a gated tool, the turn still
+ends at the gate, and the snapshot is still validated against a privately-held
+base before any durable row exists. `auto` changes what happens *after* the
+`Approval` and `Publication` rows are written, and nothing before it. A patch
+that fails validation, touches `.github/workflows`, exceeds the size cap, or
+names a repository outside the allowlist is refused under `auto` exactly as it
+is under `approve`.
+
+The two additional bounds an `auto` agent may declare are the ones that make an
+unattended pull request easier to review rather than harder: the pull request
+may be opened as a draft, and its branch may be required to carry a named
+prefix. Both are operator-set, both are enforced platform-side, and neither is
+required.
+
+### Denial keeps its meaning
+
+Nothing about the denied path changes. A denied publication redeems no
+credential and produces no GitHub side effect. Under `auto` there is no denial
+path from a human, which is the point; the refusals that remain are the
+validation refusals, which are not approvals at all.
+
+## Consequences
+
+An operator can install Curie, allowlist a repository, deploy a factory agent
+with `publication: auto`, and receive pull requests without anyone clicking
+anything. That is the capability the whole dark-factory proposal rests on, and
+it becomes a supported setting rather than a script running beside the platform.
+
+The scripted operator-principal loop stops being necessary, which removes a
+pattern where an automated actor holds a human principal's identity. That is a
+net improvement to the audit trail even though the decision it enables is a
+loosening.
+
+**The blast radius of a compromised bundle grows.** Under `approve`, a bundle
+that produced a malicious patch still had to get a human to click. Under `auto`
+it does not. What bounds it is the allowlist, the workflow-edit refusal, the
+patch cap, the fact that a pull request is not a merge, and the reviewer who
+merges it. Anyone turning this on is choosing to rely on that set, and the
+setting should say so at the point of use.
+
+**A pull request is now the last human gate, so it has to actually be one.** An
+install running `auto` against a repository with permissive merge settings, or
+against a branch nothing protects, has no human gate at all. This decision does
+not enforce branch protection and cannot; the operator wiring is where that
+lives, and the documentation for this setting has to name it.
+
+An `auto` agent produces pull requests at whatever rate its tickets arrive.
+Review capacity becomes the constraint the approval card used to be, and it is a
+constraint on people rather than on the platform.
+
+The audit trail gains a class of approvals nobody resolved. Any query, report,
+or dashboard that assumes an approval has a human principal has to learn about
+this class, and the migration adding the policy column has to say what existing
+rows mean.
+
+## Alternatives considered
+
+**Keep the gate mandatory and ship the scripted operator-principal loop.**
+Rejected as the product answer, though it stays the correct demo answer. It puts
+the decision outside the platform where no ADR governs it, records an automated
+resolver as a human principal, and gives an operator no way to express "this
+agent, this repository, unattended" that the platform can enforce or audit.
+
+**A global install-level setting rather than per-agent.** Rejected. Capacity to
+publish unattended should be as narrow as the thing that earned it. Per-agent
+means an install can run one factory agent unattended beside interactive agents
+that are still gated, which is the configuration a real team wants.
+
+**A bundle-declared setting.** Rejected, and this is the part of ADR-0125's
+clause that survives intact. The bundle is prompt-adjacent code; letting it
+declare that it needs no approval is exactly the hole 0125 closed.
+
+**Skip the `Approval` row entirely under `auto`.** Rejected. It is simpler and it
+destroys the audit trail: a publication with no approval row is a push with no
+recorded authorization. Making the row say "authorized by policy" costs one
+column and keeps the history answerable.
+
+**A task-class policy — "this kind of ticket needs no approval" — instead of a
+per-agent one.** Rejected for v1 because no task-class concept exists in the data
+model, and inventing one to carry this would be a larger decision than this one.
+Per-agent is the granularity the schema already supports.
+
+**Auto-approve only when the repository is a designated sandbox repository.**
+Considered and folded in rather than rejected: the allowlist already expresses
+this, and an operator who wants that shape sets the allowlist to that repository.
+A second mechanism naming the same thing would drift from the first.
+
+## Realizing code path
+
+Unimplemented. The named paths for the eventual work are the policy column and
+its migration in `apps/api/src/curie_api/models.py`, the resolution path in
+`apps/api/src/curie_api/routers/publications.py` and `crud.py`, the recorded
+authorizer in `apps/api/src/curie_api/authorizer.py` and the approval audit
+entries, the deploy surface in `cli/src/main.rs` and `cli/src/commands.rs`, and
+the draft-pull-request and branch-prefix bounds in
+`apps/worker/src/curie_worker/publication_clients.py`.
+
+This ADR is **Draft** and authorizes nothing by itself. Under
+[ADR-0085](0085-acceptance-not-implementation-authorizes-an-adr.md) as amended
+by [ADR-0102](0102-accepted-alongside-implementation-with-explicit-approval.md),
+acceptance is a maintainer act — and for a decision that loosens a boundary
+another ADR set on incident evidence, acceptance should be an explicit one.

--- a/docs/adr/0148-one-ticket-is-one-pull-request.md
+++ b/docs/adr/0148-one-ticket-is-one-pull-request.md
@@ -1,0 +1,150 @@
+# 148. One ticket is one pull request, and assembly is a later decision
+
+Date: 2026-09-10
+
+Status: Draft
+
+Proposed as part of the dark-factory decision set, discussed in
+[discussion #2551](https://github.com/curie-eng/curie/discussions/2551).
+
+Relies on [ADR-0143](0143-thread-owned-pull-request-lineage.md) (a coding thread
+owns one fenced pull request lineage) and on
+[ADR-0145](0145-a-labelled-issue-is-a-backlog-item-and-the-stream-is-its-queue.md)
+(a labelled issue is a backlog item). It supersedes no ADR and asks for no
+platform change.
+
+## Context
+
+The vision this decision set serves is larger than what it decides. An engineer
+plans a whole feature, files a dependency graph of linked tickets, and the
+factory produces a stack of pull requests that merge into a feature branch, on
+which one strong model runs an end-to-end verification of the whole thing. The
+dependency graph, the stack, the assembly and the feature-level verification are
+all part of the picture that makes the idea interesting.
+
+None of them are in v1, and it is worth recording why in an ADR rather than
+leaving it as a scope note, because "the factory produces stacked PRs" is the
+kind of thing a later reader will assume was always intended and quietly build
+toward.
+
+ADR-0143 decided that one agent's canonical thread identity owns at most one
+active, repository-compatible pull request lineage, enforced by a unique index
+on the agent, conversation, and repository. A merged or closed pull request is
+terminal for its thread: the platform reports that state and refuses another
+revision, and continuing requires a new thread. That decision was made for an
+interactive coding thread, where the alternative — one pull request per approved
+revision — fragmented review history and produced duplicates.
+
+Under ADR-0145 a ticket is a partition and a partition is a thread. So one
+ticket owns one lineage, and one lineage is one pull request. The shape the
+factory needs for v1 is not something to build; it is what the platform already
+enforces.
+
+Assembly is the opposite. Stacked pull requests in dependency order need a
+lineage that spans threads, a base that is another lineage's head rather than
+the default branch, an ordering derived from links between tickets that the
+platform does not read, and a merge policy for a branch that is not the default
+one. Feature-level verification needs a notion of "the feature" — a set of
+tickets and an acceptance criterion over their combined result — which does not
+exist anywhere in the data model. Each is a real decision. Bundled into v1 they
+would be several decisions taken at once, on a design whose first end-to-end
+run has not happened.
+
+## Decision
+
+**In v1, one ticket produces one pull request, and the platform's existing
+one-lineage-per-thread rule is the enforcement. Stacked pull requests,
+dependency-ordered assembly into a feature branch, and feature-level end-to-end
+verification are explicitly out of v1 and are a separate decision.**
+
+1. **The unit of work is the ticket.** A labelled issue becomes a thread, the
+   thread runs a turn, the turn ends in a publication, and the publication is one
+   pull request against the repository's default base. Nothing orders one ticket
+   against another, and nothing waits for another ticket to finish.
+
+2. **The platform reads no links between tickets.** Dependency edges an engineer
+   files between issues are real and useful, and they are for the human deciding
+   what to label and when. Curie does not parse them, does not build a graph from
+   them, and does not schedule on them. An engineer who wants a dependency
+   respected labels the blocked ticket after the blocking pull request merges.
+
+3. **A merged or closed pull request ends its ticket's thread**, exactly as
+   ADR-0143 already decides. A ticket that needs more work after its pull request
+   is merged is a new ticket, which is also how the tracker would model it.
+
+4. **Assembly is out of scope and named as such.** Extending a lineage across
+   threads, basing one lineage on another, and dependency-ordered merging are
+   left to a future decision that extends ADR-0143. This ADR exists partly to be
+   the place that decision points back to.
+
+5. **Feature-level verification is out of scope for the same reason.** Per-ticket
+   verification lives in the bundle
+   ([ADR-0150](0150-per-task-verification-is-bundle-behaviour.md)); a criterion
+   over a *set* of tickets has no home in the data model and inventing one is a
+   larger decision than this one.
+
+## Consequences
+
+Nothing is built. This is the rare decision whose implementation is the absence
+of one, and its whole value is that the constraint is written down before
+somebody works around it.
+
+The v1 factory produces a stream of independent pull requests. Whether that is
+useful on its own is the bet this decision makes, and it is a real bet: an
+engineer who wanted one reviewable feature gets N reviewable pieces and does the
+assembly by hand. If that turns out to be the thing that makes the product
+uninteresting, this ADR is where the reasoning to revisit lives.
+
+Engineers must file tickets that stand alone. A ticket whose acceptance criteria
+only make sense after a sibling ticket lands will produce a pull request that
+does not pass its own tests, and the platform will not know why. That pushes
+real work onto the planning step, which is where this vision already puts the
+expensive model, so it is a cost the design can absorb — but it is a cost, and it
+lands on the human.
+
+Sequencing a dependency means labelling in order and waiting, which is a human
+loop the factory was supposed to remove for exactly the case — a seven-ticket
+feature with three parallel and one blocked — that motivated the idea. This is
+the clearest gap between v1 and the vision, and naming it here is more honest
+than letting the scorecard's "no gap" reading suggest the problem was solved.
+
+The one thing v1 does gain toward assembly is that every pull request is already
+tied to a durable lineage keyed by agent, conversation and repository. A future
+assembly decision extends a structure that exists rather than inventing one.
+
+## Alternatives considered
+
+**Build stacked pull requests in v1.** Rejected on sequencing rather than on
+merit. It requires extending ADR-0143's lineage across threads, a cross-thread
+ordering the platform would have to derive from links it does not read, and a
+merge policy for a non-default branch. That is three decisions, and taking them
+before a single ticket has gone end to end would be designing against a guess.
+
+**Fan several tickets into one thread so they share a pull request.** Rejected,
+and ADR-0143's unique index makes it fail in an unhelpful way: several queued
+tasks in one conversation get one lineage and silently serialize. A batching
+layer would have to mint a distinct canonical conversation per task anyway,
+which is what one-ticket-one-thread already is.
+
+**Let the platform read the tracker's dependency links and schedule on them.**
+Rejected for v1. It makes the platform learn a tracker's link semantics, it
+turns Curie into the scheduler ADR-0013 declined to become, and it needs the
+task-state model [ADR-0145](0145-a-labelled-issue-is-a-backlog-item-and-the-stream-is-its-queue.md)
+deliberately does not create.
+
+**Merge to the default branch instead of opening a pull request.** Rejected
+outright. The pull request is the last human gate in a headless pipeline, and it
+is the reason the loosening in
+[ADR-0147](0147-publication-approval-is-a-per-agent-operator-policy.md) is
+defensible at all.
+
+## Realizing code path
+
+None. The behaviour this ADR decides is what
+`uq_active_thread_publication_lineage` and the lineage transitions in
+`apps/api/src/curie_api/routers/publications.py` already enforce.
+
+This ADR is **Draft** and authorizes nothing by itself. Under
+[ADR-0085](0085-acceptance-not-implementation-authorizes-an-adr.md) as amended
+by [ADR-0102](0102-accepted-alongside-implementation-with-explicit-approval.md),
+acceptance is a maintainer act.

--- a/docs/adr/0149-curie-pins-a-model-and-the-provider-routes.md
+++ b/docs/adr/0149-curie-pins-a-model-and-the-provider-routes.md
@@ -1,0 +1,170 @@
+# 149. Curie pins a model per agent and the provider does the routing
+
+Date: 2026-09-10
+
+Status: Draft
+
+Proposed as part of the dark-factory decision set, discussed in
+[discussion #2551](https://github.com/curie-eng/curie/discussions/2551).
+
+**Supersedes [ADR-0037](0037-opt-in-binding-hook-and-pareto-model-routing.md)**
+(opt-in binding hook and Pareto model routing) in whole. ADR-0037's Decision
+specifies a binding-hook port, a manifest `routing` block, an install-level
+model registry, deterministic Pareto selection with an optional LLM floor
+estimator, promotion of the routing decision into `SessionConfig`, and
+per-decision observability. This decision is that Curie builds none of it.
+
+Under [ADR-0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md),
+ADR-0037's status line and back-link are written when this decision is Accepted,
+not while it is Draft.
+
+## Context
+
+ADR-0037 was Accepted on 2026-07-16, driven by a prospective engagement asking
+for a model router: static rules-based routing first, a model-made routing
+decision second. It is a careful design. It reached the same conclusion
+OpenRouter reached independently about pinning a routed session to one model to
+protect prompt caches, it kept selection deterministic and auditable, and it
+refused the in-path gateway that #253 had already rejected on prompt-cache
+grounds.
+
+It has not been built. `BindingDecision` and `binding_hook` return no hits
+anywhere in the tree, and `model_registry` and `model_alias` — the vocabulary of
+the adjacent Draft [ADR-0128](0128-install-owned-model-gateway-and-agent-aliases.md)
+— return none either. What ships instead is a boot-time pin with a per-agent
+override: `agents.model` and `agents.thinking`, applied to the sandbox boot
+environment in `apps/worker/src/curie_worker/binding.py:838-885`, which the code
+itself notes are "the only per-agent knobs here"
+(`apps/worker/src/curie_worker/binding.py:861`). The runner resolves the
+credential to a provider by prefix and base URL, so a key for an aggregating
+provider already reaches that provider's endpoint with no Curie-side work.
+
+Two things have changed since 0037 was written.
+
+The first is that the aggregators shipped the router. A caller can name a
+provider-side routing model as the model id and get exactly what ADR-0037's
+Pareto selection promised — cheapest at or above a declared floor, chosen by
+someone whose whole business is maintaining the price and capability table that
+ADR-0037's install-level registry would have required an operator to hand-write
+and hand-maintain per install. Building the registry now means competing with a
+service already reachable through a field Curie already has.
+
+The second is the workload this decision set is about. A dark-factory agent runs
+one kind of task — implement a fully-specified ticket — on a cheap model chosen
+once. ADR-0037's premise was a mixed stream where a router earns its keep by
+telling simple work from complex; a factory lane has no mixed stream to sort.
+And ADR-0037 already decided that a route binds per session and sticks, so even
+under 0037 a factory agent would get one model per run. The router's value in
+this workload is close to zero, and the design cost is the largest single piece
+of platform work in its epic (multi-credential delivery).
+
+Nothing about this is an argument that ADR-0037 was wrong when written. It is an
+argument that the thing it would have built is now available on the other side
+of a field, and that the workload that would have justified building it anyway
+is not the workload in front of us.
+
+## Decision
+
+**Model selection stays a per-agent, boot-time pin. Curie builds no router, no
+binding-hook port, no install-level model registry, and no floor estimator.
+Where routing is wanted, the operator pins a provider-side routing model id and
+the provider routes.**
+
+1. **`agents.model` is the whole surface.** An operator selects one model per
+   agent. An install that wants a cheap tier and an expensive tier runs two
+   agents, which is a shape the platform already supports and an operator
+   already understands.
+
+2. **Routing, where it happens, happens at the provider.** A routing model id in
+   `agents.model` is a value, not a code path. Curie does not know the id is a
+   router, does not see the candidates, and does not record the choice — the
+   provider does, on its own dashboard.
+
+3. **No binding hook.** The port ADR-0037 proposed is not extracted. Under the
+   ADR-0026/0027 discipline it would have been extracted ahead of its second
+   adapter on the strength of the first; with the first adapter withdrawn there
+   is no adapter to extract it for.
+
+4. **`SessionConfig` does not gain routing fields.** ADR-0037's decision 6 was to
+   promote model id, provider base URL, and credential ref into the typed ACI as
+   a patch bump. That is withdrawn. The model still travels as it does today.
+
+5. **The credential shape is unchanged.** One model credential resolves, as
+   ADR-0009 decided. The multi-credential delivery ADR-0037 called for — its
+   largest piece of platform work — is not built.
+
+6. **Non-model routing stays out of scope**, as ADR-0037 also decided. Handler
+   dispatch above the model seam is a different problem and this decision does
+   not touch it.
+
+### What this does not decide
+
+Draft [ADR-0128](0128-install-owned-model-gateway-and-agent-aliases.md) proposes
+an install-owned model gateway with operator-selected aliases. That decision is
+about *where an install terminates its model credentials and what an operator
+calls them*, not about per-task selection, and this ADR neither accepts nor
+rejects it. If 0128 is accepted, `agents.model` names an alias instead of a raw
+model id and everything above still holds.
+
+## Consequences
+
+An entire Accepted-but-unbuilt epic is closed rather than left open. That is the
+main benefit: ADR-0037 currently reads as a live commitment, and a reader
+opening it finds a design with no code and no back-link telling them the
+thinking moved.
+
+Cost control moves to the provider and to the per-agent budget cap that already
+exists. An operator who wants to know what routing chose looks at the provider's
+records, not Curie's. That is a real loss of a property ADR-0037 valued —
+"every decision is auditable and replayable against the registry" — and it is
+traded knowingly for not maintaining a per-install price and capability table.
+
+Curie takes a dependency on a provider's routing behaviour changing underneath
+it. A routing model that silently starts choosing a different tier changes cost
+and quality with no signal on this side, and the compensating control is the
+per-agent budget cap and the bundle's own evals, not a platform mechanism.
+
+A future workload with a genuinely mixed stream — one agent, tasks of wildly
+different difficulty, and a reason the provider's router cannot see the
+difference — would reopen this. ADR-0037's reasoning stays legible for exactly
+that case, which is why it is superseded rather than deleted.
+
+Prompt-cache economics are unaffected. A pinned model per session was ADR-0037's
+own conclusion and #253's before it, and pinning per agent is strictly stronger.
+
+## Alternatives considered
+
+**Build ADR-0037 as written.** Rejected. The install-level registry requires an
+operator to maintain per-model pricing and capability scores per install, which
+is a table that is stale the week it is written, and the selection it feeds is
+now purchasable through a field that already exists.
+
+**Keep ADR-0037 Accepted and simply not implement it.** Rejected, and this is
+the status quo. An Accepted ADR authorizes implementation; leaving one Accepted
+and unbuilt for months is the exact intent-gap failure
+[ADR-0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md) was
+written to make recordable.
+
+**An in-path gateway or proxy.** Rejected again, for the reason #253 and
+ADR-0037 both gave: translation hops in the token path break byte-stable prompt
+prefixes and destroy prompt-cache economics.
+
+**A per-task model choice made by the bundle.** Rejected. It would put model
+selection in prompt-controlled code and give a bundle a say in which credential
+it consumes, which is a credential-redirection surface, and ADR-0037 rejected
+the general form of it for the same reason.
+
+**Hard-code one cheap model and drop the pin entirely.** Rejected as too narrow.
+`agents.model` already exists, costs nothing, and is what lets one install run a
+factory agent beside an interactive one on different models.
+
+## Realizing code path
+
+None required; the pin in `apps/worker/src/curie_worker/binding.py` is the
+behaviour this decision keeps. The work this decision authorizes is
+documentation: recording ADR-0037's supersession and closing its tracking epic.
+
+This ADR is **Draft** and authorizes nothing by itself. Under
+[ADR-0085](0085-acceptance-not-implementation-authorizes-an-adr.md) as amended
+by [ADR-0102](0102-accepted-alongside-implementation-with-explicit-approval.md),
+acceptance is a maintainer act.

--- a/docs/adr/0150-per-task-verification-is-bundle-behaviour.md
+++ b/docs/adr/0150-per-task-verification-is-bundle-behaviour.md
@@ -1,0 +1,154 @@
+# 150. Whether the work was right is the bundle's question, not the platform's
+
+Date: 2026-09-10
+
+Status: Draft
+
+Proposed as part of the dark-factory decision set, discussed in
+[discussion #2551](https://github.com/curie-eng/curie/discussions/2551).
+
+Builds on [ADR-0014](0014-git-push-is-the-deploy.md) and
+[ADR-0019](0019-freeze-eval-case-format.md) (evals are CI for an agent version). It
+supersedes no ADR, and it deliberately does not resolve
+[ADR-0042](0042-llm-as-a-verifier-grader-and-progress-signal.md) or
+[ADR-0132](0132-worst-cohort-eval-gates-and-cross-family-verifiers.md), which
+are about grading a bundle rather than grading a task.
+
+## Context
+
+The platform has an excellent record of *what was pushed* and no record of
+*whether it was right*. `ThreadPublicationLineage` and `Publication` carry the
+repository, branch, pull request number, head, patch, changed paths, status and
+error, all under compare-and-set, and the chain terminates the moment the pull
+request URL is posted. Nothing in the data model records what a task was
+supposed to achieve. There is no acceptance-criteria field, no done-when frame
+in the ACI, no per-task verdict, and no runs table in which one could be stored.
+The platform also never reads the produced pull request's CI: the publication
+client reads open/merged/closed state and the head sha, and nothing reads
+check-runs.
+
+The eval plane that does exist is aimed at a different object. ADR-0014 makes a
+push to a bundle's branch the deploy, ADR-0019 froze a case format, and the
+result is CI *for an agent version*: cases fan out on a bundle push and post a
+commit status on the bundle's commit. That is verification of the agent, on a
+git-push axis, and it is the right axis for what it grades.
+
+A headless factory needs the other axis — did this pull request do what this
+ticket asked — and an earlier framing of this proposal identified building it as
+the largest structural gap in the design. It would mean a task record, an
+acceptance-criteria field, a verdict, and probably a verifier grader, which is
+the ADR-0042 work that is Accepted and unbuilt.
+
+The reason not to build it is not that it is hard. It is that the thing being
+verified is not a platform artifact. "Did this satisfy the ticket" is a judgement
+about a diff against a prose criterion, made by a model, and it is exactly the
+kind of judgement that improves by iterating on a prompt and measuring the
+result. A platform release cycle is the wrong loop for that; a bundle is the
+right one, because a bundle is versioned, evaluated, and deployable by a push.
+
+There is also a boundary argument. If the platform grades the task, the platform
+needs to read the ticket, which means learning a tracker's schema — the thing
+[ADR-0145](0145-a-labelled-issue-is-a-backlog-item-and-the-stream-is-its-queue.md)
+declined to do — and it needs a model credential and an opinion about what
+"done" means, which is bundle territory in every other part of this system.
+
+## Decision
+
+**Per-task verification is bundle behaviour. The platform records what was
+produced and does not judge whether it was correct. No task record, no
+acceptance-criteria field, and no per-task verdict enters the data model.**
+
+1. **The skill verifies its own work inside its turn.** It reads the ticket, does
+   the work, runs the repository's tests, reviews the diff against the ticket's
+   acceptance criteria, and only then calls `publish_changes`. A turn that cannot
+   satisfy the criteria says so and publishes nothing, which is a far cheaper
+   outcome than a pull request that looks finished.
+
+2. **The existing eval plane is how that behaviour is measured.** The factory
+   skill is a bundle, its cases are bundle cases, and its quality is graded on
+   the axis ADR-0014 and ADR-0019 already established. Iterating on how strictly
+   the skill self-reviews is a bundle push, not a release.
+
+3. **The platform's contribution is evidence, not judgement.** What the platform
+   already records — the patch, the changed paths, the lineage, the pull request
+   URL, the publication status and error — is the evidence a human or a later
+   verifier needs. That is where its responsibility stops.
+
+4. **Reading the pull request's CI is optional platform work, and it is a
+   reading, not a verdict.** The publication reconciler already holds the
+   credential and already calls GitHub for this pull request. Adding a check-runs
+   read and persisting the rollup would give an honest "is CI green" column with
+   no new credential, no new egress, and no new architecture. It reports what
+   GitHub says. It does not decide whether the ticket was satisfied, and it does
+   not gate anything.
+
+5. **This is a v1 boundary, held explicitly rather than by default.** The
+   argument for a platform-side per-task verdict — that it is the only place a
+   *cross-bundle* quality signal could live — is real and is not answered here.
+   If a second factory bundle ever needs to be compared against a first on the
+   same tickets, this decision is what gets revisited, and ADR-0042's verifier
+   grader is where that conversation starts.
+
+## Consequences
+
+The largest item on the gap list stops being platform work. That is the whole
+practical effect: an epic-sized data-model change becomes prompt iteration
+inside a bundle, measured by machinery that already exists.
+
+Verification quality becomes a property of a bundle version, which means it can
+be improved between releases and regressed between releases. A factory whose
+skill got worse at self-review produces confident, wrong pull requests, and
+nothing in the platform will say so. The compensating control is the bundle's
+own eval suite and the human who merges.
+
+**The platform cannot answer "did that ticket succeed."** It can answer "was a
+pull request opened, and did it error", which is close enough to look like the
+same question and is not. Anyone building the board should be careful with the
+column headings, because "9 PRs out" invites the reading "9 tickets done".
+
+The failure signal for a ticket the skill could not satisfy lands in the thread
+and the trace, not in a queryable row. An operator asking "which of last night's
+forty tickets produced nothing" is reading escalation messages, which is
+worse than reading a table and is a known cost of not having the table.
+
+Nothing here forecloses the other axis. Adding a task record later is additive:
+no decision in this set depends on its absence, and the evidence the platform
+already stores would be its inputs.
+
+## Alternatives considered
+
+**Add acceptance criteria and a verdict to the data model.** Rejected for v1. It
+requires the platform to read tickets (declined in ADR-0145), to hold an opinion
+about done-ness, and to grow a task record this decision set otherwise avoids —
+and it puts the judgement on a release cycle instead of a bundle push.
+
+**Build ADR-0042's verifier grader and point it at task diffs.** Rejected as
+mis-aimed rather than wrong. ADR-0042 grades a bundle's *behaviour* against a
+frozen case; re-pointing it at per-task work products is a new axis, not a
+configuration of the existing one, and ADR-0042 remains unbuilt on its own axis.
+
+**Gate publication on green CI.** Rejected, and it is tempting. It inverts the
+order — CI runs on a pull request, which requires the pull request to exist —
+so gating on it would mean opening, testing, and closing, which is worse than
+opening and letting a human read the checks. The pull request is the artifact
+under review, not the candidate for it.
+
+**Have the platform re-run the repository's tests outside the sandbox.** Rejected.
+It duplicates the repository's own CI, needs a toolchain per target repository,
+and puts the platform in the business of building arbitrary code.
+
+**Say nothing and leave verification undefined.** Rejected, which is why this ADR
+exists at all. "The platform does not do this" is a decision with real
+consequences for what a board can claim, and it should be findable.
+
+## Realizing code path
+
+None required for the decision itself. The optional check-runs reading in point
+4 would land in `apps/worker/src/curie_worker/publication_clients.py` beside the
+existing pull request read, with the rollup persisted on the lineage in
+`apps/api/src/curie_api/models.py`.
+
+This ADR is **Draft** and authorizes nothing by itself. Under
+[ADR-0085](0085-acceptance-not-implementation-authorizes-an-adr.md) as amended
+by [ADR-0102](0102-accepted-alongside-implementation-with-explicit-approval.md),
+acceptance is a maintainer act.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -172,4 +172,10 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0140 | [Curie supports one model harness until a second one exists](0140-curie-supports-one-model-harness-until-a-second-one-exists.md) | Draft |
 | 0142 | [Database compatibility is a release contract; migrations run in one upgrade phase](0142-database-compatibility-windows-and-a-single-upgrade-phase.md) | Accepted |
 | 0143 | [A coding thread owns one fenced pull request lineage](0143-thread-owned-pull-request-lineage.md) | Accepted |
+| 0145 | [A labelled issue is a backlog item and the stream is its queue](0145-a-labelled-issue-is-a-backlog-item-and-the-stream-is-its-queue.md) | Draft |
+| 0146 | [For a headless lane, at capacity means wait, not reply](0146-headless-capacity-is-a-wait-not-a-reply.md) | Draft |
+| 0147 | [Publication approval is a per-agent operator policy, not a platform constant](0147-publication-approval-is-a-per-agent-operator-policy.md) | Draft |
+| 0148 | [One ticket is one pull request, and assembly is a later decision](0148-one-ticket-is-one-pull-request.md) | Draft |
+| 0149 | [Curie pins a model per agent and the provider does the routing](0149-curie-pins-a-model-and-the-provider-routes.md) | Draft |
+| 0150 | [Whether the work was right is the bundle's question, not the platform's](0150-per-task-verification-is-bundle-behaviour.md) | Draft |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
Six ADRs recording the platform decisions behind headless ticket-to-pull-request
execution on Curie. The proposal they belong to is discussion #2551:
https://github.com/curie-eng/curie/discussions/2551

ADRs 0146 and 0147 are `Accepted` following explicit maintainer approval in their implementation threads. The other decisions retain their recorded statuses. This PR changes documentation and the generated index only; it does not implement automatic publication.

| ADR | Decision |
| --- | --- |
| 0145 | A labelled issue is a backlog item and the stream is its queue. The tracker is the backlog; a labelled issue enters through the existing signed hook ingress, partitioned on the issue number. No task row, no polling loop. |
| 0146 | For a headless lane, at capacity means wait, not reply. A quota-refused claim now fails fast and attributably, but the turn is `terminal_ok` — replied to and acked off the stream. That is right for a human and wrong for a webhook. Extends ADR-0109's policy for the lane with nobody at the other end. |
| 0147 | Publication approval is a per-agent operator policy, not a platform constant. Supersedes one clause of ADR-0125 — the mandatory gate no bundle or operator policy can remove — with a per-agent `publication: approve \| auto` setting. Every other guardrail unchanged; the approval row still exists under `auto` and records the platform as the approver. |
| 0148 | One ticket is one pull request, and assembly is a later decision. Fixes the v1 unit at what ADR-0143 already enforces, and names stacked pull requests and feature-branch assembly as out of scope so nobody quietly builds toward them. |
| 0149 | Curie pins a model per agent and the provider does the routing. Supersedes ADR-0037 in whole: no binding-hook port, no install-level model registry, no floor estimator. |
| 0150 | Whether the work was right is the bundle's question, not the platform's. No task record, no acceptance-criteria field, no per-task verdict. The platform records evidence and does not judge. |

## Numbering

0145 through 0150. 0144 is the highest number reserved across `main`, `next`, and
open pull requests (`main` carries 0144; #2237 reserves 0141, #2344 reserves 0143,
#2188 reserves 0140).

## Supersession back-links are deliberately absent

0147 supersedes a clause of ADR-0125 and 0149 supersedes ADR-0037 in whole, but
neither of those files is touched here. ADR-0045 makes the back-link part of a
superseding decision's *implementing* work, and a Draft implements nothing. The corresponding backlinks belong with implementation of an accepted decision.

## Two corrections to the audit these were written from

Worth flagging because they change the argument, not just the wording:

1. **Capacity exhaustion no longer hangs for 90 seconds.** A quota-refused claim is
   detected from the claim's own status after a two-poll debounce and raised as
   `CapacityExhaustedError` (`apps/worker/src/curie_worker/sandbox/substrate.py:790`).
   Part of ADR-0109 shipped. The remaining problem is not the latency, it is that the
   outcome is `terminal_ok=True` (`apps/worker/src/curie_worker/kernel.py:2468`) —
   the work is acked and gone. 0146 is written against the current behaviour.
2. **The runs consumer group discards less than "any cold worker restart".** It is
   created at `$` only when it does not exist
   (`apps/worker/src/curie_worker/consumer.py:225`); an existing group is left
   untouched and crash recovery reads the pending list. The loss window is entries
   written before the group has ever been created. 0145 says so and treats a
   reconciliation sweep as a named fallback rather than a requirement.

## Review

The one to argue about is **0147**. It loosens a boundary ADR-0125 set on incident
evidence — a credential that leaked into `.git/config` and produced a pull request
outside the approval plane. The argument for loosening is that the guardrails which
do not depend on a human are all untouched, and that an operator deploying a factory
agent against a repository they allowlisted has already consented to the thing the
card asks them to re-consent to. The argument against is that the blast radius of a
compromised bundle grows and the pull request becomes the only human gate. Both are
in the ADR.

No merge is authorized by the ADR 0147 acceptance update. Implementation of #2575 remains subject to its stable publication prerequisites.

ADR 0146 implementation (#2573) remains unimplemented. Inspection of fresh next at 5a318953 found no existing operator log reply route identifying headless webhook deliveries, and no published admission ceiling from Draft ADR 0109. Hook deliveries currently carry channel reply routes. Those prerequisites need resolution before implementation can preserve interactive refusal without inventing a new policy.
