### PR TITLE
Prove BYO runner peers from a runner-labelled pod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1907,6 +1907,14 @@ jobs:
       # neither reads nor disturbs the release installed above.
       - name: Mail-adapter external-collector egress enforces (not just rendered)
         run: bash scripts/check-mail-adapter-otel-egress.sh charts/curie
+      # Runner BYO egress (#2369). Render assertions prove the CIDRs land in
+      # NetworkPolicy YAML; this proves a runner-labelled pod can actually
+      # reach each declared peer (rustfs, sts, otel, api) and that an
+      # undeclared control is blocked. Same non-vacuity gate as the mail
+      # adapter check: a non-enforcing CNI FAILS, it does not skip. Own
+      # namespace, so it neither reads nor disturbs the release above.
+      - name: Runner BYO egress enforces (not just rendered)
+        run: bash scripts/check-runner-byo-egress.sh charts/curie
       # Surface why on any failure above: pod states, recent events, and the
       # worker/runner logs are what localize a reachability or scheduling break.
       - name: Dump cluster diagnostics on failure

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -300,6 +300,15 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/security-probe-byo-postgres-assertions.sh
 
+      # Prove Claim 1d lists BYO runner peers in BYO_RUNNER_TARGETS when the
+      # corresponding -endpoint / object-store policy would render, skips when
+      # empty, and still curls Claim 1 BLOCKED (#2369). Live reachability is
+      # scripts/check-runner-byo-egress.sh, not this render pin.
+      - name: helm render assertions (BYO runner-egress security probe)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/security-probe-byo-runner-egress-assertions.sh
+
       # Keep the chart ClickHouse default and Langfuse pin as one supported
       # pair. ClickHouse 24.8 cannot apply Langfuse 3.225.x migration 39, so
       # the default must stay on 25.12 and AVX-required (#2210).

