### PR TITLE
Show a bundle-authored sentence on permission-gate approval cards

### DIFF
--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -570,6 +570,7 @@ class TurnOutcome:
     # Threaded onto the durable record. None from an older runner.
     approval_gate_kind: str | None = None
     approval_granted_tool: str | None = None
+    approval_display: str | None = None
     publication_snapshot: RunnerWorkspaceSnapshot | None = None
     publication_snapshot_error: str | None = None
 
@@ -637,6 +638,7 @@ class _StreamAccumulator:
     approval_route: str | None = None
     approval_gate_kind: str | None = None
     approval_granted_tool: str | None = None
+    approval_display: str | None = None
     # Call id -> the ledger record it opened. One CALL produces two ACI frames
     # (ADR-0117): the first opens a record, the second closes THAT record rather
     # than minting a second. A turn that calls the same tool twice is only
@@ -3385,6 +3387,7 @@ class Kernel:
         thread = qevent.conversation_id
         thread_key = _thread_key_for(qevent)
         summary = outcome.approval_summary or outcome.text or "Approval requested"
+        display_summary = outcome.approval_display or summary
 
         # Resolve the manifest route NAME (#247) to its workspace channel. A named
         # route that resolves to no binding escalates instead of widening (#544).
@@ -3474,6 +3477,7 @@ class Kernel:
                         "publication requires a deployment-managed repository workspace"
                     )
                 summary = _publication_approval_summary(snapshot)
