### PR TITLE
Record escalation cause instead of a pass-through token

### DIFF
--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -313,6 +313,50 @@ RETRYABLE_CLASSIFICATIONS = frozenset(
     {"rate-limit", "runner-error", "runner-timeout", "workspace-error"}
 )
 
+# Platform ErrorEvent.classification vocabulary. Allowlist-constrain only: do
+# not synonym-map SDK ``rate_limit`` onto platform ``rate-limit``, which would
+# make a currently non-retryable token retryable.
+PLATFORM_ERROR_CLASSIFICATIONS = frozenset({
+    "rate-limit",
+    "runner-error",
+    "runner-timeout",
+    "workspace-error",
+    "budget-exceeded",
+    "server-error",
+    "ledger-error",
+    "model-credential-rejected",
+    "approval-not-acted",
+    "false-completion",
+    "publication-unrecorded",
+})
+UNCLASSIFIED_ERROR_CLASSIFICATION = "unclassified"
+
+_ESCALATION_DETAIL_MAX = 300
+
+
+def map_error_classification(raw: str | None) -> str:
+    if raw is not None and raw in PLATFORM_ERROR_CLASSIFICATIONS:
+        return raw
+    return UNCLASSIFIED_ERROR_CLASSIFICATION
+
+
+def _escalation_text(
+    qevent: QueuedTurn,
+    *,
+    lead: str,
+    detail: str | None,
+) -> str:
+    clipped = (detail or "").strip()
+    if len(clipped) > _ESCALATION_DETAIL_MAX:
+        clipped = clipped[:_ESCALATION_DETAIL_MAX]
+    extra = (
+        f"{clipped} event_id={qevent.event_id}."
+        if clipped
+        else f"event_id={qevent.event_id}."
+    )
+    return f"{lead} {extra} Flagging for a human."
+
+
 # The floor of remaining DELIVERY budget below which a fresh attempt is not
 # started (ADR-0131). The runner cannot claim a sandbox, open a turn and stream a
 # final in a couple of seconds, so an attempt started under this floor is
@@ -546,6 +590,7 @@ class TurnOutcome:
     terminal_ok: bool
     saw_side_effect: bool = False
     classification: str | None = None
+    error_message: str | None = None
     text: str = ""
     status: SessionStatus | None = None
     steered: bool = False
@@ -608,6 +653,7 @@ class _StreamAccumulator:
     text_parts: list[str] = field(default_factory=list)
     saw_side_effect: bool = False
     classification: str | None = None
+    error_message: str | None = None
     status: SessionStatus | None = None
     final_text: str | None = None
     approval_summary: str | None = None
@@ -1548,11 +1594,18 @@ class Kernel:
                     return
 
                 if outcome.saw_side_effect:
+                    token = map_error_classification(outcome.classification)
                     await self._escalate(
                         qevent,
                         route,
-                        f"The run hit an error ({outcome.classification or 'unknown'}) after "
-                        "starting an action; not retrying automatically. Flagging for a human.",
+                        _escalation_text(
+                            qevent,
+                            lead=(
+                                f"The run hit an error ({token}) after starting an action; "
+                                "not retrying automatically."
+                            ),
+                            detail=outcome.error_message,
+                        ),
                     )
                     await self._complete(
                         qevent,
@@ -1565,11 +1618,17 @@ class Kernel:
 
                 retryable = outcome.classification in RETRYABLE_CLASSIFICATIONS
                 if not retryable or attempt >= self._config.max_attempts:
+                    token = map_error_classification(outcome.classification)
                     await self._escalate(
                         qevent,
                         route,
-                        f"The run failed ({outcome.classification or 'unknown'}) after "
-                        f"{attempt} attempt(s). Flagging for a human.",
+                        _escalation_text(
+                            qevent,
+                            lead=(
+                                f"The run failed ({token}) after {attempt} attempt(s)."
+                            ),
+                            detail=outcome.error_message,
+                        ),
                     )
                     await self._complete(
                         qevent,
@@ -3582,6 +3641,7 @@ class Kernel:
                 terminal_ok=False,
                 saw_side_effect=acc.saw_side_effect,
                 classification=classification,
+                error_message=acc.error_message,
                 text=acc.rendered(),
             )
         except ActionBackendError as exc:
@@ -3597,6 +3657,7 @@ class Kernel:
                 terminal_ok=False,
                 saw_side_effect=acc.saw_side_effect,
                 classification="ledger-error",
+                error_message=acc.error_message,
                 text=acc.rendered(),
             )
 