--- a/charts/curie/ci/security-probe-byo-runner-egress-assertions.sh
+++ b/charts/curie/ci/security-probe-byo-runner-egress-assertions.sh
@@ -1,0 +1,402 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for issue #2369. This file is the fix pin.
+#
+# Render-only: helm template --show-only templates/security-probe.yaml.
+# Live proof that a runner-labelled pod can actually reach each declared BYO
+# peer (and that an undeclared control is blocked) is
+# scripts/check-runner-byo-egress.sh, not this script.
+#
+# Claim 1 already curls BLOCKED to prove CNI enforcement. It never curls a
+# declared BYO peer, so a SaaS OTLP collector or API behind rotating LB
+# addresses can drop traffic while helm-template of the NetworkPolicy is
+# green. Claim 1d injects BYO_RUNNER_TARGETS (space-separated name=host:port)
+# for the same conditions that render the BYO runner allows, then nc/curl
+# each target and curl BLOCKED as the undeclared control.
+#
+# Asserts:
+#
+#   1. default: BYO_RUNNER_TARGETS is empty. The probe script still carries a
+#      Claim 1d SKIP path that names BYO_RUNNER_TARGETS (gated on empty).
+#      Claim 1 still curls BLOCKED; Claim 1d does not have to run on default.
+#   2. static-key rustfs BYO (deploy=false + host + egress /32, default
+#      accessKey): target includes rustfs=s3.example.com:443. The script reads
+#      BYO_RUNNER_TARGETS, nc/curl those targets, and curls BLOCKED when
+#      targets are non-empty.
+#   3. key-free rustfs BYO (accessKey empty + stsEgress): targets include
+#      rustfs=s3.example.com:443 and sts=192.0.2.11:443 (CIDR prefix stripped).
+#   4. otelCollector BYO with https://otlp.example.net:4318: target includes
+#      otel=otlp.example.net:4318 and that otel token must not use :443.
+#   5. api BYO (deploy=false + dispatcher/ui apiBaseUrl + api.egress): target
+#      includes api=api.example.net:443 (https scheme default).
+#   6. NEGATIVE: rustfs.host set while rustfs.deploy stays true (no egress).
+#      BYO_RUNNER_TARGETS must not contain s3.example.com; the in-chart pod
+#      selector still governs.
+#   7. Dedicated default pin: the Claim 1d skip path exists AND Claim 1 still
+#      curls BLOCKED (Claim 1d must not replace the undeclared before/after).
+#   8. Guard: same otel BYO as 4; the otel= token port is 4318, not 443.
+#
+# Addresses are RFC 5737 TEST-NET-1 and example.net only. Runnable locally
+# and from CI. Fails loudly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP="$(mktemp -d)"
+
+cleanup() {
+  [[ -n "${TMP:-}" && -d "$TMP" ]] && rm -rf -- "$TMP"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+render_probe() {
+  local name="$1"
+  shift
+  local out="$TMP/${name}.yaml"
+  helm template curie "$CHART" \
+    --show-only templates/security-probe.yaml \
+    "$@" >"$out"
+  printf '%s\n' "$out"
+}
+
+S3_CIDR=192.0.2.10/32
+STS_CIDR=192.0.2.11/32
+COLLECTOR_CIDR=192.0.2.20/32
+API_CIDR=192.0.2.21/32
+OTLP_ENDPOINT=https://otlp.example.net:4318
+API_BASE_URL=https://api.example.net
+
+CHECKER="$TMP/check.py"
+cat > "$CHECKER" <<'PY'
+import pathlib
+import sys
+
+import yaml
+
+
+def die(message):
+    raise SystemExit(message)
+
+
+def load_probe_job(path):
+    docs = [doc for doc in yaml.safe_load_all(pathlib.Path(path).read_text()) if doc]
+    jobs = [doc for doc in docs if doc.get("kind") == "Job"]
+    if len(jobs) != 1:
+        die(f"{path}: expected exactly one Job, found {len(jobs)}")
+    containers = (
+        jobs[0]
+        .get("spec", {})
+        .get("template", {})
+        .get("spec", {})
+        .get("containers", [])
+    )
+    probes = [container for container in containers if container.get("name") == "probe"]
+    if len(probes) != 1:
+        die(f"{path}: expected exactly one probe container, found {len(probes)}")
+    return probes[0]
+
+
+def env_entry(container, name):
+    entries = [
+        entry for entry in container.get("env", []) if entry.get("name") == name
+    ]
+    if len(entries) != 1:
+        die(
+            f"probe env {name!r} is required as exactly one literal value, "
+            f"found {len(entries)} entries"
+        )
+    if set(entries[0]) != {"name", "value"}:
+        die(f"probe env {name!r} must be one literal value, got {entries[0]!r}")
+    return entries[0]["value"]
+
+
+def command_script(container):
+    command = container.get("command") or []
+    if not command:
+        die("probe container has no command")
+    return "\n".join(str(part) for part in command)
+
+
+def claim_1d_section(script):
+    start = script.find("Claim 1d")
+    if start < 0:
+        die("probe script must contain a Claim 1d path")
+    end = script.find("Claim 2", start)
+    if end < 0:
+        end = len(script)
+    return script[start:end]
+
+
+def claim_1_before_1d(script):
+    start = script.find("Claim 1:")
+    if start < 0:
+        start = script.find("== Claim 1")
+    if start < 0:
+        die("probe script must still contain Claim 1")
+    end = script.find("Claim 1d", start)
+    if end < 0:
+        end = script.find("Claim 2", start)
+        if end < 0:
+            end = len(script)
+    return script[start:end]
+
+
+def require_claim1d_skip(script):
+    section = claim_1d_section(script)
+    if "BYO_RUNNER_TARGETS" not in section:
+        die(
+            "Claim 1d SKIP path must name BYO_RUNNER_TARGETS so the empty "
+            "list is an explicit skip, not a silent disappearance"
+        )
+    if "SKIP" not in section:
+        die("Claim 1d must SKIP when BYO_RUNNER_TARGETS is empty")
+    gated = (
+        '-z "$BYO_RUNNER_TARGETS"' in section
+        or '-z "${BYO_RUNNER_TARGETS}"' in section
+        or '-n "$BYO_RUNNER_TARGETS"' in section
+        or '-n "${BYO_RUNNER_TARGETS}"' in section
+    )
+    if not gated:
+        die("Claim 1d skip must be gated on empty BYO_RUNNER_TARGETS")
+
+
+def require_claim1_blocked(script):
+    body = claim_1_before_1d(script)
+    if "https://${BLOCKED}/" not in body:
+        die(
+            "Claim 1 must still curl BLOCKED; Claim 1d must not replace the "
+            "undeclared before/after CNI proof"
+        )
+
+
+def require_claim1d_probes_targets(script):
+    section = claim_1d_section(script)
+    if "$BYO_RUNNER_TARGETS" not in section:
+        die(
+            "probe script must read BYO_RUNNER_TARGETS at runtime so the "
+            "declared peers are not a dead env var"
+        )
+    uses_nc = "nc -z" in section or " nc " in section
+    uses_curl = "curl" in section or "probe_rc" in section
+    if not (uses_nc or uses_curl):
+        die("Claim 1d must nc or curl each BYO_RUNNER_TARGETS peer")
+    if "https://${BLOCKED}/" not in section:
+        die(
+            "Claim 1d must curl BLOCKED when targets are non-empty "
+            "(undeclared control)"
+        )
+
+
+def main():
+    path, mode = sys.argv[1], sys.argv[2]
+    container = load_probe_job(path)
+    raw = env_entry(container, "BYO_RUNNER_TARGETS")
+    if raw is None:
+        die("probe env 'BYO_RUNNER_TARGETS' is required as a literal value")
+    targets = str(raw).split()
+    script = command_script(container)
+
+    if mode == "default":
+        if str(raw).strip() != "":
+            die(f"default BYO_RUNNER_TARGETS must be empty, got {raw!r}")
+        require_claim1d_skip(script)
+        require_claim1_blocked(script)
+        print("  ok: default BYO_RUNNER_TARGETS is empty; Claim 1d skip is gated on it")
+        return
+
+    if mode == "rustfs-static":
+        if "rustfs=s3.example.com:443" not in targets:
+            die(
+                "static-key BYO must include 'rustfs=s3.example.com:443'; "
+                f"got {targets!r}"
+            )
+        if any(item.startswith("sts=") for item in targets):
+            die(f"static-key BYO must not include an sts= target; got {targets!r}")
+        if any("192.0.2.10" in item for item in targets):
+            die(
+                "rustfs target must use rustfs.host:port, not the egress CIDR; "
+                f"got {targets!r}"
+            )
+        require_claim1d_probes_targets(script)
+        print("  ok: static-key BYO lists rustfs=s3.example.com:443 and probes it")
+        return
+
+    if mode == "rustfs-keyfree":
+        if "rustfs=s3.example.com:443" not in targets:
+            die(
+                "key-free BYO must include 'rustfs=s3.example.com:443'; "
+                f"got {targets!r}"
+            )
+        if "sts=192.0.2.11:443" not in targets:
+            die(
+                "key-free BYO must include 'sts=192.0.2.11:443' (CIDR prefix "
+                f"stripped); got {targets!r}"
+            )
+        sts_tokens = [item for item in targets if item.startswith("sts=")]
+        if any("/" in item for item in sts_tokens):
+            die(f"sts token must strip the /prefix from cidr; got {sts_tokens!r}")
+        require_claim1d_probes_targets(script)
+        print("  ok: key-free BYO lists rustfs host:port and sts IP:port")
+        return
+
+    if mode == "otel":
+        if "otel=otlp.example.net:4318" not in targets:
+            die(
+                "BYO otel must include 'otel=otlp.example.net:4318'; "
+                f"got {targets!r}"
+            )
+        otel_tokens = [item for item in targets if item.startswith("otel=")]
+        if any(item.rsplit(":", 1)[-1] == "443" for item in otel_tokens):
+            die(
+                "otel token must not use :443 when the URL is "
+                f"https://otlp.example.net:4318; got {otel_tokens!r}"
+            )
+        require_claim1d_probes_targets(script)
+        print("  ok: BYO otel lists otel=otlp.example.net:4318")
+        return
+
+    if mode == "api":
+        if "api=api.example.net:443" not in targets:
+            die(
+                "BYO api must include 'api=api.example.net:443' (https scheme "
+                f"default); got {targets!r}"
+            )
+        require_claim1d_probes_targets(script)
+        print("  ok: BYO api lists api=api.example.net:443")
+        return
+
+    if mode == "host-ignored-when-deployed":
+        if any("s3.example.com" in item for item in targets):
+            die(
+                "rustfs.host must not populate BYO_RUNNER_TARGETS while "
+                f"rustfs.deploy stays true; got {targets!r}"
+            )
+        print("  ok: rustfs.host is ignored for Claim 1d while deploy is true")
+        return
+
+    if mode == "default-skip-and-claim1":
+        if str(raw).strip() != "":
+            die(f"default BYO_RUNNER_TARGETS must be empty, got {raw!r}")
+        require_claim1d_skip(script)
+        require_claim1_blocked(script)
+        print("  ok: default Claim 1d skip exists and Claim 1 still curls BLOCKED")
+        return
+
+    if mode == "otel-port-guard":
+        otel_tokens = [item for item in targets if item.startswith("otel=")]
+        if "otel=otlp.example.net:4318" not in otel_tokens:
+            die(
+                "guard: otel= token port must be 4318 (URL-explicit), "
+                f"got {otel_tokens!r} in {targets!r}"
+            )
+        if any(item.rsplit(":", 1)[-1] == "443" for item in otel_tokens):
+            die(
+                "guard: otel= token must not collapse "
+                "https://otlp.example.net:4318 to port 443; "
+                f"got {otel_tokens!r}"
+            )
+        print("  ok: otel= token keeps explicit :4318 and does not emit :443")
+        return
+
+    die(f"unknown mode {mode!r}")
+
+
+if __name__ == "__main__":
+    main()
+PY
+
+echo "=== Assertion 1: default BYO_RUNNER_TARGETS is empty; Claim 1d skip is present ==="
+DEFAULT_RENDER="$(render_probe default)"
+python3 "$CHECKER" "$DEFAULT_RENDER" default
+
+echo "=== Assertion 2: static-key rustfs BYO lists rustfs=s3.example.com:443 and probes it ==="
+STATIC_VALUES="$TMP/static.yaml"
+cat > "$STATIC_VALUES" <<EOF
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+  egress:
+    - cidr: ${S3_CIDR}
+      ports: [{ protocol: TCP, port: 443 }]
+EOF
+STATIC_RENDER="$(render_probe rustfs-static --values "$STATIC_VALUES")"
+python3 "$CHECKER" "$STATIC_RENDER" rustfs-static
+
+echo "=== Assertion 3: key-free rustfs BYO lists rustfs host:port and sts IP:port ==="
+KEYFREE_VALUES="$TMP/keyfree.yaml"
+cat > "$KEYFREE_VALUES" <<EOF
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+  auth:
+    accessKey: ""
+  egress:
+    - cidr: ${S3_CIDR}
+      ports: [{ protocol: TCP, port: 443 }]
+  stsEgress:
+    - cidr: ${STS_CIDR}
+      ports: [{ protocol: TCP, port: 443 }]
+api:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-api
+worker:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-worker
+agentSandbox:
+  runner:
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-runner
+EOF
+KEYFREE_RENDER="$(render_probe rustfs-keyfree --values "$KEYFREE_VALUES")"
+python3 "$CHECKER" "$KEYFREE_RENDER" rustfs-keyfree
+
+echo "=== Assertion 4: BYO otel lists otel=otlp.example.net:4318, not :443 ==="
+OTEL_VALUES="$TMP/otel.yaml"
+cat > "$OTEL_VALUES" <<EOF
+otelCollector:
+  deploy: false
+  endpoint: ${OTLP_ENDPOINT}
+  egress:
+    - cidr: ${COLLECTOR_CIDR}
+      ports: [{ protocol: TCP, port: 4318 }]
+EOF
+OTEL_RENDER="$(render_probe otel-byo --values "$OTEL_VALUES")"
+python3 "$CHECKER" "$OTEL_RENDER" otel
+
+echo "=== Assertion 5: BYO api lists api=api.example.net:443 ==="
+API_VALUES="$TMP/api.yaml"
+cat > "$API_VALUES" <<EOF
+api:
+  deploy: false
+  egress:
+    - cidr: ${API_CIDR}
+      ports: [{ protocol: TCP, port: 443 }]
+dispatcher:
+  apiBaseUrl: ${API_BASE_URL}
+ui:
+  apiBaseUrl: ${API_BASE_URL}
+EOF
+API_RENDER="$(render_probe api-byo --values "$API_VALUES")"
+python3 "$CHECKER" "$API_RENDER" api
+
+echo "=== Assertion 6: rustfs.host is ignored while deploy stays true ==="
+HOST_SET_RENDER="$(render_probe host-set --set rustfs.host=s3.example.com)"
+python3 "$CHECKER" "$HOST_SET_RENDER" host-ignored-when-deployed
+
+echo "=== Assertion 7: default Claim 1d skip exists and Claim 1 still curls BLOCKED ==="
+python3 "$CHECKER" "$DEFAULT_RENDER" default-skip-and-claim1
+
+echo "=== Assertion 8: otel= token port is 4318, not 443 ==="
+python3 "$CHECKER" "$OTEL_RENDER" otel-port-guard
+
+echo "PASS: security probe Claim 1d lists BYO runner peers in BYO_RUNNER_TARGETS (rustfs host:port, sts CIDR-IP:port, otel dialPort, api scheme-default), skips when empty, still curls Claim 1 BLOCKED, and ignores rustfs.host while deploy stays true"

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -1107,6 +1107,35 @@ before contacting Valkey.
 {{- end -}}
 {{- end -}}
 
+{{/* TCP port a URL actually dials. Same urlParse plus :[0-9]+$ plus
+     scheme-default pattern as curie.mailAdapter.otelEgressPort: the URL
+     port wins; else https => 443, http => 80. Empty scheme and no
+     explicit port emit empty -- do not invent 4318. Does not fail. */}}
+{{- define "curie.endpoint.dialPort" -}}
+{{- $raw := trim . -}}
+{{- if $raw -}}
+{{- $parsed := urlParse $raw -}}
+{{- $hostPort := $parsed.host | default "" -}}
+{{- $scheme := lower ($parsed.scheme | default "") -}}
+{{/* A bracketed IPv6 host is NOT skipped here, which is the opposite of
+     curie.endpoint.host: that helper leaves brackets intact because such a host
+     is never in-chart Service DNS, whereas this helper must still find the
+     port. ":[0-9]+$" is safe on a literal address because a bare bracketed host
+     ends in "]" -- only a real port can follow the closing bracket, so a hextet
+     is never mistaken for one. Skipping brackets instead left $urlPort empty,
+     fell through to the scheme default, and opened 443 while the SDK dialled
+     the port the URL actually named. */}}
+{{- $urlPort := trimPrefix ":" (regexFind ":[0-9]+$" $hostPort) -}}
+{{- if $urlPort -}}
+{{- $urlPort -}}
+{{- else if eq $scheme "https" -}}
+443
+{{- else if eq $scheme "http" -}}
+80
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{/* True when host is this release's Service DNS for component (api or
      otel-collector), including the usual cluster.local FQDNs. */}}
 {{- define "curie.host.inChartService" -}}

