### PR TITLE
Surface in-process supervised worker task restarts

### DIFF
--- a/apps/worker/src/curie_worker/publication_loop.py
+++ b/apps/worker/src/curie_worker/publication_loop.py
@@ -740,7 +740,15 @@ class PublicationReconcileLoop:
                 # error escaped. Publication mutation remains terminal and is
                 # never repeated because a reply transport is unavailable.
                 logger.exception("publication result delivery failed")
-            work = await self._store.claim_next()
+            try:
+                work = await self._store.claim_next()
+            except Exception as exc:
+                logger.exception(
+                    "publication claim_next failed cause=%s: %s",
+                    type(exc).__name__,
+                    exc,
+                )
+                raise
             if work is not None:
                 try:
                     await self._reconciler.reconcile(work)

--- a/apps/worker/src/curie_worker/run.py
+++ b/apps/worker/src/curie_worker/run.py
@@ -21,7 +21,7 @@ from typing import Any
 import httpx
 import redis
 from aci_protocol.s3 import build_s3_client
-from curie_telemetry import bootstrap_service_telemetry
+from curie_telemetry import bootstrap_service_telemetry, record_metric
 from redis.asyncio import Redis as AsyncRedis
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
@@ -483,6 +483,18 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
     )
 
 
+_SUPERVISED_OPERATIONS = frozenset(
+    {
+        "runs",
+        "killswitch",
+        "evals",
+        "heartbeat",
+        "connectors",
+        "publications",
+    }
+)
+
+
 async def _supervise(
     name: str,
     factory: Callable[[], Awaitable[None]],
@@ -503,15 +515,36 @@ async def _supervise(
 
     ``factory`` is a thunk (e.g. a bound ``run`` method) so each restart gets a
     fresh coroutine; ``run()`` is re-entrant (group creation is BUSYGROUP-safe).
+    Unknown task names map to catalog ``other`` so a test or new loop cannot
+    crash the supervisor by emitting an undeclared operation.
     """
     while not shutdown.is_set():
         try:
             await factory()
             return
-        except Exception:
+        except Exception as exc:
             if shutdown.is_set():
                 return
-            logger.exception("worker task %s crashed; restarting", name)
+            logger.exception(
+                "worker task %s crashed; restarting cause=%s: %s",
+                name,
+                type(exc).__name__,
+                exc,
+            )
+            try:
+                record_metric(
+                    "curie.worker.supervised.restart",
+                    1,
+                    attributes={
+                        "service.name": "curie-worker",
+                        "operation": (
+                            name if name in _SUPERVISED_OPERATIONS else "other"
+                        ),
+                        "outcome": "restart",
+                    },
+                )
+            except Exception:
+                logger.exception("worker task %s restart metric failed", name)
             try:
                 await asyncio.wait_for(shutdown.wait(), timeout=restart_backoff_s)
             except TimeoutError:

--- a/apps/worker/tests/test_publication_loop.py
+++ b/apps/worker/tests/test_publication_loop.py
@@ -1118,3 +1118,69 @@ async def test_cleanup_retries_beyond_result_cap_before_result_outbox_ack(
     assert PUBLICATION_ID in store.delivered
     assert cluster.terminals_cleaned
     assert PR_URL in replies.events[0][0].text
+
+
+async def test_claim_next_failure_names_the_cause_and_still_escapes(
+    publication: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    reconciler, store, *_ = _loop(publication)
+
+    async def boom() -> None:
+        raise RuntimeError("publication claim CAS was lost")
+
+    store.claim_next = boom
+    supervisor = publication.PublicationReconcileLoop(
+        store=store,
+        reconciler=reconciler,
+        interval_seconds=0.01,
+    )
+    shutdown = asyncio.Event()
+    with caplog.at_level(logging.ERROR, logger="curie_worker.publication_loop"):
+        with pytest.raises(RuntimeError, match="publication claim CAS was lost"):
+            await supervisor.run_forever(shutdown)
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "publication claim_next failed" in message
+        and "RuntimeError" in message
+        and "publication claim CAS was lost" in message
+        for message in messages
+    )
+
+
+async def test_idle_publication_loop_does_not_page(
+    publication: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    reconciler, store, *_ = _loop(publication)
+    shutdown = asyncio.Event()
+    claims = {"n": 0}
+    original = store.claim_next
+
+    async def idle_claim() -> None:
+        claims["n"] += 1
+        return await original()
+
+    store.claim_next = idle_claim
+
+    async def stop_after_one_interval() -> None:
+        while claims["n"] < 1:
+            await asyncio.sleep(0)
+        await asyncio.sleep(0.02)
+        shutdown.set()
+
+    supervisor = publication.PublicationReconcileLoop(
+        store=store,
+        reconciler=reconciler,
+        interval_seconds=0.01,
+    )
+    with caplog.at_level(logging.ERROR):
+        await asyncio.wait_for(
+            asyncio.gather(
+                supervisor.run_forever(shutdown),
+                stop_after_one_interval(),
+            ),
+            timeout=2,
+        )
+    assert claims["n"] >= 1
+    messages = [record.getMessage() for record in caplog.records]
+    assert not any("claim_next failed" in message for message in messages)
+    assert not any("crashed; restarting" in message for message in messages)

--- a/apps/worker/tests/test_run.py
+++ b/apps/worker/tests/test_run.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -580,6 +581,175 @@ def test_crashing_supervised_task_does_not_cancel_its_siblings() -> None:
 
         assert crashes["n"] == 3
         assert sibling_ran["ok"] is True
+
+    asyncio.run(go())
+
+
+def test_supervise_emits_restart_metric_and_cause_for_publications(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recorded: list[tuple[str, float, dict[str, str]]] = []
+
+    def capture(
+        name: str, value: float = 1, *, attributes: Mapping[str, str] | None = None
+    ) -> None:
+        recorded.append((name, value, dict(attributes or {})))
+
+    monkeypatch.setattr(run, "record_metric", capture)
+
+    async def go() -> None:
+        shutdown = asyncio.Event()
+        calls = {"n": 0}
+
+        async def factory() -> None:
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise RuntimeError("claim cas lost")
+            shutdown.set()
+
+        with caplog.at_level(logging.ERROR, logger="curie_worker.run"):
+            await asyncio.wait_for(
+                _supervise("publications", factory, shutdown, restart_backoff_s=0),
+                timeout=2,
+            )
+
+        assert calls["n"] == 3
+        expected = {
+            "service.name": "curie-worker",
+            "operation": "publications",
+            "outcome": "restart",
+        }
+        assert recorded == [
+            ("curie.worker.supervised.restart", 1, expected),
+            ("curie.worker.supervised.restart", 1, expected),
+        ]
+        restarts = [
+            r
+            for r in caplog.records
+            if r.name == "curie_worker.run" and "crashed; restarting" in r.getMessage()
+        ]
+        assert len(restarts) == 2
+        for rec in restarts:
+            message = rec.getMessage()
+            assert "publications" in message
+            assert "RuntimeError" in message
+            assert "claim cas lost" in message
+
+    asyncio.run(go())
+
+
+def test_supervise_emits_restart_metric_for_evals(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recorded: list[tuple[str, float, dict[str, str]]] = []
+
+    def capture(
+        name: str, value: float = 1, *, attributes: Mapping[str, str] | None = None
+    ) -> None:
+        recorded.append((name, value, dict(attributes or {})))
+
+    monkeypatch.setattr(run, "record_metric", capture)
+
+    async def go() -> None:
+        shutdown = asyncio.Event()
+        calls = {"n": 0}
+
+        async def factory() -> None:
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise RuntimeError("eval stream closed")
+            shutdown.set()
+
+        with caplog.at_level(logging.ERROR, logger="curie_worker.run"):
+            await asyncio.wait_for(
+                _supervise("evals", factory, shutdown, restart_backoff_s=0),
+                timeout=2,
+            )
+
+        assert calls["n"] == 3
+        expected = {
+            "service.name": "curie-worker",
+            "operation": "evals",
+            "outcome": "restart",
+        }
+        assert recorded == [
+            ("curie.worker.supervised.restart", 1, expected),
+            ("curie.worker.supervised.restart", 1, expected),
+        ]
+        restarts = [
+            r
+            for r in caplog.records
+            if r.name == "curie_worker.run" and "crashed; restarting" in r.getMessage()
+        ]
+        assert len(restarts) == 2
+        for rec in restarts:
+            message = rec.getMessage()
+            assert "evals" in message
+            assert "RuntimeError" in message
+            assert "eval stream closed" in message
+
+    asyncio.run(go())
+
+
+def test_supervise_idle_heartbeat_does_not_emit_restart(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recorded: list[tuple[str, float, dict[str, str]]] = []
+
+    def capture(
+        name: str, value: float = 1, *, attributes: Mapping[str, str] | None = None
+    ) -> None:
+        recorded.append((name, value, dict(attributes or {})))
+
+    monkeypatch.setattr(run, "record_metric", capture)
+
+    async def go() -> None:
+        shutdown = asyncio.Event()
+
+        async def factory() -> None:
+            return None
+
+        with caplog.at_level(logging.ERROR, logger="curie_worker.run"):
+            await asyncio.wait_for(
+                _supervise("heartbeat", factory, shutdown, restart_backoff_s=0),
+                timeout=2,
+            )
+
+        assert recorded == []
+        assert not any(
+            "crashed; restarting" in r.getMessage() for r in caplog.records
+        )
+
+    asyncio.run(go())
+
+
+def test_supervise_does_not_emit_restart_metric_after_shutdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: list[tuple[str, float, dict[str, str]]] = []
+
+    def capture(
+        name: str, value: float = 1, *, attributes: Mapping[str, str] | None = None
+    ) -> None:
+        recorded.append((name, value, dict(attributes or {})))
+
+    monkeypatch.setattr(run, "record_metric", capture)
+
+    async def go() -> None:
+        shutdown = asyncio.Event()
+        calls = {"n": 0}
+
+        async def factory() -> None:
+            calls["n"] += 1
+            shutdown.set()
+            raise ConnectionError("boom")
+
+        await asyncio.wait_for(
+            _supervise("runs", factory, shutdown, restart_backoff_s=0),
+            timeout=2,
+        )
+        assert calls["n"] == 1
+        assert recorded == []
 
     asyncio.run(go())
 

--- a/docs/interfaces/telemetry-otel/INTERFACE.md
+++ b/docs/interfaces/telemetry-otel/INTERFACE.md
@@ -75,7 +75,7 @@ than an open bag of `gen_ai.*` names.
 - The metric catalog in `packages/telemetry/schema/metrics.json` is the committed
   contract for operational counters, histograms, and gauges across turn, queue,
   thread-lock, sandbox, runner RPC, approval, completion-outbox, reply, HTTP,
-  background-loop, and eval work. `record_metric`
+  background-loop, eval work, and supervised-task restarts. `record_metric`
   (`packages/telemetry/src/curie_telemetry/metrics.py::record_metric`) rejects undeclared
   instruments, attribute keys, and enum values. Its allowlisted dimensions describe
   operation classes and outcomes, not event, run, session, sandbox, user, agent, or

--- a/packages/telemetry/schema/metrics.json
+++ b/packages/telemetry/schema/metrics.json
@@ -1302,6 +1302,30 @@
         ]
       },
       "cardinality_bound": 3
+    },
+    "curie.worker.supervised.restart": {
+      "type": "counter",
+      "unit": "{restart}",
+      "description": "In-process supervised worker task restarts.",
+      "monotonic": true,
+      "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
+        "operation": [
+          "runs",
+          "killswitch",
+          "evals",
+          "heartbeat",
+          "connectors",
+          "publications",
+          "other"
+        ],
+        "outcome": [
+          "restart"
+        ]
+      },
+      "cardinality_bound": 7
     }
   }
 }

--- a/packages/telemetry/src/curie_telemetry/metrics.py
+++ b/packages/telemetry/src/curie_telemetry/metrics.py
@@ -262,6 +262,19 @@ _EVAL_ATTRIBUTES = {
     "source": ["eval"],
     "outcome": ["success", "failure", "plumbing"],
 }
+_SUPERVISED_RESTART_ATTRIBUTES = {
+    "service.name": ["curie-worker"],
+    "operation": [
+        "runs",
+        "killswitch",
+        "evals",
+        "heartbeat",
+        "connectors",
+        "publications",
+        "other",
+    ],
+    "outcome": ["restart"],
+}
 
 
 _METRICS: dict[str, dict[str, Any]] = {
@@ -407,6 +420,13 @@ _METRICS: dict[str, dict[str, Any]] = {
     ),
     "curie.eval.process": _definition(
         "counter", "{job}", "Eval processing outcomes.", True, _EVAL_ATTRIBUTES
+    ),
+    "curie.worker.supervised.restart": _definition(
+        "counter",
+        "{restart}",
+        "In-process supervised worker task restarts.",
+        True,
+        _SUPERVISED_RESTART_ATTRIBUTES,
     ),
 }
 

--- a/packages/telemetry/tests/test_metrics.py
+++ b/packages/telemetry/tests/test_metrics.py
@@ -208,6 +208,63 @@ def test_deadline_halted_is_a_declared_terminal_turn_outcome(
         assert manifest[name]["cardinality_bound"] == 192
 
 
+def test_supervised_restart_metric_declares_closed_operation_domain() -> None:
+    manifest = _read(_MANIFEST)["metrics"]
+    definition = manifest["curie.worker.supervised.restart"]
+    assert definition["type"] == "counter"
+    assert definition["unit"] == "{restart}"
+    assert definition["description"] == "In-process supervised worker task restarts."
+    assert definition["monotonic"] is True
+    assert definition["attributes"] == {
+        "service.name": ["curie-worker"],
+        "operation": [
+            "runs",
+            "killswitch",
+            "evals",
+            "heartbeat",
+            "connectors",
+            "publications",
+            "other",
+        ],
+        "outcome": ["restart"],
+    }
+    assert definition["cardinality_bound"] == 7
+
+
+def test_supervised_restart_metric_rejects_undeclared_operation_by_execution(
+    metrics: tuple[MeterProvider, InMemoryMetricReader],
+) -> None:
+    del metrics
+    # Bounded catalog: operation is a closed supervised-task domain, not an
+    # identity label for the crashing exception or claim method.
+    record_metric(
+        "curie.worker.supervised.restart",
+        attributes={
+            "service.name": "curie-worker",
+            "operation": "publications",
+            "outcome": "restart",
+        },
+    )
+    with pytest.raises(ValueError, match="outside its declared domain"):
+        record_metric(
+            "curie.worker.supervised.restart",
+            attributes={
+                "service.name": "curie-worker",
+                "operation": "claim_next",
+                "outcome": "restart",
+            },
+        )
+    with pytest.raises(ValueError, match="outside its declared domain"):
+        record_metric(
+            "curie.worker.supervised.restart",
+            attributes={
+                "service.name": "curie-worker",
+                "operation": "publications",
+                "outcome": "crash",
+            },
+        )
+
+
 def test_record_metric_still_rejects_unknown_turn_outcome(
     metrics: tuple[MeterProvider, InMemoryMetricReader],
 ) -> None:


### PR DESCRIPTION
## Summary

A supervised worker task that crashes is restarted inside the process, so Kubernetes restart counters stay at zero. `_supervise` now emits `curie.worker.supervised.restart` and logs the task name plus exception type and message on the same line. `claim_next()` failures in the publication loop are logged with the same cause shape and still escape, so delivery behavior is unchanged. A healthy idle loop does not increment the metric or log those errors.

Closes #2554

## Fix pin verification

Fix pin: apps/worker/tests/test_run.py::test_supervise_emits_restart_metric_and_cause_for_publications

## End-to-end verification

Candidate: `3012f276a114e45878ba291270b51c760429d825` on `task/2554-supervised-task-visibility` from `origin/main`.

Discovery waiver: the soak observation was a cluster log census; this change is in-process instrumentation. The producing path is `_supervise` and `PublicationReconcileLoop.run_forever`, which were driven directly. Kubernetes `kube_pod_container_status_restarts_total` remains 0 by design (the pod still does not exit). The permanent soak was not mutated.

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin or skill packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | required | Worker process supervision and publication loop. | fake | `uv run pytest apps/worker/tests/test_run.py apps/worker/tests/test_publication_loop.py packages/telemetry/tests/test_metrics.py -q` at 3012f276a: 115 passed. Positive: crashing `publications` emits `curie.worker.supervised.restart` and a log line with task name, `RuntimeError`, and `claim cas lost`. Sibling: crashing `evals` emits the same metric with `operation=evals`. Negative: idle heartbeat and shutdown crash emit no metric; idle publication `claim_next()` returning None logs no `claim_next failed` / `crashed; restarting`. Guard: `record_metric` rejects undeclared operation `claim_next` and outcome `crash`. |
| local-release | n/a | Does not change released binary or image identity, install path, version pins, or release compose. | | |
| cluster | n/a | No chart, RBAC, securityContext, NetworkPolicy, sandbox claim, or init-container change. Soak mutation is forbidden. | | |
| live provider | n/a | No model routing, credential resolution, provider auth, or token/cost accounting. | | |
| external integration | n/a | No Slack, git webhook, connector OAuth, or third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Done check

- [x] Failing tests committed before implementation: N/A (quick tier).
- [x] Production edits were performed by a delegated native executor in the worktree; the driver ran git and tests.
- [x] Broadened return types: none.
- [x] Agent-router Code Reviewer completed (review 457, codex gpt-6-astra): approve, 0 blocking findings. Advisory noted: extra coverage for metric-emission failure and cancellation.
- [x] Agent-router Scope Reviewer completed (review 458, codex gpt-6-astra): in-scope, no passengers. Every hunk mapped to an AC or allowed test/catalog/docs exception.
- [x] Sibling-path parity: metric and cause log live on shared `_supervise`, covering runs, killswitch, evals, heartbeat, connectors, and publications. Tests arm publications and evals separately. Publication `claim_next` naming is the publications-specific sibling of the supervisor log.
- [x] Guard demonstration: `test_supervised_restart_metric_rejects_undeclared_operation_by_execution` called real `record_metric` with undeclared operation `claim_next` and outcome `crash`; both raised `ValueError` matching `outside its declared domain`.
- [x] Consolidation: N/A (quick tier).
- [x] Security review: N/A; no auth, payment, PII, or permission surface.
- [x] Observable verification: N/A; no user-facing UI change.
- [x] Deployed E2E: N/A; deployed-surface not flagged.
- [x] Train check: worktree cut from fresh `origin/main`, matching v0.8.8.
- [x] Discovery waiver: in-process producing path proven locally; soak not mutated; kube restart counter is unchanged by design.
- [x] Re-fix mechanism: N/A; no prior fix of this symptom.
- [x] Affected tests, ruff check, and mypy on changed production modules passed.

## Scope boundaries

No publication delivery rewrite, no pod-exit change, no soak/cluster/credential/schedule mutation, no frozen aci-protocol or plugin-format, schema, or ADR changes.
