### PR TITLE
Fail closed when the mail adapter dials an external OTLP collector

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1893,6 +1893,20 @@ jobs:
         env:
           CURIE_BIN: cli/target/release/curie
         run: bash scripts/check-netpol-enforcement.sh curie curie curie
+      # The mail adapter's own egress rail (#2361). It is the only first-party
+      # workload the chart gives an egress NetworkPolicy at all, so it is the
+      # only one that can silently drop its own OTLP export: with
+      # otelCollector.deploy false and an external endpoint, the export leaves
+      # the cluster through a single ipBlock peer the operator declared. That is
+      # exactly the kind of rule a render assertion cannot prove -- an applied
+      # but unenforced NetworkPolicy renders identically to a correct one, and a
+      # rule on the wrong port looks perfectly right in YAML while dropping
+      # every span. This runs on the same enforcing Calico cluster and is a
+      # non-vacuity check of its own: it proves an UNDECLARED peer is blocked
+      # before it trusts the declared one. It uses its own namespace, so it
+      # neither reads nor disturbs the release installed above.
+      - name: Mail-adapter external-collector egress enforces (not just rendered)
+        run: bash scripts/check-mail-adapter-otel-egress.sh charts/curie
       # Surface why on any failure above: pod states, recent events, and the
       # worker/runner logs are what localize a reachability or scheduling break.
       - name: Dump cluster diagnostics on failure

--- a/apps/mail-adapter/README.md
+++ b/apps/mail-adapter/README.md
@@ -224,9 +224,9 @@ and names that verb as the fix. No platform signing key is given to the adapter.
   (`otelCollector.deploy=true`) the chart both sets the OTLP env and opens the
   adapter's egress policy to the collector. With `otelCollector.deploy=false`
   and an external `otelCollector.endpoint`, the env is set but the adapter's own
-  egress policy has no peer for that address, so the operator must apply an
-  additional egress policy selecting the adapter or the exports are silently
-  dropped -- see the mail-adapter section of `charts/curie/README.md`. What is
+  egress policy has no peer for that address, so the chart requires
+  `mailAdapter.otelEgress.httpsCidrs` and refuses the render without it -- see
+  the mail-adapter section of `charts/curie/README.md`. What is
   exported is log records: the adapter authors no spans of its own yet, so a
   trace search for it comes back empty even on a healthy export path.
 

--- a/charts/curie/CLAUDE.md
+++ b/charts/curie/CLAUDE.md
@@ -141,9 +141,9 @@ component and rail detail in `charts/curie/README.md`.
   only first-party service with an egress policy at all, it is also the only one
   whose OTLP export can be dropped by its own rail: with `otelCollector.deploy`
   false and an external `otelCollector.endpoint`, this policy has no peer for
-  that address, and the fix is an operator-supplied additional egress policy
-  selecting the adapter (NetworkPolicies union), not a broad allow in the chart
-  for an address the chart cannot know. It never selects a runner sandbox and
+  that address, so the chart requires `mailAdapter.otelEgress.httpsCidrs` and
+  refuses the render without it, rather than a broad allow in the chart for an
+  address the chart cannot know. It never selects a runner sandbox and
   never allows the Kubernetes API. The runtime pod mounts no ServiceAccount
   token and has no RBAC. Prefix-0 and prefix-1 routes fail render, including
   split default routes. Do not turn provider DNS into a broad CIDR or add a

--- a/charts/curie/CLAUDE.md
+++ b/charts/curie/CLAUDE.md
@@ -134,8 +134,10 @@ component and rail detail in `charts/curie/README.md`.
   everything a pod holding three credentials can talk to -- read the rules in
   `templates/mail-adapter.yaml` for the current set rather than trusting a count
   here. As written today they are DNS, this release's API pods, those
-  `agentmail.httpsCidrs` on TCP 443, and -- only while `otelCollector.deploy` is
-  true -- this release's OTel Collector on its gRPC and HTTP ports. With
+  `agentmail.httpsCidrs` on TCP 443, and exactly one collector peer: while
+  `otelCollector.deploy` is true, this release's OTel Collector on its gRPC and
+  HTTP ports; otherwise the declared `mailAdapter.otelEgress.httpsCidrs` as an
+  external ipBlock on `mailAdapter.otelEgress.port`. With
   `api.deploy` false, `mailAdapter.apiEgress.httpsCidrs` and `.port` replace the
   API pod selector with an explicit narrow BYO-API peer. Because this is the
   only first-party service with an egress policy at all, it is also the only one

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -445,24 +445,27 @@ root filesystem remains read-only; only the state mount and an `emptyDir` at
 `/tmp` are writable. Enabling it also requires an explicit
 `mailAdapter.agentmail.httpsCidrs` list. One egress-only NetworkPolicy then
 allows DNS, this release's API pods, those provider/proxy CIDRs on TCP 443, and
--- while `otelCollector.deploy=true` -- this release's OTel Collector on its
-gRPC and HTTP ports, so the adapter's OTLP export is not dropped by its own
-rail. When `api.deploy=false`, the in-chart API selector is replaced by the
+-- when the release exports to its own in-chart collector -- that Collector on
+its gRPC and HTTP ports, or else the required `mailAdapter.otelEgress.httpsCidrs`
+peers for an external collector, so the adapter's OTLP export is not dropped by
+its own rail. When `api.deploy=false`, the in-chart API selector is replaced by the
 required `mailAdapter.apiEgress.httpsCidrs` peers on
 `mailAdapter.apiEgress.port`; the chart does not infer IPs from `apiBaseUrl`.
 The policy has no Kubernetes API carve-out and never selects runner sandboxes.
 
 The adapter is the only first-party workload with an egress-restricting