--- a/charts/curie/templates/security-probe.yaml
+++ b/charts/curie/templates/security-probe.yaml
@@ -7,7 +7,9 @@ defaults as a `helm test`. Five claims:
   1. default-deny egress + metadata endpoint blocked, WITH a before/after control
      that proves the CNI actually enforces (not a silent false-pass). Claim 1c
      additionally proves the vendored controller is not shadow-managing its own
-     permissive NetworkPolicy alongside Rail 1's (issue #765).
+     permissive NetworkPolicy alongside Rail 1's (issue #765). Claim 1d
+     additionally proves declared BYO runner peers are reachable and an
+     undeclared control stays BLOCKED (issue #2369).
   2. cross-agent secret isolation via per-agent RBAC scoping.
   3. runner containers are non-root with a read-only rootfs.
   4. gVisor RuntimeClass enforced (reported testable / not-testable honestly;
@@ -174,6 +176,7 @@ spec:
      endpoint, and helm test would fail a correct BYO/RDS install. */}}
 {{- $dt := list -}}
 {{- $pgByo := "" -}}
+{{- $byoRunner := list -}}
 {{- if and (not .Values.postgres.deploy) .Values.postgres.host -}}
 {{- $pgByo = printf "%s:%v" .Values.postgres.host .Values.postgres.port -}}
 {{- end -}}
