### PR TITLE
Back off refused mail discovery polls

### DIFF
--- a/apps/mail-adapter/README.md
+++ b/apps/mail-adapter/README.md
@@ -125,7 +125,7 @@ stray generic `PORT` or `POLL_INTERVAL` in the pod environment cannot reach one.
 | `CURIE_CHANNEL_TOKEN` | "" | the scoped `chn` token, sent as `X-API-Key` on ingress. Required |
 | `CURIE_EGRESS_SECRET` | "" | shared secret the platform presents on `X-Curie-Adapter-Secret`. Required |
 | `ADAPTER_INGRESS_ENABLED` | `true` | gates the poller only, never the egress server |
-| `CURIE_MAIL_POLL_INTERVAL_SECONDS` | `5.0` | seconds between listings; must be greater than zero. A transport failure or 429 arms bounded exponential backoff on top, up to 60s, reset by the next successful listing |
+| `CURIE_MAIL_POLL_INTERVAL_SECONDS` | `5.0` | seconds between listings; must be greater than zero. A transport failure or any 4xx refusal arms bounded exponential backoff on top, up to 60s; a successful 200 listing resets it, while 5xx responses retain their existing semantics and neither arm nor clear an already armed delay |
 | `CURIE_MAIL_INGRESS_ATTEMPTS` | `3` | short in-process attempts for transport ambiguity and retryable status; durable retry continues after this budget |
 | `CURIE_MAIL_INGRESS_RETRY_DELAY_SECONDS` | `2.0` | base delay between those attempts; 429 may extend it with `Retry-After` |
 | `CURIE_MAIL_PORT` | `8080` | port the egress server binds |

--- a/apps/mail-adapter/src/curie_mail_adapter/adapter.py
+++ b/apps/mail-adapter/src/curie_mail_adapter/adapter.py
@@ -33,12 +33,16 @@ POLL_LIMIT = 20
 POLL_MAX_PAGES = 5
 BACKOFF_STEP_SECONDS = 5.0
 BACKOFF_MAX_SECONDS = 60.0
-# Status 0 is a transport failure and 429 is provider rate limiting; both mean
-# "slow down", and neither did except 429, so a provider outage re-polled at the
-# normal cadence and burst a warning per pass (373 in 24h in the soak, #2012).
-POLL_BACKOFF_STATUSES = frozenset({0, 429})
+# Status 0 is a transport failure and every 4xx is a provider refusal. Neither
+# can recover because the adapter repeats the same request at normal cadence, so
+# both use the bounded discovery backoff. A 5xx deliberately retains its prior
+# semantics: it neither arms nor clears an already armed delay.
 CAUSE_MAX_CHARS = 120
 REJECTED_LABELS = frozenset({"unauthenticated", "spam", "blocked"})
+
+
+def _poll_should_back_off(status: int) -> bool:
+    return status == 0 or 400 <= status < 500
 
 
 class ProviderThreadDeletedError(RuntimeError):
@@ -179,7 +183,7 @@ class MailAdapter:
             if self.shutdown.is_set():
                 return
             status = self.poll_once()