@@ -3626,7 +3687,9 @@ class Kernel:
             await self._markers.mark_side_effect(qevent.event_id)
             await self._record_action(frame, acc, qevent, agent_id)
         elif isinstance(frame, ErrorEvent):
-            acc.classification = frame.classification or acc.classification
+            if frame.classification:
+                acc.classification = map_error_classification(frame.classification)
+            acc.error_message = frame.message or acc.error_message
         elif isinstance(frame, Final):
             acc.status = frame.status
             acc.final_text = frame.text
@@ -3706,6 +3769,7 @@ class Kernel:
             terminal_ok=False,
             saw_side_effect=acc.saw_side_effect,
             classification=acc.classification or "runner-error",
+            error_message=acc.error_message,
             text=acc.rendered(),
             status=acc.status,
         )

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -1150,6 +1150,180 @@ def test_rate_limit_retries_then_succeeds(make_harness) -> None:
     asyncio.run(go())
 
 
+def test_unknown_classification_escalates_as_unclassified_with_event_id(
+    make_harness,
+) -> None:
+    async def go() -> None:
+        async with make_harness(max_attempts=3) as h:
+            h.runner.default_script = [
+                ErrorEvent(message="model-said-unknown", classification="unknown"),
+                Final(text="failed", status=FAIL),
+            ]
+            ev = _qevent("go", event_id="evt-unknown-cause")
+            await h.kernel.process_event(ev)
+
+            assert h.runner.opened == ["go"]
+            reply = h.sink.last_text
+            assert reply == (
+                "The run failed (unclassified) after 1 attempt(s). "
+                "model-said-unknown event_id=evt-unknown-cause. "
+                "Flagging for a human."
+            )
+            assert "(unclassified)" in reply
+            assert "model-said-unknown" in reply
+            assert "event_id=evt-unknown-cause" in reply
+            assert "(unknown)" not in reply
+            assert reply.startswith("The run failed (")
+
+    asyncio.run(go())
+
+
+def test_side_effect_unknown_classification_escalates_with_detail_and_event_id(
+    make_harness,
+) -> None:
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [
+                SideEffectFlag(tool="deploy"),
+                ErrorEvent(message="boom-detail", classification="unknown"),
+                Final(text="failed", status=FAIL),
+            ]
+            ev = _qevent("do it", event_id="evt-unknown-side-effect")
+            await h.kernel.process_event(ev)
+
+            assert h.runner.opened == ["do it"]
+            reply = h.sink.last_text
+            assert reply is not None
+            assert reply == (
+                "The run hit an error (unclassified) after starting an action; "
+                "not retrying automatically. boom-detail "
+                "event_id=evt-unknown-side-effect. Flagging for a human."
+            )
+            assert "(unclassified)" in reply
+            assert "boom-detail" in reply
+            assert "event_id=evt-unknown-side-effect" in reply
+            assert "human" in reply.lower()
+            assert reply.startswith("The run hit an error (")
+            assert "(unknown)" not in reply
+
+    asyncio.run(go())
+
+
+def test_sdk_rate_limit_underscore_does_not_retry(make_harness) -> None:
+    async def go() -> None:
+        async with make_harness(max_attempts=3) as h:
+            h.runner.default_script = [
+                ErrorEvent(
+                    message="sdk-rate-limit-underscore",
+                    classification="rate_limit",
+                ),
+                Final(text="f", status=FAIL),
+            ]
+            ev = _qevent("go", event_id="evt-rate-limit-underscore")
+            await h.kernel.process_event(ev)
+
+            assert h.runner.opened == ["go"]
+            reply = h.sink.last_text
+            assert reply == (
+                "The run failed (unclassified) after 1 attempt(s). "
+                "sdk-rate-limit-underscore event_id=evt-rate-limit-underscore. "
+                "Flagging for a human."
+            )
+            assert "(unclassified)" in reply
+            assert "(rate_limit)" not in reply
+            assert "(rate-limit)" not in reply
+
+    asyncio.run(go())
+
+
+def test_platform_rate_limit_still_retries_then_succeeds(make_harness) -> None:
+    # Hyphenated sibling of test_sdk_rate_limit_underscore_does_not_retry:
+    # allowlist-constrain must not fold platform rate-limit, or retry dies.
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.turn_scripts = [
+                [
+                    ErrorEvent(message="rl", classification="rate-limit"),
+                    Final(text="f", status=FAIL),
+                ],
+                [Final(text="recovered", status=DONE)],
+            ]
+            await h.kernel.process_event(_qevent("go"))
+
+            assert h.runner.opened == ["go", "go"]
+            assert h.sink.last_text == "recovered"
+
+    asyncio.run(go())
+
+
+def test_empty_classification_does_not_overwrite_prior_rate_limit(make_harness) -> None:
+    # A later ErrorEvent with classification="" must not fold to unclassified
+    # and wipe a prior rate-limit, or the retry dies.
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.turn_scripts = [
+                [
+                    ErrorEvent(message="rl", classification="rate-limit"),
+                    ErrorEvent(message="empty-class", classification=""),
+                    Final(text="f", status=FAIL),
+                ],
+                [Final(text="recovered", status=DONE)],
+            ]
+            await h.kernel.process_event(_qevent("go"))
+
+            assert h.runner.opened == ["go", "go"]
+            assert h.sink.last_text == "recovered"
+
+    asyncio.run(go())
+
+
+def test_empty_classification_alone_defaults_to_retryable_runner_error(
+    make_harness,
+) -> None:
+    # Old fold treated "" as falsy so _finish defaulted to runner-error
+    # (retryable). Do not escalate on the first attempt.
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.turn_scripts = [
+                [
+                    ErrorEvent(message="blank-class", classification=""),
+                    Final(text="f", status=FAIL),
+                ],
+                [Final(text="recovered", status=DONE)],
+            ]
+            await h.kernel.process_event(_qevent("go"))
+
+            assert h.runner.opened == ["go", "go"]
+            assert h.sink.last_text == "recovered"
+
+    asyncio.run(go())
+
+
+def test_allowlisted_runner_error_escalates_with_event_id(make_harness) -> None:
+    async def go() -> None:
+        async with make_harness(max_attempts=1) as h:
+            h.runner.default_script = [
+                ErrorEvent(message="sandbox died", classification="runner-error"),
+                Final(text="failed", status=FAIL),
+            ]
+            ev = _qevent("go", event_id="evt-runner-error-cause")
+            await h.kernel.process_event(ev)
+
+            assert h.runner.opened == ["go"]
+            reply = h.sink.last_text
+            assert reply == (
+                "The run failed (runner-error) after 1 attempt(s). "
+                "sandbox died event_id=evt-runner-error-cause. "
+                "Flagging for a human."
+            )
+            assert "(runner-error)" in reply
+            assert "sandbox died" in reply
+            assert "event_id=evt-runner-error-cause" in reply
+            assert reply.startswith("The run failed (")
+
+    asyncio.run(go())
+
+
 def test_turn_start_failure_is_retryable_not_a_stall(make_harness) -> None:
     async def go() -> None:
         async with make_harness() as h:
