### PR TITLE
Resolve the channel-token Secret before minting, not after

### DIFF
--- a/cli/src/channel_token.rs
+++ b/cli/src/channel_token.rs
@@ -179,6 +179,16 @@ pub async fn channel_token(opts: ChannelTokenOpts) -> Result<ChannelTokenOutput>
     }
     let ui = crate::ui::ui();
     let cl = ui.checklist();
+    // Resolve the Secret BEFORE minting. The mint is a rotation write: the API
+    // bumps the binding's generation and signs the new value, so the token the
+    // adapter is currently holding is revoked the moment that request returns
+    // (#2379). There is no un-mint. Every step that can fail for a reason
+    // unrelated to the token -- an expired kubeconfig, a misnamed release, a
+    // `--namespace` typo, an API-server blip -- therefore has to run while
+    // failing is still free, or a failed recovery attempt turns a scheduled
+    // expiry into an outage (#2553).
+    let values = fetch_release_computed_values(&opts.common).await?;
+    let (secret_name, secret_key) = live_token_secret(&opts.common, values.as_ref()).await;
     let mint_step = cl.step(&format!("minting channel token for {kind}:{address}"));
     let token = match client.mint_channel_token(&kind, &address, ttl_s).await {
         Ok(token) => {
@@ -192,30 +202,39 @@ pub async fn channel_token(opts: ChannelTokenOpts) -> Result<ChannelTokenOutput>
     };
     let exp = token_exp(&token)?;
     let expires_at = format_exp(exp);
-    let values = fetch_release_computed_values(&opts.common).await?;
-    let (secret_name, secret_key) = live_token_secret(&opts.common, values.as_ref()).await;
     let patch = serde_json::json!({ "stringData": { &secret_key: token } });
+    // The one step that structurally cannot precede the mint: it writes the
+    // token. If it fails the install IS worse off than before the command ran,
+    // and the operator has to be told that rather than left reading a bare
+    // kubectl error about a Secret.
     run_step(
         &cl,
         &format!("writing {secret_name}/{secret_key}"),
         "written",
         &patch_command(&opts.common, &secret_name, &secret_key, patch),
     )
-    .await?;
-    run_step(
-        &cl,
-        "rolling mail adapter",
-        "restarted",
-        &rollout_restart_command(&opts.common),
-    )
-    .await?;
-    run_step(
-        &cl,
-        "waiting for mail adapter",
-        "ready",
-        &rollout_status_command(&opts.common),
-    )
-    .await?;
+    .await
+    .map_err(|err| revoked_without_install(err, &opts, &kind, &address, &secret_name))?;
+    // Past the patch the new token is installed and the old one's revocation is
+    // no longer a surprise -- the adapter simply has not reloaded yet. A rollout
+    // failure is a restart away from resolved, so it must NOT be reported as a
+    // revocation.
+    for (label, ok_detail, cmd) in [
+        (
+            "rolling mail adapter",
+            "restarted",
+            rollout_restart_command(&opts.common),
+        ),
+        (
+            "waiting for mail adapter",
+            "ready",
+            rollout_status_command(&opts.common),
+        ),
+    ] {
+        run_step(&cl, label, ok_detail, &cmd)
+            .await
+            .map_err(|err| installed_but_not_loaded(err, &opts))?;
+    }
     Ok(ChannelTokenOutput::Minted {
         agent: agent.name,
         kind,
@@ -225,6 +244,66 @@ pub async fn channel_token(opts: ChannelTokenOpts) -> Result<ChannelTokenOutput>
         secret_name,
         secret_key,
     })
+}
+
+/// The mint succeeded and the Secret write did not: the adapter is still
+/// holding a token this very command revoked. Name that state, because the
+/// underlying `kubectl` error describes a Secret and says nothing about a
+/// channel that has just stopped accepting mail.
+///
+fn revoked_without_install(
+    err: anyhow::Error,
+    opts: &ChannelTokenOpts,
+    kind: &str,
+    address: &str,
+    secret_name: &str,
+) -> anyhow::Error {
+    let message = format!(
+        "the channel token for {kind}:{address} was minted but could not be written to secret \
+         {secret_name} in namespace {}: that mint already revoked the token the mail adapter is \
+         running, so this binding refuses inbound mail until a token is installed",
+        opts.common.namespace
+    );
+    let fix = format!(
+        "grant access to secret {secret_name} (or point --release/--namespace at the install that \
+         owns it) and re-run `curie cluster channel-token {}`; every re-run mints a fresh token, \
+         so retrying costs nothing",
+        opts.agent
+    );
+    wrap(err, message, fix)
+}
+
+/// The Secret holds the new token; only the restart did not complete. Milder
+/// than [`revoked_without_install`] and deliberately worded so the two cannot
+/// be confused: here the recovery is a restart, not another mint.
+fn installed_but_not_loaded(err: anyhow::Error, opts: &ChannelTokenOpts) -> anyhow::Error {
+    let message = format!(
+        "the new channel token was written, but the mail adapter in namespace {} did not restart \
+         onto it and is still running the token this mint revoked",
+        opts.common.namespace
+    );
+    let fix = format!(
+        "restart it with `kubectl -n {} rollout restart deployment -l {}`; the new token is \
+         already installed, so do not mint another one",
+        opts.common.namespace,
+        adapter_selector(&opts.common.release)
+    );
+    wrap(err, message, fix)
+}
+
+/// Attach one `{message, fix}` pair to both operator surfaces at once, the way
+/// [`Ui::failed_report`](crate::ui::Ui::failed_report) does: the explicit JSON
+/// payload is what `--json` emits, and the operator context is what the
+/// terminal's `Error:`/`Fix:` pair reads. Wrapping with a bare
+/// [`CliError`](crate::exit::CliError) instead would reach only the JSON half,
+/// and a bare operator context only the human half.
+fn wrap(err: anyhow::Error, message: String, fix: String) -> anyhow::Error {
+    let payload = serde_json::json!({ "error": message, "fix": fix });
+    crate::exit::operator_context(
+        crate::exit::with_json_payload(err, payload),
+        message,
+        Some(fix),
+    )
 }
 
 async fn show_exp(opts: ChannelTokenOpts) -> Result<ChannelTokenOutput> {

--- a/cli/src/channel_token.rs
+++ b/cli/src/channel_token.rs
@@ -188,7 +188,26 @@ pub async fn channel_token(opts: ChannelTokenOpts) -> Result<ChannelTokenOutput>
     // failing is still free, or a failed recovery attempt turns a scheduled
     // expiry into an outage (#2553).
     let values = fetch_release_computed_values(&opts.common).await?;
-    let (secret_name, secret_key) = live_token_secret(&opts.common, values.as_ref()).await;
+    // `Ok(None)` is Helm positively reporting the release does not exist, which
+    // every other caller treats as "nothing configured yet". Here it is a
+    // refusal: this verb patches a Secret the chart rendered and rolls a
+    // Deployment the chart owns, so an absent release means `--namespace` or
+    // `--release` names an install that is not there. Falling through would
+    // mint against the live binding -- the mint is keyed by kind:address, not by
+    // the Helm release -- and revoke a working adapter's token to pay for a typo.
+    let Some(values) = values else {
+        return Err(crate::exit::CliError::failure(format!(
+            "no Helm release {} exists in namespace {}, so there is no mail adapter Secret to \
+             write a channel token to",
+            opts.common.release, opts.common.namespace
+        ))
+        .with_fix(
+            "name the install that has the adapter with --namespace/--release; `helm list -A` \
+             shows them. No token was minted, so the adapter's current token is untouched",
+        )
+        .into());
+    };
+    let (secret_name, secret_key) = live_token_secret(&opts.common, Some(&values)).await;
     let mint_step = cl.step(&format!("minting channel token for {kind}:{address}"));
     let token = match client.mint_channel_token(&kind, &address, ttl_s).await {
         Ok(token) => {
@@ -200,13 +219,20 @@ pub async fn channel_token(opts: ChannelTokenOpts) -> Result<ChannelTokenOutput>
             return Err(err);
         }
     };
-    let exp = token_exp(&token)?;
+    // Everything from here to the end of the write shares one state on failure:
+    // minted, nothing installed, the adapter's token already revoked. The decode
+    // is part of it -- a token this CLI cannot read is one it will not write --
+    // so it carries the same message rather than the bare "retry" that would
+    // send the operator into a second mint without telling them the first one
+    // already killed the channel.
+    let exp = token_exp(&token)
+        .map_err(|err| revoked_without_install(err, &opts, &kind, &address, &secret_name))?;
     let expires_at = format_exp(exp);
     let patch = serde_json::json!({ "stringData": { &secret_key: token } });
-    // The one step that structurally cannot precede the mint: it writes the
-    // token. If it fails the install IS worse off than before the command ran,
-    // and the operator has to be told that rather than left reading a bare
-    // kubectl error about a Secret.
+    // The write needs the token, so it cannot precede the mint. Some of what it
+    // can fail on could still be probed beforehand -- whether the Secret exists,
+    // whether we may patch it -- which is #2561; what is left here is the part
+    // that cannot be probed away.
     run_step(
         &cl,
         &format!("writing {secret_name}/{secret_key}"),
@@ -215,10 +241,10 @@ pub async fn channel_token(opts: ChannelTokenOpts) -> Result<ChannelTokenOutput>
     )
     .await
     .map_err(|err| revoked_without_install(err, &opts, &kind, &address, &secret_name))?;
-    // Past the patch the new token is installed and the old one's revocation is
-    // no longer a surprise -- the adapter simply has not reloaded yet. A rollout
-    // failure is a restart away from resolved, so it must NOT be reported as a
-    // revocation.
+    // Past the write the new token is installed and the adapter has merely not
+    // reloaded. This message must not read as the one above: an operator who
+    // takes a rollout failure for a revocation mints again and revokes the token
+    // they just installed. It therefore avoids the word entirely.
     for (label, ok_detail, cmd) in [
         (
             "rolling mail adapter",
@@ -259,15 +285,15 @@ fn revoked_without_install(
     secret_name: &str,
 ) -> anyhow::Error {
     let message = format!(
-        "the channel token for {kind}:{address} was minted but could not be written to secret \
-         {secret_name} in namespace {}: that mint already revoked the token the mail adapter is \
-         running, so this binding refuses inbound mail until a token is installed",
+        "the channel token for {kind}:{address} was minted but never installed: that mint already \
+         revoked the token the mail adapter is running, so this binding refuses inbound mail \
+         until a token reaches secret {secret_name} in namespace {}",
         opts.common.namespace
     );
     let fix = format!(
         "grant access to secret {secret_name} (or point --release/--namespace at the install that \
-         owns it) and re-run `curie cluster channel-token {}`; every re-run mints a fresh token, \
-         so retrying costs nothing",
+         owns it) and re-run `curie cluster channel-token {}`; a re-run mints a fresh token and \
+         the failed attempt consumed nothing, but mail is dropped until it succeeds",
         opts.agent
     );
     wrap(err, message, fix)
@@ -278,13 +304,16 @@ fn revoked_without_install(
 /// be confused: here the recovery is a restart, not another mint.
 fn installed_but_not_loaded(err: anyhow::Error, opts: &ChannelTokenOpts) -> anyhow::Error {
     let message = format!(
-        "the new channel token was written, but the mail adapter in namespace {} did not restart \
-         onto it and is still running the token this mint revoked",
+        "the new channel token was written to the Secret, but the mail adapter in namespace {} \
+         did not restart onto it and is still running the token this mint replaced",
         opts.common.namespace
     );
     let fix = format!(
-        "restart it with `kubectl -n {} rollout restart deployment -l {}`; the new token is \
-         already installed, so do not mint another one",
+        "confirm the adapter is deployed -- `kubectl -n {} get deployment -l {}` -- then restart \
+         it with `kubectl -n {} rollout restart deployment -l {}`. The new token is already \
+         installed, so do not mint another one; that would retire the token just written",
+        opts.common.namespace,
+        adapter_selector(&opts.common.release),
         opts.common.namespace,
         adapter_selector(&opts.common.release)
     );

--- a/cli/tests/channel_token_verb.rs
+++ b/cli/tests/channel_token_verb.rs
@@ -212,6 +212,10 @@ case "${0##*/}:$*" in
       echo "Error: query: failed to query with labels: secrets is forbidden" >&2
       exit 1
     fi
+    if fail helm-absent; then
+      echo "Error: release: not found" >&2
+      exit 1
+    fi
     cat "${0%/*}/values.json"; exit 0 ;;
   kubectl:*patch*)
     if fail patch; then
@@ -247,6 +251,10 @@ exit 0
         Self(temp)
     }
 
+    fn dir(&self) -> &std::path::Path {
+        self.0.path()
+    }
+
     /// Make the named stubbed step (`helm`, `patch`, `rollout`) exit nonzero.
     fn failing(self, step: &str) -> Self {
         fs::write(self.0.path().join(format!("fail.{step}")), "").unwrap();
@@ -279,14 +287,33 @@ exit 0
 }
 
 fn api_for_mint(token: &str) -> MockServer {
+    api_logging_to(token, None)
+}
+
+/// The mint is HTTP, so it leaves no trace in the stub's `calls.log` and an
+/// ordering assertion over that log alone cannot see it. Given the stub's
+/// directory the mock appends its own line, putting the mint and the shell-outs
+/// on one ordered timeline -- which is what "discovery happens before the mint"
+/// actually needs to be pinned against.
+fn api_logging_to(token: &str, log_dir: Option<&std::path::Path>) -> MockServer {
     let token = token.to_string();
     let agent = agent_json();
+    let log = log_dir.map(|dir| dir.join("calls.log"));
     serve(move |req| {
         let (m, p) = (req.method.as_str(), req.path.as_str());
         match (m, p) {
             ("GET", "/agents") => Response::json(200, &format!("[{agent}]")),
             ("GET", p) if p == format!("/agents/{AGENT_ID}") => Response::json(200, &agent),
             ("POST", "/channels/token") => {
+                if let Some(path) = log.as_ref() {
+                    use std::io::Write;
+                    let mut f = fs::OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open(path)
+                        .unwrap();
+                    writeln!(f, "api POST /channels/token").unwrap();
+                }
                 Response::json(200, &format!(r#"{{"token":"{token}"}}"#))
             }
             _ => Response::json(404, r#"{"detail":"not found"}"#),
@@ -481,25 +508,88 @@ fn a_discovery_failure_burns_no_generation() {
     assert!(stub.patched().is_empty(), "nothing may be written");
 }
 
-/// The complement: on the happy path the discovery calls still happen, and they
-/// happen before the mint. Without this a "fix" that simply dropped the Helm
-/// read would satisfy the test above while silently losing
-/// `channelTokenExistingSecret` targeting.
+/// The positive ordering pin, on the happy path where every step runs. The mock
+/// logs the mint into the same file as the shell-outs, so this asserts
+/// helm-read < mint < patch on one timeline. Reverting the reorder puts the
+/// mint first and fails here; deleting the Helm read outright (which would
+/// silently lose `channelTokenExistingSecret` targeting) fails here too.
 #[test]
 fn discovery_runs_before_the_mint_on_the_happy_path() {
     let token = sample_token(EXP);
-    let server = api_for_mint(&token);
     let stub = ClusterStub::new(serde_json::json!({"mailAdapter": {"deploy": true}}));
+    let server = api_logging_to(&token, Some(stub.dir()));
     let run = stub.run(&mint_argv(&server.base_url));
     assert_eq!(run.code, 0, "{} {}", run.stdout, run.stderr);
     let calls = stub.calls();
-    let helm_at = calls
-        .find("helm get values")
-        .unwrap_or_else(|| panic!("helm read: {calls}"));
-    let patch_at = calls
-        .find("patch secret")
-        .unwrap_or_else(|| panic!("patch: {calls}"));
-    assert!(helm_at < patch_at, "{calls}");
+    let at = |needle: &str| {
+        calls
+            .find(needle)
+            .unwrap_or_else(|| panic!("{needle} missing from: {calls}"))
+    };
+    assert!(
+        at("helm get values") < at("api POST /channels/token"),
+        "{calls}"
+    );
+    assert!(
+        at("api POST /channels/token") < at("patch secret"),
+        "{calls}"
+    );
+}
+
+/// Helm positively reporting the release absent is the `--namespace`/`--release`
+/// typo case named in the issue, and it is NOT a generic error: the shared Helm
+/// read maps it to `Ok(None)`. Falling through would mint against the live
+/// binding -- the mint is keyed by kind:address, not by the Helm release -- and
+/// revoke a healthy adapter's token to pay for a typo.
+#[test]
+fn an_absent_release_refuses_before_minting() {
+    let token = sample_token(EXP);
+    let stub = ClusterStub::new(serde_json::json!({"mailAdapter": {"deploy": true}}))
+        .failing("helm-absent");
+    let server = api_logging_to(&token, Some(stub.dir()));
+    let run = stub.run(&mint_argv(&server.base_url));
+    assert_ne!(run.code, 0, "{} {}", run.stdout, run.stderr);
+    let traffic = server
+        .recorded()
+        .iter()
+        .map(|r| format!("{} {}", r.method, r.path))
+        .collect::<Vec<_>>();
+    assert!(
+        !traffic.iter().any(|t| t.contains("/channels/token")),
+        "a typo must not revoke the running token: {traffic:?}"
+    );
+    let value: serde_json::Value = serde_json::from_str(run.stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout must be JSON: {e}; {}", run.stdout));
+    let error = value["error"].as_str().unwrap_or_default();
+    assert!(error.contains("no Helm release"), "{value}");
+    let fix = value["fix"].as_str().unwrap_or_default();
+    assert!(fix.contains("--namespace/--release"), "{value}");
+    assert!(
+        fix.contains("No token was minted"),
+        "the operator must be told their adapter is untouched: {value}"
+    );
+    assert!(stub.patched().is_empty(), "nothing may be written");
+}
+
+/// The decode sits between the mint and the write, so it shares their state: the
+/// generation is already burned and nothing is installed. A bare "retry" there
+/// sends the operator into a second mint without telling them the channel is
+/// already dead.
+#[test]
+fn an_undecodable_token_reports_the_revoked_token() {
+    let stub = ClusterStub::new(serde_json::json!({"mailAdapter": {"deploy": true}}));
+    let server = api_for_mint("chn.not-base64.SIG");
+    let run = stub.run(&mint_argv(&server.base_url));
+    assert_ne!(run.code, 0, "{} {}", run.stdout, run.stderr);
+    let value: serde_json::Value = serde_json::from_str(run.stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout must be JSON: {e}; {}", run.stdout));
+    let error = value["error"].as_str().unwrap_or_default();
+    assert!(error.contains("revoked"), "{value}");
+    assert!(error.contains("never installed"), "{value}");
+    assert!(
+        stub.patched().is_empty(),
+        "an unreadable token is not written"
+    );
 }
 
 /// The window that cannot be closed by ordering: the write needs the token, so
@@ -542,8 +632,20 @@ fn a_failed_rollout_says_installed_not_revoked() {
     let fix = value["fix"].as_str().unwrap_or_default();
     assert!(fix.contains("rollout restart"), "{value}");
     assert!(
+        fix.contains("get deployment"),
+        "a restart that just failed is not a diagnosis on its own: {value}"
+    );
+    assert!(
         fix.contains("do not mint another one"),
         "the recovery is a restart, never a second mint: {value}"
     );
+    // The word itself, not just the meaning: an operator skimming for "revoked"
+    // on this failure mints again and retires the token just written.
+    assert!(
+        !error.contains("revoked") && !fix.contains("revoked"),
+        "the milder state must not read as the revocation message: {value}"
+    );
     assert!(stub.patched().contains(&token), "the write did succeed");
+    assert!(!run.stdout.contains(&token), "{}", run.stdout);
+    assert!(!run.stderr.contains(&token), "{}", run.stderr);
 }

--- a/cli/tests/channel_token_verb.rs
+++ b/cli/tests/channel_token_verb.rs
@@ -197,13 +197,27 @@ impl ClusterStub {
             .to_string(),
         )
         .unwrap();
+        // `fail.<step>` sentinel files let a test make one stubbed step exit
+        // nonzero. The stderr text matters: `helm` must not say "release: not
+        // found" (which the CLI reads as an absent release, not a failure) and
+        // must carry no connectivity marker, so it classifies as a plain
+        // failure rather than a transient.
         let script = r#"#!/bin/sh
 log="${0%/*}/calls.log"
 printf '%s %s\n' "${0##*/}" "$*" >> "$log"
+fail() { [ -f "${0%/*}/fail.$1" ]; }
 case "${0##*/}:$*" in
   helm:"get values"*)
+    if fail helm; then
+      echo "Error: query: failed to query with labels: secrets is forbidden" >&2
+      exit 1
+    fi
     cat "${0%/*}/values.json"; exit 0 ;;
   kubectl:*patch*)
+    if fail patch; then
+      echo 'Error from server (Forbidden): secrets "acme-curie" is forbidden' >&2
+      exit 1
+    fi
     patch=
     prev=
     for arg in "$@"; do
@@ -213,6 +227,10 @@ case "${0##*/}:$*" in
     if [ -n "$patch" ]; then cp "$patch" "${0%/*}/patched.json"; fi
     exit 0 ;;
   kubectl:*rollout*)
+    if fail rollout; then
+      echo 'error: no deployments found with label selector' >&2
+      exit 1
+    fi
     exit 0 ;;
   kubectl:*--raw*)
     cat "${0%/*}/status.json"; exit 0 ;;
@@ -227,6 +245,12 @@ exit 0
             fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
         }
         Self(temp)
+    }
+
+    /// Make the named stubbed step (`helm`, `patch`, `rollout`) exit nonzero.
+    fn failing(self, step: &str) -> Self {
+        fs::write(self.0.path().join(format!("fail.{step}")), "").unwrap();
+        self
     }
 
     fn run(&self, argv: &[&str]) -> Run {
@@ -401,4 +425,125 @@ fn show_exp_does_not_post_a_token() {
         "show-exp must not mint: {traffic:?}"
     );
     assert!(stub.patched().is_empty(), "show-exp must not patch");
+}
+
+// --- #2553: the mint is a rotation write, so ordering is the whole fix -------
+//
+// `POST /channels/token` bumps the binding's generation and signs the new one,
+// which revokes the token the adapter is currently running. There is no
+// un-mint. So every step that can fail for a reason unrelated to the token has
+// to run BEFORE the mint, and the one step that cannot (the Secret write, which
+// needs the token) has to say what it left behind when it fails.
+
+fn mint_argv(base_url: &str) -> Vec<&str> {
+    vec![
+        "--json",
+        "cluster",
+        "channel-token",
+        AGENT_NAME,
+        "--kind",
+        "email",
+        "--address",
+        INBOX,
+        "--namespace",
+        "mail-test",
+        "--release",
+        "acme",
+        "--api-url",
+        base_url,
+        "--api-key",
+        "test-key",
+    ]
+}
+
+/// The ordering pin. Helm discovery fails, so the verb must abort with the
+/// binding's generation untouched -- no mint request may reach the API at all.
+/// Against the pre-fix tree the mint runs first and this fails on the recorded
+/// POST: a working token was revoked to pay for a `helm` error.
+#[test]
+fn a_discovery_failure_burns_no_generation() {
+    let token = sample_token(EXP);
+    let server = api_for_mint(&token);
+    let stub =
+        ClusterStub::new(serde_json::json!({"mailAdapter": {"deploy": true}})).failing("helm");
+    let run = stub.run(&mint_argv(&server.base_url));
+    assert_ne!(run.code, 0, "{} {}", run.stdout, run.stderr);
+    let traffic = server
+        .recorded()
+        .iter()
+        .map(|r| format!("{} {}", r.method, r.path))
+        .collect::<Vec<_>>();
+    assert!(
+        !traffic.iter().any(|t| t.contains("/channels/token")),
+        "a failure the verb could have hit before minting must not revoke the \
+         installed token: {traffic:?}"
+    );
+    assert!(stub.patched().is_empty(), "nothing may be written");
+}
+
+/// The complement: on the happy path the discovery calls still happen, and they
+/// happen before the mint. Without this a "fix" that simply dropped the Helm
+/// read would satisfy the test above while silently losing
+/// `channelTokenExistingSecret` targeting.
+#[test]
+fn discovery_runs_before_the_mint_on_the_happy_path() {
+    let token = sample_token(EXP);
+    let server = api_for_mint(&token);
+    let stub = ClusterStub::new(serde_json::json!({"mailAdapter": {"deploy": true}}));
+    let run = stub.run(&mint_argv(&server.base_url));
+    assert_eq!(run.code, 0, "{} {}", run.stdout, run.stderr);
+    let calls = stub.calls();
+    let helm_at = calls
+        .find("helm get values")
+        .unwrap_or_else(|| panic!("helm read: {calls}"));
+    let patch_at = calls
+        .find("patch secret")
+        .unwrap_or_else(|| panic!("patch: {calls}"));
+    assert!(helm_at < patch_at, "{calls}");
+}
+
+/// The window that cannot be closed by ordering: the write needs the token, so
+/// a failed write leaves a revoked token installed. The operator must be told
+/// that in the message, not left reading a `kubectl` error about a Secret.
+#[test]
+fn a_failed_secret_write_reports_the_revoked_token() {
+    let token = sample_token(EXP);
+    let server = api_for_mint(&token);
+    let stub =
+        ClusterStub::new(serde_json::json!({"mailAdapter": {"deploy": true}})).failing("patch");
+    let run = stub.run(&mint_argv(&server.base_url));
+    assert_ne!(run.code, 0, "{} {}", run.stdout, run.stderr);
+    let value: serde_json::Value = serde_json::from_str(run.stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout must be JSON: {e}; {}", run.stdout));
+    let error = value["error"].as_str().unwrap_or_default();
+    assert!(error.contains("revoked"), "{value}");
+    assert!(error.contains("email:ops@example.com"), "{value}");
+    let fix = value["fix"].as_str().unwrap_or_default();
+    assert!(fix.contains("re-run"), "{value}");
+    assert!(!run.stdout.contains(&token), "{}", run.stdout);
+    assert!(!run.stderr.contains(&token), "{}", run.stderr);
+}
+
+/// Past the write the state is milder -- the token IS installed, the adapter
+/// just has not reloaded -- and reporting it as a revocation would send the
+/// operator to mint again, revoking the token they just installed.
+#[test]
+fn a_failed_rollout_says_installed_not_revoked() {
+    let token = sample_token(EXP);
+    let server = api_for_mint(&token);
+    let stub =
+        ClusterStub::new(serde_json::json!({"mailAdapter": {"deploy": true}})).failing("rollout");
+    let run = stub.run(&mint_argv(&server.base_url));
+    assert_ne!(run.code, 0, "{} {}", run.stdout, run.stderr);
+    let value: serde_json::Value = serde_json::from_str(run.stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout must be JSON: {e}; {}", run.stdout));
+    let error = value["error"].as_str().unwrap_or_default();
+    assert!(error.contains("was written"), "{value}");
+    let fix = value["fix"].as_str().unwrap_or_default();
+    assert!(fix.contains("rollout restart"), "{value}");
+    assert!(
+        fix.contains("do not mint another one"),
+        "the recovery is a restart, never a second mint: {value}"
+    );
+    assert!(stub.patched().contains(&token), "the write did succeed");
 }


### PR DESCRIPTION
## Problem

`POST /channels/token` (`apps/api/src/curie_api/routers/channels.py:290`) is a
rotation write. It bumps the binding's `generation` under `FOR UPDATE` and signs
the NEW value, so the token the mail adapter is currently running is revoked the
instant that request returns. That is deliberate (#2379) -- the generation is one
of only two things standing in for a revocation list -- and there is no un-mint.

`curie cluster channel-token` did not respect it. The mint ran first, and only
afterwards did the verb work out where the token had to go:

- mint (generation bumped, installed token now dead)
- `fetch_release_computed_values` -- shells out to `helm get all`
- `live_token_secret` -- may shell out to `kubectl` to resolve the release fullname
- `kubectl patch secret` -- the write that actually installs the token

Every one of those fails for reasons that have nothing to do with the token: an
expired kubeconfig, a misnamed release, a `--namespace` typo, a transient
API-server error, a Secret the caller cannot patch. When one did, the verb exited
nonzero and left the install worse off than before it ran -- adapter still holding
the previous token, that token now revoked, no rollback -- and the operator read
an error about `helm` with nothing saying their channel had just gone dead.

Recovery from an expired token is the whole reason this verb exists. A failed
recovery attempt that revokes a still-working token converts a scheduled expiry
into an outage.

## Change

Shrink the unrecoverable window to the one step that structurally cannot move,
and describe the state honestly when it is hit.

- **Discovery moves ahead of the mint.** `fetch_release_computed_values` and
  `live_token_secret` do not need the token, so they now run while failing is
  still free. A discovery failure burns no generation.
- **A failed Secret write names what it left behind.** The patch genuinely cannot
  precede the mint. When it fails the error now says the mint already revoked the
  installed token and that re-running mints a fresh one, so retrying costs
  nothing.
- **A failed rollout does not claim a revocation.** Past the patch the new token
  IS installed and the adapter has merely not reloaded; that error points at
  `kubectl rollout restart` and explicitly says not to mint again -- a second
  mint there would revoke the token just installed.

Both messages reach both operator surfaces (the `--json` `{error, fix}` payload
and the terminal's `Error:`/`Fix:` pair) through the same `with_json_payload` +
`operator_context` pairing `Ui::failed_report` already uses.

- **An absent Helm release is a refusal.** The shared Helm read maps Helm's own
  `Error: release: not found` to `Ok(None)`, which is right for every other
  caller and wrong here: this verb patches a chart-rendered Secret and rolls a
  chart-owned Deployment. A `--namespace`/`--release` typo -- the case the issue
  names first -- therefore sailed past discovery, and since the mint is keyed by
  `kind:address` rather than by the release, it revoked a healthy adapter's token
  and then failed at a patch in the wrong namespace.
- **`token_exp` shares the write's message.** It sits between the mint and the
  write and used to raise a bare "retry", which is the one instruction that makes
  things worse there -- a second mint, with nothing said about the channel
  already being dead.

No API change. The rotation-at-mint semantics are correct; only the CLI's
ordering around them was not.

## Tests

`ClusterStub` gained `fail.<step>` sentinel files so a single stubbed step can be
made to exit nonzero, and the mock API appends its mint to the same `calls.log`
as the shell-outs so ordering can be asserted on one timeline. Six new tests in
`cli/tests/channel_token_verb.rs`:

- `a_discovery_failure_burns_no_generation` -- `helm` fails; the verb must abort
  with no `/channels/token` request recorded.
- `an_absent_release_refuses_before_minting` -- the typo case above.
- `discovery_runs_before_the_mint_on_the_happy_path` -- pins
  helm-read < mint < patch. (Its first version asserted only helm-before-patch,
  which held before the fix too; the review caught that.)
- `an_undecodable_token_reports_the_revoked_token`
- `a_failed_secret_write_reports_the_revoked_token`
- `a_failed_rollout_says_installed_not_revoked` -- including that the word
  "revoked" appears in neither its message nor its fix.

`curie dev verify-fix-pin` reports `PINNED` for the selector below. `cargo test`
over `channel_token_verb`, `mail_channel_health`, `json_contract`,
`cli_output_variants` and `command_surface`: 121 passed. `cargo fmt` and `cargo
clippy --all-targets` clean.

## Review

Cross-engine adversarial review (`agent-router adversarial-review --primary
claude`, routed to grok, review 439) found four real gaps in the first commit;
all are fixed in the second. Spec-vs-impl and scope-creep reviews pass.

One residual is deliberately **not** fixed here: `live_token_secret` ->
`release_fullname` (`cli/src/ops.rs:10043`) swallows a failed `kubectl get
deploy` and falls back to the chart-default Secret name, so a probe failure can
still mint against a guessed name. `release_fullname` is shared and cached
across many verbs and making it fail closed is a cross-cutting change with no
bearing on this ticket's ACs. Filed as #2561 against v0.9.0.

Closes #2553

Fix pin: cli/tests/channel_token_verb.rs::an_absent_release_refuses_before_minting