@@ -182,6 +185,50 @@ spec:
 {{- if .Values.rustfs.deploy }}{{- $dt = append $dt (printf "%s:%v" (include "curie.rustfs.host" .) .Values.rustfs.port) -}}{{- end }}
 {{- if .Values.clickhouse.deploy }}{{- $dt = append $dt (printf "%s:8123" (include "curie.clickhouse.host" .)) -}}{{- end }}
 {{- if .Values.valkey.deploy }}{{- $dt = append $dt (printf "%s:6379" (include "curie.valkey.host" .)) -}}{{- end }}
+{{- end -}}
+{{- if and .Values.agentSandbox.deploy .Values.security.networkPolicy.enabled -}}
+{{- $apiExternal := include "curie.runner.apiIsExternal" . | trim -}}
+{{- $otlpExternal := include "curie.runner.otlpIsExternal" . | trim -}}
+{{- $otlpEndpoint := include "curie.runner.effectiveOtlpEndpoint" . | trim -}}
+{{- if and (or .Values.agentSandbox.runner.bundleFetch.enabled .Values.agentSandbox.runner.workspace.enabled) (not .Values.rustfs.deploy) .Values.rustfs.egress -}}
+{{- $rustfsHost := include "curie.rustfs.host" . | trim -}}
+{{- if and $rustfsHost (not (contains ":" $rustfsHost)) (not (contains "[" $rustfsHost)) -}}
+{{- $byoRunner = append $byoRunner (printf "rustfs=%s:%v" $rustfsHost .Values.rustfs.port) -}}
+{{- end -}}
+{{- if and (not (include "curie.rustfs.staticCredentials" .)) .Values.rustfs.stsEgress -}}
+{{- $sts0 := index .Values.rustfs.stsEgress 0 -}}
+{{- $stsCidr := trim (printf "%v" ($sts0.cidr | default "")) -}}
+{{/* Only a /32 or /128 is a host. A /24 network address has no STS listener,
+     and the chart has no STS hostname field, so skip rather than probe .0. */}}
+{{- if or (hasSuffix "/32" $stsCidr) (hasSuffix "/128" $stsCidr) -}}
+{{- $stsIp := regexReplaceAll "/[0-9]+$" $stsCidr "" -}}
+{{- $stsPort := "" -}}
+{{- if $sts0.ports -}}
+{{- $stsPortItem := index $sts0.ports 0 -}}
+{{- $stsPort = printf "%v" ($stsPortItem.port | default "") -}}
+{{- end -}}
+{{- if and $stsIp $stsPort (not (contains ":" $stsIp)) -}}
+{{- $byoRunner = append $byoRunner (printf "sts=%s:%s" $stsIp $stsPort) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if and .Values.otelCollector.egress (or (and (not .Values.otelCollector.deploy) $otlpEndpoint) $otlpExternal) -}}
+{{- $otelUrl := $otlpEndpoint -}}
+{{- $otelHost := include "curie.endpoint.host" $otelUrl | trim -}}
+{{- $otelPort := include "curie.endpoint.dialPort" $otelUrl | trim -}}
+{{- if and $otelHost $otelPort (not (contains "[" $otelHost)) (not (contains ":" $otelHost)) -}}
+{{- $byoRunner = append $byoRunner (printf "otel=%s:%s" $otelHost $otelPort) -}}
+{{- end -}}
+{{- end -}}
+{{- if and .Values.api.egress (or (and (not .Values.api.deploy) (include "curie.runner.apiOverrideSet" .)) $apiExternal) -}}
+{{- $apiUrl := include "curie.runner.effectiveApiUrl" . | trim -}}
+{{- $apiHost := include "curie.endpoint.host" $apiUrl | trim -}}
+{{- $apiPort := include "curie.endpoint.dialPort" $apiUrl | trim -}}
+{{- if and $apiHost $apiPort (not (contains "[" $apiHost)) (not (contains ":" $apiHost)) -}}
+{{- $byoRunner = append $byoRunner (printf "api=%s:%s" $apiHost $apiPort) -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 apiVersion: batch/v1
 kind: Job
@@ -253,6 +300,11 @@ spec:
             # it (no in-cluster deny/allow pair exists for an external store).
             - name: POSTGRES_BYO_TARGET
               value: {{ $pgByo | quote }}
+            # Claim 1d (#2369): space-separated name=host:port for BYO runner
+            # peers whose -endpoint / object-store policy would render. Empty
+            # on the in-chart path (SKIP). IPv4 / hostname tokens only.
+            - name: BYO_RUNNER_TARGETS
+              value: {{ join " " $byoRunner | quote }}
             - name: DT_ALLOWED_POD
               value: {{ include "curie.fullname" . }}-dt-probe-allowed
             - name: DT_DENIED_POD
@@ -409,6 +461,41 @@ spec:
                   fail=1
                 else
                   echo "RESULT: PASS - no controller-managed NetworkPolicy '${SANDBOX_NP_NAME}' exists; Rail 1 is the only policy selecting these pods."
+                fi
+              fi
+
+              echo ""
+              echo "== Claim 1d: BYO runner declared peers reachable; undeclared control blocked (#2369) =="
+              if [ -z "$BYO_RUNNER_TARGETS" ]; then
+                echo "SKIP: no BYO runner peers declared (BYO_RUNNER_TARGETS empty); in-chart selectors still govern."
+              else
+                kubectl run "$EGRESS_POD" -n "$NS" --image="$NETSHOOT" --restart=Never \
+                  --labels="$PROBE_LABELS" \
+                  --command -- sleep 3600 >/dev/null
+                kubectl wait --for=condition=Ready "pod/$EGRESS_POD" -n "$NS" --timeout=120s >/dev/null
+                byo_fail=0
+                for spec in $BYO_RUNNER_TARGETS; do
+                  name=${spec%%=*}
+                  hp=${spec#*=}
+                  host=${hp%:*}
+                  port=${hp##*:}
+                  rc=$(kubectl exec -n "$NS" "$EGRESS_POD" -- nc -z -w5 "$host" "$port" >/dev/null 2>&1; echo $?)
+                  [ "$rc" = 0 ] && st=reachable || st=blocked
+                  echo "declared ${name} ${host}:${port} -> ${st}"
+                  if [ "$st" != reachable ]; then
+                    echo "RESULT: FAIL - declared ${name} unreachable (DNS/CIDR mismatch or wrong port)"
+                    byo_fail=1; fail=1
+                  fi
+                done
+                after_ext=$(classify "$(probe_rc "https://${BLOCKED}/")")
+                echo "undeclared control ${BLOCKED} -> ${after_ext}"
+                if [ "$after_ext" != blocked ]; then
+                  echo "RESULT: FAIL - undeclared control reachable (non-enforcing CNI)"
+                  byo_fail=1; fail=1
+                fi
+                kubectl delete pod "$EGRESS_POD" -n "$NS" --ignore-not-found >/dev/null
+                if [ "$byo_fail" = 0 ]; then
+                  echo "RESULT: PASS - declared BYO runner peers reachable; undeclared control blocked."
                 fi
               fi
 

--- a/scripts/check-runner-byo-egress.sh
+++ b/scripts/check-runner-byo-egress.sh
@@ -1,0 +1,500 @@
+#!/usr/bin/env bash
+# Assert each BYO runner-egress allow (object-store, collector-endpoint,
+# api-endpoint; #2369) actually ENFORCES, not merely that it renders.
+#
+# #2213 and #2317 pinned those CIDRs at helm-template tier. A render
+# assertion cannot prove a runner-labelled pod can reach the declared peer,
+# or that an undeclared control is blocked. Every NetworkPolicy this chart
+# ships is applied on any cluster; whether it is EVALUATED depends on the
+# CNI. kindnet (kind's default) and minikube's default bridge implement no
+# NetworkPolicy controller, so an ipBlock on the wrong port -- or one
+# deleted outright -- is indistinguishable from a correct one: everything
+# gets through and every "can the runner reach the BYO peer?" assertion
+# passes.
+#
+# So, like scripts/check-mail-adapter-otel-egress.sh, this is a NON-VACUITY
+# check. It asserts an UNDECLARED peer is genuinely blocked BEFORE trusting
+# the declared one. If the deny does not hold, the CNI is not enforcing (or
+# the policy is broader than declared) and the script FAILS -- it does not
+# skip and it does not pass. A green run on a non-enforcing cluster would
+# be worse than no check at all.
+set -euo pipefail
+
+CHART="${1:-${CURIE_RUNNER_BYO_CHART:-charts/curie}}"
+# Its OWN namespace, never the release's. The probe pods below wear whatever
+# labels the rendered BYO policy selects, which are the real runner-sandbox
+# labels -- dropped into an installed release's namespace they would collide
+# with live sandboxes and the policy under test would bind two workloads at
+# once.
+NS="${2:-${CURIE_RUNNER_BYO_NS:-curie-runner-byo-egress}}"
+# netshoot carries curl, getent, and nslookup. The helm-test Claim 1d
+# pod uses netshoot too; curlimages/curl has no resolver tools, so the
+# mismatch hostname leg would FAIL as "DNS did not resolve" even on a
+# correct policy. Tag-only (no digest): kind load of a digest-pinned
+# ref stores an import name containerd cannot start.
+PROBE_IMAGE="${CURIE_RUNNER_BYO_PROBE_IMAGE:-nicolaka/netshoot:v0.16}"
+TARGET_IMAGE="${CURIE_RUNNER_BYO_TARGET_IMAGE:-hashicorp/http-echo:1.0}"
+
+# Names are suffixed per key inside check_key. Re-applying the same pod
+# name against a still-Terminating predecessor binds the old object
+# (check-netpol-enforcement.sh cleanup_and_settle comment).
+ALLOWED_POD=""
+UNDECLARED_POD=""
+PROBE_POD=""
+MISMATCH_SVC=""
+CHECK_LABEL="curie.dev/check=runner-byo-egress"
+DUMMY_CIDR="192.0.2.40/32"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Non-blocking on the way out: the run is over, nothing waits on the pods.
+# The pods/policies are deleted; $NS itself deliberately is NOT. Deleting a
+# namespace from a non-blocking trap leaves it Terminating for tens of
+# seconds, and a Terminating namespace REJECTS creates.
+cleanup() {
+  kubectl -n "$NS" delete pod "$ALLOWED_POD" "$UNDECLARED_POD" "$PROBE_POD" \
+    --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  kubectl -n "$NS" delete svc "$MISMATCH_SVC" \
+    --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  kubectl -n "$NS" delete endpoints "$MISMATCH_SVC" \
+    --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  kubectl -n "$NS" delete networkpolicy -l "$CHECK_LABEL" \
+    --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+# BLOCKING before the apply. A previous run's pod may still be terminating,
+# and re-applying the same name against a deleting pod silently binds the
+# OLD one.
+cleanup_and_settle() {
+  kubectl -n "$NS" delete pod "$ALLOWED_POD" "$UNDECLARED_POD" "$PROBE_POD" \
+    --ignore-not-found --wait=true --timeout=90s >/dev/null 2>&1 || true
+  kubectl -n "$NS" delete svc "$MISMATCH_SVC" \
+    --ignore-not-found --wait=true --timeout=90s >/dev/null 2>&1 || true
+  kubectl -n "$NS" delete endpoints "$MISMATCH_SVC" \
+    --ignore-not-found --wait=true --timeout=90s >/dev/null 2>&1 || true
+  kubectl -n "$NS" delete networkpolicy -l "$CHECK_LABEL" \
+    --ignore-not-found --wait=true --timeout=90s >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "== runner BYO egress enforcement check (namespace=$NS chart=$CHART) =="
+
+command -v helm >/dev/null 2>&1 || fail "helm is required to render the policy under test"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required to extract the rendered NetworkPolicies"
+
+case "$NS" in
+  curie|default|kube-system|kube-public|kube-node-lease)
+    fail "namespace $NS is a platform or cluster namespace; this check needs its own empty namespace (default curie-runner-byo-egress)."
+    ;;
+esac
+
+kubectl get namespace "$NS" >/dev/null 2>&1 \
+  || kubectl create namespace "$NS" >/dev/null 2>&1 \
+  || kubectl get namespace "$NS" >/dev/null 2>&1 \
+  || fail "could not create namespace $NS for the runner BYO egress probe.
+
+Creating it needs cluster-scoped RBAC to get and create namespaces. Grant that,
+or set CURIE_RUNNER_BYO_NS to an existing namespace you may write pods and
+NetworkPolicies into -- but NOT to a namespace holding a real curie release, or
+the probe pod's labels would collide with live runner sandboxes."
+
+if kubectl -n "$NS" get networkpolicy -o name 2>/dev/null | grep -q 'runner-default-deny-egress'; then
+  fail "namespace $NS already has a runner-default-deny-egress NetworkPolicy.
+
+This check must not run in a live Curie release namespace: applying and then
+deleting labelled policies would disturb Rail 1. Use the default
+curie-runner-byo-egress namespace, or another empty namespace."
+fi
+
+TMP="$(mktemp -d)"
+trap 'cleanup; rm -rf -- "$TMP"' EXIT
+
+extract_policies() {
+  local byo_suffix="$1"
+  python3 -c '
+import sys, yaml
+ns, suffix, label = sys.argv[1], sys.argv[2], sys.argv[3]
+docs = [d for d in yaml.safe_load_all(sys.stdin) if isinstance(d, dict)]
+pols = [d for d in docs if d.get("kind") == "NetworkPolicy"]
+keep_suffixes = (
+    "-runner-default-deny-egress",
+    "-runner-allow-dns",
+    suffix,
+)
+kept = []
+for p in pols:
+    name = (p.get("metadata") or {}).get("name") or ""
+    if any(name.endswith(s) for s in keep_suffixes):
+        md = p.setdefault("metadata", {})
+        md["namespace"] = ns
+        md.setdefault("labels", {})[label.split("=", 1)[0]] = label.split("=", 1)[1]
+        kept.append(p)
+names = [(p.get("metadata") or {}).get("name") for p in kept]
+want = {s: False for s in keep_suffixes}
+for name in names:
+    for s in keep_suffixes:
+        if name and name.endswith(s):
+            want[s] = True
+missing = [s for s, ok in want.items() if not ok]
+if missing:
+    sys.exit(
+        "expected default-deny, allow-dns, and "
+        + suffix
+        + " from templates/security-networkpolicy.yaml; missing "
+        + ", ".join(missing)
+        + "; kept "
+        + ", ".join(n or "?" for n in names)
+    )
+if len(kept) != 3:
+    sys.exit(
+        "expected exactly 3 extracted NetworkPolicies, got "
+        + str(len(kept))
+        + ": "
+        + ", ".join(n or "?" for n in names)
+    )
+print("---\n".join(yaml.safe_dump(p) for p in kept))
+' "$NS" "$byo_suffix" "$CHECK_LABEL"
+}
+
+# Probe labels come from the BYO policy, never hardcoded. A rename in the
+# template's podSelector would otherwise leave the probe unselected.
+selector_from_byo() {
+  local byo_suffix="$1"
+  python3 -c '
+import sys, yaml
+suffix = sys.argv[1]
+docs = [d for d in yaml.safe_load_all(sys.stdin) if isinstance(d, dict)]
+byo = None
+for d in docs:
+    if d.get("kind") != "NetworkPolicy":
+        continue
+    name = (d.get("metadata") or {}).get("name") or ""
+    if name.endswith(suffix):
+        byo = d
+        break
+if byo is None:
+    sys.exit("extracted YAML has no NetworkPolicy ending " + suffix)
+ml = ((byo.get("spec") or {}).get("podSelector") or {}).get("matchLabels") or {}
+if not ml:
+    sys.exit("the BYO policy has no podSelector.matchLabels; it would select every pod in the namespace")
+print(",".join(f"{k}={v}" for k, v in ml.items()))
+' "$byo_suffix"
+}
+
+resolve_from_probe() {
+  local host="$1"
+  local out=""
+  out="$(kubectl -n "$NS" exec "$PROBE_POD" -- getent hosts "$host" 2>/dev/null | awk '{print $1; exit}' || true)"
+  if [ -n "$out" ]; then
+    printf '%s\n' "$out"
+    return 0
+  fi
+  # Busybox nslookup prints "Address 1:" / "Address:" lines; skip the DNS
+  # server by taking the last IPv4 on a Name/Address pair.
+  out="$(kubectl -n "$NS" exec "$PROBE_POD" -- nslookup "$host" 2>/dev/null | awk '
+    $1 ~ /^[Nn]ame:?$/ { seen_name=1; next }
+    seen_name && /[Aa]ddress/ {
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/) { print $i; exit }
+      }
+    }
+  ' || true)"
+  if [ -n "$out" ]; then
+    printf '%s\n' "$out"
+    return 0
+  fi
+  return 1
+}
+
+check_key() {
+  local key="$1"
+  local port="$2"
+  local byo_suffix="$3"
+  local values="$4"
+
+  ALLOWED_POD="runner-byo-${key}-allowed"
+  UNDECLARED_POD="runner-byo-${key}-undeclared"
+  PROBE_POD="runner-byo-${key}-probe"
+  MISMATCH_SVC="runner-byo-${key}-mismatch"
+
+  echo ""
+  echo "== key ${key} (TCP ${port}, policy ${byo_suffix}) =="
+
+  cleanup_and_settle
+
+  # Two listeners, identical in image, port, namespace and labels. The ONLY
+  # difference between them is whether their /32 is named in the declared
+  # list. Extra labels would let a broken rule still produce the expected
+  # blocked/reachable pair.
+  kubectl -n "$NS" apply -f - >/dev/null <<YAML
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $ALLOWED_POD
+  labels:
+    app.kubernetes.io/name: runner-byo-target
+spec:
+  restartPolicy: Never
+  containers:
+    - name: target
+      image: $TARGET_IMAGE
+      args: ["-listen=:$port", "-text=allowed"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $UNDECLARED_POD
+  labels:
+    app.kubernetes.io/name: runner-byo-target
+spec:
+  restartPolicy: Never
+  containers:
+    - name: target
+      image: $TARGET_IMAGE
+      args: ["-listen=:$port", "-text=undeclared"]
+YAML
+
+  kubectl -n "$NS" wait --for=condition=Ready \
+    "pod/$ALLOWED_POD" "pod/$UNDECLARED_POD" --timeout=180s >/dev/null \
+    || fail "the ${key} stand-in pods did not become ready in $NS"
+
+  local allowed_ip undeclared_ip
+  allowed_ip="$(kubectl -n "$NS" get pod "$ALLOWED_POD" -o jsonpath='{.status.podIP}')"
+  undeclared_ip="$(kubectl -n "$NS" get pod "$UNDECLARED_POD" -o jsonpath='{.status.podIP}')"
+  [ -n "$allowed_ip" ] || fail "could not read the declared ${key} peer's pod IP"
+  [ -n "$undeclared_ip" ] || fail "could not read the undeclared ${key} peer's pod IP"
+  [ "$allowed_ip" != "$undeclared_ip" ] \
+    || fail "both ${key} stand-ins report the same pod IP ($allowed_ip); this check cannot distinguish declared from undeclared"
+  case "$allowed_ip$undeclared_ip" in
+    *:*) fail "pod IPs must be IPv4 for this check (got declared=$allowed_ip undeclared=$undeclared_ip); a ClusterIP or IPv6 address in the CIDR is the #1153 false-pass" ;;
+  esac
+  echo "  ok  declared peer $allowed_ip, undeclared peer $undeclared_ip"
+
+  local values_file="$TMP/${key}.yaml"
+  VALUES_TEMPLATE="$values" ALLOWED_IP="$allowed_ip" python3 -c '
+import os, pathlib, sys
+pathlib.Path(sys.argv[1]).write_text(os.environ["VALUES_TEMPLATE"].replace("ALLOWED_IP", os.environ["ALLOWED_IP"]))
+' "$values_file"
+
+  local policy
+  policy="$(helm template curie "$CHART" -n "$NS" \
+    --values "$values_file" \
+    --show-only templates/security-networkpolicy.yaml \
+    | extract_policies "$byo_suffix")" \
+    || fail "rendering templates/security-networkpolicy.yaml for ${key} failed; the check cannot proceed without the policy under test"
+  [ -n "$policy" ] || fail "templates/security-networkpolicy.yaml rendered no extractable NetworkPolicies for ${key}"
+
+  # ---------------------------------------------------------------------------
+  # STRUCTURAL VACUITY GUARD, before a single packet is sent.
+  # ---------------------------------------------------------------------------
+  echo "$policy" | grep -q -- "$allowed_ip/32" \
+    || fail "the rendered ${key} policy does not carry the declared peer $allowed_ip/32.
+
+The BYO egress list was set and the template did not turn it into an ipBlock.
+The probes below would then be testing a rule that does not exist."
+  if echo "$policy" | grep -q -- "$undeclared_ip"; then
+    fail "the rendered ${key} policy names the UNDECLARED peer $undeclared_ip.
+
+Whatever produced that, the negative leg is no longer a negative leg, so a
+blocked/reachable pair below would prove nothing about the declared list."
+  fi
+  echo "  ok  rendered policy carries the declared peer and not the undeclared one"
+
+  kubectl -n "$NS" apply -f - >/dev/null <<<"$policy" \
+    || fail "could not apply the rendered ${key} policies into $NS"
+
+  local selector
+  selector="$(echo "$policy" | selector_from_byo "$byo_suffix")" \
+    || fail "could not derive the probe labels from the rendered ${key} policy's podSelector"
+  echo "  ok  probe labels derived from the policy podSelector: $selector"
+
+  kubectl -n "$NS" run "$PROBE_POD" --image="$PROBE_IMAGE" --restart=Never \
+    --image-pull-policy=IfNotPresent \
+    --labels="$selector" --command -- sleep 600 >/dev/null \
+    || fail "could not create the probe pod $PROBE_POD in $NS"
+  kubectl -n "$NS" wait --for=condition=Ready "pod/$PROBE_POD" --timeout=180s >/dev/null \
+    || fail "the probe pod did not become ready in $NS"
+
+  # `|| true` so a curl exit code never aborts the script under `set -e`: the
+  # exit code is the measurement here, not an error.
+  probe() {
+    kubectl -n "$NS" exec "$PROBE_POD" -- \
+      curl -sS -m 8 -o /dev/null -w '%{http_code}' "http://${1}:${port}/" 2>&1 || true
+  }
+
+  # ---------------------------------------------------------------------------
+  # GATE: the deny must hold. The positive below is meaningless without this.
+  # ---------------------------------------------------------------------------
+  local neg
+  neg="$(probe "$undeclared_ip")"
+  case "$neg" in
+    *"timed out"*|*"Failed to connect"*|*"Connection timed out"*|000) ;;
+    *)
+      fail "the UNDECLARED peer $undeclared_ip:$port answered ($neg).
+
+It is byte-for-byte the same workload as the declared peer except that its /32
+is not in the rendered runner BYO allow, so reaching it means one of:
+
+  - the CNI is not enforcing NetworkPolicy at all. kind needs
+    'disableDefaultCNI: true' plus a policy-enforcing CNI (the default kindnet
+    implements no NetworkPolicy controller); minikube needs '--cni=calico';
+    k3s/k3d enforce by default via kube-router.
+  - the rendered policy is BROADER than the declared list -- a wider ipBlock, a
+    second peer, or an empty 'to' -- so the runner can export to addresses
+    the operator never declared.
+
+Either way a green positive after this would prove nothing, which is the exact
+false proof this check exists to prevent (runner BYO / #2369)."
+      ;;
+  esac
+  echo "  ok  undeclared peer is blocked -- the CNI enforces this policy (non-vacuity gate)"
+
+  local pos
+  pos="$(probe "$allowed_ip")"
+  [ "$pos" = "200" ] \
+    || fail "the DECLARED peer $allowed_ip/32 on TCP $port was NOT reachable (got '$pos').
+
+The undeclared peer above was correctly blocked, so the CNI is enforcing and
+this is a POLICY defect: the rendered ipBlock does not actually permit the
+export it claims to. The usual cause is the port -- a rule on the wrong port
+looks perfectly correct in a render assertion while dropping every dial the
+runner makes to this BYO peer (#2369)."
+  echo "  ok  declared peer answers HTTP 200 on TCP $port"
+
+  # DNS/peer mismatch: a headless Service whose name resolves to the
+  # UNDECLARED pod IP while the policy CIDR names the ALLOWED pod. Probing
+  # the hostname must be blocked. Never put a Service ClusterIP in the CIDR
+  # (#1153); this Service is headless and the CIDR is a pod IP.
+  kubectl -n "$NS" apply -f - >/dev/null <<YAML
+apiVersion: v1
+kind: Service
+metadata:
+  name: $MISMATCH_SVC
+  labels:
+    curie.dev/check: runner-byo-egress
+spec:
+  clusterIP: None
+  ports:
+    - port: $port
+      targetPort: $port
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: $MISMATCH_SVC
+  labels:
+    curie.dev/check: runner-byo-egress
+subsets:
+  - addresses:
+      - ip: $undeclared_ip
+    ports:
+      - port: $port
+YAML
+
+  local mismatch_host="${MISMATCH_SVC}.${NS}.svc.cluster.local"
+  local resolved=""
+  resolved="$(resolve_from_probe "$mismatch_host" || true)"
+  if [ -z "$resolved" ]; then
+    fail "DNS did not resolve ${mismatch_host} from the probe pod.
+
+Cannot prove a DNS/CIDR mismatch if the name does not resolve. Check that
+runner-allow-dns was extracted and applied (Rail 1 allow-dns is required so
+a resolve failure is not mistaken for a mismatch pass)."
+  fi
+  if [ "$resolved" != "$undeclared_ip" ]; then
+    fail "DNS for ${mismatch_host} resolved to ${resolved}, not the undeclared pod IP ${undeclared_ip}.
+
+The mismatch leg requires the hostname to name the UNDECLARED peer while the
+policy CIDR names the declared one."
+  fi
+  echo "  ok  mismatch hostname resolves to undeclared peer $undeclared_ip"
+
+  local mismatch
+  mismatch="$(probe "$mismatch_host")"
+  case "$mismatch" in
+    *"timed out"*|*"Failed to connect"*|*"Connection timed out"*|000) ;;
+    *)
+      fail "the mismatch hostname ${mismatch_host}:${port} answered ($mismatch).
+
+DNS resolved it to the UNDECLARED pod ${undeclared_ip} while the policy CIDR
+names ${allowed_ip}/32, so a reachable result is a DNS/CIDR mismatch (rotating
+LB addresses, or a hostname the ipBlock does not cover). That is FAIL, never
+PASS -- the same silent drop a SaaS collector behind rotating IPs would see
+(#2369)."
+      ;;
+  esac
+  echo "  ok  mismatch hostname is blocked (DNS/CIDR split does not pass as success)"
+
+  cleanup_and_settle
+}
+
+RUSTFS_VALUES="$(cat <<EOF
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 9000
+  egress:
+    - cidr: ALLOWED_IP/32
+      ports: [{ protocol: TCP, port: 9000 }]
+EOF
+)"
+
+STS_VALUES="$(cat <<EOF
+rustfs:
+  deploy: false
+  host: s3.example.com
+  auth:
+    accessKey: ""
+  egress:
+    - cidr: ${DUMMY_CIDR}
+      ports: [{ protocol: TCP, port: 8443 }]
+  stsEgress:
+    - cidr: ALLOWED_IP/32
+      ports: [{ protocol: TCP, port: 8443 }]
+api:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-api
+worker:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-worker
+agentSandbox:
+  runner:
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-runner
+EOF
+)"
+
+OTEL_VALUES="$(cat <<EOF
+otelCollector:
+  deploy: false
+  endpoint: https://otlp.example.net:4318
+  egress:
+    - cidr: ALLOWED_IP/32
+      ports: [{ protocol: TCP, port: 4318 }]
+EOF
+)"
+
+API_VALUES="$(cat <<EOF
+api:
+  deploy: false
+  egress:
+    - cidr: ALLOWED_IP/32
+      ports: [{ protocol: TCP, port: 8000 }]
+dispatcher:
+  apiBaseUrl: https://api.example.net
+ui:
+  apiBaseUrl: https://api.example.net
+EOF
+)"
+
+check_key rustfs 9000 "-runner-allow-object-store" "$RUSTFS_VALUES"
+# STS is 443 in production; http-echo cannot bind that privileged port as
+# the image's non-root user, so the live listener and ipBlock use 8443.
+# A rule on the wrong port still fails the positive HTTP 200 check.
+check_key sts 8443 "-runner-allow-object-store" "$STS_VALUES"
+check_key otel 4318 "-runner-allow-collector-endpoint" "$OTEL_VALUES"
+check_key api 8000 "-runner-allow-api-endpoint" "$API_VALUES"
+
+echo "== runner BYO egress enforces: undeclared peer blocked, declared peer reachable, mismatch hostname blocked (rustfs/sts/otel/api) =="