@@ -1371,7 +1545,8 @@ def test_approval_resume_capacity_retries_then_escalates(make_harness) -> None:
                 (
                     "C1",
                     "p-1",
-                    "The run failed (runner-error) after 3 attempt(s). Flagging for a human.",
+                    "The run failed (runner-error) after 3 attempt(s). "
+                    "event_id=approval-example-resolved. Flagging for a human.",
                 )
             ]
             assert h.sink.update_endpoints == [endpoint]
@@ -1389,7 +1564,7 @@ def test_claim_timeout_without_quota_retries_then_escalates(make_harness) -> Non
             claim_timeout_seconds=0.02,
         ) as h:
             h.fake_k8s.bind_ready = False
-            ev = _qevent("go")
+            ev = _qevent("go", event_id="evt-claim-timeout")
 
             await h.kernel.process_event(ev)
 
@@ -1399,7 +1574,8 @@ def test_claim_timeout_without_quota_retries_then_escalates(make_harness) -> Non
                 (
                     "C1",
                     "p-1",
-                    "The run failed (runner-error) after 3 attempt(s). Flagging for a human.",
+                    "The run failed (runner-error) after 3 attempt(s). "
+                    "event_id=evt-claim-timeout. Flagging for a human.",
                 )
             ]
             assert "sandbox capacity" not in h.sink.updates[0][2].lower()