-NetworkPolicy, which makes one telemetry configuration asymmetric. With
-`otelCollector.deploy=false` and an external `otelCollector.endpoint`, api,
-dispatcher and worker export normally because nothing restricts their egress,
-while the adapter's exports are dropped: its policy has no peer for an address
-the chart cannot know, and the chart deliberately invents no broad allow for
-one. Because NetworkPolicies union rather than intersect, the fix needs no chart
-change -- apply an additional egress policy in the release namespace selecting
-the adapter's labels (`app.kubernetes.io/component: mail-adapter` plus the
-release's instance label) with a `to:` for the external collector. Everything
-else about the rail, including the AgentMail CIDRs, keeps working unchanged. See
+NetworkPolicy, so it is the only one whose OTLP export its own rail can drop
+while api, dispatcher and worker keep exporting from the same rendered env. That
+case therefore fails closed rather than shipping silently: when the release's
+effective OTLP endpoint is not this release's in-chart collector -- including an
+`otelCollector.endpoint` that still names the in-chart Service with
+`otelCollector.deploy=false` -- the render is refused until
+`mailAdapter.otelEgress.httpsCidrs` names the collector's narrow range (or a
+controlled egress proxy's), on `mailAdapter.otelEgress.port` or the port derived
+from the endpoint URL. The chart infers no IPs from the endpoint and invents no
+broad allow. Set `otelCollector.telemetryDisabled=true` to deliberately accept
+an unobservable release. Everything else about the rail, including the AgentMail
+CIDRs, keeps working unchanged. See
 [`docs/operations.md`](../../docs/operations.md#connecting-email) for the
 mode-0600 credential workflow, retention, erase, and recovery procedure.
 
@@ -1299,7 +1302,8 @@ to install only the control plane + backing stores without the runner substrate.
   alone gets it nowhere: `otelCollector.egress` must name the collector's CIDRs
   or the default-deny drops every sandbox span while api, dispatcher and worker
   keep exporting normally. The chart requires it at render rather than letting
-  that asymmetry ship silently.
+  that asymmetry ship silently. The mail adapter has the same requirement for
+  its own policy, under `mailAdapter.otelEgress.httpsCidrs` (above).
 
 ## Deploying without inbound access
 

--- a/charts/curie/ci/byo-endpoint-egress-assertions.sh
+++ b/charts/curie/ci/byo-endpoint-egress-assertions.sh
@@ -126,7 +126,6 @@ API_BASE_URL=https://api.example.net
 declare -a DEPLOY_GATE_EXEMPTIONS=(
   "security-networkpolicy.yaml:inference=an external inference endpoint is the model API, already governed by the operator's security.networkPolicy.allowedEgress model allowlist, which is the intended mechanism there"
   "mail-adapter.yaml:mailAdapter=this is the whole-template deploy gate for the mail adapter itself, not an egress carve-out: with mailAdapter.deploy false there is no adapter pod, no policy, and no destination to bring your own"
-  "mail-adapter.yaml:otelCollector=deliberate, documented asymmetry. The mail adapter is the only first-party workload with its own egress policy, so with otelCollector.deploy false and an external otelCollector.endpoint the chart invents no broad allow for an address it cannot know; the operator applies an additional egress policy selecting the adapter's labels, because NetworkPolicies union rather than intersect. Written up in charts/curie/README.md -- search for \"asymmetric\" in the mail adapter section"
 )
 
 fail() {

--- a/charts/curie/ci/byo-endpoint-egress-assertions.sh
+++ b/charts/curie/ci/byo-endpoint-egress-assertions.sh
@@ -116,8 +116,9 @@ API_BASE_URL=https://api.example.net
 # Each entry is `<template-basename>:<component>=reason`. The key is the FILE as
 # well as the component, because the same component gates a carve-out in more
 # than one NetworkPolicy template with different justifications (otelCollector
-# is both an in-chart runner peer and an in-chart mail-adapter peer, and only
-# one of those two is exempt).
+# is both an in-chart runner peer and an in-chart mail-adapter peer; neither is
+# exempt today -- the mail-adapter row was removed once #2361 gave that carve-out
+# a real BYO branch of its own).
 #
 # An exemption says: this in-chart `.deploy` carve-out deliberately has no BYO
 # `{{- else }}` branch, and here is why the external form of that destination is

--- a/charts/curie/ci/instrumented-workload-assertions.sh
+++ b/charts/curie/ci/instrumented-workload-assertions.sh
@@ -74,6 +74,11 @@ EXTERNAL_COLLECTOR_SET=(
   --set 'otelCollector.egress[0].cidr=192.0.2.40/32'
   --set 'otelCollector.egress[0].ports[0].protocol=TCP'
   --set 'otelCollector.egress[0].ports[0].port=4318'
+  # The mail adapter is the only first-party workload with an egress
+  # NetworkPolicy, so pairing it with a BYO collector endpoint needs a
+  # declared peer here too, or the chart refuses the render (#2361). This
+  # suite is about telemetry env wiring, not egress, hence the aside.
+  --set 'mailAdapter.otelEgress.httpsCidrs[0]=192.0.2.40/32'
 )
 
 render() {

--- a/charts/curie/ci/mail-adapter-wiring-assertions.sh
+++ b/charts/curie/ci/mail-adapter-wiring-assertions.sh
@@ -1383,6 +1383,15 @@ python3 "$OTEL_EGRESS_PY" "$byo_api_dir" yes 4 198.51.100.0/24 \
 #     policy that ALREADY carries ipBlock rules (AgentMail on 443, and a BYO API
 #     on its own port), so a line reader cannot tell which rule it is looking at
 #     and would happily accept an OTLP "peer" that is really the AgentMail rule.
+#
+#     Every render below that pairs otelCollector.deploy=false with a non-empty
+#     otelCollector.endpoint ALSO sets otelCollector.egress. That is not this
+#     section's own gate: it is the pre-existing, unrelated #2317 runner-sandbox
+#     refusal at templates/security-networkpolicy.yaml:386, which fires on that
+#     exact combination and fails the render before the mail-adapter path under
+#     test is ever reached. Without it these renders die on the runner's fail
+#     closed message instead of exercising (or refusing for) the mail-adapter
+#     reason this section asserts. Do not drop these flags as copy-paste noise.
 # ---------------------------------------------------------------------------
 OTLP_IPBLOCK_PY="$TMP/mail-otlp-ipblock.py"
 cat > "$OTLP_IPBLOCK_PY" <<'PY'
@@ -1555,7 +1564,10 @@ assert_render_fails_naming_both() {
 otlp_adapter_off_dir="$(render otlp-adapter-off \
   --set mailAdapter.deploy=false \
   --set otelCollector.deploy=false \
-  --set otelCollector.endpoint=https://otel.example.com:4318)"
+  --set otelCollector.endpoint=https://otel.example.com:4318 \
+  --set 'otelCollector.egress[0].cidr=192.0.2.40/32' \
+  --set 'otelCollector.egress[0].ports[0].protocol=TCP' \
+  --set 'otelCollector.egress[0].ports[0].port=4318')"
 python3 "$NO_MAIL_POLICY_PY" "$otlp_adapter_off_dir" \
   || fail "with mailAdapter.deploy=false an external collector endpoint must render cleanly and produce no mail-adapter policy; see the message above"
 
@@ -1586,7 +1598,10 @@ assert_render_fails_naming_both \
   "https://otel.example.com:4318" \
   "${ON[@]}" "${CREDS[@]}" \
   --set otelCollector.deploy=false \
-  --set otelCollector.endpoint=https://otel.example.com:4318
+  --set otelCollector.endpoint=https://otel.example.com:4318 \
+  --set 'otelCollector.egress[0].cidr=192.0.2.40/32' \
+  --set 'otelCollector.egress[0].ports[0].protocol=TCP' \
+  --set 'otelCollector.egress[0].ports[0].port=4318'
 
 # 23e: the positive path. Four rules, an ipBlock peer on the port derived from
 #      the URL, NO synthesized in-cluster collector peer (the chart cannot know
@@ -1594,6 +1609,9 @@ assert_render_fails_naming_both \
 otlp_external_ok_dir="$(render otlp-external-ok "${ON[@]}" "${CREDS[@]}" \
   --set otelCollector.deploy=false \
   --set otelCollector.endpoint=https://otel.example.com:4318 \
+  --set 'otelCollector.egress[0].cidr=192.0.2.40/32' \
+  --set 'otelCollector.egress[0].ports[0].protocol=TCP' \
+  --set 'otelCollector.egress[0].ports[0].port=4318' \
   --set 'mailAdapter.otelEgress.httpsCidrs[0]=192.0.2.40/32')"
 python3 "$OTEL_EGRESS_PY" "$otlp_external_ok_dir" no 4 203.0.113.0/24 \
   || fail "a declared external OTLP peer must add a FOURTH rule without synthesizing an in-cluster collector podSelector peer, and must not displace the AgentMail rule; see the message above"
@@ -1610,6 +1628,9 @@ assert_render_fails_named \
   "${ON[@]}" "${CREDS[@]}" \
   --set otelCollector.deploy=false \
   --set otelCollector.endpoint=https://otel.example.com:4318 \
+  --set 'otelCollector.egress[0].cidr=192.0.2.40/32' \
+  --set 'otelCollector.egress[0].ports[0].protocol=TCP' \
+  --set 'otelCollector.egress[0].ports[0].port=4318' \
   --set-string 'mailAdapter.otelEgress.httpsCidrs[0]=0.0.0.0/0'
 assert_render_fails_named \
   "/1 half-of-the-internet OTLP peer" \
@@ -1617,6 +1638,9 @@ assert_render_fails_named \
   "${ON[@]}" "${CREDS[@]}" \
   --set otelCollector.deploy=false \
   --set otelCollector.endpoint=https://otel.example.com:4318 \
+  --set 'otelCollector.egress[0].cidr=192.0.2.40/32' \
+  --set 'otelCollector.egress[0].ports[0].protocol=TCP' \
+  --set 'otelCollector.egress[0].ports[0].port=4318' \
   --set-string 'mailAdapter.otelEgress.httpsCidrs[0]=128.0.0.0/1'
 
 # 23g: an explicit port that CONTRADICTS the endpoint URL must refuse rather
@@ -1630,6 +1654,9 @@ assert_render_fails_naming_both \
   "${ON[@]}" "${CREDS[@]}" \
   --set otelCollector.deploy=false \
   --set otelCollector.endpoint=https://otel.example.com:4318 \
+  --set 'otelCollector.egress[0].cidr=192.0.2.40/32' \
+  --set 'otelCollector.egress[0].ports[0].protocol=TCP' \
+  --set 'otelCollector.egress[0].ports[0].port=4318' \
   --set-string mailAdapter.otelEgress.port=443 \
   --set 'mailAdapter.otelEgress.httpsCidrs[0]=192.0.2.40/32'
 
@@ -1638,6 +1665,9 @@ assert_render_fails_naming_both \
 otlp_port_agree_dir="$(render otlp-port-agree "${ON[@]}" "${CREDS[@]}" \
   --set otelCollector.deploy=false \
   --set otelCollector.endpoint=https://otel.example.com:4318 \
+  --set 'otelCollector.egress[0].cidr=192.0.2.40/32' \
+  --set 'otelCollector.egress[0].ports[0].protocol=TCP' \
+  --set 'otelCollector.egress[0].ports[0].port=4318' \
   --set-string mailAdapter.otelEgress.port=4318 \
   --set 'mailAdapter.otelEgress.httpsCidrs[0]=192.0.2.40/32')"
 python3 "$OTLP_IPBLOCK_PY" "$otlp_port_agree_dir" rule 192.0.2.40/32 4318 203.0.113.0/24 \
@@ -1646,9 +1676,17 @@ python3 "$OTLP_IPBLOCK_PY" "$otlp_port_agree_dir" rule 192.0.2.40/32 4318 203.0.
 # 23i: no explicit port anywhere. The scheme default (443 for https) is the only
 #      port the collector can be on, and guessing 4318 there renders a peer that
 #      drops every export.
+#
+#      The otelCollector.egress port below (4318) is the UNRELATED runner-sandbox
+#      peer required by the #2317 gate, not the mail adapter's derived port --
+#      the mail adapter's own peer is asserted separately below to be 443 (the
+#      https scheme default). Do not read this 4318 as this assertion's target.
 otlp_scheme_port_dir="$(render otlp-scheme-port "${ON[@]}" "${CREDS[@]}" \
   --set otelCollector.deploy=false \
   --set otelCollector.endpoint=https://otel.example.com \
+  --set 'otelCollector.egress[0].cidr=192.0.2.40/32' \
+  --set 'otelCollector.egress[0].ports[0].protocol=TCP' \
+  --set 'otelCollector.egress[0].ports[0].port=4318' \
   --set 'mailAdapter.otelEgress.httpsCidrs[0]=192.0.2.40/32')"
 python3 "$OTLP_IPBLOCK_PY" "$otlp_scheme_port_dir" rule 192.0.2.40/32 443 203.0.113.0/24 \
   || fail "an endpoint with no explicit port must derive the scheme default (443 for https); see the message above"
@@ -1663,7 +1701,10 @@ assert_render_fails_named \
   "mailAdapter.otelEgress.httpsCidrs" \
   "${ON[@]}" "${CREDS[@]}" \
   --set otelCollector.deploy=false \
-  --set otelCollector.endpoint=http://curie-otel-collector:4318
+  --set otelCollector.endpoint=http://curie-otel-collector:4318 \
+  --set 'otelCollector.egress[0].cidr=192.0.2.40/32' \
+  --set 'otelCollector.egress[0].ports[0].protocol=TCP' \
+  --set 'otelCollector.egress[0].ports[0].port=4318'
 
 # 23k: the documented escape hatch. telemetryDisabled resolves the endpoint to
 #      empty, so there is nothing to reach and nothing to declare -- three rules

--- a/charts/curie/ci/mail-adapter-wiring-assertions.sh
+++ b/charts/curie/ci/mail-adapter-wiring-assertions.sh
@@ -74,6 +74,13 @@
 #      otelCollector.deploy is true. The adapter is the ONLY first-party service
 #      with an egress-restricting policy, so OTLP env without this peer exports
 #      into a dropped connection while every render still looks green.
+#   23 An EXTERNAL OTLP endpoint fails closed. The adapter's effective endpoint
+#      is curie.otel.endpoint, so when that is not this release's in-chart
+#      Collector the render REFUSES unless mailAdapter.otelEgress.httpsCidrs
+#      declares a narrow peer, which then renders as one ipBlock rule on the
+#      port derived from the endpoint URL. Overbroad peers, a port contradicting
+#      the URL, and a stale key set while the in-chart Collector is deployed all
+#      refuse; otelCollector.telemetryDisabled=true remains the escape hatch.
 #
 # NOTE ON `--output-dir`: copied deliberately from
 # dispatcher-api-wiring-assertions.sh. In this environment `helm template` into a
@@ -1164,7 +1171,8 @@ otel_external_dir="$(render otel-external "${ON[@]}" "${CREDS[@]}" \
   --set otelCollector.endpoint=https://otel.example.com:4318 \
   --set 'otelCollector.egress[0].cidr=192.0.2.40/32' \
   --set 'otelCollector.egress[0].ports[0].protocol=TCP' \
-  --set 'otelCollector.egress[0].ports[0].port=4318')"
+  --set 'otelCollector.egress[0].ports[0].port=4318' \
+  --set 'mailAdapter.otelEgress.httpsCidrs[0]=192.0.2.40/32')"
 assert_env_value "$otel_external_dir" OTEL_EXPORTER_OTLP_ENDPOINT "https://otel.example.com:4318" \
   "otelCollector.endpoint must render verbatim on the adapter, exactly as it does on the other instrumented workloads."
 assert_env_value "$otel_external_dir" OTEL_EXPORTER_OTLP_PROTOCOL "http/protobuf" \
@@ -1346,12 +1354,325 @@ python3 "$OTEL_EGRESS_PY" "$on_dir" yes 4 203.0.113.0/24 \
 # never deployed.
 python3 "$OTEL_EGRESS_PY" "$otel_disabled_dir" no 3 203.0.113.0/24 \
   || fail "with the chart collector not deployed, the mail adapter's egress policy is not back to its three original rules; see the message above"
-python3 "$OTEL_EGRESS_PY" "$otel_external_dir" no 3 203.0.113.0/24 \
-  || fail "an EXTERNAL otelCollector.endpoint must not synthesize an in-cluster collector peer; that destination is an IP the chart cannot know (see the template comment and README)"
+# Under the #2361 contract this render must ALSO declare its own OTLP peer, so
+# the count is four: DNS, the API peer, AgentMail, and the declared external
+# collector ipBlock. The intent of the assertion is unchanged -- the external
+# collector must be reached as an operator-declared IP peer and must never be
+# synthesized as an in-cluster podSelector peer for a Collector pod that
+# otelCollector.deploy=false says does not exist.
+python3 "$OTEL_EGRESS_PY" "$otel_external_dir" no 4 203.0.113.0/24 \
+  || fail "an EXTERNAL otelCollector.endpoint must not synthesize an in-cluster collector peer; that destination is an IP the chart cannot know, and it must arrive as the declared mailAdapter.otelEgress ipBlock rule instead"
 
 # The BYO-API render assertion 17 already exercises: the collector peer must
 # coexist with the explicit BYO API CIDR rule rather than replacing it.
 python3 "$OTEL_EGRESS_PY" "$byo_api_dir" yes 4 198.51.100.0/24 \
   || fail "with api.deploy=false the collector peer and the BYO API CIDR rule do not coexist; see the message above"
 
-echo "OK: mail-adapter chart wiring and build-path render assertions passed (22 assertions)"
+# ---------------------------------------------------------------------------
+# 23: an EXTERNAL OTLP collector endpoint fails closed (#2361). The adapter is
+#     the only first-party workload with an egress-restricting policy, and it
+#     deliberately has no `mailAdapter.extraEnv`, so its effective OTLP endpoint
+#     IS `curie.otel.endpoint`. When that endpoint is not this release's in-chart
+#     Collector, the policy has no peer for it and every span, metric and log is
+#     dropped by the pod's own rail while `helm template` stays green and the
+#     rendered env still looks perfect -- exactly the silent-hole shape the
+#     adjacent mailAdapter.apiEgress gate already refuses. These assertions pin
+#     the reversal of that documented drop: refuse rather than document.
+#
+#     Read structurally, never by grep. The OTLP peer is an ipBlock rule in a
+#     policy that ALREADY carries ipBlock rules (AgentMail on 443, and a BYO API
+#     on its own port), so a line reader cannot tell which rule it is looking at
+#     and would happily accept an OTLP "peer" that is really the AgentMail rule.
+# ---------------------------------------------------------------------------
+OTLP_IPBLOCK_PY="$TMP/mail-otlp-ipblock.py"
+cat > "$OTLP_IPBLOCK_PY" <<'PY'
+"""Assert the mail adapter's EXTERNAL-OTLP ipBlock rule, structurally.
+
+argv: <rendered-dir> <expect: rule|none> <expected-cidrs-csv|-> <expected-port|->
+      <known-non-otlp-cidrs-csv>
+
+The last argument is what makes this reader honest. The mail adapter's egress
+policy legitimately carries other ipBlock rules (AgentMail on TCP 443, and, when
+api.deploy is false, the BYO API peer on its configured port). Those are named
+explicitly and excluded; whatever ipBlock rule is LEFT is the OTLP rule. That way
+a template which "renders an OTLP peer" by accidentally widening the AgentMail
+rule fails here instead of passing.
+"""
+import pathlib
+import sys
+
+import yaml
+
+rendered, expect = sys.argv[1], sys.argv[2]
+expected_cidrs = (
+    {c for c in sys.argv[3].split(",") if c} if sys.argv[3] != "-" else set()
+)
+expected_port = int(sys.argv[4]) if sys.argv[4] != "-" else None
+known_other = {c for c in sys.argv[5].split(",") if c} if len(sys.argv) > 5 else set()
+
+policies = [
+    doc
+    for path in pathlib.Path(rendered).rglob("*.yaml")
+    for doc in yaml.safe_load_all(path.read_text())
+    if isinstance(doc, dict)
+    and doc.get("kind") == "NetworkPolicy"
+    and doc.get("spec", {}).get("podSelector", {}).get("matchLabels", {}).get(
+        "app.kubernetes.io/component"
+    )
+    == "mail-adapter"
+]
+if len(policies) != 1:
+    raise SystemExit(
+        f"expected exactly ONE NetworkPolicy selecting the mail adapter, found "
+        f"{len(policies)}. Decision 3 keeps a single policy object for this "
+        "credential-bearing pod so an auditor reads one object to see every "
+        "destination it may reach; a second object hides half the answer."
+    )
+egress = policies[0].get("spec", {}).get("egress") or []
+
+ipblock_rules = []
+for rule in egress:
+    peers = rule.get("to") or []
+    if not peers or not all(peer.get("ipBlock") for peer in peers):
+        continue
+    cidrs = {peer["ipBlock"].get("cidr") for peer in peers}
+    ipblock_rules.append((cidrs, rule.get("ports") or []))
+
+candidates = [(c, p) for c, p in ipblock_rules if not c <= known_other]
+
+if expect == "none":
+    if candidates:
+        raise SystemExit(
+            f"an OTLP ipBlock rule rendered where none may exist: {candidates!r} "
+            f"(known non-OTLP CIDRs were {sorted(known_other)!r}). Either the "
+            "in-chart Collector is deployed -- in which case the peer must be the "
+            "pod-selector rule, not an IP the chart cannot know -- or telemetry is "
+            "disabled, in which case the adapter exports nothing and must be "
+            "granted nothing."
+        )
+elif expect == "rule":
+    if len(candidates) != 1:
+        raise SystemExit(
+            f"expected exactly ONE external-OTLP ipBlock rule, found "
+            f"{len(candidates)}: {candidates!r} (known non-OTLP CIDRs were "
+            f"{sorted(known_other)!r}). Zero means the operator declared "
+            "mailAdapter.otelEgress.httpsCidrs and the chart silently ignored it, "
+            "leaving the export dropped; more than one means the rule set is "
+            "widening past the single declared destination."
+        )
+    cidrs, ports = candidates[0]
+    if cidrs != expected_cidrs:
+        raise SystemExit(
+            f"the external-OTLP rule reaches {sorted(cidrs)!r}, expected exactly "
+            f"{sorted(expected_cidrs)!r}. A peer that is broader than what the "
+            "operator declared is a new egress escape hatch on the pod that holds "
+            "the channel token, the egress secret and the AgentMail API key."
+        )
+    want_ports = [{"protocol": "TCP", "port": expected_port}]
+    if ports != want_ports:
+        raise SystemExit(
+            f"the external-OTLP rule opens {ports!r}, expected {want_ports!r}. The "
+            "port is derived from the resolved endpoint URL (explicit port, else "
+            "443 for https and 80 for http); getting it wrong renders a peer that "
+            "looks configured and still drops every export."
+        )
+else:
+    raise SystemExit(f"bad expect argument {expect!r}")
+PY
+
+# Zero-policy reader for the adapter-off case. `render` already proves the exit
+# code; this proves the render is NOT empty, so "no mail-adapter policy" cannot
+# pass because nothing rendered at all.
+NO_MAIL_POLICY_PY="$TMP/mail-no-policy.py"
+cat > "$NO_MAIL_POLICY_PY" <<'PY'
+"""Assert zero mail-adapter NetworkPolicies in a NON-EMPTY render.
+
+argv: <rendered-dir>
+"""
+import pathlib
+import sys
+
+import yaml
+
+docs = [
+    doc
+    for path in pathlib.Path(sys.argv[1]).rglob("*.yaml")
+    for doc in yaml.safe_load_all(path.read_text())
+    if isinstance(doc, dict)
+]
+if len(docs) < 5:
+    raise SystemExit(
+        f"the render produced only {len(docs)} object(s); the absence assertion "
+        "below would pass because nothing rendered, not because the gate is "
+        "correctly scoped to mailAdapter.deploy."
+    )
+mail = [
+    doc
+    for doc in docs
+    if doc.get("kind") == "NetworkPolicy"
+    and doc.get("spec", {}).get("podSelector", {}).get("matchLabels", {}).get(
+        "app.kubernetes.io/component"
+    )
+    == "mail-adapter"
+]
+if mail:
+    raise SystemExit(
+        f"mailAdapter.deploy is false but {len(mail)} mail-adapter NetworkPolicy "
+        "object(s) rendered. The OTLP gate must live entirely inside the adapter's "
+        "own conditional: an operator who never asked for the mail adapter must "
+        "never be asked for its collector CIDRs, and must never receive a policy "
+        "selecting pods that do not exist."
+    )
+PY
+
+# Two-substring variant of assert_render_fails_named. The port-mismatch and
+# endpoint-naming failures are only useful if the message names BOTH halves of
+# the contradiction; a message that says "port mismatch" without printing the
+# two ports sends the operator back to the values file to guess.
+assert_render_fails_naming_both() {
+  # $1 label, $2 first required substring, $3 second required substring,
+  # remaining helm args.
+  local label="$1" first="$2" second="$3" output rc
+  shift 3
+  set +e
+  output="$(helm template "$RELEASE" "$CHART" "$@" 2>&1)"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] \
+    || fail "$label rendered successfully; this configuration must fail closed"
+  case "$output" in
+    *"$first"*) : ;;
+    *) fail "$label failed without naming '$first'; an operator cannot act on a message that omits it. Output was: $output" ;;
+  esac
+  case "$output" in
+    *"$second"*) : ;;
+    *) fail "$label failed without naming '$second'; an operator cannot act on a message that omits it. Output was: $output" ;;
+  esac
+}
+
+# 23a: the adapter is off. No policy, no demand for CIDRs, and a real render
+#      behind the absence check.
+otlp_adapter_off_dir="$(render otlp-adapter-off \
+  --set mailAdapter.deploy=false \
+  --set otelCollector.deploy=false \
+  --set otelCollector.endpoint=https://otel.example.com:4318)"
+python3 "$NO_MAIL_POLICY_PY" "$otlp_adapter_off_dir" \
+  || fail "with mailAdapter.deploy=false an external collector endpoint must render cleanly and produce no mail-adapter policy; see the message above"
+
+# 23b: the default, in-chart collector path is UNCHANGED. Assertion 22 above
+#      already pinned the pod-selector peer and the rule count; what is added
+#      here is that the chart did not ALSO invent an ipBlock for a collector it
+#      can select by label. Two peers for one destination is a widening.
+python3 "$OTLP_IPBLOCK_PY" "$on_dir" none - - 203.0.113.0/24 \
+  || fail "the default in-chart collector render grew an OTLP ipBlock peer; the in-chart Collector is selectable by pod label and must never be reached by a hardcoded address as well"
+
+# 23c: the key is read ONLY when the endpoint is external. A stale
+#      mailAdapter.otelEgress.httpsCidrs left behind after an operator moved
+#      back to the in-chart collector must be surfaced, not silently ignored --
+#      the same refusal #2367 applies to the runner's override keys. Silently
+#      ignored config is how an operator comes to believe a peer exists.
+assert_render_fails_named \
+  "in-chart collector WITH mailAdapter.otelEgress.httpsCidrs set" \
+  "mailAdapter.otelEgress.httpsCidrs" \
+  "${ON[@]}" "${CREDS[@]}" \
+  --set 'mailAdapter.otelEgress.httpsCidrs[0]=192.0.2.40/32'
+
+# 23d: the headline gate. An external endpoint with no declared peer must refuse
+#      and must name the RESOLVED endpoint, so the operator learns which address
+#      needs a CIDR rather than being told a key is missing in the abstract.
+assert_render_fails_naming_both \
+  "external otelCollector.endpoint with no mailAdapter.otelEgress.httpsCidrs" \
+  "mailAdapter.otelEgress.httpsCidrs" \
+  "https://otel.example.com:4318" \
+  "${ON[@]}" "${CREDS[@]}" \
+  --set otelCollector.deploy=false \
+  --set otelCollector.endpoint=https://otel.example.com:4318
+
+# 23e: the positive path. Four rules, an ipBlock peer on the port derived from
+#      the URL, NO synthesized in-cluster collector peer (the chart cannot know
+#      that pod exists), and the AgentMail rule still intact beside it.
+otlp_external_ok_dir="$(render otlp-external-ok "${ON[@]}" "${CREDS[@]}" \
+  --set otelCollector.deploy=false \
+  --set otelCollector.endpoint=https://otel.example.com:4318 \
+  --set 'mailAdapter.otelEgress.httpsCidrs[0]=192.0.2.40/32')"
+python3 "$OTEL_EGRESS_PY" "$otlp_external_ok_dir" no 4 203.0.113.0/24 \
+  || fail "a declared external OTLP peer must add a FOURTH rule without synthesizing an in-cluster collector podSelector peer, and must not displace the AgentMail rule; see the message above"
+python3 "$OTLP_IPBLOCK_PY" "$otlp_external_ok_dir" rule 192.0.2.40/32 4318 203.0.113.0/24 \
+  || fail "the declared external OTLP peer did not render as a narrow ipBlock rule on the endpoint's port; see the message above"
+
+# 23f: overbroad peers are refused by the SAME narrow-CIDR guard the AgentMail
+#      and BYO API lists use. A /0 or a /1 half of the address space on this pod
+#      is HTTPS-everywhere for a workload holding three live credentials, and
+#      "it is only for telemetry" is not a smaller blast radius.
+assert_render_fails_named \
+  "default-route OTLP peer" \
+  "mailAdapter.otelEgress.httpsCidrs" \
+  "${ON[@]}" "${CREDS[@]}" \
+  --set otelCollector.deploy=false \
+  --set otelCollector.endpoint=https://otel.example.com:4318 \
+  --set-string 'mailAdapter.otelEgress.httpsCidrs[0]=0.0.0.0/0'
+assert_render_fails_named \
+  "/1 half-of-the-internet OTLP peer" \
+  "mailAdapter.otelEgress.httpsCidrs" \
+  "${ON[@]}" "${CREDS[@]}" \
+  --set otelCollector.deploy=false \
+  --set otelCollector.endpoint=https://otel.example.com:4318 \
+  --set-string 'mailAdapter.otelEgress.httpsCidrs[0]=128.0.0.0/1'
+
+# 23g: an explicit port that CONTRADICTS the endpoint URL must refuse rather
+#      than pick a winner. Whichever the chart chose silently, one of the two
+#      operator statements would be quietly discarded -- and if the URL loses,
+#      the rendered policy opens a port the collector is not listening on.
+assert_render_fails_naming_both \
+  "mailAdapter.otelEgress.port disagreeing with the endpoint URL port" \
+  "4318" \
+  "443" \
+  "${ON[@]}" "${CREDS[@]}" \
+  --set otelCollector.deploy=false \
+  --set otelCollector.endpoint=https://otel.example.com:4318 \
+  --set-string mailAdapter.otelEgress.port=443 \
+  --set 'mailAdapter.otelEgress.httpsCidrs[0]=192.0.2.40/32'
+
+# 23h: an explicit port that AGREES is not a contradiction. The refusal above
+#      must be a mismatch check, not a ban on ever setting the key.
+otlp_port_agree_dir="$(render otlp-port-agree "${ON[@]}" "${CREDS[@]}" \
+  --set otelCollector.deploy=false \
+  --set otelCollector.endpoint=https://otel.example.com:4318 \
+  --set-string mailAdapter.otelEgress.port=4318 \
+  --set 'mailAdapter.otelEgress.httpsCidrs[0]=192.0.2.40/32')"
+python3 "$OTLP_IPBLOCK_PY" "$otlp_port_agree_dir" rule 192.0.2.40/32 4318 203.0.113.0/24 \
+  || fail "an explicit mailAdapter.otelEgress.port that AGREES with the endpoint URL must render that port; see the message above"
+
+# 23i: no explicit port anywhere. The scheme default (443 for https) is the only
+#      port the collector can be on, and guessing 4318 there renders a peer that
+#      drops every export.
+otlp_scheme_port_dir="$(render otlp-scheme-port "${ON[@]}" "${CREDS[@]}" \
+  --set otelCollector.deploy=false \
+  --set otelCollector.endpoint=https://otel.example.com \
+  --set 'mailAdapter.otelEgress.httpsCidrs[0]=192.0.2.40/32')"
+python3 "$OTLP_IPBLOCK_PY" "$otlp_scheme_port_dir" rule 192.0.2.40/32 443 203.0.113.0/24 \
+  || fail "an endpoint with no explicit port must derive the scheme default (443 for https); see the message above"
+
+# 23j: the leftover-Service-DNS shape. `otelCollector.deploy=false` with an
+#      endpoint that still names this release's collector Service is the most
+#      dangerous case, because the host LOOKS in-chart while no such pod exists.
+#      The gate must key off the EFFECTIVE endpoint plus deploy, not the
+#      hostname, exactly as #2367 does for the runner.
+assert_render_fails_named \
+  "in-chart Service DNS left behind with otelCollector.deploy=false" \
+  "mailAdapter.otelEgress.httpsCidrs" \
+  "${ON[@]}" "${CREDS[@]}" \
+  --set otelCollector.deploy=false \
+  --set otelCollector.endpoint=http://curie-otel-collector:4318
+
+# 23k: the documented escape hatch. telemetryDisabled resolves the endpoint to
+#      empty, so there is nothing to reach and nothing to declare -- three rules
+#      and no ipBlock beyond AgentMail. This is the answer the failure message
+#      offers an operator who genuinely wants an unobservable adapter, so it has
+#      to keep working.
+python3 "$OTEL_EGRESS_PY" "$otel_disabled_dir" no 3 203.0.113.0/24 \
+  || fail "otelCollector.telemetryDisabled=true must remain a complete escape from the OTLP peer requirement, at three rules; see the message above"
+python3 "$OTLP_IPBLOCK_PY" "$otel_disabled_dir" none - - 203.0.113.0/24 \
+  || fail "with telemetry disabled the adapter exports nothing, so it must be granted no OTLP ipBlock peer at all; see the message above"
+
+echo "OK: mail-adapter chart wiring and build-path render assertions passed (23 assertions)"

