### PR TITLE
Keep hosted connector Bearer secrets out of the sandbox env

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1543,7 +1543,7 @@ export const commandManifest = {
             },
             {
               "global": false,
-              "help": "Bind a per-agent connector secret by NAME (ADR-0009, #429). The value is resolved from your environment or the host secret vault (`curie secrets set <NAME>`) and sent to the platform, which stores it on the agent so the worker forwards it into the sandbox for a bundle's authed MCP server. The value never appears in argv. Repeatable. A hosted connector's own declared `secrets:` names are bound automatically (from the value this deploy already resolved for the connector) so its derived Bearer header expands; this flag is for names beyond that (#2503)",
+              "help": "Bind a per-agent connector secret by NAME (ADR-0009, #429). The value is resolved from your environment or the host secret vault (`curie secrets set <NAME>`) and sent to the platform, which stores it on the agent so the worker forwards it into the sandbox for a bundle's authed MCP server. The value never appears in argv. Repeatable. A hosted connector's Bearer secret (`bearer_secret`, or its single `secrets:` name) is bound automatically (from the value this deploy already resolved for the connector) so the runner can expand the derived header and drop the name from the sandbox env; this flag is for names beyond that (#2503, #2559)",
               "id": "secret",
               "long": "secret",
               "positional": false,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1540,7 +1540,7 @@
             },
             {
               "global": false,
-              "help": "Bind a per-agent connector secret by NAME (ADR-0009, #429). The value is resolved from your environment or the host secret vault (`curie secrets set <NAME>`) and sent to the platform, which stores it on the agent so the worker forwards it into the sandbox for a bundle's authed MCP server. The value never appears in argv. Repeatable. A hosted connector's own declared `secrets:` names are bound automatically (from the value this deploy already resolved for the connector) so its derived Bearer header expands; this flag is for names beyond that (#2503)",
+              "help": "Bind a per-agent connector secret by NAME (ADR-0009, #429). The value is resolved from your environment or the host secret vault (`curie secrets set <NAME>`) and sent to the platform, which stores it on the agent so the worker forwards it into the sandbox for a bundle's authed MCP server. The value never appears in argv. Repeatable. A hosted connector's Bearer secret (`bearer_secret`, or its single `secrets:` name) is bound automatically (from the value this deploy already resolved for the connector) so the runner can expand the derived header and drop the name from the sandbox env; this flag is for names beyond that (#2503, #2559)",
               "id": "secret",
               "long": "secret",
               "positional": false,

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -4618,12 +4618,13 @@ async fn prepare_deploy_with_commit_sha(
     // bundle or resolved values, so a declared-but-unbound policy fails fast
     // without doing any of that work.
     // The NAMES this deploy will actually bind into the agent sandbox: the
-    // explicit `--secret` flags, plus every env-var secret the bundle's hosted
-    // connectors declare (#2503). Curie resolves those itself, so a
+    // explicit `--secret` flags, plus the Bearer secret each hosted connector
+    // names (#2503, #2559). Curie resolves those itself, so a
     // plugin.json-declared name that connectors.yaml already auto-binds is not
     // a gap and must not be diffed against the flags alone -- the #464 gate
     // below would otherwise refuse a deploy that needs no flag. A manifest
-    // secret nothing binds still fails, unchanged.
+    // secret nothing binds still fails, unchanged. Extra `secrets:` names stay
+    // on the connector pod.
     let connector_env_secret_names =
         crate::connector_build::hosted_env_secret_names(&connector_decl);
     // Automatic delivery of connectors.yaml secrets exists only for

--- a/cli/src/connector_build.rs
+++ b/cli/src/connector_build.rs
@@ -79,6 +79,11 @@ pub struct ConnectorSpecDecl {
     // -- both --
     #[serde(default)]
     pub secrets: Vec<SecretDecl>,
+    /// The env-var name the derived `Authorization: Bearer ${NAME}` header
+    /// expands. Optional; a single `secrets:` entry is that name. See
+    /// [`bearer_secret_name`].
+    #[serde(default)]
+    pub bearer_secret: Option<String>,
     #[serde(default)]
     pub sealed_secrets: BTreeMap<String, String>,
     #[serde(default)]
@@ -135,6 +140,7 @@ impl Default for ConnectorSpecDecl {
             url: None,
             headers: BTreeMap::new(),
             secrets: Vec::new(),
+            bearer_secret: None,
             sealed_secrets: BTreeMap::new(),
             secret_files: BTreeMap::new(),
         }
@@ -1639,7 +1645,25 @@ pub fn hosted_secret_names(decl: &ConnectorsFileDecl) -> Vec<String> {
     names.into_iter().collect()
 }
 
-/// The secret NAMES a hosted connector's SANDBOX must also receive (#2503).
+/// The secret name the derived `Authorization: Bearer ${NAME}` header expands.
+///
+/// Mirrors `plugin_format.ConnectorSpec.bearer_secret_name`: an explicit
+/// `bearer_secret` wins; a single declared secret is that name; two or more
+/// without an explicit name is None (the Python validator refuses that
+/// document rather than picking `secrets[0]`).
+pub fn bearer_secret_name(spec: &ConnectorSpecDecl) -> Option<String> {
+    if let Some(name) = &spec.bearer_secret {
+        return Some(name.clone());
+    }
+    let names = declared_secret_names(spec);
+    if names.len() == 1 {
+        Some(names[0].clone())
+    } else {
+        None
+    }
+}
+
+/// The secret NAMES a hosted connector's SANDBOX must also receive (#2503, #2559).
 ///
 /// These are the names the derived `Authorization: Bearer ${NAME}` header on
 /// the mounted `.mcp.json` entry expands from: the expansion happens in the
@@ -1653,6 +1677,8 @@ pub fn hosted_secret_names(decl: &ConnectorsFileDecl) -> Vec<String> {
 ///   `unhosted_url:` override still points at that same connector's image
 ///   declaration, so it stays in scope; a pure `url:` remote is the MCP
 ///   client's own config and is not.
+/// - Only the Bearer name ([`bearer_secret_name`]), never every declared
+///   secret. Extra names stay on the connector pod.
 /// - `SecretDecl::Name` only. A `SecretDecl::Ref` names a Secret someone else
 ///   provisioned, which ADR-0090 keeps out of the deploy path entirely -- no
 ///   value for it exists here to bind.
@@ -1666,10 +1692,15 @@ pub fn hosted_env_secret_names(decl: &ConnectorsFileDecl) -> Vec<String> {
         if spec.image.is_none() && spec.build.is_none() {
             continue;
         }
-        for declared in &spec.secrets {
-            if let SecretDecl::Name(name) = declared {
-                names.insert(name.clone());
-            }
+        let Some(bearer) = bearer_secret_name(spec) else {
+            continue;
+        };
+        if spec
+            .secrets
+            .iter()
+            .any(|declared| matches!(declared, SecretDecl::Name(name) if *name == bearer))
+        {
+            names.insert(bearer);
         }
     }
     names.into_iter().collect()
@@ -1798,6 +1829,7 @@ connectors:
       - name: B
         from_secret: s
         key: k
+    bearer_secret: A
     secret_files:
       C: /x
 "#,
@@ -1854,6 +1886,7 @@ connectors:
     secrets:
       - SHARED
       - ZETA_ONLY
+    bearer_secret: SHARED
   alpha:
     build:
       context: ./alpha
@@ -1862,16 +1895,10 @@ connectors:
     secrets:
       - SHARED
       - ALPHA_ONLY
+    bearer_secret: SHARED
 "#,
         );
-        assert_eq!(
-            hosted_env_secret_names(&decl),
-            vec![
-                "ALPHA_ONLY".to_string(),
-                "SHARED".to_string(),
-                "ZETA_ONLY".to_string(),
-            ]
-        );
+        assert_eq!(hosted_env_secret_names(&decl), vec!["SHARED".to_string()]);
     }
 
     #[test]
@@ -1882,5 +1909,42 @@ connectors:
         let loaded = load(dir.path()).expect("a bundle with no connectors.yaml loads as empty");
         assert!(hosted_env_secret_names(&loaded).is_empty());
         assert!(hosted_env_secret_names(&ConnectorsFileDecl::default()).is_empty());
+    }
+
+    #[test]
+    fn multiple_secrets_without_bearer_secret_bind_nothing() {
+        // #2559: two bare names and no bearer_secret used to bind both, while
+        // only secrets[0] was the Bearer. Bind nothing until the header name
+        // is explicit; validate_connectors refuses this document on the
+        // Python side.
+        let decl = decl(
+            r#"
+connectors:
+  gh:
+    image: ghcr.io/example/gh:1
+    secrets:
+      - POD_ONLY
+      - PAT
+"#,
+        );
+        assert!(hosted_env_secret_names(&decl).is_empty());
+    }
+
+    #[test]
+    fn bearer_secret_binds_only_that_name() {
+        // Extra declared names stay on the connector pod (hosted_secret_names
+        // / secretKeyRef). The sandbox only receives the header's name.
+        let decl = decl(
+            r#"
+connectors:
+  gh:
+    image: ghcr.io/example/gh:1
+    secrets:
+      - POD_ONLY
+      - PAT
+    bearer_secret: PAT
+"#,
+        );
+        assert_eq!(hosted_env_secret_names(&decl), vec!["PAT".to_string()]);
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1772,10 +1772,11 @@ enum LocalAction {
         /// secrets set <NAME>`) and sent to the platform, which stores it on the
         /// agent so the worker forwards it into the sandbox for a bundle's authed
         /// MCP server. The value never appears in argv. Repeatable. A hosted
-        /// connector's own declared `secrets:` names are bound automatically
-        /// (from the value this deploy already resolved for the connector) so
-        /// its derived Bearer header expands; this flag is for names beyond
-        /// that (#2503).
+        /// connector's Bearer secret (`bearer_secret`, or its single `secrets:`
+        /// name) is bound automatically (from the value this deploy already
+        /// resolved for the connector) so the runner can expand the derived
+        /// header and drop the name from the sandbox env; this flag is for names
+        /// beyond that (#2503, #2559).
         #[arg(long = "secret", value_name = "NAME")]
         secret: Vec<String>,
     },
@@ -4417,10 +4418,10 @@ async fn run(command: Option<Command>) -> Result<()> {
                 // The list comes from the API, not a Rust YAML parse: ADR-0089
                 // keeps exactly one parser for this file, and a second could
                 // disagree with it about where a deploy lands.
-                // The env-var secrets this bundle's hosted connectors declare
-                // (#2503). Read once here, from the same connectors.yaml the
-                // deploy packs, so both cluster paths bind the sandbox with the
-                // names whose `${NAME}` the derived Bearer header expands.
+                // The Bearer secret names this bundle's hosted connectors
+                // declare (#2503, #2559). Read once here, from the same
+                // connectors.yaml the deploy packs, so both cluster paths bind
+                // the sandbox with only the name the derived header expands.
                 let connector_env_secret_names = curie::connector_build::hosted_env_secret_names(
                     &curie::connector_build::load(&plugin_dir)?,
                 );
@@ -4666,9 +4667,9 @@ async fn run(command: Option<Command>) -> Result<()> {
                     // are the CONNECTOR's, resolved locally and written straight to
                     // a K8s Secret, which is a different path from the sandbox
                     // secret delivery #440 tracks. The connector's own declared
-                    // secret NAMES are bound into the sandbox too (#2503),
-                    // unioned with the explicit `--secret` set, so a hosted
-                    // connector's derived Bearer header expands in the sandbox.
+                    // Bearer name is bound into the sandbox too (#2503, #2559),
+                    // unioned with the explicit `--secret` set, so the runner
+                    // can expand the derived header and then drop the name.
                     // Resolved before binding, applied after it.
                     let prepared_connectors = prepare_cluster_connectors(
                         &api_url,

--- a/docs/interfaces/bundle-format/INTERFACE.md
+++ b/docs/interfaces/bundle-format/INTERFACE.md
@@ -81,11 +81,13 @@ files**, each absent from a bundle that needs none, all three invisible to Claud
   `connectors.sealed_secrets_unsupported` until a decrypt path exists (see
   [sealed-credential](../sealed-credential/INTERFACE.md)). For a hosted (`image`/`build`) connector
   with `secrets:` declared, the rendered `.mcp.json` entry derives
-  `headers.Authorization: Bearer ${<first declared secret>}` -- the author still writes no `headers:`
-  on a hosted connector (`connectors.hosted_has_headers`) -- and `cluster deploy` binds that secret
-  name into the sandbox alongside any explicit `--secret` so the placeholder expands (#2503; a
+  `headers.Authorization: Bearer ${<bearer_secret, or the single declared secret>}` -- the author still writes no `headers:`
+  on a hosted connector (`connectors.hosted_has_headers`) -- and `cluster deploy` binds only that
+  Bearer name into the sandbox alongside any explicit `--secret` so the runner can expand the
+  placeholder at boot and then drop the name from the process env (#2503, #2559; a
   `SecretRef` value does not reach the sandbox under ADR-0090, and the `url` fallback used by tiers
-  below cluster derives no header, both tracked as follow-ups). Validated by `packages/plugin-format/src/plugin_format/validate.py::_validate_connectors`,
+  below cluster derives no header, both tracked as follow-ups). A hosted connector with several
+  secrets and no `bearer_secret` is `connectors.bearer_secret_required`. Validated by `packages/plugin-format/src/plugin_format/validate.py::_validate_connectors`,
   which emits `connectors.*` codes (`connectors.not_object`, `connectors.ambiguous`,
   `connectors.underspecified`, `connectors.reserved_name`, `connectors.duplicate_connector`,
   `connectors.duplicate_server`, `connectors.build_context_escapes`,

--- a/packages/plugin-format/src/plugin_format/connector_render.py
+++ b/packages/plugin-format/src/plugin_format/connector_render.py
@@ -576,11 +576,12 @@ def _derived_headers(spec: ConnectorSpec) -> dict[str, Any]:
 
     Derived, not authored, for the same reason the URL above is: under ADR-0086
     the author writes no URL and no header, so there is nothing to get wrong.
-    The value is the ``${NAME}`` placeholder the MCP client expands from the
-    sandbox env -- the same expansion ``unhosted_url`` documents -- so no secret
-    VALUE is ever read or rendered here. The FIRST declared secret is the one
-    used: a single-credential HTTP MCP server is the shape this covers, and the
-    remaining secrets keep their pod-side ``secretKeyRef`` delivery.
+    The value is the ``${NAME}`` placeholder -- no secret VALUE is ever read or
+    rendered here. The name is ``spec.bearer_secret`` when set, otherwise the
+    single declared secret (the github-mcp-server shape). A hosted connector
+    with several secrets and no ``bearer_secret`` is refused at validation
+    rather than silently using ``secrets[0]`` (#2559). Remaining secrets keep
+    their pod-side ``secretKeyRef`` delivery.
 
     With the header present, a wrong token surfaces from the tool call as
     GitHub's ``401 Bad credentials``; a MISSING value is refused at deploy
@@ -590,10 +591,9 @@ def _derived_headers(spec: ConnectorSpec) -> dict[str, Any]:
     logs the failure -- a known gap, tracked as a follow-up issue.
     """
 
-    if not spec.secrets:
+    name = spec.bearer_secret_name()
+    if not name:
         return {}
-    declared = spec.secrets[0]
-    name = declared if isinstance(declared, str) else declared.name
     return {"headers": {"Authorization": f"Bearer ${{{name}}}"}}
 
 
@@ -625,8 +625,8 @@ def mcp_entry(
     For a hosted connector the URL is derived from the Service that Curie just
     created; hand-writing it is how a bundle ends up with an address that does
     not resolve in the tier it is deployed to. Its ``Authorization`` header is
-    derived from the first declared secret for the same reason, so the author
-    writes no header either -- see ``_derived_headers``.
+    derived from ``bearer_secret`` (or the single declared secret) for the same
+    reason, so the author writes no header either -- see ``_derived_headers``.
     """
 
     if spec.is_hosted:

--- a/packages/plugin-format/src/plugin_format/connectors.py
+++ b/packages/plugin-format/src/plugin_format/connectors.py
@@ -169,6 +169,17 @@ class ConnectorSpec(BaseModel):
     # Secret that already exists.
     secrets: list[str | SecretRef] = Field(default_factory=list)
 
+    #   bearer_secret: PAT                    The env-var name the derived
+    #                                         Authorization: Bearer ${NAME}
+    #                                         header expands. Optional. A hosted
+    #                                         connector with exactly one secrets
+    #                                         entry still derives from that name
+    #                                         (the github-mcp-server shape). A
+    #                                         hosted connector with two or more
+    #                                         must set this rather than silently
+    #                                         using secrets[0] (#2559).
+    bearer_secret: str | None = None
+
     #   sealed_secrets:                       The bundle CARRIES the credential,
     #     TOKEN: AgBv3n2K...                  encrypted to the cluster that will
     #                                         run it (ADR-0094).
@@ -207,6 +218,22 @@ class ConnectorSpec(BaseModel):
     # each other; `/tmp` is refused because a server's scratch space is a poor
     # place for a credential and an emptyDir there would shadow the mount.
     secret_files: dict[str, str] = Field(default_factory=dict)
+
+    def bearer_secret_name(self) -> str | None:
+        """The secret name the derived Bearer header expands, or None.
+
+        Explicit ``bearer_secret`` wins. Otherwise a single declared secret is
+        that name -- the github-mcp-server shape, so existing one-secret
+        bundles keep working. Two or more without an explicit name is None:
+        validation refuses that document rather than picking ``secrets[0]``.
+        """
+
+        if self.bearer_secret:
+            return self.bearer_secret
+        names = [s if isinstance(s, str) else s.name for s in self.secrets]
+        if len(names) == 1:
+            return names[0]
+        return None
 
     def secret_names(self) -> list[str]:
         """Env var names this connector needs, any form."""
@@ -661,6 +688,29 @@ def validate_connectors(data: Any) -> tuple[ConnectorsFile | None, list[tuple[st
                         f"{where}: secret name {declared_name!r} is reserved: it is a "
                         "platform boot-env, model-credential, or redirect/capture-capable "
                         "key and cannot be used for a connector secret",
+                    )
+                )
+        if spec.is_hosted:
+            secret_env_names = [s if isinstance(s, str) else s.name for s in spec.secrets]
+            if spec.bearer_secret:
+                if spec.bearer_secret not in secret_env_names:
+                    errors.append(
+                        (
+                            "connectors.bearer_secret_unknown",
+                            f"{where}: bearer_secret {spec.bearer_secret!r} is not in "
+                            "`secrets`. The derived Authorization header names an env "
+                            "var the connector never declared, so the placeholder "
+                            "would expand empty.",
+                        )
+                    )
+            elif len(secret_env_names) > 1:
+                errors.append(
+                    (
+                        "connectors.bearer_secret_required",
+                        f"{where}: a hosted connector with more than one secret must "
+                        "set `bearer_secret` to the name the Authorization header "
+                        "expands. Picking secrets[0] is positional and binds every "
+                        "declared name into the sandbox.",
                     )
                 )
         seen_secret_names: set[str] = set()

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -1477,8 +1477,9 @@ def test_the_dns_corpus_covers_the_truncation_branch() -> None:
 # <PAT>` on every request, and an unauthenticated `GET /mcp` is a 401. Until
 # now the hosted entry carried a URL and nothing else, so the probe failed and
 # the agent simply listed no `mcp__github__*` tools -- a silent no-tools, not
-# an error. The header is DERIVED from the first declared secret for the same
-# reason the URL is derived (ADR-0086): the author writes neither.
+# an error. The header is DERIVED from ``bearer_secret`` (or the single
+# declared secret) for the same reason the URL is derived (ADR-0086): the
+# author writes neither.
 # --------------------------------------------------------------------------- #
 GITHUB = ConnectorSpec(
     image="ghcr.io/github/github-mcp-server:v0.20.1",
@@ -1545,3 +1546,31 @@ def test_only_the_placeholder_is_emitted_never_a_resolved_value(
     # anything that logs the rendered entry.
     monkeypatch.setenv("GITHUB_PERSONAL_ACCESS_TOKEN", "ghp_sentinel")
     assert "ghp_sentinel" not in json.dumps(_github_entry())
+
+
+def test_bearer_secret_names_the_header_when_several_secrets_are_declared() -> None:
+    # #2559: secrets[0] was the Bearer only because it came first. A hosted
+    # connector that also declares a pod-side credential must name the header
+    # secret, or the sandbox would bind the wrong name (or every name).
+    spec = ConnectorSpec(
+        image="ghcr.io/github/github-mcp-server:v0.20.1",
+        secrets=["POD_ONLY", "GITHUB_PERSONAL_ACCESS_TOKEN"],
+        bearer_secret="GITHUB_PERSONAL_ACCESS_TOKEN",
+    )
+    assert _github_entry(spec)["headers"] == {
+        "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
+    }
+
+
+def test_a_single_declared_secret_still_derives_the_header_without_bearer_secret() -> None:
+    # The github-mcp-server shape. Requiring the new field on every existing
+    # one-secret bundle would be a break for no security gain: there is only
+    # one name that could be the Bearer.
+    spec = ConnectorSpec(
+        image="ghcr.io/github/github-mcp-server:v0.20.1",
+        secrets=["GITHUB_PERSONAL_ACCESS_TOKEN"],
+    )
+    assert spec.bearer_secret is None
+    assert _github_entry(spec)["headers"] == {
+        "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
+    }

--- a/packages/plugin-format/tests/test_connectors.py
+++ b/packages/plugin-format/tests/test_connectors.py
@@ -333,7 +333,11 @@ def test_both_forms_can_be_mixed_on_one_connector() -> None:
     parsed, errors = validate_connectors(
         {
             "connectors": {
-                "g": {"image": "x:1", "secrets": ["OWNED", {"name": "REFD", "from_secret": "s"}]}
+                "g": {
+                    "image": "x:1",
+                    "secrets": ["OWNED", {"name": "REFD", "from_secret": "s"}],
+                    "bearer_secret": "OWNED",
+                }
             }
         }
     )
@@ -396,6 +400,75 @@ def test_a_malformed_secret_name_is_refused() -> None:
     codes = _codes({"connectors": {"g": {"image": "x:1", "secrets": ["grafana-token"]}}})
     assert "connectors.secret_name_invalid" in codes
     assert "connectors.secret_name_reserved" not in codes, "shape is reported once, not twice"
+
+
+def test_a_hosted_connector_with_several_secrets_must_name_the_bearer() -> None:
+    # #2559: picking secrets[0] as the Authorization header is positional.
+    # Two names and no bearer_secret is refused rather than silently binding
+    # both into the sandbox (and using the first as the Bearer).
+    assert "connectors.bearer_secret_required" in _codes(
+        {"connectors": {"g": {"image": "x:1", "secrets": ["POD_ONLY", "PAT"]}}}
+    )
+
+
+def test_a_named_bearer_secret_must_be_one_of_the_declared_secrets() -> None:
+    assert "connectors.bearer_secret_unknown" in _codes(
+        {
+            "connectors": {
+                "g": {
+                    "image": "x:1",
+                    "secrets": ["POD_ONLY", "PAT"],
+                    "bearer_secret": "NOT_DECLARED",
+                }
+            }
+        }
+    )
+
+
+def test_a_named_bearer_secret_is_accepted_on_a_multi_secret_hosted_connector() -> None:
+    parsed, errors = validate_connectors(
+        {
+            "connectors": {
+                "g": {
+                    "image": "x:1",
+                    "secrets": ["POD_ONLY", "PAT"],
+                    "bearer_secret": "PAT",
+                }
+            }
+        }
+    )
+    assert errors == []
+    assert parsed is not None
+    assert parsed.connectors["g"].bearer_secret == "PAT"
+
+
+def test_a_single_secret_hosted_connector_does_not_require_bearer_secret() -> None:
+    # Compat for the github-mcp-server shape: one name, that name is the Bearer.
+    parsed, errors = validate_connectors(
+        {"connectors": {"g": {"image": "x:1", "secrets": ["PAT"]}}}
+    )
+    assert errors == []
+    assert parsed is not None
+    assert parsed.connectors["g"].bearer_secret is None
+
+
+def test_a_remote_connector_does_not_require_bearer_secret_for_several_secrets() -> None:
+    # Derivation is hosted-only. A url: connector's headers are author input
+    # (ADR-0009 ${VAR} in .mcp.json / headers), so several secrets without
+    # bearer_secret stay legal.
+    parsed, errors = validate_connectors(
+        {
+            "connectors": {
+                "r": {
+                    "url": "https://mcp.example.com/mcp",
+                    "secrets": ["A", "B"],
+                    "headers": {"Authorization": "Bearer ${A}"},
+                }
+            }
+        }
+    )
+    assert errors == []
+    assert parsed is not None
 
 
 def test_an_ordinary_connector_secret_name_still_validates() -> None:

--- a/runner/README.md
+++ b/runner/README.md
@@ -72,6 +72,15 @@ readinessProbe hits `/healthz`).
   still-permitted shell tool (e.g. `Bash`) can reach the same HTTP state API
   directly. Naming `Bash` alongside the state tools closes that path today;
   removing the token itself needs a code change, not a config knob.
+  Hosted-connector Bearer secrets are a different class (#2559): the runner
+  expands `Authorization: Bearer ${NAME}` into the in-memory MCP catalog at
+  boot and drops `NAME` from the process environment (and from
+  `CURIE_CONNECTOR_SECRET_KEYS`) before the session accepts turns, so `Bash`
+  cannot read the PAT. The on-disk catalog keeps the placeholder. Residual:
+  kubelet / `docker -e` still injects the value onto the container until the
+  runner process unsets it. ADR-0009 `--secret` names that are not a hosted
+  Bearer stay in the environment, because stdio / remote MCP clients still
+  expand `${VAR}` there.
 
 ## Build and smoke
 

--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -37,7 +37,12 @@ from .approval import (
     resolve_approval_policy,
 )
 from .config import RunnerConfig
-from .connectors import build_mcp_servers, derive_mcp_servers
+from .connectors import (
+    build_mcp_servers,
+    derive_mcp_servers,
+    drop_connector_secret_names,
+    materialize_hosted_bearer_headers,
+)
 from .fake import FakeModelSession
 from .harness.contribution import HarnessContribution
 from .harness.registry import (
@@ -242,6 +247,13 @@ def build_runner(
         agent=config.connector_agent,
         namespace=config.connector_namespace,
     )
+    # Expand hosted Bearer ${NAME} headers in memory and drop NAME so Bash
+    # cannot read the PAT from the process env (#2559). The on-disk catalog
+    # keeps the placeholder; derive_mcp_servers never sees a value.
+    spawn_env = sdk_env if sdk_env is not None else os.environ
+    dropped = materialize_hosted_bearer_headers(derived_mcp_servers, spawn_env)
+    if spawn_env is not os.environ:
+        drop_connector_secret_names(os.environ, dropped)
 
     # A configured permission gate is already positive evidence that the
     # session carries an actionable approval boundary. Publication is excluded:

--- a/runner/src/curie_runner/connectors.py
+++ b/runner/src/curie_runner/connectors.py
@@ -36,10 +36,13 @@ rather than silently displacing the approval server.
 from __future__ import annotations
 
 import logging
+import re
+from collections.abc import Collection, MutableMapping
 from pathlib import Path
 from typing import Any
 
 import yaml
+from aci_protocol import BootEnv
 from plugin_format.connector_render import (
     AmbiguousObjectName,
     mcp_entry,
@@ -164,3 +167,58 @@ def build_mcp_servers(platform: dict[str, Any], derived: dict[str, Any]) -> dict
     """
 
     return {**derived, **platform}
+
+
+_BEARER_PLACEHOLDER = re.compile(r"^Bearer \$\{([A-Za-z_][A-Za-z0-9_]*)\}$")
+
+
+def materialize_hosted_bearer_headers(
+    servers: dict[str, Any],
+    env: MutableMapping[str, str],
+) -> frozenset[str]:
+    """Expand hosted ``Bearer ${NAME}`` headers in memory and drop NAME from env.
+
+    ``derive_mcp_servers`` / ``mcp_entry`` keep the placeholder so a value never
+    lands on disk. The MCP client still needs the real header, so the runner
+    expands it here and unsets the name before the SDK session (and Bash) can
+    read the process environment (#2559). Names that were never in ``env`` stay
+    as the placeholder (the empty-Bearer gap, #2519). Unrelated secrets are
+    left in ``env`` so ADR-0009 stdio / remote ``${VAR}`` expansion still works.
+    """
+
+    dropped: set[str] = set()
+    for server in servers.values():
+        if not isinstance(server, dict):
+            continue
+        headers = server.get("headers")
+        if not isinstance(headers, dict):
+            continue
+        auth = headers.get("Authorization")
+        if not isinstance(auth, str):
+            continue
+        match = _BEARER_PLACEHOLDER.fullmatch(auth)
+        if match is None:
+            continue
+        name = match.group(1)
+        value = env.get(name)
+        if value is None:
+            continue
+        headers["Authorization"] = f"Bearer {value}"
+        dropped.add(name)
+    drop_connector_secret_names(env, dropped)
+    return frozenset(dropped)
+
+
+def drop_connector_secret_names(env: MutableMapping[str, str], names: Collection[str]) -> None:
+    """Remove hosted Bearer names from a process or spawn env mapping."""
+
+    for name in names:
+        env.pop(name, None)
+    marker = BootEnv.env_key("connector_secret_keys")
+    raw = env.get(marker)
+    if raw and names:
+        remaining = [key for key in raw.split(",") if key and key not in names]
+        if remaining:
+            env[marker] = ",".join(sorted(remaining))
+        else:
+            env.pop(marker, None)

--- a/runner/tests/test_connectors.py
+++ b/runner/tests/test_connectors.py
@@ -699,3 +699,99 @@ def test_the_mounted_hosted_server_carries_the_declared_credential(tmp_path: Pat
     # sandbox environment, so nothing resolved is written to disk here.
     servers = derive_mcp_servers(_bundle(tmp_path, GITHUB), **SCOPE)
     assert servers["github"]["headers"] == _BEARER
+
+
+def test_materialize_expands_the_bearer_and_drops_it_from_env() -> None:
+    # #2559: the derived catalog keeps the placeholder (derive_mcp_servers
+    # above); the runner expands in memory and unsets the name so Bash cannot
+    # read the PAT. The value must not appear in os.environ or the SDK spawn
+    # env after this call, and must not be logged.
+    from aci_protocol import BootEnv
+    from curie_runner.connectors import materialize_hosted_bearer_headers
+
+    marker = BootEnv.env_key("connector_secret_keys")
+    servers = {
+        "github": {
+            "type": "http",
+            "url": "http://example.svc/mcp",
+            "headers": {"Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"},
+        }
+    }
+    env = {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_sentinel",
+        "STDIO_ONLY": "keep-me",
+        marker: "GITHUB_PERSONAL_ACCESS_TOKEN,STDIO_ONLY",
+    }
+    dropped = materialize_hosted_bearer_headers(servers, env)
+    assert dropped == frozenset({"GITHUB_PERSONAL_ACCESS_TOKEN"})
+    assert servers["github"]["headers"]["Authorization"] == "Bearer ghp_sentinel"
+    assert "GITHUB_PERSONAL_ACCESS_TOKEN" not in env
+    assert env["STDIO_ONLY"] == "keep-me"
+    assert env[marker] == "STDIO_ONLY"
+
+
+def test_materialize_leaves_a_missing_bearer_as_the_placeholder() -> None:
+    # A SecretRef / unset value still expands empty today (#2519). Dropping a
+    # name that was never in env would hide that gap; leave the placeholder.
+    from curie_runner.connectors import materialize_hosted_bearer_headers
+
+    servers = {
+        "github": {
+            "type": "http",
+            "headers": {"Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"},
+        }
+    }
+    env = {"STDIO_ONLY": "keep-me"}
+    dropped = materialize_hosted_bearer_headers(servers, env)
+    assert dropped == frozenset()
+    assert servers["github"]["headers"] == {
+        "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
+    }
+    assert env == {"STDIO_ONLY": "keep-me"}
+
+
+def test_materialize_does_not_drop_an_unrelated_secret() -> None:
+    # ADR-0009 stdio / remote ${VAR} secrets stay in env for the MCP client.
+    from curie_runner.connectors import materialize_hosted_bearer_headers
+
+    servers = {
+        "github": {
+            "type": "http",
+            "headers": {"Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"},
+        }
+    }
+    env = {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_sentinel",
+        "STDIO_TOKEN": "stdio-secret",
+    }
+    materialize_hosted_bearer_headers(servers, env)
+    assert env["STDIO_TOKEN"] == "stdio-secret"
+    assert "GITHUB_PERSONAL_ACCESS_TOKEN" not in env
+
+
+def test_build_runner_expands_the_bearer_and_drops_it_from_spawn_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Wiring pin for #2559: materialize runs on the SDK spawn env inside
+    # build_runner, so a PAT that arrived as a connector secret is gone before
+    # the session (and Bash) starts, while the in-memory MCP header is expanded.
+    monkeypatch.delenv("CURIE_STATE_URL", raising=False)
+    config = _config_for(
+        _bundle(tmp_path, GITHUB), release="curie", agent="acme-dev", namespace="curie"
+    )
+    spawn = {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_sentinel",
+        "STDIO_TOKEN": "keep-me",
+    }
+
+    async def probe(*_args: Any, **_kwargs: Any) -> McpToolCapabilityProbe:
+        return McpToolCapabilityProbe(complete=True, has_potential_write_tool=False, tool_count=0)
+
+    monkeypatch.setattr(boot, "probe_mcp_tool_capability", probe)
+    monkeypatch.setattr(boot, "ClaudeAgentSession", _CapturedSession)
+    session = build_runner(config, fake_model=False, sdk_env=spawn)._factory()
+    assert isinstance(session, _CapturedSession)
+    assert "GITHUB_PERSONAL_ACCESS_TOKEN" not in spawn
+    assert spawn["STDIO_TOKEN"] == "keep-me"
+    github = session.options.mcp_servers["github"]
+    assert github["headers"]["Authorization"] == "Bearer ghp_sentinel"

--- a/tests/vectors/connector-fields.json
+++ b/tests/vectors/connector-fields.json
@@ -3,6 +3,7 @@
   "models": {
     "ConnectorSpec": [
       "args",
+      "bearer_secret",
       "build",
       "env",
       "headers",


### PR DESCRIPTION
## Summary

#2520 derived `Authorization: Bearer ${NAME}` for a hosted connector and bound every `secrets:` name into the sandbox so the placeholder could expand. That put a GitHub PAT (and any extra declared secret) in the agent process environment, where Bash can read it.

This names the Bearer (`bearer_secret`, or the single declared secret), binds only that name into the sandbox, expands the header in the in-memory MCP catalog at boot, and drops the name from the process env before the session accepts turns. Extra `secrets:` names stay on the connector pod. ADR-0009 `--secret` names that are not a hosted Bearer stay in env.

`runner/README.md` now states that hosted connector Bearer secrets are expanded then stripped. Residual: kubelet / `docker -e` still injects the value onto the container until the runner process unsets it. `CURIE_STATE_TOKEN` is unchanged and still stays in env.

## Related issue

Closes #2559

## Fix pin verification

Fix pin: runner/tests/test_connectors.py::test_build_runner_expands_the_bearer_and_drops_it_from_spawn_env

## End-to-end verification

Candidate: `9e5b6db49503c2569ddc7d1858659be2a2303bdb`

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | required | Runner MCP catalog projection: expand hosted Bearer headers and drop the secret from process env | fake | `uv run pytest runner/tests/test_connectors.py packages/plugin-format/tests/test_connectors.py packages/plugin-format/tests/test_connector_render.py -q` on `9e5b6db49`. Observed: 265 passed including `test_build_runner_expands_the_bearer_and_drops_it_from_spawn_env` (`GITHUB_PERSONAL_ACCESS_TOKEN` absent from spawn env; header `Bearer ghp_sentinel`) and `test_a_hosted_connector_with_several_secrets_must_name_the_bearer` (`connectors.bearer_secret_required`). Negative: `test_materialize_leaves_a_missing_bearer_as_the_placeholder` keeps `${NAME}` when the value is unset; `test_materialize_does_not_drop_an_unrelated_secret` keeps `STDIO_TOKEN`. |
| local | required | CLI `hosted_env_secret_names` and local deploy `--secret` help | fake | `cargo test --lib hosted_env_secret_names -- --test-threads=1` on `9e5b6db49`. Observed: 7 passed, including `bearer_secret_binds_only_that_name` (`["PAT"]`) and `multiple_secrets_without_bearer_secret_bind_nothing` (empty). |
| local-release | n/a | Does not change released binary identity, the install path, version pins, or release compose | | |
| cluster | required | `cluster deploy` binds via `hosted_env_secret_names`, the same function both cluster paths call | fake | Same `hosted_env_secret_names` tests as local. `cluster_connector_bind_values` is unchanged and still keys off that name list. Live kind apply not re-run in this job. |
| live provider | required | Path set: runner MCP catalog projection. A hosted GitHub MCP still has to authenticate after expand-and-strip | fake | Wiring tests above prove expansion and strip. Live GitHub round-trip (the #2520 cluster proof) was not re-run here. |
| external integration | required | Path set: runner MCP catalog projection also requires Slack on this path | fake | No Slack adapter change. Slack round-trip not run in this job. |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [ ] No required tier is left unproved; any blocked tier names its blocker in the table.

Live-provider and Slack rows are required by the path-set rule and were not driven against a live GitHub MCP or Slack workspace in this job. The fake-mode wiring and bind-narrowing tests are the evidence recorded here.

Sibling paths: skill/local hosted-secret staging remains #2518. Empty Bearer from `SecretRef` remains #2519. ADR-0009 stdio / remote `${VAR}` secrets stay in the sandbox env by design.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision.