--- a/apps/worker/tests/kernel/test_vector_error_classification.py
+++ b/apps/worker/tests/kernel/test_vector_error_classification.py
@@ -1,0 +1,95 @@
+"""Worker half of the ErrorEvent.classification allowlist-constrain vector (#2556)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from curie_worker.kernel import map_error_classification
+
+_VECTOR = (
+    Path(__file__).resolve().parents[4]
+    / "tests"
+    / "vectors"
+    / "error-event-classification.json"
+)
+_TOP_LEVEL_KEYS = frozenset({"comment", "unclassified", "platform", "vectors"})
+_VECTOR_KEYS = frozenset({"name", "input", "expected"})
+_PLATFORM = (
+    "rate-limit",
+    "runner-error",
+    "runner-timeout",
+    "workspace-error",
+    "budget-exceeded",
+    "server-error",
+    "ledger-error",
+    "model-credential-rejected",
+    "approval-not-acted",
+    "false-completion",
+    "publication-unrecorded",
+)
+
+
+def _load_payload() -> dict:
+    payload = json.loads(_VECTOR.read_text(encoding="utf-8"))
+    extra = set(payload) - _TOP_LEVEL_KEYS
+    missing = _TOP_LEVEL_KEYS - set(payload)
+    assert not extra and not missing, (
+        f"tests/vectors/error-event-classification.json has unexpected keys "
+        f"{sorted(extra)} and is missing {sorted(missing)}. A new input is "
+        "rejected on purpose: one this lane cannot see would pass vacuously. "
+        "Teach it to this test and runner/tests/test_vector_error_classification.py."
+    )
+    assert payload["comment"]
+    return payload
+
+
+def _assert_known_vector_keys(vector: dict[str, object]) -> None:
+    keys = set(vector)
+    if keys != _VECTOR_KEYS:
+        raise AssertionError(
+            f"vector {vector.get('name')!r} in {_VECTOR} has unexpected keys "
+            f"{sorted(keys - _VECTOR_KEYS)} and is missing "
+            f"{sorted(_VECTOR_KEYS - keys)}. A new input is rejected on "
+            "purpose: one this lane cannot see would pass vacuously. Teach the "
+            "new key to both Python loaders."
+        )
+
+
+def test_vector_rejects_unknown_fields() -> None:
+    payload = _load_payload()
+    assert payload["vectors"], f"no vectors parsed from {_VECTOR}"
+    for vector in payload["vectors"]:
+        _assert_known_vector_keys(vector)
+
+
+def test_mapper_matches_every_classification_vector() -> None:
+    payload = _load_payload()
+    assert payload["unclassified"] == "unclassified"
+    assert payload["platform"] == list(_PLATFORM)
+    vectors = payload["vectors"]
+    assert vectors, f"no vectors parsed from {_VECTOR}"
+
+    passthrough = {
+        vector["input"]
+        for vector in vectors
+        if vector["input"] in _PLATFORM and vector["expected"] == vector["input"]
+    }
+    assert passthrough == set(_PLATFORM), (
+        "every platform vocabulary token must have a pass-through vector "
+        f"(expected == input). missing={sorted(set(_PLATFORM) - passthrough)}"
+    )
+
+    for vector in vectors:
+        _assert_known_vector_keys(vector)
+        raw = vector["input"]
+        if raw is not None and not isinstance(raw, str):
+            raise AssertionError(
+                f"vector {vector['name']!r} input must be str or null, got {type(raw)}"
+            )
+        got = map_error_classification(raw)
+        assert got == vector["expected"], vector["name"]
+        assert got != "unknown"
+        assert got != "rate_limit"
+        assert got != "error_during_execution"
+        assert got != "server_error"

--- a/runner/src/curie_runner/translate.py
+++ b/runner/src/curie_runner/translate.py
@@ -51,6 +51,30 @@ from .side_effects import SideEffectClassifier
 # is set to clear a realistic snapshot and refuse a blob.
 RESULT_MAX_BYTES = 64_000
 
+# Platform ErrorEvent.classification vocabulary. Allowlist-constrain only: do
+# not synonym-map SDK ``rate_limit`` onto platform ``rate-limit``, which would
+# make a currently non-retryable token retryable.
+PLATFORM_ERROR_CLASSIFICATIONS = frozenset({
+    "rate-limit",
+    "runner-error",
+    "runner-timeout",
+    "workspace-error",
+    "budget-exceeded",
+    "server-error",
+    "ledger-error",
+    "model-credential-rejected",
+    "approval-not-acted",
+    "false-completion",
+    "publication-unrecorded",
+})
+UNCLASSIFIED_ERROR_CLASSIFICATION = "unclassified"
+
+
+def map_error_classification(raw: str | None) -> str:
+    if raw is not None and raw in PLATFORM_ERROR_CLASSIFICATIONS:
+        return raw
+    return UNCLASSIFIED_ERROR_CLASSIFICATION
+
 
 @dataclass
 class TurnState:
@@ -176,8 +200,9 @@ def _translate_assistant(
 
     error = getattr(message, "error", None)
     if error:
-        state.error_classification = error
-        events.append(ErrorEvent(message=f"model error: {error}", classification=error))
+        mapped = map_error_classification(error)
+        state.error_classification = mapped
+        events.append(ErrorEvent(message=f"model error: {error}", classification=mapped))
 
     for block in message.content:
         if isinstance(block, TextBlock):
@@ -340,8 +365,13 @@ def _translate_result(
         text = message.result or "run failed"
         events: list[OutboundEvent] = []
         if state.error_classification is None:
+            raw = subtype or "server-error"
+            mapped = map_error_classification(raw)
             events.append(
-                ErrorEvent(message=text, classification=subtype or "server-error")
+                ErrorEvent(
+                    message=text if mapped == raw else f"{text}: {raw}",
+                    classification=mapped,
+                )
             )
         events.append(Final(text=text, status=SessionStatus.CLASSIFIED_FAILURE))
         return events

--- a/runner/tests/test_approval_gate_enforcement.py
+++ b/runner/tests/test_approval_gate_enforcement.py
@@ -576,10 +576,15 @@ def test_gated_turn_that_also_hit_a_model_error_ends_classified_failure() -> Non
     assert final.status == SessionStatus.CLASSIFIED_FAILURE
     assert final.status != SessionStatus.AWAITING_APPROVAL
     assert not final.approval_summary
-    # And the failure is still reported as itself, not swallowed.
+    # And the failure is still reported as itself, not swallowed. The SDK token
+    # is constrained to unclassified; the raw token survives in the message.
+    error_events = [e for e in events if e.type == "error"]
+    assert error_events, "the model's own error frame must survive"
+    assert any(e.classification == "unclassified" for e in error_events)
+    assert all(e.classification != "server_error" for e in error_events)
     assert any(
-        e.type == "error" and e.classification == "server_error" for e in events
-    ), "the model's own error frame must survive"
+        "server_error" in getattr(e, "message", "") for e in error_events
+    ), "the raw token must survive in the ErrorEvent message"
 
 
 def test_a_done_gated_turn_still_flips_even_after_a_model_error_frame() -> None:

--- a/runner/tests/test_session.py
+++ b/runner/tests/test_session.py
@@ -1152,8 +1152,8 @@ def test_auth_fast_fail_survives_a_wedged_interrupt(caplog) -> None:
 
 def test_transient_model_error_is_not_fast_failed() -> None:
     # A transient AssistantMessage.error (e.g. a hard rate-limit) is NOT a
-    # credential rejection: it must flow through translation unchanged and reach
-    # the model's own terminal result, so genuine retry/backoff is preserved.
+    # credential rejection: it must not credential-reject; must reach DONE.
+    # The SDK token is constrained to unclassified rather than passed through.
     script = [
         AssistantMessage(content=[], model="m", error="rate_limit"),
         ResultMessage(
@@ -1166,7 +1166,8 @@ def test_transient_model_error_is_not_fast_failed() -> None:
 
     classifications = [getattr(e, "classification", None) for e in events]
     assert "model-credential-rejected" not in classifications
-    assert "rate_limit" in classifications  # translated, non-terminal
+    assert "unclassified" in classifications
+    assert "rate_limit" not in classifications
     assert events[-1].status == SessionStatus.DONE  # reached the model's result
     assert fake.interrupts == 0  # not aborted
 

--- a/runner/tests/test_translate.py
+++ b/runner/tests/test_translate.py
@@ -184,7 +184,11 @@ def test_sdk_abort_result_is_error_then_classified_final(
 
     assert [event.type for event in events] == ["error", "final"]
     assert isinstance(events[0], ErrorEvent)
-    assert events[0].classification == "error_during_execution"
+    assert events[0].classification == "unclassified"
+    assert events[0].classification != "error_during_execution"
+    # Allowlist-constrain must not drop the raw subtype from the message.
+    assert "error_during_execution" in events[0].message
+    assert "run failed" in events[0].message
     assert isinstance(events[1], Final)
     assert events[1].status is SessionStatus.CLASSIFIED_FAILURE
 
@@ -193,7 +197,19 @@ def test_assistant_error_field_emits_error_event() -> None:
     msg = AssistantMessage(content=[], model="m", error="rate_limit")
     events = _translate(msg)
     assert [e.type for e in events] == ["error"]
-    assert events[0].classification == "rate_limit"
+    assert events[0].classification == "unclassified"
+    assert events[0].classification != "rate_limit"
+    assert "rate_limit" in events[0].message
+
+
+def test_assistant_unknown_error_is_unclassified_not_passthrough() -> None:
+    msg = AssistantMessage(content=[], model="m", error="unknown")
+    events = _translate(msg)
+    assert [e.type for e in events] == ["error"]
+    assert isinstance(events[0], ErrorEvent)
+    assert events[0].classification == "unclassified"
+    assert "unknown" in events[0].message
+    assert events[0].classification != "unknown"
 
 
 def test_rate_limit_rejected_maps_to_error() -> None:

--- a/runner/tests/test_vector_error_classification.py
+++ b/runner/tests/test_vector_error_classification.py
@@ -1,0 +1,96 @@
+"""Runner half of the ErrorEvent.classification allowlist-constrain vector (#2556)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from curie_runner.translate import map_error_classification
+
+_VECTOR = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "vectors"
+    / "error-event-classification.json"
+)
+_TOP_LEVEL_KEYS = frozenset({"comment", "unclassified", "platform", "vectors"})
+_VECTOR_KEYS = frozenset({"name", "input", "expected"})
+_PLATFORM = (
+    "rate-limit",
+    "runner-error",
+    "runner-timeout",
+    "workspace-error",
+    "budget-exceeded",
+    "server-error",
+    "ledger-error",
+    "model-credential-rejected",
+    "approval-not-acted",
+    "false-completion",
+    "publication-unrecorded",
+)
+
+
+def _load_payload() -> dict:
+    payload = json.loads(_VECTOR.read_text(encoding="utf-8"))
+    extra = set(payload) - _TOP_LEVEL_KEYS
+    missing = _TOP_LEVEL_KEYS - set(payload)
+    assert not extra and not missing, (
+        f"tests/vectors/error-event-classification.json has unexpected keys "
+        f"{sorted(extra)} and is missing {sorted(missing)}. A new input is "
+        "rejected on purpose: one this lane cannot see would pass vacuously. "
+        "Teach it to this test and apps/worker/tests/kernel/"
+        "test_vector_error_classification.py."
+    )
+    assert payload["comment"]
+    return payload
+
+
+def _assert_known_vector_keys(vector: dict[str, object]) -> None:
+    keys = set(vector)
+    if keys != _VECTOR_KEYS:
+        raise AssertionError(
+            f"vector {vector.get('name')!r} in {_VECTOR} has unexpected keys "
+            f"{sorted(keys - _VECTOR_KEYS)} and is missing "
+            f"{sorted(_VECTOR_KEYS - keys)}. A new input is rejected on "
+            "purpose: one this lane cannot see would pass vacuously. Teach the "
+            "new key to both Python loaders."
+        )
+
+
+def test_vector_rejects_unknown_fields() -> None:
+    payload = _load_payload()
+    assert payload["vectors"], f"no vectors parsed from {_VECTOR}"
+    for vector in payload["vectors"]:
+        _assert_known_vector_keys(vector)
+
+
+def test_mapper_matches_every_classification_vector() -> None:
+    payload = _load_payload()
+    assert payload["unclassified"] == "unclassified"
+    assert payload["platform"] == list(_PLATFORM)
+    vectors = payload["vectors"]
+    assert vectors, f"no vectors parsed from {_VECTOR}"
+
+    passthrough = {
+        vector["input"]
+        for vector in vectors
+        if vector["input"] in _PLATFORM and vector["expected"] == vector["input"]
+    }
+    assert passthrough == set(_PLATFORM), (
+        "every platform vocabulary token must have a pass-through vector "
+        f"(expected == input). missing={sorted(set(_PLATFORM) - passthrough)}"
+    )
+
+    for vector in vectors:
+        _assert_known_vector_keys(vector)
+        raw = vector["input"]
+        if raw is not None and not isinstance(raw, str):
+            raise AssertionError(
+                f"vector {vector['name']!r} input must be str or null, got {type(raw)}"
+            )
+        got = map_error_classification(raw)
+        assert got == vector["expected"], vector["name"]
+        assert got != "unknown"
+        assert got != "rate_limit"
+        assert got != "error_during_execution"
+        assert got != "server_error"