--- a/charts/curie/ci/mail-adapter-wiring-assertions.sh
+++ b/charts/curie/ci/mail-adapter-wiring-assertions.sh
@@ -1716,4 +1716,66 @@ python3 "$OTEL_EGRESS_PY" "$otel_disabled_dir" no 3 203.0.113.0/24 \
 python3 "$OTLP_IPBLOCK_PY" "$otel_disabled_dir" none - - 203.0.113.0/24 \
   || fail "with telemetry disabled the adapter exports nothing, so it must be granted no OTLP ipBlock peer at all; see the message above"
 
-echo "OK: mail-adapter chart wiring and build-path render assertions passed (23 assertions)"
+# 23l: a bracketed IPv6 endpoint WITH a port. Port extraction used to be
+#      skipped whenever the host contained "[", which left the URL port unseen,
+#      fell through to the https scheme default, and opened 443 while the SDK
+#      dialled 4318 -- a peer that looks configured and drops every export. The
+#      rule must be on 4318.
+otlp_v6_port_dir="$(render otlp-v6-port "${ON[@]}" "${CREDS[@]}" \
+  --set-string 'otelCollector.endpoint=https://[2001:db8::1]:4318' \
+  --set otelCollector.deploy=false \
+  --set 'otelCollector.egress[0].cidr=192.0.2.40/32' \
+  --set 'otelCollector.egress[0].ports[0].protocol=TCP' \
+  --set 'otelCollector.egress[0].ports[0].port=4318' \
+  --set-string 'mailAdapter.otelEgress.httpsCidrs[0]=2001:db8::1/128')"
+python3 "$OTLP_IPBLOCK_PY" "$otlp_v6_port_dir" rule 2001:db8::1/128 4318 203.0.113.0/24 \
+  || fail "a bracketed IPv6 OTLP endpoint that names a port must open THAT port, not the https scheme default; see the message above"
+
+# 23m: the same bracketed IPv6 endpoint with a DISAGREEING explicit port. The
+#      bracket skip also disabled the mismatch refusal, so this shape used to
+#      render silently. It must refuse, exactly as 23g does for a DNS host.
+assert_render_fails_naming_both \
+  "bracketed IPv6 endpoint port disagreeing with mailAdapter.otelEgress.port" \
+  "4318" \
+  "443" \
+  "${ON[@]}" "${CREDS[@]}" \
+  --set-string 'otelCollector.endpoint=https://[2001:db8::1]:4318' \
+  --set otelCollector.deploy=false \
+  --set 'otelCollector.egress[0].cidr=192.0.2.40/32' \
+  --set 'otelCollector.egress[0].ports[0].protocol=TCP' \
+  --set 'otelCollector.egress[0].ports[0].port=4318' \
+  --set-string mailAdapter.otelEgress.port=443 \
+  --set-string 'mailAdapter.otelEgress.httpsCidrs[0]=2001:db8::1/128'
+
+# 23n: a URL that omits its port still has a determined dial port. The mismatch
+#      check used to compare the explicit key against a ":port" SUBSTRING, so a
+#      portless https:// endpoint plus port=4318 passed unchallenged and opened
+#      4318 while the exporter connected to 443. Compare against the resolved
+#      dial port instead, and name both numbers.
+assert_render_fails_naming_both \
+  "explicit port against a portless https endpoint dialled on its scheme default" \
+  "4318" \
+  "443" \
+  "${ON[@]}" "${CREDS[@]}" \
+  --set otelCollector.deploy=false \
+  --set otelCollector.endpoint=https://otel.example.com \
+  --set 'otelCollector.egress[0].cidr=192.0.2.40/32' \
+  --set 'otelCollector.egress[0].ports[0].protocol=TCP' \
+  --set 'otelCollector.egress[0].ports[0].port=4318' \
+  --set-string mailAdapter.otelEgress.port=4318 \
+  --set 'mailAdapter.otelEgress.httpsCidrs[0]=192.0.2.40/32'
+
+# 23o: a stale CIDR left behind on a release that exports NOTHING. Both the
+#      in-chart and the disabled release are "not external", but only one of
+#      them has a pod-selector rule; curie.otel.validate forbids
+#      telemetryDisabled with deploy=true, so quoting that rule here names a
+#      rule that was never rendered. The remedy must say nothing is exported.
+assert_render_fails_named \
+  "telemetryDisabled with a stale mailAdapter.otelEgress.httpsCidrs" \
+  "exports nothing at all" \
+  "${ON[@]}" "${CREDS[@]}" \
+  --set otelCollector.telemetryDisabled=true \
+  --set otelCollector.deploy=false \
+  --set 'mailAdapter.otelEgress.httpsCidrs[0]=192.0.2.40/32'
+
+echo "OK: mail-adapter chart wiring and build-path render assertions passed (27 assertions)"

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -1264,23 +1264,38 @@ true
 {{- $parsed := urlParse $endpoint -}}
 {{- $hostPort := $parsed.host | default "" -}}
 {{- $scheme := lower ($parsed.scheme | default "") -}}
