### PR TITLE
Give cluster up an explicit --adopt override for a pre-existing namespace

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -2537,6 +2537,18 @@ export const commandManifest = {
             },
             {
               "global": false,
+              "help": "Adopt a pre-existing namespace that already has its own labels or objects. Without this, such a namespace is refused. The adoption is recorded on the namespace (curietech.ai/adopted-by, adopted-in, and the adopted-at/adopted-labels/adopted-contents annotations), and an adopted namespace is RETAINED by cluster down rather than deleted, so your pre-existing objects are never swept. It never adopts the shared agent-sandbox-system namespace or a terminating one, and it never admits a namespace whose contents cannot be read",
+              "id": "adopt",
+              "long": "adopt",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
               "help": "Force the sealed fake-model install even when CURIE_CREDENTIALS is set (dev/CI escape hatch); suppresses the fake-model warning",
               "id": "fake_model",
               "long": "fake-model",

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -2534,6 +2534,18 @@
             },
             {
               "global": false,
+              "help": "Adopt a pre-existing namespace that already has its own labels or objects. Without this, such a namespace is refused. The adoption is recorded on the namespace (curietech.ai/adopted-by, adopted-in, and the adopted-at/adopted-labels/adopted-contents annotations), and an adopted namespace is RETAINED by cluster down rather than deleted, so your pre-existing objects are never swept. It never adopts the shared agent-sandbox-system namespace or a terminating one, and it never admits a namespace whose contents cannot be read",
+              "id": "adopt",
+              "long": "adopt",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
               "help": "Force the sealed fake-model install even when CURIE_CREDENTIALS is set (dev/CI escape hatch); suppresses the fake-model warning",
               "id": "fake_model",
               "long": "fake-model",

--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -789,6 +789,10 @@ fn plan_installation_inner(
         secrets: vec![],
         github_token: crate::ops::GithubTokenPlan::Untouched,
         dev: false,
+        // Installation apply has no adoption surface of its own; a namespace
+        // that needs the #2557 override is adopted by an explicit
+        // `curie cluster up --adopt` first.
+        adopt: false,
     };
     crate::ops::validate_up_inputs(&up, github_token.as_deref(), false)?;
     Ok(LocalInstallationPlan {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2026,6 +2026,16 @@ enum ClusterAction {
         /// Keep the UI and Langfuse services ClusterIP instead of NodePort.
         #[arg(long)]
         no_expose: bool,
+        /// Adopt a pre-existing namespace that already has its own labels or
+        /// objects. Without this, such a namespace is refused. The adoption is
+        /// recorded on the namespace (curietech.ai/adopted-by, adopted-in, and
+        /// the adopted-at/adopted-labels/adopted-contents annotations), and an
+        /// adopted namespace is RETAINED by cluster down rather than deleted,
+        /// so your pre-existing objects are never swept. It never adopts the
+        /// shared agent-sandbox-system namespace or a terminating one, and it
+        /// never admits a namespace whose contents cannot be read.
+        #[arg(long)]
+        adopt: bool,
         /// Force the sealed fake-model install even when CURIE_CREDENTIALS
         /// is set (dev/CI escape hatch); suppresses the fake-model warning.
         #[arg(long)]
@@ -3845,6 +3855,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 release,
                 chart,
                 no_expose,
+                adopt,
                 fake_model,
                 model,
                 local_model,
@@ -3905,6 +3916,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                             // the pure builder starts clean.
                             github_token: ops::GithubTokenPlan::Untouched,
                             dev,
+                            adopt,
                         },
                         github_token,
                         clear_github_token,

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -8469,7 +8469,7 @@ pub async fn down(opts: DownOpts) -> Result<ClusterDownOutput> {
         }));
     }
     ui.warn(&format!(
-        "this uninstalls release '{0}' in namespace '{1}', removes only that release's Helm hook Jobs, and deletes only namespaces carrying curietech.ai/created-by={0} AND curietech.ai/created-in={1}. Empty primary namespaces adopted by `cluster up` carry that pair; legacy unlabeled, foreign-content, foreign-owned, and shared controller namespaces are retained",
+        "this uninstalls release '{0}' in namespace '{1}', removes only that release's Helm hook Jobs, and deletes only namespaces carrying curietech.ai/created-by={0} AND curietech.ai/created-in={1}. Empty primary namespaces adopted by `cluster up` carry that pair; legacy unlabeled, foreign-content, foreign-owned, `--adopt`-adopted, and shared controller namespaces are retained",
         opts.common.release, opts.common.namespace
     ));
     if !opts.yes

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -610,6 +610,11 @@ pub struct UpOpts {
     /// generating strong per-release randoms (the first-class dev escape hatch
     /// that replaces hand-passing `--set` for every secret).
     pub dev: bool,
+    /// `--adopt`: the explicit operator override for the three pre-existing
+    /// namespace refusals (#2557). It never reaches the Helm value plan --
+    /// it is consumed entirely by [`establish_primary_namespace_ownership`]
+    /// before Helm starts -- so the pure argv tests leave it `false`.
+    pub adopt: bool,
 }
 
 impl UpOpts {
@@ -5966,6 +5971,33 @@ fn ns_common(opts: &CommonOpts, ns: &str, dry_run: bool) -> CommonOpts {
 const CREATED_BY_LABEL: &str = "curietech.ai/created-by";
 const CREATED_IN_LABEL: &str = "curietech.ai/created-in";
 
+/// #2557 override ownership. An operator adoption is stamped with this pair
+/// INSTEAD of the [`CREATED_BY_LABEL`]/[`CREATED_IN_LABEL`] pair, and the
+/// difference is the whole safety property: `down_commands` selects on the
+/// created-by/created-in conjunction, so a namespace adopted under `--adopt`
+/// does not match the teardown sweep. The release is uninstalled and the
+/// namespace -- with whatever the operator already had in it -- is retained.
+/// This is the same deliberate fail-safe-toward-retention shape #1654 gave a
+/// namespace stamped by an older single-label CLI.
+const ADOPTED_BY_LABEL: &str = "curietech.ai/adopted-by";
+const ADOPTED_IN_LABEL: &str = "curietech.ai/adopted-in";
+
+/// What the override adopted, written onto the Namespace so `kubectl get
+/// namespace -o yaml` answers "who took this over, when, and over what?" long
+/// after the install output has scrolled away.
+const ADOPTED_AT_ANNOTATION: &str = "curietech.ai/adopted-at";
+const ADOPTED_LABELS_ANNOTATION: &str = "curietech.ai/adopted-labels";
+const ADOPTED_CONTENTS_ANNOTATION: &str = "curietech.ai/adopted-contents";
+
+/// Longest recorded annotation value. Kubernetes caps total metadata at 256KB
+/// and a busy namespace inventory can be long; a truncated record still names
+/// the first objects and says it was truncated.
+const ADOPTION_RECORD_LIMIT: usize = 4096;
+
+/// Appended to the three refusals `--adopt` can override, and to nothing else.
+const ADOPT_HINT: &str =
+    "; pass --adopt to adopt it anyway, recording what was adopted on the namespace";
+
 /// `kubectl get namespace <ns>` using the API's machine-readable absence
 /// contract. `--ignore-not-found` returns exit 0 plus empty stdout for an absent
 /// namespace; every nonzero result is therefore a real read failure and must
@@ -5987,6 +6019,12 @@ fn namespace_get_cmd(namespace: &str) -> OpsCommand {
 #[derive(Debug, Clone)]
 struct NamespaceRecord {
     labels: BTreeMap<String, String>,
+    /// Read so an override adoption can MERGE its record into whatever the
+    /// namespace already carries. The guarded patch rewrites the whole
+    /// annotations map, so anything not read here would be destroyed -- an
+    /// Argo CD tracking annotation, say. The uid/resourceVersion preconditions
+    /// on the same patch are what make that read-modify-write safe.
+    annotations: BTreeMap<String, String>,
     uid: String,
     resource_version: String,
     terminating: bool,
@@ -6021,6 +6059,11 @@ fn parse_namespace_probe(namespace: &str, output: &str) -> Result<NamespaceProbe
         Some(value) => serde_json::from_value(value.clone())
             .with_context(|| format!("Namespace `{namespace}` has malformed labels"))?,
     };
+    let annotations = match metadata.get("annotations") {
+        None | Some(serde_json::Value::Null) => BTreeMap::new(),
+        Some(value) => serde_json::from_value(value.clone())
+            .with_context(|| format!("Namespace `{namespace}` has malformed annotations"))?,
+    };
     let uid = metadata
         .get("uid")
         .and_then(serde_json::Value::as_str)
@@ -6035,6 +6078,7 @@ fn parse_namespace_probe(namespace: &str, output: &str) -> Result<NamespaceProbe
         .to_string();
     Ok(NamespaceProbe::Present(NamespaceRecord {
         labels,
+        annotations,
         uid,
         resource_version,
         terminating,
@@ -6320,7 +6364,16 @@ async fn verify_remote_apiservices_available(namespace: &str) -> Result<()> {
     Ok(())
 }
 
-async fn verify_namespace_is_empty(namespace: &str) -> Result<()> {
+/// Read every namespaced object in `namespace` that Kubernetes did not put
+/// there itself, as the rendered `Kind (n): names` detail. `None` means the
+/// namespace holds nothing beyond the default ServiceAccount and root CA
+/// ConfigMap and is safely adoptable without an operator override.
+///
+/// Every READ failure here is still fatal, with or without `--adopt` (#2557).
+/// The override admits contents the operator accepts; it never admits contents
+/// nobody can see, because an unseen object cannot be recorded in the adoption
+/// annotations that make the decision auditable afterward.
+async fn namespace_foreign_contents(namespace: &str) -> Result<Option<String>> {
     verify_remote_apiservices_available(namespace).await?;
     let (ok, discovered, err) = run_capture(&namespaced_resources_cmd()).await?;
     if !ok {
@@ -6374,34 +6427,99 @@ async fn verify_namespace_is_empty(namespace: &str) -> Result<()> {
             foreign.entry(kind).or_default().push(name);
         }
     }
-    if !foreign.is_empty() {
-        let detail = foreign
+    if foreign.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(
+        foreign
             .into_iter()
             .map(|(kind, mut names)| {
                 names.sort();
                 format!("{kind} ({}): {}", names.len(), names.join(", "))
             })
             .collect::<Vec<_>>()
-            .join("; ");
-        bail!(
-            "namespace `{namespace}` contains non-default objects and cannot be adopted: {detail}"
-        );
+            .join("; "),
+    ))
+}
+
+/// What an explicit `--adopt` run took over, in the operator's terms. Built
+/// only when the flag actually overrode a refusal; a `--adopt` run over a
+/// namespace the default guards would have adopted anyway produces `None` and
+/// takes the ordinary created-by/created-in path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AdoptionOverride {
+    /// The labels the namespace carried before this run, rendered `k=v`.
+    prior_labels: String,
+    /// The non-default objects found, in [`namespace_foreign_contents`] form.
+    prior_contents: String,
+    /// RFC 3339 UTC, when the override was taken.
+    at: String,
+}
+
+/// Render one recorded field, bounded by [`ADOPTION_RECORD_LIMIT`], saying so
+/// when it had to be cut rather than silently presenting a partial list as
+/// complete.
+fn adoption_record_value(value: &str) -> String {
+    if value.is_empty() {
+        return "(none)".to_string();
     }
-    Ok(())
+    if value.len() <= ADOPTION_RECORD_LIMIT {
+        return value.to_string();
+    }
+    let mut cut = ADOPTION_RECORD_LIMIT;
+    while cut > 0 && !value.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    format!("{} (truncated)", &value[..cut])
+}
+
+fn rendered_labels(labels: &BTreeMap<String, String>) -> String {
+    labels
+        .iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn namespace_adoption_cmd(
     namespace: &str,
     release: &str,
     record: &NamespaceRecord,
+    overridden: Option<&AdoptionOverride>,
 ) -> Result<OpsCommand> {
     let mut labels = record.labels.clone();
-    labels.insert(CREATED_BY_LABEL.to_string(), release.to_string());
-    labels.insert(CREATED_IN_LABEL.to_string(), namespace.to_string());
+    let mut annotations = record.annotations.clone();
+    match overridden {
+        None => {
+            labels.insert(CREATED_BY_LABEL.to_string(), release.to_string());
+            labels.insert(CREATED_IN_LABEL.to_string(), namespace.to_string());
+        }
+        Some(taken) => {
+            // Drop any stale or foreign created-by/created-in pair rather than
+            // leaving it half-owned: this install is the owner now, and a
+            // leftover foreign pair is exactly the cross-release delete #1654
+            // reports. The adopted-by/adopted-in pair that replaces it is
+            // deliberately NOT the sweep selector.
+            labels.remove(CREATED_BY_LABEL);
+            labels.remove(CREATED_IN_LABEL);
+            labels.insert(ADOPTED_BY_LABEL.to_string(), release.to_string());
+            labels.insert(ADOPTED_IN_LABEL.to_string(), namespace.to_string());
+            annotations.insert(ADOPTED_AT_ANNOTATION.to_string(), taken.at.clone());
+            annotations.insert(
+                ADOPTED_LABELS_ANNOTATION.to_string(),
+                adoption_record_value(&taken.prior_labels),
+            );
+            annotations.insert(
+                ADOPTED_CONTENTS_ANNOTATION.to_string(),
+                adoption_record_value(&taken.prior_contents),
+            );
+        }
+    }
     let patch = serde_json::to_string(&serde_json::json!([
         {"op": "test", "path": "/metadata/uid", "value": record.uid.clone()},
         {"op": "test", "path": "/metadata/resourceVersion", "value": record.resource_version.clone()},
         {"op": "add", "path": "/metadata/labels", "value": labels},
+        {"op": "add", "path": "/metadata/annotations", "value": annotations},
     ]))
     .context("serializing the guarded Namespace ownership patch")?;
     Ok(OpsCommand::new(
@@ -6426,7 +6544,47 @@ fn labels_allow_empty_adoption(labels: &BTreeMap<String, String>, namespace: &st
                 == Some(namespace))
 }
 
-async fn establish_primary_namespace_ownership(o: &CommonOpts) -> Result<()> {
+fn adoption_timestamp() -> Result<String> {
+    time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .context("formatting the adoption timestamp")
+}
+
+/// Say on the terminal exactly what the override took over. The durable record
+/// is the annotation set written by [`namespace_adoption_cmd`]; this is the
+/// operator's chance to notice it was wrong before Helm runs.
+fn announce_adoption_override(namespace: &str, taken: &AdoptionOverride) {
+    let ui = crate::ui::ui();
+    ui.warn(&format!(
+        "--adopt: took over pre-existing namespace `{namespace}` at {}",
+        taken.at
+    ));
+    ui.warn(&format!(
+        "--adopt: pre-existing labels: {}",
+        adoption_record_value(&taken.prior_labels)
+    ));
+    ui.warn(&format!(
+        "--adopt: pre-existing objects: {}",
+        adoption_record_value(&taken.prior_contents)
+    ));
+    ui.warn(&format!(
+        "--adopt: recorded on the namespace as {ADOPTED_BY_LABEL}/{ADOPTED_IN_LABEL} plus the {ADOPTED_AT_ANNOTATION}, {ADOPTED_LABELS_ANNOTATION} and {ADOPTED_CONTENTS_ANNOTATION} annotations; read it back with `kubectl get namespace {namespace} -o yaml`"
+    ));
+    ui.warn(&format!(
+        "--adopt: `curie cluster down` will uninstall the release and RETAIN namespace `{namespace}`, because an adopted namespace is not stamped with the sweep's ownership labels. Delete it yourself if you want it gone."
+    ));
+}
+
+/// Establish this install's ownership of the primary namespace before Helm.
+///
+/// `adopt` is the explicit `--adopt` operator override (#2557). It admits a
+/// pre-existing namespace past exactly three refusals -- foreign or incomplete
+/// ownership labels, foreign labels, and non-default contents -- and nothing
+/// else. A terminating namespace and the shared controller namespace still
+/// refuse with the flag present, and so does every read failure underneath.
+/// An override adoption is recorded on the object and leaves the namespace
+/// outside the `cluster down` sweep; see [`ADOPTED_BY_LABEL`].
+async fn establish_primary_namespace_ownership(o: &CommonOpts, adopt: bool) -> Result<()> {
     match namespace_probe(&o.namespace).await? {
         NamespaceProbe::Absent => {
             let manifest = namespace_manifest(&o.namespace, &o.release)?;
@@ -6454,29 +6612,71 @@ async fn establish_primary_namespace_ownership(o: &CommonOpts) -> Result<()> {
             {
                 return Ok(());
             }
-            if created_by.is_some() || created_in.is_some() {
+            // An earlier `--adopt` by this exact (release, install namespace)
+            // pair is already a recorded decision. A re-run converges without
+            // asking for the flag again and without re-stamping the record,
+            // which would overwrite the original adoption timestamp and the
+            // contents as they were when the operator accepted them.
+            if record.labels.get(ADOPTED_BY_LABEL).map(String::as_str) == Some(o.release.as_str())
+                && record.labels.get(ADOPTED_IN_LABEL).map(String::as_str)
+                    == Some(o.namespace.as_str())
+            {
+                return Ok(());
+            }
+            if (created_by.is_some() || created_in.is_some()) && !adopt {
                 let by = created_by.map(String::as_str).unwrap_or("<missing>");
                 let install = created_in.map(String::as_str).unwrap_or("<missing>");
                 bail!(
-                    "namespace `{}` has incomplete or foreign ownership labels: {CREATED_BY_LABEL}={by}, {CREATED_IN_LABEL}={install}; refusing to mutate it",
+                    "namespace `{}` has incomplete or foreign ownership labels: {CREATED_BY_LABEL}={by}, {CREATED_IN_LABEL}={install}; refusing to mutate it{ADOPT_HINT}",
                     o.namespace
                 );
             }
+            // Never overridable. The controller namespace is a cluster
+            // singleton shared by every install and keeps #707's create-only
+            // rule, so `--adopt` must fall through to this refusal rather than
+            // around it.
             if o.namespace == CONTROLLER_DEPLOYMENT_NAMESPACE {
                 bail!(
-                    "pre-existing shared controller namespace `{}` is never eligible for adoption",
+                    "pre-existing shared controller namespace `{}` is never eligible for adoption, with or without --adopt",
                     o.namespace
                 );
             }
-            if !labels_allow_empty_adoption(&record.labels, &o.namespace) {
+            let foreign_labels = !labels_allow_empty_adoption(&record.labels, &o.namespace);
+            if foreign_labels && !adopt {
                 let keys = record.labels.keys().cloned().collect::<Vec<_>>().join(", ");
                 bail!(
-                    "namespace `{}` has foreign labels ({keys}) and cannot be adopted",
+                    "namespace `{}` has foreign labels ({keys}) and cannot be adopted{ADOPT_HINT}",
                     o.namespace
                 );
             }
-            verify_namespace_is_empty(&o.namespace).await?;
-            let command = namespace_adoption_cmd(&o.namespace, &o.release, &record)?;
+            let contents = namespace_foreign_contents(&o.namespace).await?;
+            if let Some(detail) = &contents {
+                if !adopt {
+                    bail!(
+                        "namespace `{}` contains non-default objects and cannot be adopted: {detail}{ADOPT_HINT}",
+                        o.namespace
+                    );
+                }
+            }
+            // `--adopt` with nothing to override is not an adoption override:
+            // an empty, unlabelled namespace takes the ordinary owned path and
+            // stays sweepable, exactly as it does without the flag.
+            let overridden = if adopt
+                && (created_by.is_some()
+                    || created_in.is_some()
+                    || foreign_labels
+                    || contents.is_some())
+            {
+                Some(AdoptionOverride {
+                    prior_labels: rendered_labels(&record.labels),
+                    prior_contents: contents.clone().unwrap_or_default(),
+                    at: adoption_timestamp()?,
+                })
+            } else {
+                None
+            };
+            let command =
+                namespace_adoption_cmd(&o.namespace, &o.release, &record, overridden.as_ref())?;
             let (ok, _out, err) = run_capture(&command).await?;
             if !ok {
                 bail!(
@@ -6484,6 +6684,9 @@ async fn establish_primary_namespace_ownership(o: &CommonOpts) -> Result<()> {
                     o.namespace,
                     failure_reason(&err)
                 );
+            }
+            if let Some(taken) = &overridden {
+                announce_adoption_override(&o.namespace, taken);
             }
         }
     }
@@ -7647,7 +7850,7 @@ async fn run_prepared_up(
         cmds = preview;
     } else {
         require_on_path("kubectl")?;
-        establish_primary_namespace_ownership(&opts.common).await?;
+        establish_primary_namespace_ownership(&opts.common, opts.adopt).await?;
     }
 
     // Count named provider intent on both live and dry runs, plus egress
@@ -7690,6 +7893,12 @@ async fn run_prepared_up(
             "# The Namespace manifest supplied on stdin carries {CREATED_BY_LABEL}={} and {CREATED_IN_LABEL}={}; a live run instead safely adopts an existing empty primary namespace.",
             opts.common.release, opts.common.namespace
         ));
+        if opts.adopt {
+            lines.insert(2, format!(
+                "# --adopt: a live run would also adopt an existing primary namespace that has foreign labels or non-default contents, stamp it {ADOPTED_BY_LABEL}={}/{ADOPTED_IN_LABEL}={} with a record of what it adopted, and leave it retained by `cluster down`. It never adopts `{CONTROLLER_DEPLOYMENT_NAMESPACE}` or a terminating namespace.",
+                opts.common.release, opts.common.namespace
+            ));
+        }
         lines.push("# After Helm and create-only controller namespace stamping, verify convergence for at most 300 seconds; repeat observations every 2 seconds while rollout is pending.".to_owned());
         lines.push(convergence::DRY_RUN_NOTE.to_owned());
         lines.extend(
@@ -10863,6 +11072,7 @@ mod tests {
                 secrets: vec![],
                 github_token: GithubTokenPlan::Untouched,
                 dev: true,
+                adopt: false,
             },
             Some(existing),
             None,
@@ -11044,6 +11254,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: false,
             set: vec![],
             set_string: vec![],
@@ -11088,6 +11299,7 @@ mod tests {
                 chart: "charts/curie".into(),
                 secrets: vec![],
                 dev: false,
+                adopt: false,
                 no_expose: false,
                 set: vec![],
                 set_string: vec![],
@@ -11142,6 +11354,7 @@ mod tests {
                 chart: "charts/curie".into(),
                 secrets: vec![],
                 dev: false,
+                adopt: false,
                 no_expose: true,
                 set: vec![],
                 set_string: vec![
@@ -11197,6 +11410,7 @@ mod tests {
                 chart: "charts/curie".into(),
                 secrets: vec![],
                 dev: false,
+                adopt: false,
                 no_expose: true,
                 set: vec![],
                 set_string: vec![],
@@ -11246,6 +11460,7 @@ mod tests {
                 chart: "charts/curie".into(),
                 secrets: vec![],
                 dev: false,
+                adopt: false,
                 no_expose: true,
                 set: vec![],
                 set_string: vec![],
@@ -11291,6 +11506,7 @@ mod tests {
                 chart: "charts/curie".into(),
                 secrets: vec![],
                 dev: false,
+                adopt: false,
                 no_expose: true,
                 set: vec![],
                 set_string: vec!["worker.slackTrustedOrigins=https://trusted.example.com".into()],
@@ -11336,6 +11552,7 @@ mod tests {
                 chart: "charts/curie".into(),
                 secrets: vec![],
                 dev: false,
+                adopt: false,
                 no_expose: true,
                 set: vec!["worker.slackTrustedOrigins=https://trusted.example.com".into()],
                 set_string: vec![],
@@ -11382,6 +11599,7 @@ mod tests {
                 chart: "charts/curie".into(),
                 secrets: vec![],
                 dev: false,
+                adopt: false,
                 no_expose: true,
                 set: vec![],
                 set_string: vec![],
@@ -11437,6 +11655,7 @@ mod tests {
                     chart: "charts/curie".into(),
                     secrets: vec![],
                     dev: false,
+                    adopt: false,
                     no_expose: true,
                     set: vec![],
                     set_string: vec![],
@@ -11490,6 +11709,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: true,
             set: vec![],
             allow_web_egress: vec![],
@@ -11514,6 +11734,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: true,
             set: vec!["worker.replicas=2".into(), "dispatcher.deploy=false".into()],
             set_string: vec![],
@@ -11544,6 +11765,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: false,
             set: vec![],
             allow_web_egress: vec![],
@@ -11571,6 +11793,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: false,
             set: vec![],
             set_string: vec![],
@@ -11597,6 +11820,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: false,
             set: vec![],
             allow_web_egress: vec![],
@@ -11732,6 +11956,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: true,
             set: vec![],
             set_string: vec![],
@@ -11758,6 +11983,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: true,
             set: vec![],
             allow_web_egress: vec![],
@@ -11783,6 +12009,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: true,
             set: vec![],
             set_string: vec![],
@@ -11812,6 +12039,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: true,
             set: vec![],
             allow_web_egress: vec![],
@@ -11837,6 +12065,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: true,
             set: vec!["agentSandbox.runner.model=z-ai/glm-5.2".into()],
             set_string: vec![],
@@ -11870,6 +12099,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: true,
             set: vec!["worker.replicas=2,agentSandbox.runner.model=glm".into()],
             allow_web_egress: vec![],
@@ -11945,6 +12175,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: false,
             set: vec![],
             set_string: vec![],
@@ -11985,6 +12216,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: false,
             set: vec![],
             allow_web_egress: vec!["0.0.0.0/0".into()],
@@ -12020,6 +12252,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: false,
             set: vec![],
             set_string: vec![],
@@ -12056,6 +12289,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: false,
             set: vec![],
             allow_web_egress: vec![],
@@ -12076,6 +12310,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: false,
             set: vec![],
             set_string: vec![],
@@ -13508,6 +13743,7 @@ mod tests {
                 "xoxb-preserved-secret".into(),
             )],
             dev: false,
+            adopt: false,
             no_expose: true,
             set: vec![],
             allow_web_egress: vec![],
@@ -13714,6 +13950,7 @@ mod tests {
                 chart: "charts/curie".into(),
                 secrets: vec![],
                 dev: true,
+                adopt: false,
                 no_expose: true,
                 set,
                 set_string: vec![],
@@ -14063,6 +14300,7 @@ mod tests {
                 ),
             ],
             dev: false,
+            adopt: false,
             no_expose: true,
             set: vec![],
             set_string: vec![],
@@ -14115,6 +14353,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: true,
+            adopt: false,
             no_expose: true,
             set: vec![],
             allow_web_egress: vec![],
@@ -14141,6 +14380,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: true,
+            adopt: false,
             no_expose: true,
             set: vec![],
             set_string: vec![],
@@ -14171,6 +14411,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: true,
             set: vec![],
             allow_web_egress: vec![],
@@ -15277,6 +15518,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: true,
             set: vec![],
             set_string: vec![],
@@ -15329,6 +15571,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: true,
             set: vec![],
             allow_web_egress: vec![],
@@ -15362,6 +15605,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: true,
             set: vec![],
             set_string: vec![],
@@ -15410,6 +15654,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: false,
+            adopt: false,
             no_expose: true,
             set: vec![],
             allow_web_egress: vec![],
@@ -15788,6 +16033,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: true,
+            adopt: false,
             no_expose: true,
             set: vec![],
             set_string: vec![],
@@ -16040,6 +16286,7 @@ mod tests {
             chart: "charts/curie".into(),
             secrets: vec![],
             dev: true,
+            adopt: false,
             no_expose: false,
             set: vec![],
             set_string: vec!["security.allowDevDefaults=false".into()],
@@ -16183,6 +16430,7 @@ mod tests {
                 ),
             ],
             dev: false,
+            adopt: false,
             no_expose: true,
             set: vec![],
             allow_web_egress: vec![],

--- a/cli/tests/cluster_namespace_ownership.rs
+++ b/cli/tests/cluster_namespace_ownership.rs
@@ -1063,6 +1063,54 @@ fn adopt_override_records_what_it_adopted_and_stays_out_of_the_teardown_sweep() 
         "a re-run rewrote the recorded adoption"
     );
 
+    // #1654's legacy case: a namespace stamped by an older single-label CLI is
+    // deliberately unswept and, until now, had no supported way to complete its
+    // stamp. `--adopt` is that way, and it removes the half-pair rather than
+    // leaving the namespace half-owned -- which also means it converts a
+    // legacy namespace into a RETAINED one, so the record must say so.
+    let legacy = Fixture::new(
+        json!({NS: Fixture::namespace(
+            json!({"curietech.ai/created-by": RELEASE}),
+            Fixture::default_furniture()
+        )}),
+        json!({}),
+        false,
+        false,
+    );
+    let refused = legacy.up();
+    assert_blocked_before_helm(&legacy, &refused, "incomplete or foreign ownership labels");
+    assert!(
+        shown(&refused).contains("--adopt"),
+        "the legacy-stamp refusal must name the override: {}",
+        shown(&refused)
+    );
+    let output = legacy.up_in(NS, &["--adopt"]);
+    assert!(
+        !output.status.success(),
+        "the fixture Helm hook must still fail after adopting a legacy stamp"
+    );
+    let state = legacy.state();
+    let labels = &state["namespaces"][NS]["labels"];
+    assert!(
+        labels.get("curietech.ai/created-by").is_none(),
+        "the legacy half-pair survived the override: {labels}"
+    );
+    assert_eq!(
+        labels["curietech.ai/adopted-by"],
+        json!(RELEASE),
+        "the legacy stamp was not completed as an adoption: {labels}"
+    );
+    assert_eq!(
+        state["namespaces"][NS]["annotations"]["curietech.ai/adopted-labels"],
+        json!(format!("curietech.ai/created-by={RELEASE}")),
+        "the override did not record the legacy ownership label it removed"
+    );
+    assert!(legacy.down().status.success());
+    assert!(
+        legacy.state()["namespaces"].get(NS).is_some(),
+        "an adopted legacy namespace must be retained by down"
+    );
+
     // The load bearing negative control: teardown must retain it and its
     // pre-existing objects, because it never carries the sweep selector.
     let down = fixture.down();

--- a/cli/tests/cluster_namespace_ownership.rs
+++ b/cli/tests/cluster_namespace_ownership.rs
@@ -68,6 +68,8 @@ def ns_json(name, record):
     metadata = {
         "name":name, "labels":record.get("labels", {}), "uid":record["uid"],
         "resourceVersion":record["resourceVersion"]}
+    if record.get("annotations"):
+        metadata["annotations"] = record["annotations"]
     if "deletionTimestamp" in record:
         metadata["deletionTimestamp"] = record["deletionTimestamp"]
     return {"apiVersion":"v1", "kind":"Namespace", "metadata":metadata}
@@ -96,9 +98,16 @@ def guarded(payload, record):
         payload, "resourceVersion", record["resourceVersion"])
 
 def desired_labels(payload):
+    # An ordinary adoption writes the created-by/created-in sweep pair; the
+    # #2557 operator override writes adopted-by/adopted-in INSTEAD, and writing
+    # both would put an operator's namespace back into the teardown sweep.
     rendered = json.dumps(payload)
-    return ("curietech.ai" in rendered and "created-by" in rendered
-            and RELEASE in rendered and "created-in" in rendered and NS in rendered)
+    owned = "created-by" in rendered and "created-in" in rendered
+    adopted = "adopted-by" in rendered and "adopted-in" in rendered
+    if owned and adopted:
+        return False
+    return ("curietech.ai" in rendered and RELEASE in rendered and NS in rendered
+            and (owned or adopted))
 
 program = pathlib.Path(sys.argv[0]).name
 if program == "helm":
@@ -210,7 +219,13 @@ if args and args[0] in ("patch", "replace") and "namespace" in args:
         fail("adoption omitted the namespace uid/resourceVersion ownership precondition")
     if state.get("version_conflict"):
         fail(f'Error from server (Conflict): Operation cannot be fulfilled on namespaces "{name}": the object has been modified')
-    record["labels"] = {"curietech.ai/created-by":RELEASE, "curietech.ai/created-in":NS}
+    for operation in payload:
+        if operation.get("op") != "add":
+            continue
+        if operation.get("path") == "/metadata/labels":
+            record["labels"] = operation["value"]
+        elif operation.get("path") == "/metadata/annotations":
+            record["annotations"] = operation["value"]
     record["resourceVersion"] = str(int(record["resourceVersion"]) + 1)
     state["adoption_guarded"] = True
     save(); print(f'namespace/{name} patched'); raise SystemExit(0)
@@ -292,6 +307,11 @@ impl Fixture {
         json!({"labels":labels, "uid":"uid-agent-ns", "resourceVersion":"17", "objects":objects})
     }
 
+    fn annotated_namespace(labels: Value, annotations: Value, objects: Value) -> Value {
+        json!({"labels":labels, "annotations":annotations, "uid":"uid-agent-ns",
+               "resourceVersion":"17", "objects":objects})
+    }
+
     fn command(&self) -> Command {
         let mut paths = vec![self.bin_dir.clone()];
         paths.extend(std::env::split_paths(
@@ -315,28 +335,35 @@ impl Fixture {
     }
 
     fn up(&self) -> Output {
-        self.command()
-            .args([
-                "--color",
-                "never",
-                "cluster",
-                "up",
-                "--chart",
-                chart(),
-                "--namespace",
-                NS,
-                "--release",
-                RELEASE,
-                "--dev",
-                "--no-expose",
-                "--fake-model",
-                "--set",
-                "agentSandbox.controller.deploy=false",
-                "--set",
-                "security.gvisor.mode=off",
-            ])
-            .output()
-            .expect("run cluster up")
+        self.up_in(NS, &[])
+    }
+
+    /// `cluster up` against `namespace` with `extra` operator flags appended,
+    /// so one fixture can drive the plain install, the `--adopt` override, and
+    /// the shared controller namespace that the override must never reach.
+    fn up_in(&self, namespace: &str, extra: &[&str]) -> Output {
+        let mut command = self.command();
+        command.args([
+            "--color",
+            "never",
+            "cluster",
+            "up",
+            "--chart",
+            chart(),
+            "--namespace",
+            namespace,
+            "--release",
+            RELEASE,
+            "--dev",
+            "--no-expose",
+            "--fake-model",
+            "--set",
+            "agentSandbox.controller.deploy=false",
+            "--set",
+            "security.gvisor.mode=off",
+        ]);
+        command.args(extra);
+        command.output().expect("run cluster up")
     }
 
     fn down(&self) -> Output {
@@ -891,4 +918,267 @@ fn failed_install_cleanup_and_empty_namespace_adoption() {
     // regressions remain independently runnable by their focused test names.
     terminating_namespace_blocks_up_but_down_still_cleans_owned_hooks();
     empty_namespace_adoption_fails_closed_on_unavailable_remote_apiservices();
+    adopt_override_records_what_it_adopted_and_stays_out_of_the_teardown_sweep();
+    adopt_override_never_reaches_the_controller_namespace_or_an_unreadable_one();
+}
+
+/// #2557: the explicit operator override for the three pre-existing namespace
+/// refusals. It admits a namespace that already has its own labels and its own
+/// objects, records what it took over on the object itself, and -- the load
+/// bearing half -- leaves that namespace OUT of the `cluster down` sweep, so
+/// the operator's pre-existing objects are never collateral of a teardown.
+#[test]
+fn adopt_override_records_what_it_adopted_and_stays_out_of_the_teardown_sweep() {
+    let occupied = json!({
+        "serviceaccounts":[{"apiVersion":"v1", "kind":"ServiceAccount",
+            "metadata":{"name":"default", "namespace":NS}}],
+        "configmaps":[{"apiVersion":"v1", "kind":"ConfigMap",
+            "metadata":{"name":"kube-root-ca.crt", "namespace":NS},
+            "data":{"ca.crt":"PLACEHOLDER CERTIFICATE"}}],
+        "secrets":[{"apiVersion":"v1", "kind":"Secret",
+            "metadata":{"name":"platform-pull-secret", "namespace":NS}}],
+        "events":[], "jobs.batch":[],
+        "deployments.apps":[{"apiVersion":"apps/v1", "kind":"Deployment",
+            "metadata":{"name":"platform-agent", "namespace":NS}}]
+    });
+    let platform_labels = json!({
+        "kubernetes.io/metadata.name": NS,
+        "pod-security.kubernetes.io/enforce": "restricted",
+        "argocd.argoproj.io/instance": "platform"
+    });
+    let fixture = Fixture::new(
+        json!({NS: Fixture::annotated_namespace(
+            platform_labels,
+            json!({"openshift.io/description":"pre-provisioned by the platform team"}),
+            occupied
+        )}),
+        json!({}),
+        false,
+        false,
+    );
+
+    // Without the flag the refusal stands, and now names the way through.
+    let refused = fixture.up();
+    assert_blocked_before_helm(&fixture, &refused, "cannot be adopted");
+    assert!(
+        shown(&refused).contains("--adopt"),
+        "the refusal must name the override that gets past it: {}",
+        shown(&refused)
+    );
+
+    // With the flag the install proceeds (the fixture's Helm hook still fails).
+    let adopted = fixture.up_in(NS, &["--adopt"]);
+    assert!(
+        !adopted.status.success(),
+        "the fixture Helm hook must still fail after an override adoption"
+    );
+    let state = fixture.state();
+    assert_eq!(
+        state["adoption_guarded"],
+        true,
+        "the override adoption dropped the uid/resourceVersion guard: {}",
+        shown(&adopted)
+    );
+    assert_eq!(
+        state["helm_upgrades"],
+        1,
+        "the install did not continue past the override: {}",
+        shown(&adopted)
+    );
+
+    let labels = &state["namespaces"][NS]["labels"];
+    assert_eq!(
+        labels["curietech.ai/adopted-by"],
+        json!(RELEASE),
+        "override adoption did not stamp adopted-by: {labels}"
+    );
+    assert_eq!(
+        labels["curietech.ai/adopted-in"],
+        json!(NS),
+        "override adoption did not stamp adopted-in: {labels}"
+    );
+    assert!(
+        labels.get("curietech.ai/created-by").is_none()
+            && labels.get("curietech.ai/created-in").is_none(),
+        "an adopted namespace must NOT carry the sweep's ownership pair: {labels}"
+    );
+    assert_eq!(
+        labels["pod-security.kubernetes.io/enforce"],
+        json!("restricted"),
+        "override adoption destroyed a pre-existing label: {labels}"
+    );
+
+    let annotations = &state["namespaces"][NS]["annotations"];
+    assert_eq!(
+        annotations["openshift.io/description"],
+        json!("pre-provisioned by the platform team"),
+        "override adoption destroyed a pre-existing annotation: {annotations}"
+    );
+    let recorded_labels = annotations["curietech.ai/adopted-labels"]
+        .as_str()
+        .expect("override adoption must record the labels it found");
+    assert!(
+        recorded_labels.contains("pod-security.kubernetes.io/enforce=restricted")
+            && recorded_labels.contains("argocd.argoproj.io/instance=platform"),
+        "recorded labels omitted what was adopted: {recorded_labels}"
+    );
+    let recorded_contents = annotations["curietech.ai/adopted-contents"]
+        .as_str()
+        .expect("override adoption must record the objects it found");
+    assert!(
+        recorded_contents.contains("platform-pull-secret")
+            && recorded_contents.contains("platform-agent"),
+        "recorded contents omitted what was adopted: {recorded_contents}"
+    );
+    let recorded_at = annotations["curietech.ai/adopted-at"]
+        .as_str()
+        .expect("override adoption must record when it happened")
+        .to_string();
+    assert!(
+        recorded_at.starts_with("20") && recorded_at.ends_with('Z'),
+        "adopted-at is not an RFC 3339 UTC instant: {recorded_at}"
+    );
+    assert!(
+        shown(&adopted).contains("platform-pull-secret") && shown(&adopted).contains("RETAIN"),
+        "the override must say on the terminal what it took and that down retains it: {}",
+        shown(&adopted)
+    );
+
+    // A re-run needs no flag and must not rewrite the original decision.
+    let rerun = fixture.up();
+    assert!(
+        !rerun.status.success(),
+        "the fixture Helm hook must still fail"
+    );
+    let state = fixture.state();
+    assert_eq!(
+        state["helm_upgrades"],
+        2,
+        "a re-run over an already adopted namespace was refused: {}",
+        shown(&rerun)
+    );
+    assert_eq!(
+        state["namespaces"][NS]["annotations"]["curietech.ai/adopted-at"],
+        json!(recorded_at),
+        "a re-run rewrote the recorded adoption"
+    );
+
+    // The load bearing negative control: teardown must retain it and its
+    // pre-existing objects, because it never carries the sweep selector.
+    let down = fixture.down();
+    assert!(
+        down.status.success(),
+        "teardown of an adopted namespace failed: {}",
+        shown(&down)
+    );
+    let state = fixture.state();
+    assert!(
+        state["namespaces"].get(NS).is_some(),
+        "cluster down deleted an adopted namespace and the operator's objects with it"
+    );
+    assert_eq!(
+        state["namespaces"][NS]["objects"]["secrets"][0]["metadata"]["name"],
+        json!("platform-pull-secret"),
+        "the operator's pre-existing objects were swept"
+    );
+}
+
+/// #2557 negative controls. `--adopt` overrides exactly three refusals; every
+/// other refusal on this path must be byte-for-byte unchanged with the flag
+/// present.
+#[test]
+fn adopt_override_never_reaches_the_controller_namespace_or_an_unreadable_one() {
+    let empty = Fixture::default_furniture();
+
+    // The shared, cluster-singleton controller namespace: never adoptable.
+    let controller = Fixture::new(
+        json!({"agent-sandbox-system": Fixture::namespace(json!({}), empty.clone())}),
+        json!({}),
+        false,
+        false,
+    );
+    let output = controller.up_in("agent-sandbox-system", &["--adopt"]);
+    assert_blocked_before_helm(&controller, &output, "never eligible for adoption");
+    assert_eq!(
+        controller.state()["namespaces"]["agent-sandbox-system"]["labels"],
+        json!({}),
+        "--adopt mutated the shared controller namespace"
+    );
+
+    // A terminating namespace cannot hold new objects at all.
+    let mut record = Fixture::namespace(json!({}), empty.clone());
+    record["deletionTimestamp"] = json!("2026-09-10T14:30:00Z");
+    let terminating = Fixture::new(json!({NS: record}), json!({}), false, false);
+    let output = terminating.up_in(NS, &["--adopt"]);
+    assert_blocked_before_helm(&terminating, &output, "terminating");
+
+    // An unreadable inventory stays fatal: contents nobody can read are
+    // contents the adoption record cannot name.
+    let unreadable = Fixture::new(
+        json!({NS: Fixture::namespace(json!({"argocd.argoproj.io/instance":"platform"}), empty.clone())}),
+        json!({}),
+        true,
+        false,
+    );
+    let output = unreadable.up_in(NS, &["--adopt"]);
+    assert_blocked_before_helm(&unreadable, &output, "inventory forbidden");
+    assert_eq!(
+        unreadable.state()["namespaces"][NS]["labels"],
+        json!({"argocd.argoproj.io/instance":"platform"}),
+        "--adopt stamped a namespace whose contents it could not read"
+    );
+
+    // So does a concurrent modification of the namespace being adopted.
+    let conflict = Fixture::new(
+        json!({NS: Fixture::namespace(json!({"argocd.argoproj.io/instance":"platform"}), empty.clone())}),
+        json!({}),
+        false,
+        true,
+    );
+    let output = conflict.up_in(NS, &["--adopt"]);
+    assert_blocked_before_helm(&conflict, &output, "modified");
+
+    // An unavailable aggregated APIService means the inventory is incomplete.
+    let incomplete = Fixture::new(
+        json!({NS: Fixture::namespace(json!({"argocd.argoproj.io/instance":"platform"}), empty.clone())}),
+        json!({}),
+        false,
+        false,
+    );
+    incomplete.set_apiservices(
+        json!({"apiVersion":"v1", "kind":"List", "items":[remote_apiservice("False")]}),
+        false,
+    );
+    let output = incomplete.up_in(NS, &["--adopt"]);
+    assert_blocked_before_helm(&incomplete, &output, "Available");
+
+    // `--adopt` with nothing to override is not an override: an empty,
+    // unlabelled namespace still takes the ordinary owned path and therefore
+    // stays sweepable.
+    let ordinary = Fixture::new(
+        json!({NS: Fixture::namespace(json!({}), empty)}),
+        json!({}),
+        false,
+        false,
+    );
+    let output = ordinary.up_in(NS, &["--adopt"]);
+    assert!(
+        !output.status.success(),
+        "the fixture Helm hook must still fail"
+    );
+    let labels = &ordinary.state()["namespaces"][NS]["labels"];
+    assert_eq!(
+        labels["curietech.ai/created-by"],
+        json!(RELEASE),
+        "--adopt changed the ordinary empty-namespace adoption: {labels}"
+    );
+    assert!(
+        labels.get("curietech.ai/adopted-by").is_none(),
+        "--adopt recorded an override it did not take: {labels}"
+    );
+    assert!(ordinary.down().status.success());
+    assert!(
+        ordinary.state()["namespaces"].get(NS).is_none(),
+        "an ordinary owned namespace must still be swept by down"
+    );
 }

--- a/cli/tests/cluster_secret_hardening.rs
+++ b/cli/tests/cluster_secret_hardening.rs
@@ -445,6 +445,7 @@ fn pure_up() -> UpOpts {
         secrets: vec![],
         github_token: GithubTokenPlan::Untouched,
         dev: true,
+        adopt: false,
     }
 }
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -149,6 +149,7 @@ that release's retained values.
 | `-f <compose>` | Override a resolved local-dev artifact path. |
 | `--image <ref>` | Override a resolved image reference. |
 | `--no-expose` | Keep the UI and Langfuse ClusterIP-only instead of exposing them on node ports. |
+| `--adopt` | Install into a pre-existing namespace that already has its own labels or its own objects. Without it, such a namespace is refused. See [Adopting a pre-existing namespace](#adopting-a-pre-existing-namespace). |
 | `CURIE_CREDENTIALS` (alias `CURIE_MODEL_CREDENTIALS`) | A real model credential. The interactive check accepts Anthropic `sk-ant-`, OpenRouter `sk-or-`, Zhipu `id.secret`, and bare `sk-` shapes for Moonshot or DeepSeek. The first two prefixes select one provider and infer its egress when no provider flag is present. Other shapes do not identify a provider. Present credentials install live through masked `--set` machinery, so `--dry-run` never prints them. An absent credential uses fake mode on a fresh install and preserves the recorded model configuration on a rerun. |
 | `--fake-model` | Explicitly downgrade to fake mode, even when a credential is present or a rerun has recorded live model configuration. |
 | `--github-token <token>` (or `CURIE_GITHUB_TOKEN`) | The Curie API's own GitHub credential, for cloning a PRIVATE repo during a git-flow bundle deploy and for posting the eval commit status. Goes to helm through a private mode-0600 values file, never a command-line argument, so it never appears in the helm command, the printed plan, or that plan's JSON. Prefer the environment variable: a token typed after the flag still sits in `curie`'s own argv, so it still reaches your shell history and `ps`. Omitting both on a later `cluster up` preserves whatever the release already has. Errors if combined with `--set api.githubToken=`. |
@@ -158,6 +159,69 @@ that release's retained values.
 
 A downloaded release binary needs no repo checkout; the chart resolves from
 the version-pinned release asset by default.
+
+#### Adopting a pre-existing namespace
+
+`cluster up` creates its namespace, and stamps what it created with
+`curietech.ai/created-by=<release>` and `curietech.ai/created-in=<namespace>`.
+`cluster down` deletes namespaces by exactly that label pair, so the stamp is
+what makes a teardown safe: it can only delete what this install made.
+
+That is also why a namespace which already exists is refused rather than
+adopted. Adopting someone else's namespace would stamp it, and a later
+`cluster down` would then delete it along with whatever was already inside.
+`cluster up` therefore refuses a pre-existing namespace that has its own labels,
+its own ownership labels, or any object beyond the two Kubernetes puts there
+itself (the `default` ServiceAccount and the `kube-root-ca.crt` ConfigMap).
+
+On a cluster where the namespace is pre-provisioned -- with a quota, a
+NetworkPolicy, a Pod Security label, an Argo CD tracking label, or a pull
+secret -- that refusal is the normal case, and deleting the namespace to get
+past it is worse than the thing the refusal is protecting against. `--adopt` is
+the supported way through:
+
+```bash
+curie cluster up --namespace platform-curie --adopt
+```
+
+**What it records.** The adoption is written onto the Namespace, not just to the
+terminal, so it can be read back long afterward:
+
+```bash
+kubectl get namespace platform-curie -o yaml
+```
+
+| Key | What it holds |
+|---|---|
+| `curietech.ai/adopted-by` (label) | The release that adopted the namespace. |
+| `curietech.ai/adopted-in` (label) | The install namespace of that release. |
+| `curietech.ai/adopted-at` (annotation) | When the adoption happened, RFC 3339 UTC. |
+| `curietech.ai/adopted-labels` (annotation) | The labels the namespace already carried. |
+| `curietech.ai/adopted-contents` (annotation) | The non-default objects that were already in it. |
+
+Pre-existing labels and annotations are preserved; the adoption record is merged
+into them. A very long inventory is truncated, and says so.
+
+**An adopted namespace is retained, not deleted.** `curietech.ai/adopted-by` and
+`curietech.ai/adopted-in` are deliberately *not* the pair `cluster down` selects
+on. A later `curie cluster down` uninstalls the release and leaves the namespace
+and everything in it in place. Delete it yourself when you want it gone. A
+namespace `cluster up` created itself is unaffected and is still swept.
+
+**What `--adopt` does not do.**
+
+- It never adopts the shared `agent-sandbox-system` controller namespace. That
+  namespace is a cluster singleton shared by every install on the cluster.
+- It never adopts a terminating namespace, which cannot accept new objects.
+- It never weakens a read. If the namespace, the namespaced API inventory, or an
+  aggregated `APIService` cannot be read completely, or the namespace is modified
+  concurrently, the install still fails closed -- contents that cannot be read
+  cannot be recorded.
+- Passing it when nothing needed overriding changes nothing: an empty, unlabelled
+  namespace is adopted the ordinary way and stays sweepable by `cluster down`.
+
+A re-run does not need the flag again. `cluster up` recognises a namespace this
+same release already adopted and converges without rewriting the original record.
 
 **Provider-native runtime configuration.** Zhipu, Moonshot, and DeepSeek need
 their matching documented `CURIE_MODEL_BASE_URL` in worker runtime configuration,


### PR DESCRIPTION
Closes #2557

Fix pin: cli/tests/cluster_namespace_ownership.rs::adopt_override_records_what_it_adopted_and_stays_out_of_the_teardown_sweep

`curie cluster up` refused a pre-existing namespace at three points and offered the operator no way past any of them:

| Refusal | Where |
|---|---|
| foreign or incomplete ownership labels | `cli/src/ops.rs:6460-6463` (`origin/main` `d734c802c`) |
| foreign labels | `cli/src/ops.rs:6471-6477` |
| non-default contents | `cli/src/ops.rs:6386-6388` |

On a cluster where the namespace is pre-provisioned -- a quota, a NetworkPolicy, a Pod Security label, an Argo CD tracking label, a pull secret -- that is an unconditional refusal to install, and the only way through was `kubectl delete namespace`: strictly more destructive than the thing the guard is protecting against.

## Why the default is kept exactly as it is

An ordinary adoption stamps `curietech.ai/created-by` + `curietech.ai/created-in`, and `down_commands` deletes whole namespaces by exactly that conjunction (#1654). Adopting a namespace that already holds someone else's objects would silently enrol them into a later `cluster down`. Failing closed by default is right. What was missing is the operator's half of the decision.

## `--adopt`

- **Admits those three refusals and nothing else.** The shared `agent-sandbox-system` controller namespace (cluster singleton, #707 create-only rule) and a terminating namespace still refuse with the flag present. The controller refusal now says "with or without `--adopt`".
- **Never weakens a read.** An unreadable namespace, an unreadable namespaced API inventory, an unavailable aggregated `APIService` and a `resourceVersion` conflict all still fail closed with the flag present. The override admits contents the operator accepts; it never admits contents nobody can see, because an unseen object cannot be recorded.
- **Records what it took over, on the object.** `curietech.ai/adopted-by` / `adopted-in` labels plus `curietech.ai/adopted-at`, `adopted-labels` and `adopted-contents` annotations, merged into whatever the namespace already carried (a pre-existing Argo CD annotation survives), bounded at 4 KiB per value with an explicit "(truncated)". Also echoed as warnings before Helm runs, so a wrong `--adopt` is visible while it is still cheap.
- **Stays out of the teardown sweep.** The adopted pair is deliberately *not* the selector `down_commands` uses, so `cluster down` uninstalls the release and RETAINS the namespace and everything the operator already had in it. This is the same fail-safe-toward-retention shape #1654 gave a namespace stamped by an older single-label CLI.
- **Is a no-op when nothing needed overriding.** An empty, unlabelled namespace still takes the ordinary owned path under the flag, and stays sweepable.
- **Is not needed on a re-run.** A namespace this same release already adopted converges without the flag and without rewriting the original `adopted-at`.

The three refusals now name the flag, so an operator is pointed at the supported way through rather than at `kubectl delete namespace`.

## Implementation notes

- `verify_namespace_is_empty` became `namespace_foreign_contents -> Result<Option<String>>`: same reads, same fail-closed behaviour, but the caller decides what a non-empty result means. Every read failure inside it stayed fatal.
- `NamespaceRecord` now also reads `metadata.annotations`, because the guarded patch rewrites the whole annotations map and anything unread would be destroyed. The existing uid/resourceVersion `test` preconditions on that same patch are what make the read-modify-write safe.
- `adopt` is a new `UpOpts` field. It never reaches the Helm value plan -- it is consumed entirely before Helm starts -- which is why the pure argv literals all take `adopt: false`. That accounts for the mechanical one-line additions across `cli/src/ops.rs` tests, `cli/src/installation.rs` and `cli/tests/cluster_secret_hardening.rs`.
- `cli/command-manifest.json` regenerated for the new flag.

## Tests

`cli/tests/cluster_namespace_ownership.rs`, driving the real binary against the fake `kubectl`/`helm`:

- `adopt_override_records_what_it_adopted_and_stays_out_of_the_teardown_sweep` (the fix pin) -- a namespace with three foreign labels, a pre-existing annotation, a foreign Secret and a foreign Deployment. Asserts the refusal without the flag names `--adopt`; that the override stamps `adopted-by`/`adopted-in` and *not* `created-by`/`created-in`; that pre-existing labels and annotations survive; that the recorded labels/contents/timestamp name what was actually there; that a re-run needs no flag and does not rewrite the record; and that `cluster down` afterwards retains the namespace with the operator's Secret still in it.
- `adopt_override_never_reaches_the_controller_namespace_or_an_unreadable_one` (the negative control) -- `--adopt` still refuses `agent-sandbox-system`, a terminating namespace, an unreadable inventory, an unavailable aggregated `APIService`, and a concurrent `resourceVersion` conflict, mutating nothing in any of those cases; and `--adopt` over an ordinary empty namespace still produces the sweepable `created-by`/`created-in` stamp.

The fake `kubectl` was tightened alongside: its patch handler now applies the labels and annotations the patch actually carries instead of hardcoding the expected result, and it rejects a patch that writes *both* ownership pairs, since that would put an operator's namespace back into the sweep.

Full `cli` suite green (2382 tests). `docs/operations.md` gains an "Adopting a pre-existing namespace" section covering the flag, what it records, and the retention consequence.