--- a/tests/vectors/error-event-classification.json
+++ b/tests/vectors/error-event-classification.json
@@ -1,0 +1,104 @@
+{
+  "comment": "Single source of truth for ErrorEvent.classification allowlist-constrain across the Python runner (curie_runner.translate.map_error_classification) and the Python worker (curie_worker.kernel.map_error_classification). The two lanes cannot share code, so the rule is frozen here: a platform vocabulary token passes through unchanged; any other raw value, including SDK tokens (unknown, rate_limit, error_during_execution, server_error), empty, and null, becomes unclassified. Do not synonym-map SDK rate_limit onto platform rate-limit: that would make a currently non-retryable token retryable (RETRYABLE_CLASSIFICATIONS contains rate-limit only) and is classification/retry policy, out of scope for cause recording. Changing a rule here requires changing both lanes; changing a lane without this file fails that lane's test. Read by runner/tests/test_vector_error_classification.py and apps/worker/tests/kernel/test_vector_error_classification.py. Both loaders reject unknown top-level and per-vector keys, so a key one lane cannot see cannot pass vacuously.",
+  "unclassified": "unclassified",
+  "platform": [
+    "rate-limit",
+    "runner-error",
+    "runner-timeout",
+    "workspace-error",
+    "budget-exceeded",
+    "server-error",
+    "ledger-error",
+    "model-credential-rejected",
+    "approval-not-acted",
+    "false-completion",
+    "publication-unrecorded"
+  ],
+  "vectors": [
+    {
+      "name": "sdk_unknown_is_unclassified",
+      "input": "unknown",
+      "expected": "unclassified"
+    },
+    {
+      "name": "sdk_rate_limit_underscore_is_unclassified",
+      "input": "rate_limit",
+      "expected": "unclassified"
+    },
+    {
+      "name": "sdk_error_during_execution_is_unclassified",
+      "input": "error_during_execution",
+      "expected": "unclassified"
+    },
+    {
+      "name": "sdk_server_error_underscore_is_unclassified",
+      "input": "server_error",
+      "expected": "unclassified"
+    },
+    {
+      "name": "empty_string_is_unclassified",
+      "input": "",
+      "expected": "unclassified"
+    },
+    {
+      "name": "null_is_unclassified",
+      "input": null,
+      "expected": "unclassified"
+    },
+    {
+      "name": "platform_rate_limit",
+      "input": "rate-limit",
+      "expected": "rate-limit"
+    },
+    {
+      "name": "platform_runner_error",
+      "input": "runner-error",
+      "expected": "runner-error"
+    },
+    {
+      "name": "platform_runner_timeout",
+      "input": "runner-timeout",
+      "expected": "runner-timeout"
+    },
+    {
+      "name": "platform_workspace_error",
+      "input": "workspace-error",
+      "expected": "workspace-error"
+    },
+    {
+      "name": "platform_budget_exceeded",
+      "input": "budget-exceeded",
+      "expected": "budget-exceeded"
+    },
+    {
+      "name": "platform_server_error",
+      "input": "server-error",
+      "expected": "server-error"
+    },
+    {
+      "name": "platform_ledger_error",
+      "input": "ledger-error",
+      "expected": "ledger-error"
+    },
+    {
+      "name": "platform_model_credential_rejected",
+      "input": "model-credential-rejected",
+      "expected": "model-credential-rejected"
+    },
+    {
+      "name": "platform_approval_not_acted",
+      "input": "approval-not-acted",
+      "expected": "approval-not-acted"
+    },
+    {
+      "name": "platform_false_completion",
+      "input": "false-completion",
+      "expected": "false-completion"
+    },
+    {
+      "name": "platform_publication_unrecorded",
+      "input": "publication-unrecorded",
+      "expected": "publication-unrecorded"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Operator-facing escalation replies were printing an unvalidated upstream classification token (including `unknown`) and dropping both the ErrorEvent message and the queued event id. The runner now allowlist-constrains ErrorEvent.classification; unrecognized SDK tokens become `unclassified` and the raw token stays in the message. The kernel folds that message into the escalate record and puts `event_id=` in the classification replies. Retry membership is unchanged: `rate_limit` is not mapped onto `rate-limit`.

## Related issue

Closes #2556

## Fix pin verification

Fix pin: apps/worker/tests/kernel/test_kernel.py::test_unknown_classification_escalates_as_unclassified_with_event_id

## End-to-end verification

Discovery: soak/cluster. Waiver: the ticket forbids reconstructing the two historical soak rows and mandates synthetic errors only. Proof is skill (runner ErrorEvent map) plus local (kernel escalate reply).

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | required | runner turn loop / ACI ErrorEvent | fake | `uv run pytest -q runner/tests/test_translate.py runner/tests/test_session.py runner/tests/test_vector_error_classification.py` at `5f3de73c1`. Observed: AssistantMessage.error `unknown`/`rate_limit` emit `unclassified`; RateLimitEvent stays `rate-limit`; SessionRunner still reaches DONE on a transient model error. |
| local | required | worker kernel escalate reply | fake | `uv run pytest -q apps/worker/tests/kernel/test_kernel.py apps/worker/tests/kernel/test_vector_error_classification.py` at `5f3de73c1`. Observed: `The run failed (unclassified) after 1 attempt(s). model-said-unknown event_id=evt-unknown-cause. Flagging for a human.`; `rate-limit` still retries; empty classification still retries as runner-error; `(unknown)` absent. |
| local-release | n/a | no install, image, or compose pin | | |
| cluster | n/a | no chart, RBAC, or sandbox claim | | |
| live provider | n/a | synthetic errors only | | |
| external integration | n/a | no Slack/git/OAuth shape | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Siblings: eval runner already kept ErrorEvent.message; CLI already prints classification plus message. Restart-side-effect escalate copy is pinned verbatim by #2010 and is unchanged.

## Checklist

- [x] Tests pass for the area I touched.
- [x] Docs updated if behavior changed. (vector file is the contract; no user-facing doc claimed `unknown` as a vocabulary token)
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. (n/a: cause recording, not a new decision)