-{{- $urlPort := "" -}}
-{{- if not (contains "[" $hostPort) -}}
-{{- $urlPort = trimPrefix ":" (regexFind ":[0-9]+$" $hostPort) -}}
+{{/* A bracketed IPv6 host is NOT skipped here, which is the opposite of
+     curie.endpoint.host: that helper leaves brackets intact because such a host
+     is never in-chart Service DNS, whereas this helper must still find the
+     port. ":[0-9]+$" is safe on a literal address because a bare bracketed host
+     ends in "]" -- only a real port can follow the closing bracket, so a hextet
+     is never mistaken for one. Skipping brackets instead left $urlPort empty,
+     fell through to the scheme default, and opened 443 while the SDK dialled
+     the port the URL actually named. */}}
+{{- $urlPort := trimPrefix ":" (regexFind ":[0-9]+$" $hostPort) -}}
+{{/* The port the SDK will actually dial, whether or not the URL writes it: a
+     portless https:// endpoint is dialled on 443 just as definitely as an
+     explicit :4318. The explicit key is compared against THIS, not against the
+     presence of a ":port" substring -- otherwise an explicit 4318 beside a
+     portless https:// URL passed unchallenged and rendered a 4318 peer for a
+     443 dial. */}}
+{{- $dialPort := $urlPort -}}
+{{- if not $dialPort -}}
+{{- if eq $scheme "https" -}}
+{{- $dialPort = "443" -}}
+{{- else if eq $scheme "http" -}}
+{{- $dialPort = "80" -}}
+{{- end -}}
 {{- end -}}
 {{- $explicit := trim (printf "%v" (.Values.mailAdapter.otelEgress.port | default "")) -}}
 {{- $port := "" -}}
 {{- if $explicit -}}