### PR DESCRIPTION
#2213 and #2317/#2367 closed BYO runner-egress gaps at render tier. A NetworkPolicy that names the declared CIDRs still drops traffic when DNS returns a different address, and a CNI that does not enforce NetworkPolicy makes the whole rail a silent false pass.

Claim 1d of the helm-test security probe now nc/curls each declared rustfs, STS, OTLP, and API peer from a pod wearing this release's runner-sandbox labels, then curls the undeclared BLOCKED control. Empty BYO keys skip. `scripts/check-runner-byo-egress.sh` is the cluster pin: undeclared blocked first, then declared HTTP 200 on the expected port, then a hostname that resolves outside the CIDR is FAIL.

## Related issue

Closes #2369

## Fix pin verification

Fix pin: charts/curie/ci/security-probe-byo-runner-egress-assertions.sh

## End-to-end verification

| Tier | Required / n/a | Reason | Mode | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Chart/NetworkPolicy probe, not plugin or runner turn loop | | |
| local | n/a | Not compose/dispatcher/worker/API wiring | | |
| local-release | n/a | Not released binary or image identity | | |
| cluster | required | Live runner-labelled egress on an enforcing CNI | live | `bash scripts/check-runner-byo-egress.sh charts/curie` on kind `curie-2369-e2e` with disableDefaultCNI plus Calico: rustfs:9000, sts:8443, otel:4318, api:8000 each undeclared blocked, declared HTTP 200, mismatch hostname blocked |
| live provider | n/a | Not model routing or credentials | | |
| external integration | n/a | Not Slack/git/OAuth | | |

Positive: each of the four declared peers answered HTTP 200 on the policy port from a runner-sandbox-labelled pod. Negative: undeclared peer blocked (non-enforcing CNI would have failed here); hostname resolving to the undeclared IP while the CIDR named the allowed IP was blocked.

Render pin: `bash charts/curie/ci/security-probe-byo-runner-egress-assertions.sh` PASS on the candidate.

Adversarial review: Code and Security (Codex) requested STS /32-only, skip IPv6 authority, nc via exec argv, and refuse a live-script namespace that already carries Rail 1; those landed. Scope approved. Claim 1d is skip-on-default in helm test; the live script is the cluster consumer of the same selector and BYO policies.