-            if status in POLL_BACKOFF_STATUSES:
+            if _poll_should_back_off(status):
                 backoff = min(backoff * 2 + BACKOFF_STEP_SECONDS, BACKOFF_MAX_SECONDS)
                 logger.warning(
                     "poll: status=%s, backing off %ss before the next discovery pass",
@@ -292,7 +296,11 @@ class MailAdapter:
         depend on a stdlib rendering staying that way.
         """
         if status != 0:
-            return "unavailable"
+            # The status line is the only provider-authored response metadata
+            # admitted into this diagnostic. Valid HTTP codes have a fixed
+            # three-digit budget; an impossible value gets one fixed fallback
+            # rather than an unbounded rendering of the integer.
+            return f"http_{status}" if 100 <= status <= 599 else "http_invalid"
         if not isinstance(body, dict):
             return "unavailable"
         error = body.get("error")

--- a/apps/mail-adapter/tests/test_poll_transport.py
+++ b/apps/mail-adapter/tests/test_poll_transport.py
@@ -6,9 +6,10 @@ one. A 24h soak of the deployed adapter produced 373 identical
 `poll: list failed with status=0` warnings (#2012) — the numeric status was the
 whole record, so the outage was undiagnosable from the log, and because status 0
 reset the backoff the poller kept hammering the dead endpoint at its normal
-interval. The fix reads the structured body `agentmail.request` already builds
-and arms the existing bounded backoff for transport failures too; these tests
-pin both halves, plus the reset that must still happen on recovery.
+interval. A later soak found the same cadence problem for persistent HTTP 403
+responses (#2555). The fixes expose only bounded, locally synthesized causes and
+arm the existing bounded backoff for transport failures and HTTP refusals; these
+tests pin both halves, plus the reset that must still happen on recovery.
 """
 
 from __future__ import annotations
@@ -126,16 +127,18 @@ def test_a_long_credential_bearing_cause_is_redacted_and_truncated(
         f"the cause is unbounded at {len(cause)} characters: {cause!r}"
     )
     assert cause.endswith("..."), f"the character budget never truncated: {cause!r}"
-    assert adapter._transport_cause(500, {"error": leaked}) == "unavailable", (
-        "a status the adapter did not synthesize the body for was rendered anyway"
+    assert adapter._transport_cause(500, {"error": leaked}) == "http_500", (
+        "a nonzero status was not rendered as its bounded status-only token"
     )
 
 
-def test_a_provider_error_body_is_never_rendered_into_the_log(
+@pytest.mark.parametrize("http_status", [403, 500])
+def test_a_provider_error_body_is_replaced_by_a_bounded_status_token(
     mail: MailState,
     ingress: IngressState,
     adapter: MailAdapter,
     caplog: pytest.LogCaptureFixture,
+    http_status: int,
 ) -> None:
     """A non-200 body is provider-authored, so the adapter must not read it at all.
 
@@ -150,18 +153,111 @@ def test_a_provider_error_body_is_never_rendered_into_the_log(
     decides, and every other failure is recorded by its status code.
     """
     mail.injected_body = {"error": "Subject: payroll spreadsheet; body: SSN 123-45-6789"}
-    mail.fail_next_list = 500
+    mail.fail_next_list = http_status
 
     with caplog.at_level(logging.WARNING, logger="curie_mail_adapter.adapter"):
-        status = adapter.poll_once()
+        observed_status = adapter.poll_once()
 
-    assert status == 500, f"the injected provider failure did not surface, got {status}"
-    message = _failure_record(caplog)
-    assert "cause=unavailable" in message, (
-        f"a provider-authored failure body was rendered into the log: {message!r}"
+    assert observed_status == http_status, (
+        f"the injected provider failure did not surface, got {observed_status}"
     )
+    message = _failure_record(caplog)
+    cause = message.partition("cause=")[2]
+    assert cause == f"http_{http_status}", (
+        f"the provider failure was not reduced to its status-only token: {message!r}"
+    )
+    assert len(cause) <= adapter_module.CAUSE_MAX_CHARS, f"cause is unbounded: {cause!r}"
     assert "SSN" not in message, f"mail content reached the log: {message!r}"
     assert "payroll" not in message, f"mail content reached the log: {message!r}"
+
+
+@pytest.mark.parametrize("refusal_status", [401, 403, 429])
+def test_persistent_http_refusals_back_off_then_200_resets_cadence(
+    mail: MailState,
+    ingress: IngressState,
+    make_adapter: Callable[..., MailAdapter],
+    monkeypatch: pytest.MonkeyPatch,
+    refusal_status: int,
+) -> None:
+    """Repeated HTTP refusals slow discovery; the first 200 restores cadence.
+
+    The fake's HTTP fault is one-shot, so the test re-arms it during the delay
+    that follows each refusal. Every observed status still comes from a real
+    request to the local provider server. Parametrizing 403 with a sibling auth
+    refusal and the already backed-off 429 case protects the full 4xx rule.
+    """
+    monkeypatch.setattr(adapter_module, "BACKOFF_STEP_SECONDS", 0.2)
+    monkeypatch.setattr(adapter_module, "BACKOFF_MAX_SECONDS", 0.6)
+    adapter = make_adapter(poll_interval_seconds=0.01)
+    thread = threading.Thread(target=adapter.poll_loop, daemon=True)
+    refusal_indexes: list[int] = []
+
+    try:
+        thread.start()
+        assert adapter.ready.wait(10), "prime never completed against an empty inbox"
+        for _ in range(3):
+            mail.fail_next_list = refusal_status
+            assert wait_until(lambda: mail.fail_next_list is None, timeout=5), (
+                f"the fake never served HTTP {refusal_status}"
+            )
+            refusal_indexes.append(len(mail.list_times) - 1)
+
+        recovery = refusal_indexes[-1] + 1
+        assert wait_until(lambda: len(mail.list_times) >= recovery + 3, timeout=10), (
+            "the poller never made enough successful passes to expose the 200 reset"
+        )
+    finally:
+        adapter.shutdown.set()
+        thread.join(timeout=10)
+
+    times = mail.list_times
+    assert refusal_indexes == list(range(refusal_indexes[0], refusal_indexes[0] + 3)), (
+        f"the repeated refusals were not consecutive provider calls: {refusal_indexes}"
+    )
+    waits_after_refusals = [
+        times[refusal_indexes[index] + 1] - times[refusal_indexes[index]]
+        for index in range(len(refusal_indexes))
+    ]
+    assert waits_after_refusals[1] > waits_after_refusals[0] + 0.15, (
+        f"HTTP {refusal_status} did not grow the backoff: {waits_after_refusals}"
+    )
+    assert waits_after_refusals[-1] <= 0.61 + 0.25, (
+        f"HTTP {refusal_status} grew past the bounded ceiling: {waits_after_refusals}"
+    )
+    assert times[recovery + 2] - times[recovery + 1] < 0.15, (
+        f"a 200 did not clear the HTTP {refusal_status} backoff"
+    )
+
+
+def test_a_5xx_does_not_arm_backoff(
+    mail: MailState,
+    ingress: IngressState,
+    make_adapter: Callable[..., MailAdapter],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 5xx from an unarmed poller retains its documented normal cadence."""
+    monkeypatch.setattr(adapter_module, "BACKOFF_STEP_SECONDS", 0.2)
+    adapter = make_adapter(poll_interval_seconds=0.01)
+    thread = threading.Thread(target=adapter.poll_loop, daemon=True)
+
+    try:
+        thread.start()
+        assert adapter.ready.wait(10), "prime never completed against an empty inbox"
+        mail.fail_next_list = 500
+        assert wait_until(lambda: mail.fail_next_list is None, timeout=5), (
+            "the fake never served the 500 control"
+        )
+        failed_500 = len(mail.list_times) - 1
+        assert wait_until(lambda: len(mail.list_times) >= failed_500 + 3, timeout=5), (
+            "the poller never made a pass after the 500 control"
+        )
+    finally:
+        adapter.shutdown.set()
+        thread.join(timeout=10)
+
+    assert mail.list_times[failed_500 + 1] - mail.list_times[failed_500] < 0.15, (
+        "a 5xx armed discovery backoff even though that behavior remains out of scope"
+    )
 
 
 def test_repeated_list_transport_failures_back_off_then_reset_on_recovery(


### PR DESCRIPTION
Closes #2555

Backs off status `0` and all 4xx discovery refusals, preserves the documented 200/5xx behavior, and replaces nonzero `cause=unavailable` with a bounded status-only token without reading provider payloads.

Fix pin: apps/mail-adapter/tests/test_poll_transport.py::test_persistent_http_refusals_back_off_then_200_resets_cadence[403]

Discovery waiver: the defect was observed against a deployed provider, but this task explicitly prohibits a live mailbox hit. Evidence below uses the package's real localhost HTTP provider seam; no live-provider proof is claimed.

Tier classification:

- **skill — N/A:** no plugin packaging, runner loop, ACI events, or skill eval/check path changes.
- **local — required and passed:** the mail-adapter process's discovery loop was exercised through the real localhost HTTP provider seam; all 10 transport scenarios passed on `60f55a58a`.
- **local-release — N/A:** no released binary/image identity, install path, version pin, or release Compose change.
- **cluster — N/A:** no chart, RBAC, securityContext, NetworkPolicy, sandbox, or init-container change.
- **live provider — N/A:** no model/provider routing, credentials, auth, token, cost, MCP, workspace, or coding-tool behavior changes.
- **external integration — N/A:** no AgentMail request/response schema or auth contract changed; the implementation consumes only generic HTTP status metadata and never parses the provider payload.

Done-check:

- [x] Failing-tests-first commit — N/A for quick tier; the exact fix pin passes on the candidate and fails when product hunks are reversed.
- [x] Production edits were made by the delegated Codex implementer; the driver made no production/test edits.
- [x] No public function return type was broadened.
- [x] Agent-router Code review 459 approved with file/line evidence.
- [x] Agent-router Scope review 460 found one stale README sentence; the delegated docs fix resolved it and Scope round 465 approved with no findings.
- [x] Sibling-path parity checked: prime and restart confirmation already back off every non-200 response; this diff changes only the requested steady-state discovery poll path.
- [x] Guard demonstration — N/A; no gate, validator, denylist, or preflight changed.
- [x] Consolidation — N/A for quick tier.
- [x] Security review — N/A; no auth, credential, permission, PII handling, or trust-boundary behavior changed.
- [x] Observable verification passed: status 0, 401/403/429, 200 recovery, 500 non-arm/non-clear, bounded causes, and payload-negative controls all passed through local HTTP servers.
- [x] Deployed E2E — N/A; no deployed-surface tier applies and live mailbox access is prohibited.
- [x] Train check passed: v0.8.8 general bug fix is based on and targets `main`.
- [x] Discovery surface is explicitly waived above; no live-provider proof is claimed.
- [x] Re-fix mechanism — N/A; #2012 covered status 0, while #2555 covers omitted 4xx behavior and nonzero diagnostics.
- [x] Final affected validation on `60f55a58a`: lock check, Ruff, scoped mypy, docs-lint, and 175 mail-adapter tests passed.