-{{- if and $urlPort (regexMatch "^[0-9]+$" $explicit) (ne (int $explicit) (int $urlPort)) -}}
-{{- fail (printf "mailAdapter.otelEgress.port is %s but the resolved OTLP endpoint %s already names port %s. Set one of them, or make them agree: opening %s while the collector listens on %s renders a peer that looks configured and still drops every export." $explicit $endpoint $urlPort $explicit $urlPort) -}}
+{{- if and $dialPort (regexMatch "^[0-9]+$" $explicit) (ne (int $explicit) (int $dialPort)) -}}
+{{- fail (printf "mailAdapter.otelEgress.port is %s but the OTLP endpoint %s is dialed on port %s (the port its URL names, or the scheme default when the URL names none). Set one of them, or make them agree: opening %s while the exporter connects to %s renders a peer that looks configured and still drops every export." $explicit $endpoint $dialPort $explicit $dialPort) -}}
 {{- end -}}
 {{- $port = $explicit -}}
-{{- else if $urlPort -}}
-{{- $port = $urlPort -}}
-{{- else if eq $scheme "https" -}}
-{{- $port = "443" -}}
-{{- else if eq $scheme "http" -}}
-{{- $port = "80" -}}
+{{- else -}}
+{{- $port = $dialPort -}}
 {{- end -}}
 {{- if or (not (regexMatch "^[0-9]+$" $port)) (lt (int $port) 1) (gt (int $port) 65535) -}}
 {{- fail (printf "mailAdapter.otelEgress.port must be an integer from 1 through 65535, or empty to derive it from the resolved OTLP endpoint %s" $endpoint) -}}

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -1223,6 +1223,71 @@ true
 {{- end -}}
 {{- end -}}
 
+{{/* OTLP URL the mail adapter actually dials (#2361). The adapter passes
+     curie.env.otel an EMPTY extraEnv list on purpose -- there is no
+     mailAdapter.extraEnv key, so this pod cannot be repointed independently --
+     which makes its effective endpoint exactly curie.otel.endpoint. That is
+     written as its own named helper anyway: the reason is then recorded next to
+     the runner's equivalent, and if a mailAdapter.extraEnv surface is ever
+     accepted there is one place to teach it rather than a bare
+     curie.otel.endpoint include scattered through the template. */}}
+{{- define "curie.mailAdapter.effectiveOtlpEndpoint" -}}
+{{- include "curie.otel.endpoint" . | trim -}}
+{{- end -}}
+
+{{/* True when the adapter's effective endpoint is one the rendered in-chart
+     collector peer does NOT cover (#2361). Deliberately keyed off deploy AND
+     the host, not the host alone: otelCollector.deploy=false with an endpoint
+     that still names this release's collector Service is the dangerous leftover
+     shape -- the host looks in-chart while no such pod exists, so the
+     pod-selector rule the adapter would otherwise get selects nothing. Empty
+     endpoint (telemetry disabled, or no-endpoint mode) exports nothing and is
+     therefore not external: it needs no peer at all. */}}
+{{- define "curie.mailAdapter.otlpIsExternal" -}}
+{{- $url := include "curie.mailAdapter.effectiveOtlpEndpoint" . | trim -}}
+{{- if empty $url -}}
+{{- else if and .Values.otelCollector.deploy (include "curie.host.inChartService" (dict "root" . "host" (include "curie.endpoint.host" $url) "component" "otel-collector")) -}}
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/* TCP port the adapter's external-OTLP ipBlock rule opens (#2361).
+     Precedence: an explicit mailAdapter.otelEgress.port, else the port the
+     endpoint URL names, else the scheme default. A rule on the wrong port looks
+     configured and still drops every export, so a disagreement between the two
+     operator statements is refused rather than resolved by picking a winner --
+     whichever lost would have been discarded silently. Only meaningful, and
+     only included, on the external path. */}}
+{{- define "curie.mailAdapter.otelEgressPort" -}}
+{{- $endpoint := include "curie.mailAdapter.effectiveOtlpEndpoint" . | trim -}}
+{{- $parsed := urlParse $endpoint -}}
+{{- $hostPort := $parsed.host | default "" -}}
+{{- $scheme := lower ($parsed.scheme | default "") -}}
+{{- $urlPort := "" -}}
+{{- if not (contains "[" $hostPort) -}}
+{{- $urlPort = trimPrefix ":" (regexFind ":[0-9]+$" $hostPort) -}}
+{{- end -}}
+{{- $explicit := trim (printf "%v" (.Values.mailAdapter.otelEgress.port | default "")) -}}
+{{- $port := "" -}}
+{{- if $explicit -}}
+{{- if and $urlPort (regexMatch "^[0-9]+$" $explicit) (ne (int $explicit) (int $urlPort)) -}}
+{{- fail (printf "mailAdapter.otelEgress.port is %s but the resolved OTLP endpoint %s already names port %s. Set one of them, or make them agree: opening %s while the collector listens on %s renders a peer that looks configured and still drops every export." $explicit $endpoint $urlPort $explicit $urlPort) -}}
+{{- end -}}
+{{- $port = $explicit -}}
+{{- else if $urlPort -}}
+{{- $port = $urlPort -}}
+{{- else if eq $scheme "https" -}}
+{{- $port = "443" -}}
+{{- else if eq $scheme "http" -}}
+{{- $port = "80" -}}
+{{- end -}}
+{{- if or (not (regexMatch "^[0-9]+$" $port)) (lt (int $port) 1) (gt (int $port) 65535) -}}
+{{- fail (printf "mailAdapter.otelEgress.port must be an integer from 1 through 65535, or empty to derive it from the resolved OTLP endpoint %s" $endpoint) -}}
+{{- end -}}
+{{- $port -}}
+{{- end -}}
+
 {{/* Coalesce the worker's chart-managed egress credentials and the first-party
      mail adapter's chart-managed paired credential. The chart Secret and the
      worker rollout checksum must use this same rendered JSON so a rotation

--- a/charts/curie/templates/mail-adapter.yaml
+++ b/charts/curie/templates/mail-adapter.yaml
@@ -146,7 +146,17 @@ list order or an exact string comparison.
   {{- $otelPort = include "curie.mailAdapter.otelEgressPort" . | trim }}
 {{- else }}
   {{- if .Values.mailAdapter.otelEgress.httpsCidrs }}
+  {{- /* Not-external covers two unrelated releases, and one remedy for both
+       mis-diagnoses one of them: an empty effective endpoint (telemetry
+       disabled, or deploy=false with no endpoint) has no in-chart collector at
+       all -- curie.otel.validate forbids telemetryDisabled with deploy=true --
+       so telling that operator a pod-selector rule covers their export names a
+       rule that was never rendered. Each case gets its own true remedy. */}}
+  {{- if include "curie.mailAdapter.effectiveOtlpEndpoint" . | trim }}
   {{- fail "mailAdapter.otelEgress.httpsCidrs is set, but the key is only read when this release's effective OTLP endpoint is external. This release exports to its own in-chart collector, and egress to it is governed by the rendered pod-selector rule -- these CIDRs would be silently ignored, leaving an operator believing a peer exists. Clear mailAdapter.otelEgress.httpsCidrs, or point the release at an external collector with otelCollector.deploy=false and otelCollector.endpoint." }}
