### PR TITLE
Redact Discord bot token contexts

### DIFF
--- a/packages/telemetry/src/curie_telemetry/redact.py
+++ b/packages/telemetry/src/curie_telemetry/redact.py
@@ -104,6 +104,28 @@ REDACTION_RULES: tuple[RedactionRule, ...] = (
         _placeholder("google_api_key"),
     ),
     RedactionRule(
+        "discord_bot_authorization",
+        # Discord's API reference demonstrates bot credentials in an
+        # ``Authorization: Bot <token>`` header:
+        # https://docs.discord.com/developers/reference
+        re.compile(
+            r"(?<![A-Za-z0-9_-])(Authorization:\s+Bot\s+)(?!\[REDACTED:)"
+            r"[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"
+            r"(?![A-Za-z0-9_-]|\.[A-Za-z0-9_-]+)",
+            re.IGNORECASE,
+        ),
+        r"\1[REDACTED:discord_bot_authorization]",
+    ),
+    RedactionRule(
+        "discord_bot_token_assignment",
+        re.compile(
+            r"(?<![A-Za-z0-9_])(DISCORD_BOT_TOKEN=)"
+            r"(?!\[REDACTED:)[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"
+            r"(?![A-Za-z0-9_-]|\.[A-Za-z0-9_-]+)"
+        ),
+        r"\1[REDACTED:discord_bot_token_assignment]",
+    ),
+    RedactionRule(
         "secret_assignment",
         # ``\b`` does not fire before ``token`` in ``CURIE_CHANNEL_TOKEN=``
         # because ``_`` is a word character. Require a non-alphanumeric

--- a/packages/telemetry/tests/test_logging.py
+++ b/packages/telemetry/tests/test_logging.py
@@ -15,6 +15,26 @@ from opentelemetry.sdk._logs.export import (
 )
 from opentelemetry.sdk.trace import TracerProvider
 
+_FAKE_DISCORD_BOT_TOKEN = (
+    "FAKEFAKEFAKEFAKEFAKE0000." + "FAKE00." + "FAKEFAKEFAKEFAKEFAKEFAKE000"
+)
+_FAKE_DISCORD_BOT_AUTHORIZATION = (
+    "Authorization: Bot " + _FAKE_DISCORD_BOT_TOKEN
+)
+_FAKE_DISCORD_BOT_TOKEN_ASSIGNMENT = (
+    "DISCORD_BOT_TOKEN=" + _FAKE_DISCORD_BOT_TOKEN
+)
+_DISCORD_VECTOR_EXPECTATIONS = {
+    _FAKE_DISCORD_BOT_AUTHORIZATION: (
+        "discord_bot_authorization",
+        "Authorization: Bot ",
+    ),
+    _FAKE_DISCORD_BOT_TOKEN_ASSIGNMENT: (
+        "discord_bot_token_assignment",
+        "DISCORD_BOT_TOKEN=",
+    ),
+}
+
 _SECRET_VECTORS = (
     "sk-" + "FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE0000",
     "AKIA" + "EXAMPLEFAKEKEY0000",
@@ -40,6 +60,8 @@ _SECRET_VECTORS = (
     "CURIE_CHANNEL_TOKEN=" + "FAKEFAKEFAKEHEADERVALUE0000",
     "CURIE_EGRESS_SECRET=" + "FAKEFAKEFAKEEGRESS0000",
     "X-API-Key: " + "FAKEFAKEFAKEHEADERVALUE0000",
+    _FAKE_DISCORD_BOT_AUTHORIZATION,
+    _FAKE_DISCORD_BOT_TOKEN_ASSIGNMENT,
 )
 
 
@@ -303,12 +325,26 @@ def test_args_style_service_log_is_correlated_redacted_and_preserved_on_stderr(
         assert stderr_record["severity"] == "ERROR"
         assert stderr_record["trace_id"] == f"{expected_trace_id:032x}"
         assert stderr_record["span_id"] == f"{expected_span_id:016x}"
+        assert "runner request failed value=" in stderr_record["message"]
         assert redaction_probe not in stderr_record["message"]
         assert "[REDACTED:" in stderr_record["message"]
+        discord_expectation = _DISCORD_VECTOR_EXPECTATIONS.get(redaction_probe)
+        if discord_expectation is not None:
+            rule_name, carrier = discord_expectation
+            assert _FAKE_DISCORD_BOT_TOKEN not in stderr_record["message"]
+            assert f"[REDACTED:{rule_name}]" in stderr_record["message"]
+            assert carrier in stderr_record["message"]
 
         (exported,) = exporter.get_finished_logs()
-        assert redaction_probe not in _body(exported)
-        assert "[REDACTED:" in _body(exported)
+        exported_body = _body(exported)
+        assert "runner request failed value=" in exported_body
+        assert redaction_probe not in exported_body
+        assert "[REDACTED:" in exported_body
+        if discord_expectation is not None:
+            rule_name, carrier = discord_expectation
+            assert _FAKE_DISCORD_BOT_TOKEN not in exported_body
+            assert f"[REDACTED:{rule_name}]" in exported_body
+            assert carrier in exported_body
         assert _trace_ids(exported) == (expected_trace_id, expected_span_id)
     finally:
         logger.handlers[:] = original_handlers

--- a/packages/telemetry/tests/test_redact.py
+++ b/packages/telemetry/tests/test_redact.py
@@ -19,6 +19,15 @@ FAKE_CHANNEL_TOKEN = "chn." + "ZXhhbXBsZWNoYW5uZWxwYXlsb2Fk." + "FAKEFAKEFAKESIG
 FAKE_AGENTMAIL_API_KEY = "am_" + "FAKEFAKEFAKEFAKEFAKE0000"
 FAKE_EGRESS_SECRET = "FAKEFAKEFAKEEGRESS0000"
 FAKE_HEADER_VALUE = "FAKEFAKEFAKEHEADERVALUE0000"
+# Discord documents ``Authorization: Bot id.timestamp.hmac``:
+# https://docs.discord.com/developers/reference
+# These synthetic segments mirror its example's 24/6/27 lengths only to keep
+# the positive representative; the lengths are not part of the asserted grammar.
+FAKE_DISCORD_BOT_TOKEN = (
+    "FAKEFAKEFAKEFAKEFAKE0000." + "FAKE00." + "FAKEFAKEFAKEFAKEFAKEFAKE000"
+)
+FAKE_DISCORD_BOT_AUTHORIZATION = "Authorization: Bot " + FAKE_DISCORD_BOT_TOKEN
+FAKE_DISCORD_BOT_TOKEN_ASSIGNMENT = "DISCORD_BOT_TOKEN=" + FAKE_DISCORD_BOT_TOKEN
 # Delivery correlation id from the channel protocol tests, not a credential.
 BENIGN_EVENT_ID = "chn-7f3-a1b2c3d4e5f60718"
 
@@ -92,6 +101,89 @@ def test_unprefixed_secret_without_assignment_or_header_context_is_not_redacted(
     line = f"retry after {FAKE_EGRESS_SECRET} milliseconds"
 
     assert redact_text(line) == line
+
+
+def test_discord_bot_authorization_is_redacted() -> None:
+    redacted = redact_text(
+        f"request used {FAKE_DISCORD_BOT_AUTHORIZATION} and was rejected"
+    )
+
+    assert FAKE_DISCORD_BOT_TOKEN not in redacted
+    assert redacted == (
+        "request used Authorization: Bot "
+        "[REDACTED:discord_bot_authorization] and was rejected"
+    )
+
+
+def test_discord_bot_authorization_is_matched_case_insensitively() -> None:
+    mixed_case_authorization = "aUtHoRiZaTiOn: bOt " + FAKE_DISCORD_BOT_TOKEN
+
+    redacted = redact_text(f"request used {mixed_case_authorization} and was rejected")
+
+    assert FAKE_DISCORD_BOT_TOKEN not in redacted
+    assert redacted == (
+        "request used aUtHoRiZaTiOn: bOt "
+        "[REDACTED:discord_bot_authorization] and was rejected"
+    )
+
+
+def test_discord_bot_token_assignments_are_redacted() -> None:
+    redacted = redact_text(f"boot {FAKE_DISCORD_BOT_TOKEN_ASSIGNMENT} ready")
+
+    assert FAKE_DISCORD_BOT_TOKEN not in redacted
+    assert redacted == (
+        "boot DISCORD_BOT_TOKEN=[REDACTED:discord_bot_token_assignment] ready"
+    )
+
+
+def test_bare_discord_bot_token_without_context_is_not_redacted() -> None:
+    for line in (
+        FAKE_DISCORD_BOT_TOKEN,
+        f"provider diagnostic value={FAKE_DISCORD_BOT_TOKEN}",
+    ):
+        assert redact_text(line) == line
+
+
+def test_ordinary_three_segment_diagnostic_is_not_redacted() -> None:
+    for line in (
+        "retry route=worker.us-east-1.stable after backoff",
+        "bot 1.0.0 started",
+        "the Bot v1.2.3 worker is healthy",
+    ):
+        assert redact_text(line) == line
+
+
+def test_discord_bot_token_near_matches_are_not_redacted() -> None:
+    two_segments = "FAKEFAKEFAKEFAKEFAKE0000." + "FAKE00"
+    four_segments = FAKE_DISCORD_BOT_TOKEN + "." + "FAKE_EXTRA-0000"
+
+    for line in (
+        two_segments,
+        four_segments,
+        "Authorization: Bot " + two_segments,
+        "Authorization: Bot " + four_segments,
+    ):
+        assert redact_text(line) == line
+
+
+def test_discord_bot_assignment_near_matches_use_generic_redaction() -> None:
+    two_segments = "FAKEFAKEFAKEFAKEFAKE0000." + "FAKE00"
+    four_segments = FAKE_DISCORD_BOT_TOKEN + "." + "FAKE_EXTRA-0000"
+
+    for malformed_value in (two_segments, four_segments):
+        redacted = redact_text("DISCORD_BOT_TOKEN=" + malformed_value)
+
+        assert malformed_value not in redacted
+        assert redacted == "DISCORD_BOT_TOKEN=[REDACTED:secret_assignment]"
+        assert "[REDACTED:discord_bot_token_assignment]" not in redacted
+
+
+def test_discord_bot_redaction_is_idempotent() -> None:
+    for secret in (
+        FAKE_DISCORD_BOT_AUTHORIZATION,
+        FAKE_DISCORD_BOT_TOKEN_ASSIGNMENT,
+    ):
+        assert redact_text(redact_text(secret)) == redact_text(secret)
 
 
 def test_x_api_key_header_value_is_redacted() -> None:

--- a/runner/tests/test_redact.py
+++ b/runner/tests/test_redact.py
@@ -66,6 +66,11 @@ FAKE_SECRET_ASSIGNMENT = "secret=" + "0000FAKEFAKEFAKEVALUE"
 FAKE_HOME_PATH = "/home/theconnman/.config/curie/settings.json"
 FAKE_CHANNEL_TOKEN = "chn." + "ZXhhbXBsZWNoYW5uZWxwYXlsb2Fk." + "FAKEFAKEFAKESIG0000"
 FAKE_X_API_KEY_HEADER = "X-API-Key: " + "FAKEFAKEFAKEHEADERVALUE0000"
+_FAKE_DISCORD_BOT_TOKEN = (
+    "FAKEFAKEFAKEFAKEFAKE0000." + "FAKE00." + "FAKEFAKEFAKEFAKEFAKEFAKE000"
+)
+FAKE_DISCORD_BOT_AUTHORIZATION = "Authorization: Bot " + _FAKE_DISCORD_BOT_TOKEN
+FAKE_DISCORD_BOT_TOKEN_ASSIGNMENT = "DISCORD_BOT_TOKEN=" + _FAKE_DISCORD_BOT_TOKEN
 
 # The sensitive substring that must be absent from every boundary's output,
 # keyed by rule name. VECTORS is derived from this so the two cannot drift.
@@ -86,6 +91,8 @@ SECRET_LITERALS: dict[str, str] = {
     "home_path": FAKE_HOME_PATH,
     "channel_token": FAKE_CHANNEL_TOKEN,
     "x_api_key": FAKE_X_API_KEY_HEADER,
+    "discord_bot_authorization": FAKE_DISCORD_BOT_AUTHORIZATION,
+    "discord_bot_token_assignment": FAKE_DISCORD_BOT_TOKEN_ASSIGNMENT,
 }
 
 # One frozen vector per rule: a realistic runner output line carrying that class


### PR DESCRIPTION
Closes #2532

Adds context-bound redaction for Discord's documented `Authorization: Bot <token>` form and the real `DISCORD_BOT_TOKEN=` assignment. Bare three-segment strings remain untouched outside those contexts, and all fixtures are synthetic.

Provider grounding: https://docs.discord.com/developers/reference

Fix pin: packages/telemetry/tests/test_redact.py::test_discord_bot_authorization_is_redacted

Done-check:

- [x] Failing tests were committed before production implementation.
- [x] All production and test edits were performed by delegated native Codex workers.
- [x] No public return type was broadened.
- [x] Routed Code and Scope reviews converged with file-evidenced findings resolved.
- [x] Sibling-path parity is pinned through shared telemetry plus runner stdout, logging-args, and gen-AI span boundary vectors.
- [x] Guard demonstration executed both positive contexts and bare, semver, and malformed negative controls.
- [x] Consolidation fallback found no safe simplification; no consolidation diff required revalidation or re-review.
- [x] Routed Security review converged with no blocking findings.
- [x] Observable user-facing verification: N/A; no user flow changed.
- [x] Deployed E2E: N/A; no service wiring, chart, image, credential resolution, or external Discord traffic changed.
- [x] Train check: rebased final candidate onto current `origin/main` for the v0.8.8 stable-line fix.
- [x] Discovery-surface proof: N/A; this defense-in-depth gap was identified at unit/source review, not from cluster or live traffic.
- [x] Re-fix mechanism: N/A; #2359 established the contextual pattern but did not claim Discord coverage.
- [x] Full affected verification passed: 1,073 tests, Ruff, mypy, docs/interface checks, and exact fix-pin `PINNED`.