+                display_summary = summary
                 published = await publication_creator.create_publication(
                     PublicationCreateRequest(
                         deployment_id=deployment_id,
@@ -3643,7 +3647,7 @@ class Kernel:
         # resumed reply (#817), so collapse the interpolated summary to one
         # logical line -- the notice is always a single clean block. The durable
         # ``Approval`` record and the Block Kit card keep the original summary.
-        notice_summary = " ".join(summary.split())
+        notice_summary = " ".join(display_summary.split())
         if is_publication:
             notice = (
                 f"Awaiting approval ({created.id}): {notice_summary}\n"
@@ -3711,11 +3715,11 @@ class Kernel:
         try:
             card_message = OutboundMessage(
                 version=MESSAGE_VERSION,
-                text=summary,
+                text=display_summary,
                 interaction=ConfirmIntent(
                     kind="confirm",
                     id=created.id,
-                    prompt=summary,
+                    prompt=display_summary,
                     confirm=Action(label="Approve", value=created.id),
                     cancel=Action(label="Reject", value=created.id),
                     # An approval decision may carry a reason (#1053). This says
@@ -3785,7 +3789,7 @@ class Kernel:
                         str(created.id),
                         channel=card_channel,
                         ts=card_ts,
-                        summary=summary,
+                        summary=display_summary,
                         endpoint=card_endpoint,
                         # The whole destination, not just the endpoint: the
                         # settle path posts to THIS card, so it must re-use the
@@ -3966,6 +3970,7 @@ class Kernel:
             acc.approval_route = frame.approval_route
             acc.approval_gate_kind = frame.approval_gate_kind
             acc.approval_granted_tool = frame.approval_granted_tool
+            acc.approval_display = frame.approval_display
 
     async def _record_action(
         self,
@@ -4032,6 +4037,7 @@ class Kernel:
                 approval_route=acc.approval_route,
                 approval_gate_kind=acc.approval_gate_kind,
                 approval_granted_tool=acc.approval_granted_tool,
+                approval_display=acc.approval_display,
             )
         # classified-failure, or the stream ended with no final at all.
         return TurnOutcome(

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -149,6 +149,20 @@ def _awaiting_script(summary: str) -> list:
     ]
 
 
+def _awaiting_script_with_display(summary: str, display: str) -> list:
+    return [
+        TextDelta(text="Requesting sign-off"),
+        Final(
+            text="Requesting sign-off",
+            status=AWAITING,
+            approval_summary=summary,
+            approval_display=display,
+            approval_gate_kind="permission",
+            approval_granted_tool="Bash",
+        ),
+    ]
+
+
 class _LineageFenceRunner:
     def __init__(self, status: dict[str, object]) -> None:
         self._status = status
@@ -1756,6 +1770,45 @@ def test_awaiting_approval_creates_record_and_suspends(make_harness) -> None:
             assert "Awaiting approval (appr-1)" in h.sink.last_text
             assert "Give ACME a 20% discount" in h.sink.last_text
             assert await h.async_redis.exists(h.config.done_key(ev.event_id))
+
+    asyncio.run(go())
+
+
+def test_templated_display_reaches_the_notice_and_card_not_the_record(
+    make_harness,
+) -> None:
+    """#2565: the sentence is what a person reads; the record keeps the machine string."""
+
+    sentence = "File FY26Q1: 11 workbooks into Approved, 25 cells going out blank. Approve?"
+    machine = (
+        "Tool call awaiting approval: mcp__plugin_demo_files__approve_batch "
+        '{"expected": {"a.xlsx": "aaa"}}'
+    )
+
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        async with make_harness(approvals=approvals) as h:
+            h.runner.default_script = _awaiting_script_with_display(machine, sentence)
+            ev = _qevent("please file", event_id="ev-appr-display")
+            await h.kernel.process_event(ev)
+
+            assert len(approvals.requests) == 1
+            assert approvals.requests[0].summary == machine
+
+            assert h.sink.last_text is not None
+            notice_lines = [
+                line
+                for line in h.sink.last_text.splitlines()
+                if line.startswith("Awaiting approval (")
+            ]
+            assert notice_lines == [f"Awaiting approval (appr-1): {sentence}"]
+            assert machine not in h.sink.last_text
+
+            assert h.sink.posts
+            card_message = h.sink.posts[0][1]
+            assert card_message.text == sentence
+            assert isinstance(card_message.interaction, ConfirmIntent)
+            assert card_message.interaction.prompt == sentence
 
     asyncio.run(go())
 

--- a/apps/worker/tests/test_blocks.py
+++ b/apps/worker/tests/test_blocks.py
@@ -568,6 +568,66 @@ def test_a_settled_card_without_a_remembered_requester_omits_the_line() -> None:
     assert any("Rejected by <@U_MANAGER>" in str(b) for b in blocks)
 
 
+def test_approval_card_keeps_interpolated_markdown_literal() -> None:
+    """Consumer-path pin for #2565: to_mrkdwn must not revive a model-supplied link.
+
+    ``render_gate_summary`` strips ``[]`` so ``[Review](url)`` cannot become
+    ``<url|Review>`` when the Slack card runs ``to_mrkdwn``.
+    """
+
+    from curie_worker.blocks import approval_card
+    from plugin_format.gate_summary import render_gate_summary
+
+    rendered = render_gate_summary(
+        "Approve {title}?",
+        {"title": "[Review](https://evil.example.com)"},
+    )
+    assert rendered is not None
+    _fallback, live = approval_card(
+        approval_id="appr-1", summary=rendered, requested_by="U_AE"
+    )
+    section = live[1]["text"]["text"]
+    assert "<https://evil.example.com|" not in section
+    assert "evil.example.com|Review" not in section
+
+
+def test_resolved_card_with_a_human_sentence_puts_the_verdict_first() -> None:
+    """#2565: once the section is a sentence, fallback starts with the verdict.
+
+    The Block Kit structure is unchanged (#1084); the first line of the
+    fallback text is ``Approved by <@user>`` and the section is the sentence,
+    never the machine JSON.
+    """
+
+    from curie_worker.blocks import approval_card, resolved_approval_card
+
+    sentence = "File FY26Q1: 11 workbooks into Approved, 25 cells going out blank. Approve?"
+    machine = (
+        "Tool call awaiting approval: mcp__plugin_demo_files__approve_batch "
+        '{"expected": {"a.xlsx": "aaa"}}... (truncated)'
+    )
+    _fallback, live = approval_card(
+        approval_id="appr-1",
+        summary=sentence,
+        requested_by="U_AE",
+    )
+    assert sentence in live[1]["text"]["text"]
+    assert machine not in live[1]["text"]["text"]
+
+    text, blocks = resolved_approval_card(
+        summary=sentence,
+        requested_by="U_AE",
+        decision="approved",
+        resolver="U_MANAGER",
+        note=None,
+    )
+    assert text.splitlines()[0] == "Approved by <@U_MANAGER>"
+    assert sentence in text
+    assert machine not in text
+    assert any(sentence in str(b) for b in blocks)
+    assert not any("truncated" in str(b) for b in blocks)
+
+
 def test_approval_card_clamps_oversized_summary() -> None:
     from curie_worker.blocks import approval_card
 

--- a/cli/src/chat.rs
+++ b/cli/src/chat.rs
@@ -920,6 +920,20 @@ mod tests {
     }
 
     #[test]
+    fn parse_approval_id_reads_a_human_sentence_tail() {
+        // #2565: a bundle-authored sentence replaces the machine JSON in the
+        // notice tail. The parser still only needs the UUID head.
+        let id = "44c2cc21-7b0a-4f3e-9c1d-aaaaaaaaaaaa";
+        let text = format!(
+            "Awaiting approval ({id}): File FY26Q1: 11 workbooks into Approved, \
+             25 cells going out blank. Approve?\n\
+             The session is paused and will resume once an authorized member \
+             resolves this request."
+        );
+        assert_eq!(parse_approval_id(&text).as_deref(), Some(id));
+    }
+
+    #[test]
     fn parse_approval_id_survives_the_base_prefix() {
         // The real shape when a prior answer exists: `f"{base}\n\n{notice}"`
         // (kernel.py:929). The id must still be recovered after the prefix.

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -7071,6 +7071,10 @@ struct ApprovalGateDecl {
     #[allow(dead_code)]
     #[serde(default, rename = "grantableViaPolicy")]
     grantable_via_policy: bool,
+    /// Bundle-authored human sentence for the approval card (#2565).
+    #[allow(dead_code)]
+    #[serde(default)]
+    summary: Option<String>,
 }
 
 /// The manifest `approvalPolicy` object; mirrors `plugin_format.models.ApprovalPolicy`.
@@ -9193,6 +9197,15 @@ mod tests {
         )
         .expect("a gate with grantableViaPolicy:true parses");
         assert!(with.grantable_via_policy);
+
+        let templated: ApprovalGateDecl = serde_json::from_str(
+            r#"{"gate":"Bash","route":"managers","summary":"Run {command}. Approve?"}"#,
+        )
+        .expect("a gate with a summary template parses");
+        assert_eq!(
+            templated.summary.as_deref(),
+            Some("Run {command}. Approve?")
+        );
     }
 
     #[tokio::test]

--- a/cli/src/evals.rs
+++ b/cli/src/evals.rs
@@ -767,6 +767,7 @@ mod tests {
             approval_route: None,
             approval_gate_kind: None,
             approval_granted_tool: None,
+            approval_display: None,
             input_tokens: None,
             output_tokens: None,
         }

--- a/cli/src/ndjson.rs
+++ b/cli/src/ndjson.rs
@@ -84,6 +84,7 @@ mod tests {
                 approval_route: None,
                 approval_gate_kind: None,
                 approval_granted_tool: None,
+                approval_display: None,
                 input_tokens: None,
                 output_tokens: None,
             }

--- a/cli/src/render.rs
+++ b/cli/src/render.rs
@@ -156,6 +156,7 @@ mod tests {
             approval_route: None,
             approval_gate_kind: None,
             approval_granted_tool: None,
+            approval_display: None,
             input_tokens: None,
             output_tokens: None,
         };
@@ -178,6 +179,7 @@ mod tests {
             approval_route: None,
             approval_gate_kind: None,
             approval_granted_tool: None,
+            approval_display: None,
             input_tokens: None,
             output_tokens: None,
         };
@@ -198,6 +200,7 @@ mod tests {
             approval_route: None,
             approval_gate_kind: None,
             approval_granted_tool: None,
+            approval_display: None,
             input_tokens: None,
             output_tokens: None,
         };

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -373,6 +373,9 @@ pub fn scaffold_from_spec(dir: &Path, spec: &AgentSpec) -> Result<Vec<PathBuf>> 
                 if g.grantable_via_policy {
                     gate.insert("grantableViaPolicy".into(), serde_json::json!(true));
                 }
+                if let Some(summary) = &g.summary {
+                    gate.insert("summary".into(), serde_json::json!(summary));
+                }
                 Value::Object(gate)
             })
             .collect();

--- a/cli/src/spec.rs
+++ b/cli/src/spec.rs
@@ -41,6 +41,9 @@ pub struct ApprovalGateSpec {
     /// load-bearing, a bool with a safe default may collapse absent and false.
     #[serde(default, rename = "grantableViaPolicy")]
     pub grantable_via_policy: bool,
+    /// Bundle-authored human sentence for the approval card (#2565).
+    #[serde(default)]
+    pub summary: Option<String>,
 }
 
 /// The `approvalPolicy` a spec declares. Mirrors `plugin_format.models.ApprovalPolicy`.

--- a/cli/tests/eval_falsifiability.rs
+++ b/cli/tests/eval_falsifiability.rs
@@ -108,6 +108,7 @@ fn done_turn(text: &str) -> Vec<OutboundEvent> {
         approval_route: None,
         approval_gate_kind: None,
         approval_granted_tool: None,
+        approval_display: None,
         input_tokens: None,
         output_tokens: None,
     }]

--- a/cli/tests/fake_tier_plumbing.rs
+++ b/cli/tests/fake_tier_plumbing.rs
@@ -288,6 +288,7 @@ fn final_event(text: &str, status: SessionStatus) -> OutboundEvent {
         approval_route: None,
         approval_gate_kind: None,
         approval_granted_tool: None,
+        approval_display: None,
         input_tokens: None,
         output_tokens: None,
     }

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -1165,6 +1165,7 @@ fn skill_message_awaiting_approval_output_preserves_final_approval_fields() {
         approval_route: Some("reviewers".to_string()),
         approval_gate_kind: Some("permission".to_string()),
         approval_granted_tool: Some("ExampleTool".to_string()),
+        approval_display: None,
         input_tokens: Some(10),
         output_tokens: Some(5),
     };
@@ -1197,6 +1198,7 @@ fn skill_message_awaiting_approval_output_is_not_finalized() {
         approval_route: Some("reviewers".to_string()),
         approval_gate_kind: Some("policy".to_string()),
         approval_granted_tool: None,
+        approval_display: None,
         input_tokens: None,
         output_tokens: None,
     };
@@ -1233,6 +1235,7 @@ fn skill_message_only_marks_awaiting_approval_as_not_finalized() {
             approval_route: None,
             approval_gate_kind: None,
             approval_granted_tool: None,
+            approval_display: None,
             input_tokens: None,
             output_tokens: None,
         };

--- a/docs/adr/0151-bundle-authored-human-approval-summary.md
+++ b/docs/adr/0151-bundle-authored-human-approval-summary.md
@@ -1,0 +1,150 @@
+# 151. A permission-gate card shows a bundle-authored sentence; the machine summary stays the audit record
+
+Date: 2026-09-10
+
+Status: Draft
+
+Implements [#2565](https://github.com/curie-eng/curie/issues/2565).
+Does not change [ADR-0035](0035-one-shot-post-approval-allowance.md) or
+[ADR-0046](0046-converged-approval-gates-and-durable-provenance.md): the
+one-shot grant is still minted from `gate_kind` / `granted_tool`, never from
+summary text. `guard_reserved_summary` stays the defense for
+model-authored policy summaries.
+
+Realizing path (named so a later Accepted-alongside landing has one):
+`plugin_format.models.ApprovalGate.summary`,
+`plugin_format.gate_summary.render_gate_summary`,
+`curie_runner.approval.ApprovalGate._record_pending`,
+`aci_protocol.events.Final.approval_display`,
+`curie_worker.kernel.Kernel._pause_for_approval`.
+
+## Context
+
+A permission-gate pause currently shows the runner's machine summary on every
+human surface: the Slack card section, the awaiting-approval placeholder
+notice, and the resolved card. That string is `Tool call awaiting approval:
+<tool> <json>`, truncated at 300 characters of input. For a gate whose
+arguments are a map of filenames-to-digests plus a list of cell addresses, the
+person whose click is the control sees three digests and `... (truncated)`,
+then the same blob again in the notice with a UUID.
+
+ADR-0035 used that prefix as grant provenance. ADR-0046 moved provenance to
+the `gate_kind` / `granted_tool` columns, so the summary text is no longer
+load-bearing for security. It is only what a person reads. A bundle still has
+no lever that names the act for a person: `approvalPolicy.gates[]` carries
+`gate`, `route`, and `grantableViaPolicy`. A tool result's `summary` field is
+the receipt trailer after execution, not the card before it.
+
+The CLI's `parse_approval_id` needs only the `Awaiting approval (<id>)` head
+of the notice (#766, #817). That head can stay while the tail becomes a
+sentence.
+
+## Decision
+
+**A permission gate may declare a human summary template, versioned with the
+agent. The runner renders it from the blocked call's arguments with a small
+safe formatter. The card, the notice, and the resolved card show that
+sentence. The durable record keeps the machine string.**
+
+### 1. The template is a bundle field, not a model argument
+
+`ApprovalGate` gains an optional `summary` string. Example:
+
+```json
+{
+  "gate": "mcp__plugin_acme_files__approve_batch",
+  "route": "filing",
+  "summary": "File {period}: {expected|count} workbooks into Approved, {going_out_blank|count} cells going out blank. Approve?"
+}
+```
+
+The template is operator-authored and reviewed with the bundle. It is not
+model-authored, so `guard_reserved_summary` does not apply to it. A template
+that starts with the reserved permission-gate prefix is a deploy error, so a
+bundle cannot park a forged prefix on the display path either.
+
+A gate that omits `summary` is unchanged: the machine string is what people
+see, byte for byte.
+
+### 2. One grammar, shared by the validator and the renderer
+
+Placeholders are `{ident}` or `{ident|filter}`. `ident` is a top-level
+argument name (`[A-Za-z_][A-Za-z0-9_]*`). Filters are `count` and `length`
+(both `len` of a string, list, tuple, or dict). A bare `{ident}` interpolates
+only a scalar (`str`, `int`, `float`, `bool`). Nested dumps, attribute
+access, and unknown filters are not in the grammar.
+
+`plugin_format.gate_summary` is the single module both the deploy validator
+and the runtime renderer call, so a template that validates green cannot
+render under different rules (the #453/#544 class). Deploy rejects unmatched
+braces, unknown filters, an empty template, an over-long template, and a
+template that starts with the reserved prefix. Runtime type or missing-key
+failure does not fail the gate: the runner falls back to the machine string
+so a bad argument shape cannot strand an approval.
+
+Interpolated scalars are collapsed to one line, length-capped, and escaped
+for Slack mrkdwn (`&`, `<`, `>`). Counts and lengths are integers. The model
+supplies the arguments; the template is trusted, the values are not.
+
+### 3. Two strings on the wire; one string on the durable row
+
+`summarize_tool_call` still produces the machine string and still owns the
+reserved prefix. That string is `Final.approval_summary` and
+`Approval.summary`. It is what the `gate_kind IS NULL` rolling-deploy
+fallback sniffs, and what an auditor reads.
+
+When a template renders, the runner also stamps optional
+`Final.approval_display` (ACI patch bump: a new optional field, ignored by
+older consumers). The worker uses `approval_display or approval_summary` for
+the Slack card, the placeholder notice, the Valkey card-ref, and the resolved
+card. It never writes `approval_display` onto `Approval.summary`. A worker
+that predates the field keeps showing the machine string.
+
+The resolved card is not a new layout. `settled_approval_card` already
+builds fallback text as `{verdict}\n{summary}`, so once `summary` is the
+sentence the first line is `Approved by <@user>` (or `Rejected by <@user>`)
+and the section is the sentence. The Block Kit structure stays the #1084
+edit/rebuild pair.
+
+The notice stays `Awaiting approval (<id>): <sentence-or-machine>\n...`.
+The UUID head is unchanged; the interpolated tail is still collapsed to one
+logical line (#817).
+
+### 4. Grants do not read the display
+
+`approval_grant_tool` continues to read `gate_kind` / `granted_tool`, with
+the prefix parse only for `gate_kind IS NULL`. Display text is not an input
+to that function. A template cannot select a tool, a route, or a grant.
+
+## Consequences
+
+- A bundle that wants a readable card must author a template. The platform
+  does not invent a sentence from argument shape.
+- An old bundle, an operator-only `CURIE_APPROVAL_REQUIRED_TOOLS` gate, a
+  policy-gate `request_approval`, and a publication pause are unchanged.
+- Adding `summary` is a backward-compatible plugin-format extension (optional
+  field, lenient models). The CLI `ApprovalGateSpec` / `ApprovalGateDecl`
+  mirrors must carry it because those structs deny unknown fields.
+- Adding `approval_display` is a backward-compatible ACI patch. Older
+  workers ignore it and keep today's card text.
+- If the Valkey card-ref expires, a rebuild degrades to the durable machine
+  string, the same degradation a lost ref already has.
+
+## Alternatives considered
+
+1. Put the human sentence in `Approval.summary` and keep the machine string
+   in a new `detail` column. Rejected because the rolling-deploy prefix
+   fallback still reads `summary`. Moving the machine string off that column
+   would reopen #430 for `gate_kind IS NULL` rows.
+2. Store tool arguments on the Approval row and let the worker render.
+   Rejected: the record does not currently store arguments, and adding them
+   is an audit-surface expansion the card text does not require.
+3. Dual-encode both strings in `approval_summary`. Rejected: it changes
+   today's bytes for every permission gate and risks the CLI notice parser.
+4. Reorder the resolved card so the verdict replaces the "Approval required"
+   header. Rejected for the no-template path (byte-for-byte). The existing
+   fallback line already puts the verdict first once the section is the
+   sentence.
+5. Infer a sentence from argument shape when no template is declared.
+   Rejected: a guessed sentence is not versioned with the agent and will be
+   wrong for any gate whose arguments are not the guessed shape.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -172,4 +172,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0140 | [Curie supports one model harness until a second one exists](0140-curie-supports-one-model-harness-until-a-second-one-exists.md) | Draft |
 | 0142 | [Database compatibility is a release contract; migrations run in one upgrade phase](0142-database-compatibility-windows-and-a-single-upgrade-phase.md) | Accepted |
 | 0143 | [A coding thread owns one fenced pull request lineage](0143-thread-owned-pull-request-lineage.md) | Accepted |
+| 0151 | [A permission-gate card shows a bundle-authored sentence; the machine summary stays the audit record](0151-bundle-authored-human-approval-summary.md) | Draft |
 <!-- END GENERATED: adr-index -->

--- a/docs/diagrams/aci.md
+++ b/docs/diagrams/aci.md
@@ -113,7 +113,7 @@ regenerated and committed together it **always goes green**. It pins artifact
 *sync*; it never pinned *compatibility*. Three things carry the contract
 instead:
 
-- **Semver, not a freeze.** `PROTOCOL_VERSION` is `0.4.4`
+- **Semver, not a freeze.** `PROTOCOL_VERSION` is `0.4.5`
   ([`packages/aci-protocol/src/aci_protocol/version.py`](../../packages/aci-protocol/src/aci_protocol/version.py)),
   versioned independently of the Curie release. Under 0.x a consumer accepts
   the same `major.minor`; only a new optional field is compatible (patch), and

--- a/docs/interfaces/aci-producer/implementing-an-aci-server.md
+++ b/docs/interfaces/aci-producer/implementing-an-aci-server.md
@@ -75,7 +75,7 @@ Import everything from `aci_protocol`; do not hand-roll JSON.
   made and once when its result arrives, joined on `call_id` (ADR-0117)
 
 **Version gate (strict producer, tolerant consumer).** Your producer emits its
-**exact build `PROTOCOL_VERSION`** (currently `0.4.4`) on every outbound event and
+**exact build `PROTOCOL_VERSION`** (currently `0.4.5`) on every outbound event and
 constructs strictly -- an unknown field is an error at construction, catching your
 mistakes at the source. A **consumer** decoding the wire is tolerant the other way:
 it accepts any version compatible with its own build (`major.minor` match under

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -61,6 +61,13 @@ in code now:
   fields (ADR-0036) and are persisted as the `gate_kind`/`granted_tool` columns on the
   `Approval` record (migration `0015_approval_gate_provenance`). They replace the old
   summary-prefix sniff as the durable source of grant provenance — see the #430 bullet below.
+  A further optional `Final` field, `approval_display` (#2565, Draft ADR-0151), carries the
+  human sentence a bundle-authored `approvalPolicy.gates[].summary` template rendered. It is
+  additive (ACI patch 0.4.5). The worker uses `approval_display or approval_summary` for the
+  Slack card, the awaiting-approval notice (`Awaiting approval (<id>): ...`), and the
+  resolved card; `Approval.summary` stays the machine `summarize_tool_call` string so the
+  `gate_kind IS NULL` prefix fallback and the audit record are unchanged. A gate without a
+  template leaves `approval_display` unset, which is today's bytes.
 - **The lifecycle (landed, #244; pager advertisement narrowed, #1444).** A skill raises a
   policy gate through the runner's in-process `mcp__curie__request_approval` tool
   (`runner/src/curie_runner/approval.py`) when that tool is present. The runner advertises

--- a/docs/interfaces/bundle-format/INTERFACE.md
+++ b/docs/interfaces/bundle-format/INTERFACE.md
@@ -272,7 +272,7 @@ trigger declarations) alongside this.
 Three of those Curie authoring extensions are **deploy-time validated** (shape enforced, malformed
 declarations rejected), but they differ in whether the runtime acts on them yet:
 
-- `approvalPolicy` (`{gates: [{gate, route, grantableViaPolicy}]}` approval declarations, #273) is **consumed at
+- `approvalPolicy` (`{gates: [{gate, route, grantableViaPolicy, summary}]}` approval declarations, #273) is **consumed at
   runtime**, not merely validated: the runner reads the gates at boot (`load_approval_policy`,
   #247 / ADR-0010) and arms each `{gate, route}` on the permission gate — so calling this
   "not-yet-built" is stale (see the [approval seam](../approval/INTERFACE.md)). A declared
@@ -287,7 +287,12 @@ declarations rejected), but they differ in whether the runtime acts on them yet:
   tool (`approval_policy.grant_route_ambiguous`), because the shared normalizer
   (`packages/plugin-format/src/plugin_format/approval_policy.py::grantable_routes`, the same helper
   the runner's loader calls) excludes an ambiguous route, so the policy would otherwise validate
-  green and arm no grant.
+  green and arm no grant. A fourth optional field, `summary` (#2565, Draft ADR-0151), is a
+  bundle-authored sentence template rendered from the blocked call's arguments (`{ident}`
+  scalars, `{ident|count}` / `{ident|length}`). The grammar lives in
+  `packages/plugin-format/src/plugin_format/gate_summary.py` so the deploy validator and the
+  runtime renderer cannot drift. A gate that omits `summary` keeps today's machine
+  `summarize_tool_call` string on the card and notice.
 - `triggers` (a list of `cron`/`webhook` declarations for waking the agent beyond chat, #273/#270 —
   see the [triggers seam](../triggers/INTERFACE.md)) is still **declaration-only**: its validator
   runs at deploy, but no runtime scheduler/ingress consumes a declared trigger yet (Epic #29).

--- a/packages/aci-protocol/README.md
+++ b/packages/aci-protocol/README.md
@@ -24,9 +24,9 @@ string rather than a `const`. Artifact sync is enforced by the
 schema-compat gate (`tests/test_schema_compat.py`); an unbumped wire change is
 caught by the wire-lock gate (`tests/test_wire_lock.py`).
 
-## Contract surface (v0.4.4)
+## Contract surface (v0.4.5)
 
-`PROTOCOL_VERSION = "0.4.4"` is embedded in the schema and in every outbound
+`PROTOCOL_VERSION = "0.4.5"` is embedded in the schema and in every outbound
 event.
 
 **Session setup** (`SessionConfig`, with `to_env()` / `from_env()`):

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: &str = "0.4.4";
+pub const PROTOCOL_VERSION: &str = "0.4.5";
 
 pub const RUNS_STREAM_DEFAULT: &str = "curie:runs";
 
@@ -373,6 +373,8 @@ pub enum OutboundEvent {
         #[serde(default)]
         approval_granted_tool: Option<String>,
         #[serde(default)]
+        approval_display: Option<String>,
+        #[serde(default)]
         input_tokens: Option<i64>,
         #[serde(default)]
         output_tokens: Option<i64>,
@@ -418,6 +420,7 @@ mod tests {
             approval_route: None,
             approval_gate_kind: None,
             approval_granted_tool: None,
+            approval_display: None,
             input_tokens: None,
             output_tokens: None,
         };
@@ -436,6 +439,7 @@ mod tests {
             approval_route: Some("managers".to_string()),
             approval_gate_kind: Some("policy".to_string()),
             approval_granted_tool: None,
+            approval_display: None,
             input_tokens: None,
             output_tokens: None,
         };
@@ -491,13 +495,13 @@ mod tests {
 
     #[test]
     fn accepts_compatible_patch() {
-        let raw = r#"{"type":"final","version":"0.4.5","text":"x","status":"done"}"#;
+        let raw = r#"{"type":"final","version":"0.4.6","text":"x","status":"done"}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_ok());
     }
 
     #[test]
     fn accepts_unknown_fields() {
-        let raw = r#"{"type":"final","version":"0.4.4","text":"x","status":"done","extra":1}"#;
+        let raw = r#"{"type":"final","version":"0.4.5","text":"x","status":"done","extra":1}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_ok());
     }
 }

--- a/packages/aci-protocol/generated/ts/aci-protocol.ts
+++ b/packages/aci-protocol/generated/ts/aci-protocol.ts
@@ -20,7 +20,7 @@ export type ExpiresInSeconds = number | null;
  * authority-bearing per #544/ADR-0046, so the value domain is a named, exported
  * part of the contract rather than an inline annotation.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "GateKind".
  */
 export type GateKind = "permission" | "policy";
@@ -93,6 +93,7 @@ export type Text = string;
 export type Ts = string;
 export type Type1 = "message" | "job" | "eval_case";
 export type User = string;
+export type ApprovalDisplay = string | null;
 export type ApprovalGateKind = string | null;
 export type ApprovalGrantedTool = string | null;
 export type ApprovalRoute = string | null;
@@ -110,14 +111,14 @@ export type Text1 = string;
 export type Type2 = "final";
 export type Version1 = string;
 /**
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "InboundMessage".
  */
 export type InboundMessage = Event | Interrupt;
 export type Kind1 = "interrupt";
 export type Reason = string;
 /**
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "OutboundEvent".
  */
 export type OutboundEvent = TextDelta | ToolNote | Final | ErrorEvent | SideEffectFlag;
@@ -181,7 +182,7 @@ export type Text4 = string;
  * Wire tokens follow the section 0 spelling; ``classified failure`` in prose
  * becomes the token ``classified-failure`` on the wire.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "SessionStatus".
  */
 export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failure" | "awaiting-approval";
@@ -209,12 +210,12 @@ export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failur
  * ENUM VALUE -- breaking under this package's rules, so it is a deliberate,
  * separately-decided bump rather than something this change assumes.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "TurnSource".
  */
 export type TurnSource1 = "slack" | "webhook" | "cron";
 
-export interface ACIProtocolV044 {
+export interface ACIProtocolV045 {
   [k: string]: unknown;
 }
 /**
@@ -238,7 +239,7 @@ export interface ACIProtocolV044 {
  * nullable because ``slack`` legitimately has no adapter -- its route is the
  * worker's configured Slack origin.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "ApprovalRequest".
  */
 export interface ApprovalRequest {
@@ -285,7 +286,7 @@ export interface ApprovalRequest {
  * baked template default, the worker's value is per-agent model routing. Do not
  * collapse either producer list to a single value.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "BootEnv".
  */
 export interface BootEnv {
@@ -325,7 +326,7 @@ export interface BootEnv {
  * section 0 describes these as per-tool secrets via K8s Secret refs, so the
  * contract carries the reference, not the secret material itself.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "SessionConfig".
  */
 export interface SessionConfig {
@@ -344,7 +345,7 @@ export interface SessionConfig {
  * ``task_budget_hint`` is the optional hint passed through to the model so it
  * self paces (section 6b); it is not a hard ceiling.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "Budget".
  */
 export interface Budget {
@@ -360,7 +361,7 @@ export interface Budget {
  * fields the prototype used (endpoint, headers, protocol); any others pass
  * through as raw env vars untouched and are out of scope for this typed view.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "OtelConfig".
  */
 export interface OtelConfig {
@@ -372,7 +373,7 @@ export interface OtelConfig {
 /**
  * A classified failure surfaced to the platform.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "ErrorEvent".
  */
 export interface ErrorEvent {
@@ -389,7 +390,7 @@ export interface ErrorEvent {
  * worker consumes off it (formerly the API's ``EvalJobRequest`` and the
  * worker's ``EvalWorkItem``, which had drifted on ``bundle_ref``).
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "EvalJob".
  */
 export interface EvalJob {
@@ -409,7 +410,7 @@ export interface EvalJob {
  * Byte-identical across both lanes before this promotion, so it carries no
  * semantic decisions.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "EvalReport".
  */
 export interface EvalReport {
@@ -427,7 +428,7 @@ export interface EvalReport {
  * runner after its sandbox is bound. Both remain optional so older producers
  * can omit them and tolerant consumers can adopt the additive wire shape.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "Event".
  */
 export interface Event {
@@ -464,6 +465,13 @@ export interface Event {
  * Both ``None`` on every other status, and ``None`` from an older runner that
  * predates these fields (the worker falls back to the prefix parse then).
  *
+ * ``approval_display`` is the optional human sentence a bundle-authored
+ * permission-gate template rendered (#2565). ``None`` means the card and
+ * notice use ``approval_summary`` (today's machine string). It is never the
+ * grant-provenance signal; that stays ``approval_gate_kind`` /
+ * ``approval_granted_tool``. Additive optional scalar: a tolerant consumer
+ * decoding an older producer's ``final`` simply sees it absent.
+ *
  * ``input_tokens``/``output_tokens`` carry the turn's model token usage when
  * the harness reported it (#390): the runner stamps them from the SDK result's
  * ``usage`` so a consumer can attribute a dollar cost to the turn (model
@@ -474,10 +482,11 @@ export interface Event {
  * scalars: a tolerant consumer decoding an older producer's ``final`` simply
  * sees them absent.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "Final".
  */
 export interface Final {
+  approval_display?: ApprovalDisplay;
   approval_gate_kind?: ApprovalGateKind;
   approval_granted_tool?: ApprovalGrantedTool;
   approval_route?: ApprovalRoute;
@@ -493,7 +502,7 @@ export interface Final {
 /**
  * A hard stop delivered on the control channel, distinct from a steer.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "Interrupt".
  */
 export interface Interrupt {
@@ -504,7 +513,7 @@ export interface Interrupt {
 /**
  * A streamed chunk of assistant text.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "TextDelta".
  */
 export interface TextDelta {
@@ -516,7 +525,7 @@ export interface TextDelta {
 /**
  * A human readable note about a tool call the harness is making.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "ToolNote".
  */
 export interface ToolNote {
@@ -545,7 +554,7 @@ export interface ToolNote {
  * turn that calls the same tool twice is otherwise indistinguishable from one
  * that called it once.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "SideEffectFlag".
  */
 export interface SideEffectFlag {
@@ -575,7 +584,7 @@ export interface SideEffectFlag {
  * to the non-job value is also the safe direction -- an unset ``source`` reads
  * as a person's message, so a job can never be created by omission.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "QueuedTurn".
  */
 export interface QueuedTurn {
@@ -624,7 +633,7 @@ export interface QueuedTurn {
  * third-party or pre-upgrade producer is not rejected outright, but every
  * first-party mint site sets it explicitly.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "ReplyHandle".
  */
 export interface ReplyHandle {

--- a/packages/aci-protocol/schema/aci-protocol.schema.json
+++ b/packages/aci-protocol/schema/aci-protocol.schema.json
@@ -840,8 +840,20 @@
       "type": "object"
     },
     "Final": {
-      "description": "The terminal response event, carrying the session status.\n\n``approval_summary`` accompanies an ``awaiting-approval`` status (ADR-0010):\nthe human-readable statement of what needs approval, captured from the\nrun's approval request so the platform can persist it on the durable\n``Approval`` record and show it to the approver. ``approval_route`` names\nthe approval route the request targets (#247): declared in the bundle\nmanifest's ``approvalPolicy`` (versioned with the agent), bound to a\nworkspace channel per deployment by the worker. Both ``None`` on every\nother status; ``approval_route`` also ``None`` when the request named no\nroute (the platform falls back to the requesting channel).\n\n``approval_gate_kind`` records which gate produced the request (#544):\n``'permission'`` when the runner's tool-permission gate denied a real tool\ncall, ``'policy'`` when the model asked for a business-decision approval.\nIt is the durable provenance the worker branches on instead of sniffing the\nsummary prefix. ``approval_granted_tool`` carries the tool name the\npermission gate denied -- the trusted ``can_use_tool`` value the resume-turn\ngrant is bound to -- and is only ever set for ``approval_gate_kind =\n'permission'``; a policy gate never authorizes a tool, so it stays ``None``.\nBoth ``None`` on every other status, and ``None`` from an older runner that\npredates these fields (the worker falls back to the prefix parse then).\n\n``input_tokens``/``output_tokens`` carry the turn's model token usage when\nthe harness reported it (#390): the runner stamps them from the SDK result's\n``usage`` so a consumer can attribute a dollar cost to the turn (model\npricing lives with the consumer, not on the wire). Both ``None`` when usage\nwas unavailable -- the fake-model path, a provider that reports no usage, or\nan older runner that predates these fields -- so a consumer computing cost\nleaves it unknown rather than counting the turn as free. Additive optional\nscalars: a tolerant consumer decoding an older producer's ``final`` simply\nsees them absent.",
+      "description": "The terminal response event, carrying the session status.\n\n``approval_summary`` accompanies an ``awaiting-approval`` status (ADR-0010):\nthe human-readable statement of what needs approval, captured from the\nrun's approval request so the platform can persist it on the durable\n``Approval`` record and show it to the approver. ``approval_route`` names\nthe approval route the request targets (#247): declared in the bundle\nmanifest's ``approvalPolicy`` (versioned with the agent), bound to a\nworkspace channel per deployment by the worker. Both ``None`` on every\nother status; ``approval_route`` also ``None`` when the request named no\nroute (the platform falls back to the requesting channel).\n\n``approval_gate_kind`` records which gate produced the request (#544):\n``'permission'`` when the runner's tool-permission gate denied a real tool\ncall, ``'policy'`` when the model asked for a business-decision approval.\nIt is the durable provenance the worker branches on instead of sniffing the\nsummary prefix. ``approval_granted_tool`` carries the tool name the\npermission gate denied -- the trusted ``can_use_tool`` value the resume-turn\ngrant is bound to -- and is only ever set for ``approval_gate_kind =\n'permission'``; a policy gate never authorizes a tool, so it stays ``None``.\nBoth ``None`` on every other status, and ``None`` from an older runner that\npredates these fields (the worker falls back to the prefix parse then).\n\n``approval_display`` is the optional human sentence a bundle-authored\npermission-gate template rendered (#2565). ``None`` means the card and\nnotice use ``approval_summary`` (today's machine string). It is never the\ngrant-provenance signal; that stays ``approval_gate_kind`` /\n``approval_granted_tool``. Additive optional scalar: a tolerant consumer\ndecoding an older producer's ``final`` simply sees it absent.\n\n``input_tokens``/``output_tokens`` carry the turn's model token usage when\nthe harness reported it (#390): the runner stamps them from the SDK result's\n``usage`` so a consumer can attribute a dollar cost to the turn (model\npricing lives with the consumer, not on the wire). Both ``None`` when usage\nwas unavailable -- the fake-model path, a provider that reports no usage, or\nan older runner that predates these fields -- so a consumer computing cost\nleaves it unknown rather than counting the turn as free. Additive optional\nscalars: a tolerant consumer decoding an older producer's ``final`` simply\nsees them absent.",
       "properties": {
+        "approval_display": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Approval Display"
+        },
         "approval_gate_kind": {
           "anyOf": [
             {
@@ -1396,6 +1408,6 @@
   },
   "$id": "https://curietech.ai/schemas/aci-protocol.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "protocolVersion": "0.4.4",
-  "title": "ACI Protocol v0.4.4"
+  "protocolVersion": "0.4.5",
+  "title": "ACI Protocol v0.4.5"
 }

--- a/packages/aci-protocol/schema/wire.lock
+++ b/packages/aci-protocol/schema/wire.lock
@@ -1,4 +1,4 @@
 {
-  "protocol_version": "0.4.4",
-  "wire_sha256": "df4e3a1360567a04f15ba5261dc0418e80b50a3bf26dc26c2476833d47eb49b1"
+  "protocol_version": "0.4.5",
+  "wire_sha256": "b320295c47c730462b5bff1e6b4d80fe09dcaa72fa53c2f8ae937a6d15b31656"
 }

--- a/packages/aci-protocol/src/aci_protocol/events.py
+++ b/packages/aci-protocol/src/aci_protocol/events.py
@@ -164,6 +164,13 @@ class Final(_OutboundBase):
     Both ``None`` on every other status, and ``None`` from an older runner that
     predates these fields (the worker falls back to the prefix parse then).
 
+    ``approval_display`` is the optional human sentence a bundle-authored
+    permission-gate template rendered (#2565). ``None`` means the card and
+    notice use ``approval_summary`` (today's machine string). It is never the
+    grant-provenance signal; that stays ``approval_gate_kind`` /
+    ``approval_granted_tool``. Additive optional scalar: a tolerant consumer
+    decoding an older producer's ``final`` simply sees it absent.
+
     ``input_tokens``/``output_tokens`` carry the turn's model token usage when
     the harness reported it (#390): the runner stamps them from the SDK result's
     ``usage`` so a consumer can attribute a dollar cost to the turn (model
@@ -182,6 +189,7 @@ class Final(_OutboundBase):
     approval_route: str | None = None
     approval_gate_kind: str | None = None
     approval_granted_tool: str | None = None
+    approval_display: str | None = None
     input_tokens: int | None = None
     output_tokens: int | None = None
 

--- a/packages/aci-protocol/src/aci_protocol/rust_export.py
+++ b/packages/aci-protocol/src/aci_protocol/rust_export.py
@@ -310,6 +310,7 @@ mod tests {
             approval_route: None,
             approval_gate_kind: None,
             approval_granted_tool: None,
+            approval_display: None,
             input_tokens: None,
             output_tokens: None,
         };
@@ -328,6 +329,7 @@ mod tests {
             approval_route: Some("managers".to_string()),
             approval_gate_kind: Some("policy".to_string()),
             approval_granted_tool: None,
+            approval_display: None,
             input_tokens: None,
             output_tokens: None,
         };

--- a/packages/aci-protocol/src/aci_protocol/version.py
+++ b/packages/aci-protocol/src/aci_protocol/version.py
@@ -20,7 +20,7 @@ the guard.
 import re
 from typing import Final
 
-PROTOCOL_VERSION: Final = "0.4.4"
+PROTOCOL_VERSION: Final = "0.4.5"
 
 # The wire field carrying the protocol version on every outbound event. Both
 # exporters special-case this field by name; do not rename without updating them.

--- a/packages/aci-protocol/tests/test_events.py
+++ b/packages/aci-protocol/tests/test_events.py
@@ -142,6 +142,26 @@ def test_awaiting_approval_wire_value_and_final_round_trip() -> None:
     # summary to None -- the additive-change guarantee.
     legacy = Final.model_validate({"type": "final", "text": "ok", "status": "done"})
     assert legacy.approval_summary is None
+    assert legacy.approval_display is None
+
+
+def test_awaiting_approval_display_is_optional_and_round_trips() -> None:
+    """#2565: a rendered human sentence rides beside the machine summary.
+
+    Omitted on older producers (default None). Present, it round-trips and does
+    not replace approval_summary.
+    """
+
+    final = Final(
+        text="Requesting sign-off",
+        status=SessionStatus.AWAITING_APPROVAL,
+        approval_summary="Tool call awaiting approval: Bash {\"command\": \"ls\"}",
+        approval_display="Run ls. Approve?",
+    )
+    wire = final.model_dump(mode="json")
+    assert wire["approval_display"] == "Run ls. Approve?"
+    assert wire["approval_summary"].startswith("Tool call awaiting approval:")
+    assert Final.model_validate(wire) == final
 
 
 # --- What a side-effecting call reports (ADR-0117) -----------------------------

--- a/packages/aci-protocol/tests/test_wire_lock.py
+++ b/packages/aci-protocol/tests/test_wire_lock.py
@@ -175,9 +175,9 @@ def test_committed_lock_matches_the_current_wire() -> None:
     assert lock["wire_sha256"] == wire_fingerprint()
 
 
-def test_event_session_context_contract_uses_patch_version_0_4_4() -> None:
+def test_event_session_context_contract_uses_patch_version_0_4_5() -> None:
     lock_path = schema_export.schema_path().parent / "wire.lock"
     lock = json.loads(lock_path.read_text(encoding="utf-8"))
 
-    assert PROTOCOL_VERSION == "0.4.4"
-    assert lock["protocol_version"] == "0.4.4"
+    assert PROTOCOL_VERSION == "0.4.5"
+    assert lock["protocol_version"] == "0.4.5"

--- a/packages/plugin-format/README.md
+++ b/packages/plugin-format/README.md
@@ -57,8 +57,10 @@ Pydantic models mirroring the Claude Code shapes:
   is a separate not-yet-built seam (see `docs/interfaces/triggers/INTERFACE.md`),
   so this is validation only today.
 - `ApprovalPolicy` / `ApprovalGate` (the manifest `approvalPolicy` field, #273):
-  `{gates: [{gate, route}]}` — each gate names a pause point and the approval
-  route that decides it; both are required. **Deploy-time validation** rejects a
+  `{gates: [{gate, route, grantableViaPolicy, summary}]}` — each gate names a pause
+  point and the approval route that decides it; both `gate` and `route` are
+  required. Optional `summary` (#2565) is a bundle-authored sentence template
+  rendered onto the approval card. **Deploy-time validation** rejects a
   malformed policy or a gate missing `gate`/`route`. It also rejects a gate whose
   (whitespace-stripped) name starts with `mcp__` but is not a live,
   fully-namespaced tool name for a server the bundle declares

--- a/packages/plugin-format/schema/plugin-format.schema.json
+++ b/packages/plugin-format/schema/plugin-format.schema.json
@@ -2,7 +2,7 @@
   "$defs": {
     "ApprovalGate": {
       "additionalProperties": true,
-      "description": "One approval gate declaration: a gate point plus the route it sends to.\n\n``gate`` names the point at which the agent pauses for approval (e.g. a tool\nclass or lifecycle point); ``route`` names the approval route that decides.\nBoth are required \u2014 an incomplete gate is rejected at deploy.\n``grantableViaPolicy`` is the operator opt-in (#558): when true, a policy-gate\napproval on this gate's route MAY mint a one-shot grant for the manifest tool\n``gate`` names; default false preserves #544's policy-never-grants behavior.",
+      "description": "One approval gate declaration: a gate point plus the route it sends to.\n\n``gate`` names the point at which the agent pauses for approval (e.g. a tool\nclass or lifecycle point); ``route`` names the approval route that decides.\nBoth are required \u2014 an incomplete gate is rejected at deploy.\n``grantableViaPolicy`` is the operator opt-in (#558): when true, a policy-gate\napproval on this gate's route MAY mint a one-shot grant for the manifest tool\n``gate`` names; default false preserves #544's policy-never-grants behavior.\n``summary`` is an optional bundle-authored sentence template (#2565) rendered\nfrom the blocked call's arguments onto the approval card and notice. Absent,\nthe platform keeps the machine ``summarize_tool_call`` string.",
       "properties": {
         "gate": {
           "title": "Gate",
@@ -16,6 +16,18 @@
         "route": {
           "title": "Route",
           "type": "string"
+        },
+        "summary": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Summary"
         }
       },
       "required": [

--- a/packages/plugin-format/src/plugin_format/__init__.py
+++ b/packages/plugin-format/src/plugin_format/__init__.py
@@ -23,6 +23,11 @@ from .archive import (
     check_archive_bounds,
     safe_extract,
 )
+from .gate_summary import (
+    RESERVED_PERMISSION_PREFIX,
+    check_gate_summary_template,
+    render_gate_summary,
+)
 from .manifest import MANIFEST_LOCATIONS, resolve_manifest
 from .models import (
     ApprovalGate,
@@ -81,6 +86,9 @@ __all__ = [
     "ApprovalGate",
     "ToolPolicy",
     "grantable_routes",
+    "RESERVED_PERMISSION_PREFIX",
+    "check_gate_summary_template",
+    "render_gate_summary",
     "declared_mcp_server_names",
     "connector_server_names",
     "connector_tool_prefix",

--- a/packages/plugin-format/src/plugin_format/gate_summary.py
+++ b/packages/plugin-format/src/plugin_format/gate_summary.py
@@ -1,0 +1,105 @@
+"""Safe human-summary templates for a permission-gate card (#2565).
+
+A bundle may declare ``approvalPolicy.gates[].summary`` as a sentence with
+placeholders over the blocked call's arguments. The deploy validator and the
+runtime renderer share this module so a template that validates green cannot
+render under different rules (the #453/#544 class).
+
+Grammar: ``{ident}`` interpolates a scalar (str/int/float/bool); ``{ident|count}``
+and ``{ident|length}`` interpolate ``len`` of a str/list/tuple/dict. Nested
+dumps, attribute access, and unknown filters are not in the grammar. Runtime
+type or missing-key failure returns ``None`` so the runner falls back to the
+machine string rather than stranding the approval.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Byte-identical to ``curie_runner.approval.APPROVAL_SUMMARY_PREFIX``. Kept here
+# so deploy validation can reject a template that would park a forged prefix on
+# the display path without importing the runner. A runner test pins the two
+# literals equal.
+RESERVED_PERMISSION_PREFIX = "Tool call awaiting approval: "
+
+_TEMPLATE_MAX = 400
+_SCALAR_MAX = 80
+_IDENT = r"[A-Za-z_][A-Za-z0-9_]*"
+_PLACEHOLDER = re.compile(r"\{(" + _IDENT + r")(?:\|(" + _IDENT + r"))?\}")
+_FILTERS = frozenset({"count", "length"})
+_SCALARS = (str, int, float, bool)
+_COUNTED = (str, list, tuple, dict)
+
+
+def check_gate_summary_template(template: str) -> str | None:
+    """Return an error message if ``template`` is not a legal summary, else None."""
+
+    if not isinstance(template, str):
+        return "summary must be a string"
+    stripped = template.strip()
+    if not stripped:
+        return "summary must be a non-empty string"
+    if len(stripped) > _TEMPLATE_MAX:
+        return f"summary must be at most {_TEMPLATE_MAX} characters"
+    if stripped.startswith(RESERVED_PERMISSION_PREFIX):
+        return "summary must not start with the reserved permission-gate prefix"
+    remainder = _PLACEHOLDER.sub("", stripped)
+    if "{" in remainder or "}" in remainder:
+        return "summary has unmatched braces or an invalid placeholder"
+    for match in _PLACEHOLDER.finditer(stripped):
+        filt = match.group(2)
+        if filt is not None and filt not in _FILTERS:
+            return f"summary filter {filt!r} is not count or length"
+    return None
+
+
+def render_gate_summary(template: str, args: dict[str, Any]) -> str | None:
+    """Render ``template`` from ``args``, or None when it cannot render safely."""
+
+    if check_gate_summary_template(template) is not None:
+        return None
+    if not isinstance(args, dict):
+        return None
+    stripped = template.strip()
+
+    def repl(match: re.Match[str]) -> str:
+        name, filt = match.group(1), match.group(2)
+        if name not in args:
+            raise KeyError(name)
+        value = args[name]
+        if filt is None:
+            if not isinstance(value, _SCALARS):
+                raise TypeError(name)
+            return _escape_scalar(str(value))
+        if isinstance(value, _COUNTED):
+            return str(len(value))
+        raise TypeError(name)
+
+    try:
+        rendered = _PLACEHOLDER.sub(repl, stripped)
+    except (KeyError, TypeError):
+        return None
+    if not rendered.strip():
+        return None
+    if rendered.startswith(RESERVED_PERMISSION_PREFIX):
+        return None
+    return rendered
+
+
+def _escape_scalar(value: str) -> str:
+    collapsed = " ".join(value.split())
+    if len(collapsed) > _SCALAR_MAX:
+        collapsed = collapsed[:_SCALAR_MAX]
+    # Neutralize Markdown constructs ``to_mrkdwn`` would rewrite into Slack
+    # markup ([text](url) -> <url|text>, **bold**, ATX headings). The card
+    # renderer always runs ``to_mrkdwn``, so escaping ``& < >`` alone is not
+    # enough: a model-supplied ``[Review](https://evil.example.com)`` would
+    # become a live link on the card.
+    collapsed = (
+        collapsed.replace("[", "")
+        .replace("]", "")
+        .replace("*", "")
+        .replace("#", "")
+    )
+    return collapsed.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")

--- a/packages/plugin-format/src/plugin_format/models.py
+++ b/packages/plugin-format/src/plugin_format/models.py
@@ -120,6 +120,9 @@ class ApprovalGate(BaseModel):
     ``grantableViaPolicy`` is the operator opt-in (#558): when true, a policy-gate
     approval on this gate's route MAY mint a one-shot grant for the manifest tool
     ``gate`` names; default false preserves #544's policy-never-grants behavior.
+    ``summary`` is an optional bundle-authored sentence template (#2565) rendered
+    from the blocked call's arguments onto the approval card and notice. Absent,
+    the platform keeps the machine ``summarize_tool_call`` string.
     """
 
     model_config = _LENIENT
@@ -127,6 +130,7 @@ class ApprovalGate(BaseModel):
     gate: str
     route: str
     grantableViaPolicy: bool = False
+    summary: str | None = None
 
 
 class ApprovalPolicy(BaseModel):

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -31,6 +31,7 @@ from .connector_lock import (
 )
 from .connectors import CONNECTORS_FILE, ConnectorsFile, validate_connectors
 from .deploy_targets import validate_deploy_targets
+from .gate_summary import check_gate_summary_template
 from .manifest import resolve_manifest
 from .models import (
     _TRIGGER_TYPES,
@@ -938,6 +939,10 @@ def _validate_approval_policy(
         # looks built-in on the raw string would arm a mis-namespaced tool at
         # runtime and silently never fire (#453).
         stripped_gate = gate.gate.strip()
+        if gate.summary is not None:
+            summary_err = check_gate_summary_template(gate.summary)
+            if summary_err is not None:
+                c.error("approval_policy.summary_invalid", summary_err, loc)
         if expected_prefixes is None or not stripped_gate.startswith("mcp__"):
             continue
 

--- a/packages/plugin-format/tests/test_gate_summary.py
+++ b/packages/plugin-format/tests/test_gate_summary.py
@@ -1,0 +1,97 @@
+"""Safe gate-summary template grammar (#2565).
+
+The deploy validator and the runtime renderer share this module so a template
+that validates green cannot render under different rules.
+"""
+
+from plugin_format.gate_summary import (
+    RESERVED_PERMISSION_PREFIX,
+    check_gate_summary_template,
+    render_gate_summary,
+)
+
+
+def test_scalar_and_count_render() -> None:
+    template = (
+        "File {period}: {expected|count} workbooks into Approved, "
+        "{going_out_blank|count} cells going out blank. Approve?"
+    )
+    assert check_gate_summary_template(template) is None
+    rendered = render_gate_summary(
+        template,
+        {
+            "period": "FY26Q1",
+            "expected": {"a.xlsx": "aaa", "b.xlsx": "bbb"},
+            "going_out_blank": ["I35", "J12", "K1"],
+        },
+    )
+    assert rendered == (
+        "File FY26Q1: 2 workbooks into Approved, 3 cells going out blank. Approve?"
+    )
+
+
+def test_length_filter_on_a_string() -> None:
+    assert render_gate_summary("note is {body|length} chars", {"body": "abcd"}) == (
+        "note is 4 chars"
+    )
+
+
+def test_missing_key_returns_none() -> None:
+    assert render_gate_summary("File {period}", {"other": "x"}) is None
+
+
+def test_non_scalar_bare_placeholder_returns_none() -> None:
+    assert render_gate_summary("dump {expected}", {"expected": {"a": "b"}}) is None
+
+
+def test_count_on_a_scalar_returns_none() -> None:
+    assert render_gate_summary("{n|count} items", {"n": 3}) is None
+
+
+def test_unknown_filter_is_invalid() -> None:
+    err = check_gate_summary_template("{files|json}")
+    assert err is not None
+    assert "filter" in err.lower()
+
+
+def test_unmatched_brace_is_invalid() -> None:
+    assert check_gate_summary_template("File {period") is not None
+    assert check_gate_summary_template("File period}") is not None
+
+
+def test_empty_template_is_invalid() -> None:
+    assert check_gate_summary_template("   ") is not None
+
+
+def test_reserved_prefix_is_invalid() -> None:
+    err = check_gate_summary_template(f"{RESERVED_PERMISSION_PREFIX}not allowed")
+    assert err is not None
+
+
+def test_nested_ident_is_invalid() -> None:
+    assert check_gate_summary_template("{foo.bar}") is not None
+
+
+def test_newlines_in_scalar_collapse() -> None:
+    rendered = render_gate_summary("do {title}", {"title": "one\n\ntwo"})
+    assert rendered == "do one two"
+    assert "\n" not in rendered
+
+
+def test_slack_markup_in_scalar_is_escaped() -> None:
+    rendered = render_gate_summary("do {title}", {"title": "<@U_TARGET> <!channel>"})
+    assert rendered is not None
+    assert "<@U_TARGET>" not in rendered
+    assert "<!channel>" not in rendered
+    assert "&lt;" in rendered
+
+
+def test_markdown_link_in_scalar_cannot_form_a_slack_link() -> None:
+    rendered = render_gate_summary(
+        "Approve {title}?",
+        {"title": "[Review](https://evil.example.com)"},
+    )
+    assert rendered is not None
+    assert "[" not in rendered
+    assert "]" not in rendered
+    assert "Approve Review(https://evil.example.com)?" == rendered

--- a/packages/plugin-format/tests/test_models.py
+++ b/packages/plugin-format/tests/test_models.py
@@ -113,6 +113,27 @@ def test_approval_gate_grantable_via_policy_field() -> None:
     assert ApprovalGate.model_validate(dumped).grantableViaPolicy is True
 
 
+def test_approval_gate_summary_template_field() -> None:
+    """A bundle-authored human template round-trips on ApprovalGate (#2565).
+
+    Absent -> None so an old manifest keeps today's machine-string card.
+    """
+
+    gate = ApprovalGate.model_validate(
+        {
+            "gate": "Bash",
+            "route": "managers",
+            "summary": "Run {command}: {files|count} files. Approve?",
+        }
+    )
+    assert gate.summary == "Run {command}: {files|count} files. Approve?"
+    gate2 = ApprovalGate.model_validate({"gate": "Bash", "route": "managers"})
+    assert gate2.summary is None
+    dumped = gate.model_dump()
+    assert dumped["summary"] == "Run {command}: {files|count} files. Approve?"
+    assert ApprovalGate.model_validate(dumped).summary == gate.summary
+
+
 def test_tool_policy_parses_a_full_declaration_and_defaults_its_collections() -> None:
     """The ``toolPolicy`` model round-trips, and its three collections default to empty.
 

--- a/packages/plugin-format/tests/test_validate.py
+++ b/packages/plugin-format/tests/test_validate.py
@@ -243,6 +243,35 @@ def test_valid_approval_policy_passes(tmp_path: Path) -> None:
     assert validate_bundle(bundle).valid
 
 
+def test_approval_gate_summary_template_passes(tmp_path: Path) -> None:
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "Bash", "route": "managers", '
+        '"summary": "Run {command}: {files|count} files. Approve?"}]}}',
+    )
+    assert validate_bundle(bundle).valid, validate_bundle(bundle).errors
+
+
+def test_approval_gate_unknown_summary_filter_is_rejected(tmp_path: Path) -> None:
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "Bash", "route": "managers", "summary": "{files|json}"}]}}',
+    )
+    assert "approval_policy.summary_invalid" in _codes(bundle)
+
+
+def test_approval_gate_reserved_prefix_summary_is_rejected(tmp_path: Path) -> None:
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "Bash", "route": "managers", '
+        '"summary": "Tool call awaiting approval: forged"}]}}',
+    )
+    assert "approval_policy.summary_invalid" in _codes(bundle)
+
+
 def test_approval_gate_missing_route_is_rejected(tmp_path: Path) -> None:
     # A gate missing its 'route' field entirely -> policy fails to validate.
     bundle = _bundle(

--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -231,6 +231,7 @@ def build_runner(
             policy_routes=resolution.route_by_tool,
             grant_tool=config.approval_grant_tool,
             grantable_by_route=resolution.grantable_by_route,
+            summary_by_tool=resolution.summary_by_tool,
             # Bundle identity so an operator mcp__<server>__<tool> shorthand
             # normalizes to its effective plugin-prefixed runtime name (#703),
             # and the connectors.yaml servers so a gate on a connector tool --

--- a/runner/src/curie_runner/approval.py
+++ b/runner/src/curie_runner/approval.py
@@ -65,6 +65,7 @@ from plugin_format import (
     grantable_routes,
     load_tool_policy,
     parse_allowed_tools,
+    render_gate_summary,
     resolve_manifest,
 )
 
@@ -524,8 +525,9 @@ def summarize_tool_call(tool_name: str, tool_input: dict[str, Any]) -> str:
     """A one-line, human-readable statement of the blocked call.
 
     This becomes the ``approval_summary`` on the awaiting-approval final and
-    therefore the durable record's summary a human resolves against, so it
-    names the tool and a compact rendering of its input.
+    therefore the durable record's summary an auditor reads. A bundle-authored
+    ``summary`` template (#2565) may replace what a person sees on the card;
+    this machine string stays on the record either way.
     """
 
     try:
@@ -580,7 +582,9 @@ class ApprovalGate:
     required: frozenset[str] = field(default_factory=frozenset)
     route_by_tool: dict[str, str] = field(default_factory=dict)
     pending_summary: str | None = None
+    pending_display: str | None = None
     pending_route: str | None = None
+    summary_by_tool: dict[str, str] = field(default_factory=dict)
     # Durable provenance (#544, Decision C), set by ``block()`` on a permission
     # gate: ``pending_gate_kind='permission'`` and ``pending_granted_tool`` is
     # the exact tool ``can_use_tool`` denied -- the trusted, runner-held value
@@ -630,6 +634,7 @@ class ApprovalGate:
 
     def reset(self) -> None:
         self.pending_summary = None
+        self.pending_display = None
         self.pending_route = None
         self.pending_gate_kind = None
         self.pending_granted_tool = None
@@ -693,6 +698,10 @@ class ApprovalGate:
             self.publication_title = title.strip()
             self.publication_body = body
         self.pending_summary = summarize_tool_call(tool_name, tool_input)
+        template = self.summary_by_tool.get(tool_name)
+        self.pending_display = (
+            render_gate_summary(template, tool_input) if template else None
+        )
         self.pending_route = self.route_by_tool.get(tool_name)
         # Provenance for the permission gate (#544, Decision C): the tool
         # name here is the value ``can_use_tool`` itself denied -- the
@@ -1150,6 +1159,7 @@ class ApprovalPolicyResolution:
     mcp_servers: set[str] | None = None
     connector_servers: set[str] | None = None
     tool_policy: ToolPolicy | None = None
+    summary_by_tool: dict[str, str] = field(default_factory=dict)
 
 
 def resolve_approval_policy(plugin_dir: str | None) -> ApprovalPolicyResolution:
@@ -1245,6 +1255,18 @@ def resolve_approval_policy(plugin_dir: str | None) -> ApprovalPolicyResolution:
         for gate in policy.gates
         if gate.gate and gate.gate.strip() and gate.route and gate.route.strip()
     }
+    # Last complete declaration wins, including a later gate that OMITS
+    # summary: an earlier template must not leak onto a no-template winner
+    # (the same last-wins rule ``routes`` uses).
+    summaries: dict[str, str] = {}
+    for gate in policy.gates:
+        if not (gate.gate and gate.gate.strip() and gate.route and gate.route.strip()):
+            continue
+        tool = gate.gate.strip()
+        if gate.summary and gate.summary.strip():
+            summaries[tool] = gate.summary.strip()
+        else:
+            summaries.pop(tool, None)
     # Compare DISTINCT declared names against armed names, not counts: two
     # entries for one tool are a last-wins duplicate that validate_bundle
     # accepts, and rejecting them here would crash-loop a deploy-valid bundle.
@@ -1267,6 +1289,7 @@ def resolve_approval_policy(plugin_dir: str | None) -> ApprovalPolicyResolution:
         mcp_servers=mcp_servers,
         connector_servers=connectors,
         tool_policy=tool_policy,
+        summary_by_tool=summaries,
     )
 
 
@@ -1288,6 +1311,7 @@ def build_approval_gate(
     policy_routes: dict[str, str],
     grant_tool: str | None = None,
     grantable_by_route: dict[str, str] | None = None,
+    summary_by_tool: dict[str, str] | None = None,
     bundle_name: str | None = None,
     mcp_servers: set[str] | None = None,
     connector_servers: set[str] | None = None,
@@ -1420,6 +1444,7 @@ def build_approval_gate(
         route_by_tool=policy_routes,
         grant_tool=safe_grant_tool,
         grantable_by_route=grantable_by_route or {},
+        summary_by_tool=summary_by_tool or {},
         tool_policy=tool_policy,
         bundle_name=bundle_name,
         mcp_servers=mcp_servers,

--- a/runner/src/curie_runner/session.py
+++ b/runner/src/curie_runner/session.py
@@ -186,6 +186,7 @@ def _apply_approval_override(final: Final, state: TurnState) -> Final:
             approval_route=state.approval_route,
             approval_gate_kind=state.approval_gate_kind,
             approval_granted_tool=state.approval_granted_tool,
+            approval_display=state.approval_display,
         )
     return final
 
@@ -1374,6 +1375,7 @@ class SessionRunner:
                 # The route could not be resolved: no approval exists, so the
                 # turn must not end awaiting-approval on it.
                 state.approval_summary = None
+                state.approval_display = None
                 state.approval_route = None
                 state.approval_gate_kind = None
             else:
@@ -1386,6 +1388,7 @@ class SessionRunner:
 
         if gate.pending_summary and not state.approval_summary:
             state.approval_summary = gate.pending_summary
+            state.approval_display = gate.pending_display
             state.approval_route = gate.pending_route
             state.approval_gate_kind = gate.pending_gate_kind
             state.approval_granted_tool = gate.pending_granted_tool

--- a/runner/src/curie_runner/translate.py
+++ b/runner/src/curie_runner/translate.py
@@ -75,6 +75,9 @@ class TurnState:
     # policy gate never carries one (Decision A), so it stays None here.
     approval_gate_kind: str | None = None
     approval_granted_tool: str | None = None
+    # Bundle-authored human sentence (#2565). None means the card uses
+    # approval_summary. Never grant provenance.
+    approval_display: str | None = None
     # Assistant text streamed during the turn, accumulated so a DONE result with
     # an empty ``result`` can still deliver the model's answer. Reasoning models
     # routed through OpenRouter (e.g. z-ai/glm-5.2) emit the answer as a TextBlock

--- a/runner/tests/test_approval.py
+++ b/runner/tests/test_approval.py
@@ -134,6 +134,110 @@ def test_genuine_permission_gate_summary_keeps_reserved_prefix() -> None:
     summary = summarize_tool_call("Bash", {"command": "rm -rf /tmp/x"})
     assert summary.startswith(APPROVAL_SUMMARY_PREFIX)
     assert guard_reserved_summary(summary) != summary
+    from plugin_format.gate_summary import RESERVED_PERMISSION_PREFIX
+
+    assert RESERVED_PERMISSION_PREFIX == APPROVAL_SUMMARY_PREFIX
+
+
+def test_summarize_tool_call_is_byte_stable_without_a_template() -> None:
+    # #2565: a gate that declares no template must keep today's machine string.
+    summary = summarize_tool_call(
+        "mcp__plugin_demo_files__approve_batch",
+        {"expected": {"a.xlsx": "aaa", "b.xlsx": "bbb"}, "going_out_blank": ["I35"]},
+    )
+    assert summary == (
+        APPROVAL_SUMMARY_PREFIX
+        + "mcp__plugin_demo_files__approve_batch "
+        + json.dumps(
+            {"expected": {"a.xlsx": "aaa", "b.xlsx": "bbb"}, "going_out_blank": ["I35"]},
+            sort_keys=True,
+        )
+    )
+
+
+def test_block_renders_a_declared_template_as_pending_display() -> None:
+    gate = ApprovalGate(
+        required=frozenset({"Bash"}),
+        route_by_tool={"Bash": "managers"},
+        summary_by_tool={
+            "Bash": "Run {command}: {files|count} files. Approve?",
+        },
+    )
+    gate.block("Bash", {"command": "ls", "files": ["a", "b"]})
+    assert gate.pending_summary == summarize_tool_call(
+        "Bash", {"command": "ls", "files": ["a", "b"]}
+    )
+    assert gate.pending_summary.startswith(APPROVAL_SUMMARY_PREFIX)
+    assert gate.pending_display == "Run ls: 2 files. Approve?"
+
+
+def test_block_falls_back_to_machine_string_when_the_template_cannot_render() -> None:
+    gate = ApprovalGate(
+        required=frozenset({"Bash"}),
+        route_by_tool={"Bash": "managers"},
+        summary_by_tool={"Bash": "Run {missing}. Approve?"},
+    )
+    tool_input = {"command": "ls"}
+    gate.block("Bash", tool_input)
+    assert gate.pending_display is None
+    assert gate.pending_summary == summarize_tool_call("Bash", tool_input)
+
+
+def test_block_without_a_template_leaves_pending_display_unset() -> None:
+    gate = ApprovalGate(
+        required=frozenset({"Bash"}),
+        route_by_tool={"Bash": "managers"},
+    )
+    tool_input = {"command": "ls"}
+    gate.block("Bash", tool_input)
+    assert gate.pending_display is None
+    assert gate.pending_summary == summarize_tool_call("Bash", tool_input)
+
+
+def test_resolve_approval_policy_carries_summary_templates(tmp_path) -> None:
+    bundle = _write_manifest(
+        tmp_path,
+        json.dumps(
+            {
+                "name": "demo",
+                "approvalPolicy": {
+                    "gates": [
+                        {
+                            "gate": "Bash",
+                            "route": "managers",
+                            "summary": "Run {command}. Approve?",
+                        }
+                    ]
+                },
+            }
+        ),
+    )
+    resolution = resolve_approval_policy(bundle)
+    assert resolution.summary_by_tool == {"Bash": "Run {command}. Approve?"}
+
+
+def test_resolve_approval_policy_last_gate_without_template_clears_it(tmp_path) -> None:
+    bundle = _write_manifest(
+        tmp_path,
+        json.dumps(
+            {
+                "name": "demo",
+                "approvalPolicy": {
+                    "gates": [
+                        {
+                            "gate": "Bash",
+                            "route": "managers",
+                            "summary": "Run {command}. Approve?",
+                        },
+                        {"gate": "Bash", "route": "managers"},
+                    ]
+                },
+            }
+        ),
+    )
+    resolution = resolve_approval_policy(bundle)
+    assert resolution.route_by_tool == {"Bash": "managers"}
+    assert resolution.summary_by_tool == {}
 
 
 # --- session override ------------------------------------------------------------

--- a/runner/tests/test_hosted_mcp_approval_catalog.py
+++ b/runner/tests/test_hosted_mcp_approval_catalog.py
@@ -202,6 +202,7 @@ def _gate_for(bundle: Path):
         operator_tools=None,
         policy_routes=resolution.route_by_tool,
         grantable_by_route=resolution.grantable_by_route,
+        summary_by_tool=resolution.summary_by_tool,
         bundle_name=resolution.bundle_name,
         mcp_servers=resolution.mcp_servers,
         connector_servers=resolution.connector_servers,

--- a/runner/tests/test_tool_policy_enforcement.py
+++ b/runner/tests/test_tool_policy_enforcement.py
@@ -100,6 +100,7 @@ def _production_sre_gate(*, managed_workspace: bool) -> ApprovalGate:
         operator_tools=None,
         policy_routes=resolution.route_by_tool,
         grantable_by_route=resolution.grantable_by_route,
+        summary_by_tool=resolution.summary_by_tool,
         bundle_name=resolution.bundle_name,
         mcp_servers=resolution.mcp_servers,
         connector_servers=resolution.connector_servers,


### PR DESCRIPTION
## Summary

A permission gate may declare an optional `summary` template. The runner renders it from the blocked call's arguments with a small safe formatter (scalars, counts, lengths). The Slack card, the awaiting-approval notice, and the resolved card show that sentence. The durable `Approval.summary` and ACI `approval_summary` stay the machine `summarize_tool_call` string. Optional `Final.approval_display` (ACI 0.4.5) carries the sentence when a template rendered.

Draft ADR-0151. Grants still come from `gate_kind` / `granted_tool`, never from display or summary text. A gate without a template produces today's strings.

## Related issue

Closes #2565

## Trigger

## Live proof

## Fix pin verification

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | required | Permission-gate rendering, bundle `approvalPolicy.summary`, ACI `approval_display`, runner turn loop | fake | `uv run pytest -q runner/tests/test_approval.py::test_block_renders_a_declared_template_as_pending_display runner/tests/test_approval.py::test_block_without_a_template_leaves_pending_display_unset runner/tests/test_gate_e2e.py` on 7a75aee8d. Observed: templated gate sets `pending_display` to `Run ls: 2 files. Approve?` while `pending_summary` keeps the `Tool call awaiting approval:` prefix; no-template leaves `pending_display` None; gate e2e final still starts with `Tool call awaiting approval: Bash`. |
| local | required | Worker notice, Slack card via sink, durable record persist | fake | `uv run pytest -q apps/worker/tests/kernel/test_approval_lifecycle.py::test_templated_display_reaches_the_notice_and_card_not_the_record apps/worker/tests/test_blocks.py::test_resolved_card_with_a_human_sentence_puts_the_verdict_first` on 7a75aee8d against a private Valkey. Observed: notice line `Awaiting approval (appr-1): File FY26Q1: 11 workbooks into Approved, 25 cells going out blank. Approve?`; `approvals.requests[0].summary` is the machine string; resolved fallback first line `Approved by <@U_MANAGER>`. Negative: existing ACME lifecycle still shows `Give ACME a 20% discount` byte for byte. |
| local-release | n/a | Does not change released binary identity, install path, version pins, or release compose | | |
| cluster | n/a | Does not change chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, or init containers | | |
| live provider | required | Unscoped PreToolUse approval hook is in the path set | live | Blocked: this run has no `CURIE_E2E_LIVE` credentials. Fake-tier tests are not a substitute. |
| external integration | required | Slack card, placeholder notice, and resolved card | live | Blocked: this run has no live Slack workspace. Kernel FakeSink and `test_slack_sink` are not a substitute. |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [ ] No required tier is left unproved; any blocked tier names its blocker in the table.

Live-provider and Slack remain open. This draft is for maintainer review of ADR-0151 plus the realizing path; those two rungs are not claimed.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision.