+  {{- else }}
+  {{- fail "mailAdapter.otelEgress.httpsCidrs is set, but this release exports nothing at all: its effective OTLP endpoint is empty, so there is no collector -- in-chart or external -- for these CIDRs to reach, and no peer to declare. They would be silently ignored. Clear mailAdapter.otelEgress.httpsCidrs, or configure a collector to export to (otelCollector.deploy=true, or otelCollector.deploy=false with otelCollector.endpoint set) and declare its narrow IP range here." }}
+  {{- end }}
   {{- end }}
 {{- end }}
 {{/*
@@ -443,7 +453,14 @@ spec:
       ports:
         - { protocol: TCP, port: {{ .Values.otelCollector.service.grpcPort }} }
         - { protocol: TCP, port: {{ .Values.otelCollector.service.httpPort }} }
-    {{- end }}
+    {{- else }}
+    {{- /* The external peer is the ELSE of the in-chart gate, not a sibling
+         `if`: as siblings the #2317 class guard read this file as a .deploy
+         carve-out with no BYO branch and needed an exemption, so deleting the
+         rule below would have restored the silent drop with the suite still
+         green. The inner gate keeps the two peers mutually exclusive -- a
+         release that exports nowhere (empty effective endpoint) lands here and
+         correctly renders neither. */}}
     {{- if $otelExternal }}
     # An external collector has no in-chart pod labels to select, and
     # NetworkPolicy cannot resolve its DNS name, so the operator declares its
@@ -457,5 +474,6 @@ spec:
         {{- end }}
       ports:
         - { protocol: TCP, port: {{ $otelPort | int }} }
+    {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/curie/templates/mail-adapter.yaml
+++ b/charts/curie/templates/mail-adapter.yaml
@@ -127,6 +127,28 @@ list order or an exact string comparison.
   {{- fail "mailAdapter.apiEgress.port must be an integer from 1 through 65535" }}
   {{- end }}
 {{- end }}
+{{- /* The adapter is the only first-party workload with an egress-restricting
+     policy, so it is the only one whose OTLP export its own rail can drop
+     while api/dispatcher/worker keep exporting from the same rendered env
+     (#2361). Resolve the endpoint it actually dials, and either select the
+     in-chart collector by pod label or require an operator-declared IP peer;
+     never both, and never neither. */}}
+{{- $otelCidrs := list }}
+{{- $otelExternal := include "curie.mailAdapter.otlpIsExternal" . | trim }}
+{{- $otelPort := "" }}
+{{- if $otelExternal }}
+  {{- if not .Values.mailAdapter.otelEgress.httpsCidrs }}
+  {{- fail (printf "This release's effective OTLP endpoint is %s, which is not this release's in-chart collector, so set at least one narrow mailAdapter.otelEgress.httpsCidrs entry reaching it. The mail adapter is the only first-party workload with an egress policy, so with no peer for that address its every span, metric and log is dropped by its own rail while api, dispatcher and worker keep exporting and the rendered env still looks correct. NetworkPolicy cannot target a DNS name, so the chart cannot derive this peer from the endpoint; declare the collector's narrow IP range (or that of a controlled egress proxy). To deliberately accept an unobservable release instead, set otelCollector.telemetryDisabled=true." (include "curie.mailAdapter.effectiveOtlpEndpoint" .)) }}
+  {{- end }}
+  {{- range .Values.mailAdapter.otelEgress.httpsCidrs }}
+  {{- $otelCidrs = append $otelCidrs (include "curie.mailAdapter.narrowCidr" (dict "key" "mailAdapter.otelEgress.httpsCidrs" "cidr" .) | trim) }}
+  {{- end }}
+  {{- $otelPort = include "curie.mailAdapter.otelEgressPort" . | trim }}
+{{- else }}
+  {{- if .Values.mailAdapter.otelEgress.httpsCidrs }}
+  {{- fail "mailAdapter.otelEgress.httpsCidrs is set, but the key is only read when this release's effective OTLP endpoint is external. This release exports to its own in-chart collector, and egress to it is governed by the rendered pod-selector rule -- these CIDRs would be silently ignored, leaving an operator believing a peer exists. Clear mailAdapter.otelEgress.httpsCidrs, or point the release at an external collector with otelCollector.deploy=false and otelCollector.endpoint." }}
+  {{- end }}
+{{- end }}
 {{/*
 The first-party email channel (#1515): the adapter polls an AgentMail inbox,
 posts each allowed message to the platform as a turn, and replies on the same
@@ -343,9 +365,12 @@ spec:
 # otelCollector.deploy is true -- this release's collector. Read the rules
 # below for the current set rather than trusting a count in prose.
 #
-# With otelCollector.deploy false and an external otelCollector.endpoint set,
-# this policy has no peer for that address and OTLP export is dropped; see
-# charts/curie/README.md for the operator remedy.
+# The collector destination is fail-closed rather than documented (#2361): when
+# the release's effective OTLP endpoint is this release's in-chart collector the
+# peer is the pod-selector rule below, and when it is anything else the operator
+# must declare mailAdapter.otelEgress.httpsCidrs or the render is refused. The
+# two are mutually exclusive; an unobservable adapter is reachable only through
+# otelCollector.telemetryDisabled=true, which leaves nothing to export.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -400,7 +425,7 @@ spec:
         {{- end }}
       ports:
         - { protocol: TCP, port: 443 }
-    {{- if .Values.otelCollector.deploy }}
+    {{- if and .Values.otelCollector.deploy (not $otelExternal) }}
     # This release's in-chart OTel Collector. The adapter is the only
     # first-party service with an egress policy, so unlike api/dispatcher/worker
     # it needs an explicit peer or every OTLP export is dropped by this rail
@@ -418,5 +443,19 @@ spec:
       ports:
         - { protocol: TCP, port: {{ .Values.otelCollector.service.grpcPort }} }
         - { protocol: TCP, port: {{ .Values.otelCollector.service.httpPort }} }
+    {{- end }}
+    {{- if $otelExternal }}
+    # An external collector has no in-chart pod labels to select, and
+    # NetworkPolicy cannot resolve its DNS name, so the operator declares its
+    # narrow IP peer at render time -- the same shape as the BYO API rule above.
+    # One rule, on the port resolved from mailAdapter.otelEgress.port or the
+    # endpoint URL, so this stays the complete list of what the pod may reach.
+    - to:
+        {{- range $otelCidrs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      ports:
+        - { protocol: TCP, port: {{ $otelPort | int }} }
     {{- end }}
 {{- end }}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -1392,6 +1392,21 @@ mailAdapter:
   apiEgress:
     httpsCidrs: []
     port: 8000
+  # NetworkPolicy peer for the collector this release exports to. This block is
+  # ignored while that effective OTLP endpoint is this release's own in-chart
+  # collector, which the policy selects by pod label; setting it then fails the
+  # render rather than being silently ignored. When the endpoint is external
+  # (otelCollector.deploy=false with an otelCollector.endpoint, including one
+  # that still names the in-chart Service), at least one narrow CIDR is
+  # required -- the adapter is the only first-party workload under an egress
+  # policy, so without a peer its telemetry is dropped by its own rail. Entries
+  # go through the same narrow-CIDR rule as the AgentMail and BYO-API lists, so
+  # default routes and /1 halves are refused. An empty port derives from the
+  # endpoint URL (its explicit port, else 443 for https and 80 for http); an
+  # explicit port that disagrees with the URL fails the render.
+  otelEgress:
+    httpsCidrs: []
+    port: ""
   image:
     repository: ghcr.io/curie-eng/curie-mail-adapter
     # Empty -> chart appVersion (immutable). Set to pin an explicit version tag.

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -816,10 +816,18 @@ otelCollector:
   #
   # One asymmetry an operator hits here: the mail adapter is the only
   # first-party service with its own egress NetworkPolicy, and that policy has
-  # no peer for an external endpoint (an address the chart cannot know). An
-  # install using this key with mailAdapter.deploy true needs an operator-
-  # supplied egress policy selecting the adapter, or its exports are dropped
-  # while every other workload's succeed.
+  # no peer for an external endpoint (an address the chart cannot know). With
+  # mailAdapter.deploy true, setting this key to an external endpoint (or
+  # leaving deploy false with the in-chart Service named here) now REQUIRES
+  # mailAdapter.otelEgress.httpsCidrs -- the render is refused without it,
+  # rather than silently dropping the adapter's exports. Upgrade note: a
+  # currently-green install with mailAdapter.deploy=true,
+  # otelCollector.deploy=false and an external endpoint becomes un-renderable
+  # until mailAdapter.otelEgress.httpsCidrs is set; an operator who previously
+  # worked around this by hand-applying an extra NetworkPolicy for the adapter
+  # will hit that refusal on the next helm upgrade. The break is intentional
+  # (fail-closed). Set otelCollector.telemetryDisabled=true to deliberately
+  # accept an unobservable release instead.
   endpoint: ""
   # Runner sandbox egress to an external collector endpoint (#2317, #2367).
   # Rail 1 is fail-closed. The in-chart runner-allow-collector policy selects

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -722,6 +722,7 @@ mailAdapter:
 | `mailAdapter.agentmail.apiKeyExistingSecret` / `apiKeyExistingSecretKey` | Source the AgentMail API key from an operator-managed Secret instead of the chart Secret (default key `mailAgentmailApiKey`). |
 | `mailAdapter.agentmail.httpsCidrs` | Required provider/proxy destination CIDRs on TCP 443. The mail pod's egress policy otherwise allows only DNS and this release's API pods. |
 | `mailAdapter.apiEgress.httpsCidrs` / `port` | Required narrow destination peers when `api.deploy=false`; default port `8000`. Ignored for the in-chart API, whose pod selector and service port are used instead. |
+| `mailAdapter.otelEgress.httpsCidrs` / `port` | Required narrow destination peers when the release's effective OTLP endpoint is external (`otelCollector.deploy=false` with `otelCollector.endpoint` set); the render is refused without it. `port` is optional and derives from the endpoint URL. Ignored for the in-chart collector, whose pod selector is used instead. |
 | `mailAdapter.persistence.size` / `storageClass` | Chart-managed RWO SQLite PVC. The default size is `1Gi`; empty storage class inherits `global.storageClass` and then the cluster default. |
 | `mailAdapter.persistence.existingClaim` | Mount an existing same-namespace RWO Filesystem PVC instead of rendering one. An install/upgrade hook checks the exact claim before replacing the pod. |
 

--- a/scripts/check-mail-adapter-otel-egress.sh
+++ b/scripts/check-mail-adapter-otel-egress.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# Assert the mail adapter's EXTERNAL OTel collector egress rule (#2361) actually
+# ENFORCES, not merely that it renders.
+#
+# The mail adapter is the only first-party workload the chart gives an egress
+# NetworkPolicy at all, so it is the only one whose own rail can silently drop
+# its OTLP export. With `otelCollector.deploy` false and an external
+# `otelCollector.endpoint`, that export leaves the cluster to an address the
+# chart cannot know, so the operator declares it as
+# `mailAdapter.otelEgress.httpsCidrs` and the template renders one ipBlock peer.
+#
+# A render assertion cannot prove that rule. Every NetworkPolicy this chart ships
+# is applied on any cluster; whether it is EVALUATED depends on the CNI. kindnet
+# (kind's default) and minikube's default bridge implement no NetworkPolicy
+# controller, so an ipBlock on the wrong port -- or one deleted outright -- is
+# indistinguishable from a correct one: everything gets through and every
+# "can the adapter reach the collector?" assertion passes.
+#
+# So, like scripts/check-netpol-enforcement.sh, this is a NON-VACUITY check. It
+# asserts an UNDECLARED peer is genuinely blocked BEFORE trusting the declared
+# one. If the deny does not hold, the CNI is not enforcing (or the policy is
+# broader than declared) and the script FAILS -- it does not skip and it does not
+# pass. A green run on a non-enforcing cluster would be worse than no check at
+# all, because it reads as proof that AC5 holds.
+set -euo pipefail
+
+CHART="${1:-${CURIE_MAIL_OTEL_CHART:-charts/curie}}"
+# Its OWN namespace, never the release's. The probe pods below wear whatever
+# labels the rendered policy selects, which are the real mail-adapter labels --
+# dropped into an installed release's namespace they would collide with the
+# actual adapter pod and the policy under test would bind two workloads at once.
+NS="${2:-${CURIE_MAIL_OTEL_NS:-curie-mail-otel-egress}}"
+PROBE_IMAGE="${CURIE_MAIL_OTEL_PROBE_IMAGE:-curlimages/curl:8.10.1}"
+# The peers must actually LISTEN, so a blocked attempt is a timeout rather than
+# an ambiguous connection-refused that a missing listener would also give.
+TARGET_IMAGE="${CURIE_MAIL_OTEL_TARGET_IMAGE:-hashicorp/http-echo:1.0}"
+# One port for both the listeners and the rendered `mailAdapter.otelEgress.port`,
+# so a mismatch between the declared port and the reachable one is a FAILURE of
+# this check rather than something it papers over.
+PORT="${CURIE_MAIL_OTEL_PORT:-5678}"
+
+ALLOWED_POD="mail-otel-target-allowed"
+UNDECLARED_POD="mail-otel-target-undeclared"
+PROBE_POD="mail-otel-probe"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Non-blocking on the way out: the run is over, nothing waits on the pods.
+# The pods are deleted; $NS itself deliberately is NOT. Deleting a namespace
+# from a non-blocking trap leaves it Terminating for tens of seconds, and a
+# Terminating namespace REJECTS creates -- so the next run would fail on
+# namespace creation for reasons that have nothing to do with policy. That is
+# the same race cleanup_and_settle exists to avoid, one level up. An empty
+# namespace is inert; the pods and the policy are what must not leak.
+cleanup() {
+  kubectl -n "$NS" delete pod "$ALLOWED_POD" "$UNDECLARED_POD" "$PROBE_POD" \
+    --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  kubectl -n "$NS" delete networkpolicy -l "curie.dev/check=mail-adapter-otel-egress" \
+    --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+# BLOCKING before the apply. A previous run's pod may still be terminating, and
+# re-applying the same name against a deleting pod silently binds the OLD one --
+# `wait --for=Ready` then passes on a pod that is on its way out and every exec
+# after it fails for reasons that have nothing to do with policy.
+cleanup_and_settle() {
+  kubectl -n "$NS" delete pod "$ALLOWED_POD" "$UNDECLARED_POD" "$PROBE_POD" \
+    --ignore-not-found --wait=true --timeout=90s >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "== mail-adapter external-collector egress enforcement check (namespace=$NS chart=$CHART port=$PORT) =="
+
+command -v helm >/dev/null 2>&1 || fail "helm is required to render the policy under test"
+
+# Re-check existence after a failed create rather than trusting the create's exit
+# status: two runs against one cluster both miss on `get`, one create wins, and
+# the loser hard-fails on AlreadyExists for a namespace that by then exists and
+# is perfectly usable.
+kubectl get namespace "$NS" >/dev/null 2>&1 \
+  || kubectl create namespace "$NS" >/dev/null 2>&1 \
+  || kubectl get namespace "$NS" >/dev/null 2>&1 \
+  || fail "could not create namespace $NS for the mail-adapter egress probe.
+
+Creating it needs cluster-scoped RBAC to get and create namespaces. Grant that,
+or set CURIE_MAIL_OTEL_NS to an existing namespace you may write pods and
+NetworkPolicies into -- but NOT to a namespace holding a real curie release, or
+the probe pod's labels would collide with the live mail adapter."
+
+cleanup_and_settle
+
+# Two listeners, identical in image, port, namespace and labels. The ONLY
+# difference between them is whether their /32 is named in the declared list, so
+# a difference in reachability is attributable to the ipBlock and to nothing
+# else. Anything that made them differ otherwise -- a distinct port, a label the
+# policy happens to select -- would let a broken rule still produce the expected
+# blocked/reachable pair.
+kubectl -n "$NS" apply -f - >/dev/null <<YAML
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $ALLOWED_POD
+  labels:
+    app.kubernetes.io/name: mail-otel-target
+spec:
+  restartPolicy: Never
+  containers:
+    - name: target
+      image: $TARGET_IMAGE
+      args: ["-listen=:$PORT", "-text=allowed"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $UNDECLARED_POD
+  labels:
+    app.kubernetes.io/name: mail-otel-target
+spec:
+  restartPolicy: Never
+  containers:
+    - name: target
+      image: $TARGET_IMAGE
+      args: ["-listen=:$PORT", "-text=undeclared"]
+YAML
+
+kubectl -n "$NS" wait --for=condition=Ready \
+  "pod/$ALLOWED_POD" "pod/$UNDECLARED_POD" --timeout=180s >/dev/null \
+  || fail "the collector-stand-in pods did not become ready in $NS"
+
+ALLOWED_IP="$(kubectl -n "$NS" get pod "$ALLOWED_POD" -o jsonpath='{.status.podIP}')"
+UNDECLARED_IP="$(kubectl -n "$NS" get pod "$UNDECLARED_POD" -o jsonpath='{.status.podIP}')"
+[ -n "$ALLOWED_IP" ] || fail "could not read the declared peer's pod IP"
+[ -n "$UNDECLARED_IP" ] || fail "could not read the undeclared peer's pod IP"
+# Equal IPs would make the two probes the same probe: the negative leg would be
+# testing the very address the positive leg declares, so one of the two must be
+# wrong and yet the pair could still read as green.
+[ "$ALLOWED_IP" != "$UNDECLARED_IP" ] \
+  || fail "both collector stand-ins report the same pod IP ($ALLOWED_IP); this check cannot distinguish declared from undeclared"
+echo "  ok  declared peer $ALLOWED_IP, undeclared peer $UNDECLARED_IP"
+
+# Render ONLY the mail adapter's own template from the REAL chart. Rendering the
+# shipped template rather than hand-writing a policy is the point: this proves
+# what the chart produces, so deleting the ipBlock rule or moving it to the wrong
+# port makes this check go red.
+#
+# `otelCollector.deploy=false` plus an external `otelCollector.endpoint` is the
+# exact configuration #2361 exists for -- the in-chart collector peer is gone and
+# the ipBlock is the only thing that can carry the export.
+#
+# The `otelCollector.egress[0]` triple is UNRELATED to the policy under test. It
+# is the RUNNER's BYO-collector peer, demanded by the pre-existing #2317 gate in
+# templates/security-networkpolicy.yaml, which refuses to render at all when an
+# external endpoint is configured with no runner-side peer. It is set here only
+# so the render succeeds; only `mailAdapter.otelEgress.*` governs the mail
+# adapter's rule.
+POLICY="$(helm template curie "$CHART" -n "$NS" \
+  --set mailAdapter.deploy=true \
+  --set mailAdapter.agentmail.apiKey=check-mail-otel-egress-key \
+  --set mailAdapter.agentmail.inboxId=probe@example.test \
+  --set mailAdapter.egressSecret=check-mail-otel-egress-secret \
+  --set mailAdapter.channelToken=check-mail-otel-egress-token \
+  --set 'mailAdapter.agentmail.httpsCidrs[0]=203.0.113.0/24' \
+  --set otelCollector.deploy=false \
+  --set "otelCollector.endpoint=https://otel.example.test:$PORT" \
+  --set 'otelCollector.egress[0].cidr=192.0.2.40/32' \
+  --set 'otelCollector.egress[0].ports[0].protocol=TCP' \
+  --set "otelCollector.egress[0].ports[0].port=$PORT" \
+  --set "mailAdapter.otelEgress.httpsCidrs[0]=$ALLOWED_IP/32" \
+  --set-string "mailAdapter.otelEgress.port=$PORT" \
+  --show-only templates/mail-adapter.yaml \
+  | python3 -c '
+import sys, yaml
+docs = [d for d in yaml.safe_load_all(sys.stdin) if isinstance(d, dict)]
+pols = [d for d in docs if d.get("kind") == "NetworkPolicy"]
+if len(pols) != 1:
+    sys.exit(f"expected exactly 1 NetworkPolicy from templates/mail-adapter.yaml, got {len(pols)}")
+p = pols[0]
+p.setdefault("metadata", {}).setdefault("labels", {})["curie.dev/check"] = "mail-adapter-otel-egress"
+print(yaml.safe_dump(p))')" \
+  || fail "rendering templates/mail-adapter.yaml failed; the check cannot proceed without the policy under test"
+[ -n "$POLICY" ] || fail "templates/mail-adapter.yaml rendered no NetworkPolicy"
+
+# ---------------------------------------------------------------------------
+# STRUCTURAL VACUITY GUARD, before a single packet is sent.
+# ---------------------------------------------------------------------------
+# A policy that allowed everything would sail through the positive probe and
+# would only be caught by the negative one -- and the negative one is also what
+# catches a non-enforcing CNI, so the two failure modes would be
+# indistinguishable. Asserting the shape first separates them: past this point a
+# reachable undeclared peer means the CNI, not the rule.
+echo "$POLICY" | grep -q -- "$ALLOWED_IP/32" \
+  || fail "the rendered policy does not carry the declared peer $ALLOWED_IP/32.
+
+mailAdapter.otelEgress.httpsCidrs was set and the template did not turn it into
+an ipBlock. The probes below would then be testing a rule that does not exist."
+if echo "$POLICY" | grep -q -- "$UNDECLARED_IP"; then
+  fail "the rendered policy names the UNDECLARED peer $UNDECLARED_IP.
+
+Whatever produced that, the negative leg is no longer a negative leg, so a
+blocked/reachable pair below would prove nothing about the declared list."
+fi
+echo "  ok  rendered policy carries the declared peer and not the undeclared one"
+
+kubectl -n "$NS" apply -f - >/dev/null <<<"$POLICY" \
+  || fail "could not apply the rendered mail-adapter policy into $NS"
+
+# The probe wears exactly the labels the rendered policy selects, DERIVED from
+# the policy rather than hardcoded. Hardcoding them would silently decouple this
+# check from the chart: a rename in the template's podSelector would leave the
+# probe unselected, the policy would bind nothing, both peers would answer, and
+# the negative leg would report a non-enforcing CNI on a perfectly good cluster.
+SELECTOR="$(echo "$POLICY" | python3 -c '
+import sys, yaml
+p = yaml.safe_load(sys.stdin)
+ml = (p.get("spec", {}).get("podSelector", {}) or {}).get("matchLabels") or {}
+if not ml:
+    sys.exit("the rendered policy has no podSelector.matchLabels; it would select every pod in the namespace")
+print(",".join(f"{k}={v}" for k, v in ml.items()))')" \
+  || fail "could not derive the probe labels from the rendered policy's podSelector"
+echo "  ok  probe labels derived from the policy podSelector: $SELECTOR"
+
+kubectl -n "$NS" run "$PROBE_POD" --image="$PROBE_IMAGE" --restart=Never \
+  --labels="$SELECTOR" --command -- sleep 600 >/dev/null \
+  || fail "could not create the probe pod $PROBE_POD in $NS"
+kubectl -n "$NS" wait --for=condition=Ready "pod/$PROBE_POD" --timeout=180s >/dev/null \
+  || fail "the probe pod did not become ready in $NS"
+
+# `|| true` so a curl exit code never aborts the script under `set -e`: the exit
+# code is the measurement here, not an error.
+probe() {
+  kubectl -n "$NS" exec "$PROBE_POD" -- \
+    curl -sS -m 8 -o /dev/null -w '%{http_code}' "http://${1}:${PORT}/" 2>&1 || true
+}
+
+# ---------------------------------------------------------------------------
+# GATE: the deny must hold. The positive below is meaningless without this.
+# ---------------------------------------------------------------------------
+NEG="$(probe "$UNDECLARED_IP")"
+case "$NEG" in
+  *"timed out"*|*"Failed to connect"*|*"Connection timed out"*|000) ;;
+  *)
+    fail "the UNDECLARED peer $UNDECLARED_IP:$PORT answered ($NEG).
+
+It is byte-for-byte the same workload as the declared peer except that its /32
+is not in mailAdapter.otelEgress.httpsCidrs, so reaching it means one of:
+
+  - the CNI is not enforcing NetworkPolicy at all. kind needs
+    'disableDefaultCNI: true' plus a policy-enforcing CNI (the default kindnet
+    implements no NetworkPolicy controller); minikube needs '--cni=calico';
+    k3s/k3d enforce by default via kube-router.
+  - the rendered policy is BROADER than the declared list -- a wider ipBlock, a
+    second peer, or an empty 'to' -- so the mail adapter can export to addresses
+    the operator never declared.
+
+Either way a green positive after this would prove nothing, which is the exact
+false proof this check exists to prevent (#2361)."
+    ;;
+esac
+echo "  ok  undeclared peer is blocked -- the CNI enforces this policy (non-vacuity gate)"
+
+# ---------------------------------------------------------------------------
+# Now the allow direction means something.
+# ---------------------------------------------------------------------------
+POS="$(probe "$ALLOWED_IP")"
+[ "$POS" = "200" ] \
+  || fail "the DECLARED peer $ALLOWED_IP/32 on TCP $PORT was NOT reachable (got '$POS').
+
+The undeclared peer above was correctly blocked, so the CNI is enforcing and
+this is a POLICY defect: the rendered ipBlock does not actually permit the
+export it claims to. The usual cause is the port -- the rule renders on
+mailAdapter.otelEgress.port, and a rule on the wrong port looks perfectly
+correct in a render assertion while dropping every OTLP span the adapter emits
+to an external collector (#2361)."
+echo "  ok  declared peer answers HTTP 200 on TCP $PORT"
+
+echo "== the mail adapter's external-collector egress rule enforces: undeclared peer blocked, declared peer reachable =="


### PR DESCRIPTION
The mail adapter is the only first-party workload the chart gives an egress-restricting
NetworkPolicy, so it is the only one that can silently drop its own OTLP export. #2331 gave it
a collector peer gated on `otelCollector.deploy` and **documented** the external-endpoint gap
rather than gating it — while the BYO-API case a couple of hundred lines above already **fails
closed**. An operator who set an external collector got a green install with one permanently
unobservable pod, which is precisely the failure mode this whole area exists to prevent.

This reverses that decision and makes the two cases symmetric.

## What changed

- New `mailAdapter.otelEgress.{httpsCidrs,port}`. When the release's **effective** OTLP endpoint
  is not this release's in-chart collector, at least one narrow CIDR is required or the render is
  refused, with a message naming the resolved endpoint, the key to set, and the
  `otelCollector.telemetryDisabled=true` escape for deliberately accepting an unobservable release.
- Entries go through the existing `curie.mailAdapter.narrowCidr` guard, so `/0` and `/1` peers
  still refuse. `port` is optional and derives from the endpoint URL; a port that disagrees with
  the port the exporter will actually dial is refused rather than silently resolved.
- **Effective endpoint, not `deploy=false`.** The `deploy=false` + in-chart-Service-DNS leftover
  shape counts as external too — the host looks in-chart while no such pod exists.
- Setting the key while the release exports to its in-chart collector (or exports nowhere at all)
  is also refused, so a stale key surfaces instead of being ignored. Each of those two cases gets
  its own accurate remedy.
- The in-chart pod-selector peer and the external ipBlock are mutually exclusive branches of one
  gate, so the pod never has both peers and never has none while it is still exporting.

Nothing widens: `otelCollector.egress`, `security.networkPolicy.allowedEgress`, the runner rails
and the #2367/#2368 helpers are untouched.

## Alternative weighed

The issue asked whether a render-time **warning** would be better than a hard `fail`, since an
operator may knowingly accept an unobservable adapter. Rejected: Helm has no warning channel —
a `printf` lands inside the rendered manifest stream, so it would be either invisible or a
corruption. The adjacent API gate chose `fail`, and `telemetryDisabled=true` already expresses
"I accept no telemetry" precisely.

## Upgrade impact (intentional)

A currently-green install with `mailAdapter.deploy=true`, `otelCollector.deploy=false` and an
external endpoint becomes un-renderable until the new key is set — including an operator who
applied the extra NetworkPolicy the old docs recommended. That break is the point of the ticket,
and it is now announced on the `otelCollector.endpoint` key itself rather than only in the
failure string. Default `mailAdapter.deploy` is false, so a default upgrade is unaffected.

## Verification

- `charts/curie/ci/mail-adapter-wiring-assertions.sh` — 27 assertions, up from 22. Covers adapter
  disabled, in-chart collector unchanged, stale key on the in-chart path, external endpoint with
  missing / valid / `0.0.0.0/0` / `128.0.0.0/1` peers, port mismatch and agreement, scheme-default
  443, bracketed IPv6 with and without a port, the in-chart-Service-DNS leftover, and
  `telemetryDisabled`. Structural YAML reads throughout, never grep.
- `byo-endpoint-egress-assertions.sh`, `object-store-byo-egress-assertions.sh`,
  `render-assertions.sh`, `helm lint` — all pass. The `DEPLOY_GATE_EXEMPTIONS` waiver for
  `mail-adapter.yaml:otelCollector` is **deleted**: the BYO branch is now the deploy gate's `else`,
  so the class-guard covers this file for real instead of being waived past it.
- **Enforcing-CNI proof**, since render evidence cannot prove connectivity:
  `scripts/check-mail-adapter-otel-egress.sh`, wired into the existing kind + Calico CI job beside
  the Rail 1 enforcement check. Negative-first, like its sibling: an undeclared peer must be
  blocked before the declared one is trusted, so a non-enforcing CNI fails the run rather than
  turning it green. Verified on a disposable kind + Calico v3.28.2 cluster — undeclared peer timed
  out, declared peer returned 200 — and **demonstrated rejecting a bad rule**: rendering the peer
  on the wrong port exits non-zero and correctly reports it as a policy defect, not a CNI one.

## Review

Cross-engine adversarial review (code, then scope) via `agent-router`. The code pass found five
real defects, all fixed in `56edaecb`: an IPv6 bracket skip that opened the scheme default while
the exporter dialled the URL's port, a mismatch check that never fired for a portless URL, a
failure message that mis-diagnosed a release exporting nowhere, the class-guard vacuity above, and
stale operator docs. The scope pass mapped every hunk to an AC and found the live proof was only a
gitignored transcript — that is what `831e352a` fixes.

Closes #2361
