### PR TITLE
Refuse empty observability filters and cap series before query

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -656,6 +656,21 @@ fn parse_api_timestamp(raw: &str) -> Option<time::OffsetDateTime> {
                 normalized.insert_str(offset_start, ":00");
             }
         }
+        // Python 3.11+ datetime.fromisoformat accepts a compact ±HHMM offset
+        // (no colon). RFC 3339 does not, so an over-cap span in that form
+        // would skip the pre-dispatch cap and still execute upstream (#1948
+        // code review). Insert the colon so the estimate sees the same window.
+        let bytes = normalized.as_bytes();
+        if let Some(sign_at) = bytes[11.min(bytes.len())..]
+            .iter()
+            .position(|byte| *byte == b'+' || *byte == b'-')
+            .map(|index| 11 + index)
+        {
+            let offset = &normalized[sign_at + 1..];
+            if offset.len() == 4 && offset.as_bytes().iter().all(|byte| byte.is_ascii_digit()) {
+                normalized.insert(sign_at + 3, ':');
+            }
+        }
         let bytes = normalized.as_bytes();
         // Nothing after byte 10 can carry an offset when the value is this
         // short, and slicing past the end would panic on an arbitrary
@@ -3079,6 +3094,7 @@ mod tests {
             ("1970-01-01T00:00:00", "2026-01-01T00:00:00"),
             ("1970-01-01T00:00Z", "2026-01-01T00:00Z"),
             ("1970-01-01T00:00+00:00", "2026-01-01T00:00+00:00"),
+            ("1970-01-01T00:00:00+0000", "2026-01-01T00:00:00+0000"),
         ] {
             let error = prevalidate_series_span("hour", Some(start), Some(end))
                 .expect_err("a 56 year hourly window must be refused in every API-accepted form");

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -544,6 +544,175 @@ pub struct MetricSeries {
 /// response check keeps a skewed backend from violating the public result bound.
 pub const MAX_OBSERVABILITY_METRIC_POINTS: usize = 1000;
 
+/// Match one agent by exact name or id. Free-standing so the deploy flow's
+/// [`ApiClient::find_agent`] and the observability lookup can never
+/// grow different identity rules; the no-match case is the typed
+/// [`AgentLookupNotFound`] marker.
+fn match_agent(
+    agents: Vec<Agent>,
+    identifier: &str,
+) -> std::result::Result<Agent, AgentLookupNotFound> {
+    agents
+        .into_iter()
+        .find(|a| a.name == identifier || a.id == identifier)
+        .ok_or_else(|| AgentLookupNotFound(identifier.to_string()))
+}
+
+/// The Langfuse timeDimension bucket each shipped granularity maps to, and the
+/// number of buckets a window touches. Buckets are wall-clock aligned: hour and
+/// day boundaries are epoch-aligned in UTC, so the touched count is the
+/// difference of the epoch bucket floors over the half-open `[start, end)`
+/// window, which charges the window for BOTH partial end buckets (#1948
+/// review). Langfuse's week boundary anchoring is not the epoch, so week adds
+/// one safety bucket against the alignment skew. An unknown granularity has no
+/// client-side estimate; the server answers it with a 422, which the CLI
+/// preserves.
+fn series_bucket_estimate(
+    granularity: &str,
+    start: time::OffsetDateTime,
+    end: time::OffsetDateTime,
+) -> Option<i64> {
+    let bucket_seconds: i64 = match granularity {
+        "hour" => 3600,
+        "day" => 86_400,
+        "week" => 604_800,
+        _ => return None,
+    };
+    // Bucket floors are computed at nanosecond precision: whole_seconds()
+    // truncates toward zero, which on a negative (pre-epoch) fractional
+    // duration rounds UP and under-counts the window's first partial bucket
+    // (#1948 review, round 5). div_euclid on the nanosecond remainder is a
+    // true floor for every sign.
+    let epoch = time::OffsetDateTime::UNIX_EPOCH;
+    let bucket_nanos = bucket_seconds as i128 * 1_000_000_000;
+    let bucket_floor =
+        |dt: time::OffsetDateTime| ((dt - epoch).whole_nanoseconds()).div_euclid(bucket_nanos);
+    // The half-open window's last instant is end minus an arbitrarily small
+    // epsilon, so an exactly bucket-aligned end contributes its previous
+    // bucket, while an end even a fraction of a second past a boundary (RFC
+    // 3339 accepts fractional seconds) still touches the bucket that boundary
+    // opens (#1948 review, round 3).
+    let end_nanos = (end - epoch).whole_nanoseconds();
+    let end_aligned = end_nanos.rem_euclid(bucket_nanos) == 0;
+    let end_floor = if end_aligned {
+        end_nanos.div_euclid(bucket_nanos) - 1
+    } else {
+        end_nanos.div_euclid(bucket_nanos)
+    };
+    let touched = (end_floor - bucket_floor(start) + 1) as i64;
+    Some(if granularity == "week" {
+        touched + 1
+    } else {
+        touched
+    })
+}
+
+/// #1948: enforce the CLI's series point cap on the requested span before the
+/// upstream query is dispatched, so an over-cap window never reaches Langfuse
+/// and ClickHouse. Absent `--start` is bounded server-side by the metrics
+/// default window (168 hours, `apps/api` config), under the cap at every
+/// shipped granularity, so no estimate is attempted there; the post-dispatch
+/// bound still catches an operator-raised default. Absent `--end` defaults to
+/// now on the server (`apps/api/src/curie_api/metrics.py::resolve_window`), so
+/// `now` is the effective bound here too. Values the CLI cannot parse stay the
+/// server's 422 business rather than a stricter client-side format contract.
+/// Parse a `--start`/`--end` value with the same leniency the platform API's
+/// `datetime.fromisoformat` accepts for its documented common forms (#1948
+/// scope review): strict RFC 3339, a date-only value (midnight UTC), a space
+/// separator between date and time, a time without seconds, and a naive
+/// timestamp (assumed UTC for the estimate). A value none of these cover is
+/// `None`: the guard skips it and the API's own 422 or the post-dispatch bound
+/// answers, because the CLI must not become stricter than the API on formats
+/// neither documents.
+fn parse_api_timestamp(raw: &str) -> Option<time::OffsetDateTime> {
+    use time::format_description::well_known::Rfc3339;
+    use time::OffsetDateTime;
+
+    let trimmed = raw.trim();
+    if let Ok(parsed) = OffsetDateTime::parse(trimmed, &Rfc3339) {
+        return Some(parsed);
+    }
+    let mut normalized = String::from(trimmed);
+    let bytes = normalized.as_bytes();
+    if bytes.len() == 10 && bytes[4] == b'-' && bytes[7] == b'-' {
+        // Date-only: the API resolves it to midnight.
+        normalized.push_str("T00:00:00Z");
+    } else {
+        normalized = normalized.replacen(' ', "T", 1);
+        let bytes = normalized.as_bytes();
+        if bytes.len() >= 16 && bytes[10] == b'T' {
+            // Where does the time end? The time-of-day segment runs from
+            // index 11 to the first offset marker (Z, +, -) if any.
+            let offset_start = bytes[11..]
+                .iter()
+                .position(|byte| *byte == b'Z' || *byte == b'+' || *byte == b'-')
+                .map(|index| 11 + index)
+                .unwrap_or(bytes.len());
+            let time_len = offset_start - 11;
+            if time_len == 5 {
+                // A time truncated at the minute (HH:MM), with or without an
+                // offset: fromisoformat accepts it, RFC 3339 does not, so the
+                // seconds segment is inserted before any offset marker.
+                normalized.insert_str(offset_start, ":00");
+            }
+        }
+        let bytes = normalized.as_bytes();
+        // Nothing after byte 10 can carry an offset when the value is this
+        // short, and slicing past the end would panic on an arbitrary
+        // --start/--end value; the parse below answers instead (scope review
+        // round 3).
+        let has_offset = normalized.ends_with('Z')
+            || (bytes.len() > 11
+                && bytes[11..]
+                    .iter()
+                    .any(|byte| *byte == b'+' || *byte == b'-'));
+        if !has_offset {
+            // A naive timestamp has no offset in fromisoformat; the estimate
+            // assumes UTC and the post-dispatch bound stays the backstop.
+            normalized.push('Z');
+        }
+    }
+    OffsetDateTime::parse(&normalized, &Rfc3339).ok()
+}
+
+fn prevalidate_series_span(
+    granularity: &str,
+    start: Option<&str>,
+    end: Option<&str>,
+) -> Result<()> {
+    let Some(start) = start else {
+        return Ok(());
+    };
+    let start_dt = match parse_api_timestamp(start) {
+        Some(parsed) => parsed,
+        None => return Ok(()),
+    };
+    let end_dt = match end {
+        Some(end) => match parse_api_timestamp(end) {
+            Some(parsed) => parsed,
+            None => return Ok(()),
+        },
+        None => time::OffsetDateTime::now_utc(),
+    };
+    if end_dt <= start_dt {
+        // An inverted or empty window is the server's business.
+        return Ok(());
+    }
+    let Some(buckets) = series_bucket_estimate(granularity, start_dt, end_dt) else {
+        return Ok(());
+    };
+    if buckets > MAX_OBSERVABILITY_METRIC_POINTS as i64 {
+        return Err(anyhow::Error::from(
+            crate::exit::CliError::failure(format!(
+                "--start/--end span {start} to {} is about {buckets} {granularity} buckets, above the CLI maximum of {MAX_OBSERVABILITY_METRIC_POINTS}",
+                end.unwrap_or("now")
+            ))
+            .with_fix("narrow --start/--end or choose a coarser --granularity"),
+        ));
+    }
+    Ok(())
+}
+
 #[derive(Debug)]
 struct ObservabilityApiUnavailable(String);
 
@@ -561,6 +730,33 @@ pub fn is_observability_api_unavailable(error: &anyhow::Error) -> bool {
             .downcast_ref::<ObservabilityApiUnavailable>()
             .is_some()
     })
+}
+
+/// The agent lookup found no record matching the identifier. A typed marker
+/// rather than a bare message so the observability query path can tell a
+/// genuine no-match (operator input, a usage refusal) from a transport or
+/// availability failure, which must keep its transient or failure class
+/// (#1948 review). The display text is unchanged from the message the deploy
+/// flow's callers already render.
+#[derive(Debug)]
+struct AgentLookupNotFound(String);
+
+impl std::fmt::Display for AgentLookupNotFound {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "no agent found matching {:?} (by name or id); deploy it first with `curie cluster deploy`",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for AgentLookupNotFound {}
+
+pub fn is_agent_lookup_not_found(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.downcast_ref::<AgentLookupNotFound>().is_some())
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1469,6 +1665,12 @@ impl ApiClient {
         environment: Option<&str>,
         agent: Option<&str>,
     ) -> Result<MetricSeries> {
+        // #1948: refuse an over-cap span before the request, because the
+        // backend has already executed the query by the time a response can be
+        // buffered and rejected. The post-dispatch bound below stays as the
+        // defense against a server that returns more points than the
+        // requested span implies.
+        prevalidate_series_span(granularity, start, end)?;
         let mut query = vec![
             ("metric", metric.to_string()),
             ("granularity", granularity.to_string()),
@@ -2022,15 +2224,34 @@ impl ApiClient {
     /// deploy flow uses (`resolve_agent`), so the lifecycle verbs never grow a
     /// second resolution path. Errors when nothing matches; never creates.
     pub async fn find_agent(&self, identifier: &str) -> Result<Agent> {
-        self.list_agents()
+        match_agent(self.list_agents().await?, identifier).map_err(anyhow::Error::new)
+    }
+
+    /// The observability query path's agent lookup (#1948): the same exact
+    /// name-or-id match as [`Self::find_agent`], but the `/agents` GET is
+    /// classified with the observability status semantics, so a 5xx stays
+    /// transient, an auth failure keeps its credential fix, and only a genuine
+    /// no-match reaches the caller's usage refusal.
+    pub(crate) async fn find_agent_observability(&self, identifier: &str) -> Result<Agent> {
+        let resp = self
+            .send_request(
+                self.http
+                    .get(format!("{}/agents", self.base_url))
+                    .header("X-API-Key", &self.api_key)
+                    // The same request budget the observability reads carry:
+                    // the client default is a connect timeout only, so a
+                    // stalled-but-accepted connection must not hang the query
+                    // indefinitely (#1948 review, round 4).
+                    .timeout(std::time::Duration::from_secs(30)),
+                "GET /agents",
+            )
+            .await?;
+        let agents: Vec<Agent> = Self::expect_observability_ok(resp, "listing agents")
             .await?
-            .into_iter()
-            .find(|a| a.name == identifier || a.id == identifier)
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "no agent found matching {identifier:?} (by name or id); deploy it first with `curie cluster deploy`"
-                )
-            })
+            .json()
+            .await
+            .context("decoding agent list")?;
+        match_agent(agents, identifier).map_err(anyhow::Error::new)
     }
 
     /// Flip the agent kill switch on: `POST /agents/{id}/kill` (no request body).
@@ -2733,8 +2954,150 @@ impl ApiClient {
 mod tests {
     use super::{
         add_channel_body, agent_create_body, agent_update_body, is_insecure_endpoint,
-        validate_allowlist_entry,
+        prevalidate_series_span, validate_allowlist_entry, MAX_OBSERVABILITY_METRIC_POINTS,
     };
+
+    /// The pre-dispatch span guard allows exactly the cap (#1948): 1,000 hour
+    /// buckets from 1970-01-01T00:00:00Z is legal, one more is not.
+    #[test]
+    fn series_span_guard_enforces_the_point_cap_boundary() {
+        prevalidate_series_span(
+            "hour",
+            Some("1970-01-01T00:00:00Z"),
+            Some("1970-02-11T16:00:00Z"),
+        )
+        .expect("exactly the cap dispatches");
+        let error = prevalidate_series_span(
+            "hour",
+            Some("1970-01-01T00:00:00Z"),
+            Some("1970-02-11T17:00:00Z"),
+        )
+        .expect_err("one bucket over the cap is refused");
+        assert!(error.to_string().contains("buckets"));
+    }
+
+    /// Wall-clock buckets charge an unaligned window for its partial leading
+    /// and trailing buckets (#1948 review): a span of exactly 1,000 hours that
+    /// starts mid-hour touches 1,001 hour buckets and must be refused before
+    /// dispatch, while the aligned same-length span stays at the cap.
+    #[test]
+    fn series_span_guard_charges_partial_boundary_buckets() {
+        prevalidate_series_span(
+            "hour",
+            Some("1970-01-01T00:00:00Z"),
+            Some("1970-02-11T16:00:00Z"),
+        )
+        .expect("the aligned cap-length window dispatches");
+        let error = prevalidate_series_span(
+            "hour",
+            Some("1970-01-01T00:30:00Z"),
+            Some("1970-02-11T16:30:00Z"),
+        )
+        .expect_err("the unaligned same-length window touches one more bucket");
+        assert!(error.to_string().contains("1001"));
+
+        // A fractional-second end past the cap boundary still opens the
+        // boundary's bucket (RFC 3339 accepts fractional seconds, round 3).
+        let error = prevalidate_series_span(
+            "hour",
+            Some("1970-01-01T00:00:00Z"),
+            Some("1970-02-11T16:00:00.500Z"),
+        )
+        .expect_err("a half-second-past-cap end touches one more bucket");
+        assert!(error.to_string().contains("1001"));
+        prevalidate_series_span(
+            "hour",
+            Some("1970-01-01T00:00:00Z"),
+            Some("1970-02-11T15:00:00.500Z"),
+        )
+        .expect("a fractional end still under the cap dispatches");
+
+        // A fractional pre-epoch start floors DOWN at nanosecond precision:
+        // epoch minus half a second sits in bucket -1, so the same cap-length
+        // window touches 1,001 buckets (round 5).
+        let error = prevalidate_series_span(
+            "hour",
+            Some("1969-12-31T23:59:59.500Z"),
+            Some("1970-02-11T16:00:00Z"),
+        )
+        .expect_err("a pre-epoch fractional start opens its partial bucket");
+        assert!(error.to_string().contains("1001"));
+
+        // Langfuse's week anchoring is not the epoch, so week carries one
+        // safety bucket: an aligned 999-week window is the last allowed.
+        prevalidate_series_span(
+            "week",
+            Some("1970-01-01T00:00:00Z"),
+            Some("1989-02-23T00:00:00Z"),
+        )
+        .expect("999 aligned weeks stay at the cap");
+        prevalidate_series_span(
+            "week",
+            Some("1970-01-01T00:00:00Z"),
+            Some("1989-03-02T00:00:00Z"),
+        )
+        .expect_err("1,000 aligned weeks exceed the cap with the safety bucket");
+    }
+
+    /// An absent --start is bounded by the server's default window and an
+    /// unparseable bound stays the server's 422 business: neither may invent a
+    /// client-side refusal.
+    #[test]
+    fn series_span_guard_skips_what_the_server_owns() {
+        prevalidate_series_span("hour", None, None).expect("absent start stays server-owned");
+        prevalidate_series_span(
+            "hour",
+            Some("not-a-timestamp"),
+            Some("2026-01-01T00:00:00Z"),
+        )
+        .expect("unparseable start stays server-owned");
+        prevalidate_series_span("hour", Some("x"), Some("2026-01-01T00:00:00Z"))
+            .expect("a too-short value must never panic the guard");
+        prevalidate_series_span("hour", Some("19700101"), Some("2026-01-01T00:00:00Z"))
+            .expect("a basic-format date this parser does not model stays server-owned");
+        prevalidate_series_span(
+            "fortnight",
+            Some("1970-01-01T00:00:00Z"),
+            Some("2026-01-01T00:00:00Z"),
+        )
+        .expect("unknown granularity stays server-owned");
+    }
+
+    /// The API's datetime.fromisoformat accepts lenient timestamp forms the
+    /// strict RFC 3339 parser rejects (#1948 scope review). The guard must
+    /// parse those forms too, or an over-cap span in an accepted format
+    /// reaches the backend unprevalidated. Naive values are assumed UTC for
+    /// the estimate; the post-dispatch bound is the backstop for anything
+    /// else fromisoformat accepts that this parser does not.
+    #[test]
+    fn series_span_guard_parses_the_api_lenient_timestamp_forms() {
+        for (start, end) in [
+            ("1970-01-01", "2026-01-01"),
+            ("1970-01-01 00:00:00", "2026-01-01 00:00:00"),
+            ("1970-01-01T00:00", "2026-01-01T00:00"),
+            ("1970-01-01 00:00", "2026-01-01 00:00"),
+            ("1970-01-01T00:00:00", "2026-01-01T00:00:00"),
+            ("1970-01-01T00:00Z", "2026-01-01T00:00Z"),
+            ("1970-01-01T00:00+00:00", "2026-01-01T00:00+00:00"),
+        ] {
+            let error = prevalidate_series_span("hour", Some(start), Some(end))
+                .expect_err("a 56 year hourly window must be refused in every API-accepted form");
+            assert!(error.to_string().contains("buckets"), "{start} to {end}");
+        }
+    }
+
+    /// A --start with no --end is unbounded server-side (the API defaults end
+    /// to now), so the guard validates it against the current clock.
+    #[test]
+    fn series_span_guard_bounds_a_one_sided_start_window() {
+        let error = prevalidate_series_span("hour", Some("1970-01-01T00:00:00Z"), None)
+            .expect_err("a start of 1970 with no end exceeds the cap against now");
+        assert!(error.to_string().contains("now"));
+        assert_eq!(
+            MAX_OBSERVABILITY_METRIC_POINTS, 1000,
+            "the pre-dispatch guard and the post-dispatch bound share one cap"
+        );
+    }
 
     #[test]
     fn allowlist_entries_accept_owner_repo_and_owner_wildcard() {

--- a/cli/src/observability.rs
+++ b/cli/src/observability.rs
@@ -215,6 +215,36 @@ pub enum ObservabilityQuery {
     },
 }
 
+/// Validate a present-but-empty agent filter value (#1948). An empty string is
+/// not an absent one: forwarded verbatim it reaches FastAPI as a falsey query
+/// value the API treats as no filter at all, so a "scoped" export silently
+/// returns every agent's data. A whitespace-only value is the same refusal.
+/// A non-empty value passes through VERBATIM: agent names are exact-match
+/// identifiers and the API intentionally accepts names with leading or
+/// trailing whitespace, so trimming here would resolve a different agent.
+/// `accepted` names the value forms the flag takes, so the refusal's fix stays
+/// complete per flag.
+fn non_empty_filter(raw: Option<&str>, flag: &str, accepted: &str) -> Result<Option<String>> {
+    match raw {
+        None => Ok(None),
+        Some(value) => {
+            if value.trim().is_empty() {
+                return Err(anyhow::Error::from(
+                    crate::exit::CliError::usage(format!(
+                        "--{flag} was given an empty value; a present-but-empty filter would \
+                         drop the scope and query every agent"
+                    ))
+                    .with_fix(format!(
+                        "--{flag} accepts {accepted}; pass a non-empty value or omit \
+                         --{flag} entirely"
+                    )),
+                ));
+            }
+            Ok(Some(value.to_string()))
+        }
+    }
+}
+
 /// Execute one read-only observability query through the Curie platform API.
 /// The returned trait object still flows through the single `Ui::emit` success
 /// decision in `main.rs`; this function never writes a success payload itself.
@@ -227,6 +257,8 @@ pub async fn query(
     let client = ApiClient::new(api_url, api_key)?;
     let output: Box<dyn CliOutput> = match query {
         ObservabilityQuery::Runs { limit, agent_id } => {
+            let agent_id =
+                non_empty_filter(agent_id.as_deref(), "agent-id", "a platform agent id")?;
             let mut runs = client
                 .list_observability_runs(limit, agent_id.as_deref())
                 .await
@@ -260,32 +292,76 @@ pub async fn query(
             end,
             environment,
             agent,
-        } => match metric {
-            Some(metric) => Box::new(ObservabilityMetricsOutput::Series(
-                client
-                    .observability_metric_series(
-                        &metric,
-                        &granularity,
-                        start.as_deref(),
-                        end.as_deref(),
-                        environment.as_deref(),
-                        agent.as_deref(),
-                    )
-                    .await
-                    .map_err(|error| classify_api_error(error, tier))?,
-            )),
-            None => Box::new(ObservabilityMetricsOutput::Summary(
-                client
-                    .observability_metrics_summary(
-                        start.as_deref(),
-                        end.as_deref(),
-                        environment.as_deref(),
-                        agent.as_deref(),
-                    )
-                    .await
-                    .map_err(|error| classify_api_error(error, tier))?,
-            )),
-        },
+        } => {
+            // #1948: the API's `agent` filter is a trace-name contains token
+            // `agent-<agent_id>` (apps/api/src/curie_api/metrics.py::
+            // agent_trace_filter), because production traces are named
+            // `curie-run:agent-<agent_id>-thread-<ts>`. Forwarding the
+            // human-readable name matched nothing and read as false zeroes, so
+            // the name is resolved to its agent record first, by name or by
+            // id, reusing the deploy flow's one resolution path.
+            let agent = non_empty_filter(
+                agent.as_deref(),
+                "agent",
+                "a platform agent's name or agent id",
+            )?;
+            let agent_filter = match agent {
+                None => None,
+                Some(name) => {
+                    let resolved =
+                        client
+                            .find_agent_observability(&name)
+                            .await
+                            .map_err(|error| {
+                                // Only a genuine no-match is operator input error. A
+                                // transport or availability failure keeps its own
+                                // transient/failure class instead of masquerading as
+                                // "no such agent" (#1948 review).
+                                if crate::api::is_agent_lookup_not_found(&error) {
+                                    anyhow::Error::from(
+                                        crate::exit::CliError::usage(format!(
+                                    "--agent {name:?} does not match any platform agent by \
+                                     name or agent id"
+                                ))
+                                        .with_fix(format!(
+                                    "--agent accepts a deployed agent's name or agent id; list \
+                                     agents with `curie {tier} versions`"
+                                )),
+                                    )
+                                } else {
+                                    classify_api_error(error, tier)
+                                }
+                            })?;
+                    Some(format!("agent-{}", resolved.id))
+                }
+            };
+            match metric {
+                Some(metric) => Box::new(ObservabilityMetricsOutput::Series(
+                    client
+                        .observability_metric_series(
+                            &metric,
+                            &granularity,
+                            start.as_deref(),
+                            end.as_deref(),
+                            environment.as_deref(),
+                            agent_filter.as_deref(),
+                        )
+                        .await
+                        .map_err(|error| classify_api_error(error, tier))?,
+                )),
+                None => Box::new(ObservabilityMetricsOutput::Summary(
+                    client
+                        .observability_metrics_summary(
+                            start.as_deref(),
+                            end.as_deref(),
+                            environment.as_deref(),
+                            agent_filter.as_deref(),
+                        )
+                        .await
+                        .map_err(|error| classify_api_error(error, tier))?,
+                )),
+            }
+        }
     };
     Ok(output)
 }

--- a/cli/tests/observability_query.rs
+++ b/cli/tests/observability_query.rs
@@ -496,8 +496,16 @@ fn metrics_preserve_complete_summary_and_series_dtos_and_filters() {
     let series = metric_series();
     let summary_body = serde_json::to_string(&summary).unwrap();
     let series_body = serde_json::to_string(&series).unwrap();
+    let agents = serde_json::to_string(&json!([
+        {"id": AGENT_ID, "name": "acme-bot", "channels": [{"kind": "slack", "address": "C0EXAMPLE1"}], "memory": false}
+    ]))
+    .unwrap();
     let server = serve(move |request| {
-        if request.method == "GET" && request.path.starts_with("/observability/metrics/summary?") {
+        if request.method == "GET" && request.path == "/agents" {
+            Response::json(200, &agents)
+        } else if request.method == "GET"
+            && request.path.starts_with("/observability/metrics/summary?")
+        {
             Response::json(200, &summary_body)
         } else if request.method == "GET"
             && request.path.starts_with("/observability/metrics/series?")
@@ -559,12 +567,29 @@ fn metrics_preserve_complete_summary_and_series_dtos_and_filters() {
     }
 
     let recorded = server.recorded();
-    assert_eq!(recorded.len(), 4, "summary and series read once per tier");
+    assert_eq!(
+        recorded.len(),
+        8,
+        "agent lookup plus summary and series per tier"
+    );
     for request in &recorded {
         assert_eq!(request.header("x-api-key"), Some(TEST_API_KEY));
+    }
+    for request in recorded
+        .iter()
+        .filter(|request| request.path.starts_with("/observability/metrics/"))
+    {
         assert!(request.path.contains("start=2026-08-22T00%3A00%3A00Z"));
         assert!(request.path.contains("end=2026-08-23T00%3A00%3A00Z"));
-        assert!(request.path.contains("agent=acme-bot"));
+        // The name resolves to the agent's id and travels as the API's
+        // documented trace-name token (apps/api/src/curie_api/metrics.py::
+        // agent_trace_filter), never as the human-readable name.
+        assert!(
+            request.path.contains(&format!("agent=agent-{AGENT_ID}")),
+            "path: {}",
+            request.path
+        );
+        assert!(!request.path.contains("agent=acme-bot"));
     }
     for request in recorded
         .iter()
@@ -897,6 +922,449 @@ fn observability_api_errors_keep_specific_recovery_guidance() {
             .unwrap()
             .contains("narrow --start/--end"),
         "the typed bound's recovery must survive classification: {oversized_value}"
+    );
+}
+
+#[test]
+fn runs_refuse_an_empty_or_whitespace_agent_id_before_http() {
+    // #1948 AC1: a present-but-empty --agent-id is not an absent one. Forwarded
+    // verbatim it reaches FastAPI as agent_id=, which the API treats as no
+    // filter, and the "scoped" export silently returns every agent's traces.
+    let server = serve(|_| Response::json(500, r#"{"detail":"must not be called"}"#));
+    for tier in ["local", "cluster"] {
+        for raw in ["", "   "] {
+            let output = query(tier, &["runs", "--agent-id", raw], &server, true, false);
+            assert_eq!(
+                output.status.code(),
+                Some(2),
+                "{tier} --agent-id {raw:?} must be a usage refusal\nstdout: {}\nstderr: {}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let value = one_stdout_object(&output);
+            assert_only_error_fix(&value);
+            let error = value["error"].as_str().unwrap();
+            assert!(
+                error.contains("--agent-id"),
+                "the error must name the offending flag: {value}"
+            );
+            let fix = value["fix"].as_str().unwrap();
+            assert!(
+                fix.contains("agent id"),
+                "the fix must name what a usable --agent-id value is: {value}"
+            );
+        }
+    }
+    assert!(
+        server.recorded().is_empty(),
+        "an empty scope must be refused before any HTTP request is made"
+    );
+}
+
+#[test]
+fn metrics_agent_name_resolves_to_the_documented_trace_filter_token() {
+    // #1948 AC2: production trace names carry agent-<agent_id> (the runner
+    // names every trace curie-run:agent-<agent_id>-thread-<ts>), so the API's
+    // `agent` filter is a trace-name contains token agent-<agent_id>
+    // (apps/api/src/curie_api/metrics.py::agent_trace_filter). Forwarding the
+    // human-readable name matched nothing and read as zeroes. The mock below
+    // returns nonzero data ONLY for the resolved token, so the filter value
+    // the CLI actually sends decides the result: on pre-fix code this test
+    // reads the zero payloads and fails.
+    let agents = serde_json::to_string(&json!([
+        {"id": AGENT_ID, "name": "acme-bot", "channels": [{"kind": "slack", "address": "C0EXAMPLE1"}], "memory": false},
+        {"id": "22222222-2222-2222-2222-222222222222", "name": "other-agent", "channels": [{"kind": "slack", "address": "C0EXAMPLE2"}], "memory": false}
+    ]))
+    .unwrap();
+    let token = format!("agent-{AGENT_ID}");
+    let summary_hit = json!({
+        "start": START, "end": END, "runs": 7, "latency_p95_ms": 125.5,
+        "tokens": 987, "cost_usd": 0.5, "cost_known": true, "error_rate": 0.125
+    });
+    let summary_zero = json!({
+        "start": START, "end": END, "runs": 0, "latency_p95_ms": 0.0,
+        "tokens": 0, "cost_usd": 0.0, "cost_known": true, "error_rate": 0.0
+    });
+    let series_hit = json!({
+        "metric": "runs", "granularity": "day", "start": START, "end": END,
+        "points": [{"ts": START, "value": 3.0}]
+    });
+    let series_zero = json!({
+        "metric": "runs", "granularity": "day", "start": START, "end": END,
+        "points": [{"ts": START, "value": 0.0}]
+    });
+    let summary_hit_body = serde_json::to_string(&summary_hit).unwrap();
+    let summary_zero_body = serde_json::to_string(&summary_zero).unwrap();
+    let series_hit_body = serde_json::to_string(&series_hit).unwrap();
+    let series_zero_body = serde_json::to_string(&series_zero).unwrap();
+    let server = serve(move |request| {
+        if request.method == "GET" && request.path == "/agents" {
+            Response::json(200, &agents)
+        } else if request.method == "GET"
+            && request.path.starts_with("/observability/metrics/summary?")
+        {
+            if request.path.contains(&format!("agent={token}")) {
+                Response::json(200, &summary_hit_body)
+            } else {
+                Response::json(200, &summary_zero_body)
+            }
+        } else if request.method == "GET"
+            && request.path.starts_with("/observability/metrics/series?")
+        {
+            if request.path.contains(&format!("agent={token}")) {
+                Response::json(200, &series_hit_body)
+            } else {
+                Response::json(200, &series_zero_body)
+            }
+        } else {
+            Response::json(500, r#"{"detail":"unexpected test request"}"#)
+        }
+    });
+
+    for tier in ["local", "cluster"] {
+        // The documented human name resolves to the agent's id and is sent as
+        // the API's trace-name token, not as the raw name.
+        let output = query(
+            tier,
+            &["metrics", "--agent", "acme-bot"],
+            &server,
+            true,
+            false,
+        );
+        let value = assert_success(&output, &format!("{tier} metrics --agent by name"));
+        assert_schema("observability-metrics.schema.json", &value);
+        assert_eq!(
+            value["runs"], 7,
+            "a named agent's metrics must come back nonzero: {value}"
+        );
+
+        let output = query(
+            tier,
+            &[
+                "metrics", "--metric", "runs", "--agent", "acme-bot", "--start", START, "--end",
+                END,
+            ],
+            &server,
+            true,
+            false,
+        );
+        let value = assert_success(&output, &format!("{tier} metrics series --agent by name"));
+        assert_eq!(
+            value["points"][0]["value"], 3.0,
+            "a named agent's series must come back nonzero: {value}"
+        );
+
+        // Passing the agent id directly keeps working and normalizes to the
+        // same documented token.
+        let output = query(
+            tier,
+            &["metrics", "--agent", AGENT_ID],
+            &server,
+            true,
+            false,
+        );
+        let value = assert_success(&output, &format!("{tier} metrics --agent by id"));
+        assert_eq!(
+            value["runs"], 7,
+            "an id-valued --agent resolves too: {value}"
+        );
+    }
+
+    let recorded = server.recorded();
+    let lookups = recorded
+        .iter()
+        .filter(|request| request.path == "/agents")
+        .count();
+    assert_eq!(
+        lookups, 6,
+        "every --agent query resolves the name through one agent-list lookup"
+    );
+    for request in recorded
+        .iter()
+        .filter(|request| request.path.starts_with("/observability/metrics/"))
+    {
+        assert!(
+            request.path.contains(&format!("agent=agent-{AGENT_ID}")),
+            "the outgoing filter must be the documented trace-name token: {}",
+            request.path
+        );
+        assert!(
+            !request.path.contains("agent=acme-bot"),
+            "the human name must never be forwarded as the filter value: {}",
+            request.path
+        );
+    }
+}
+
+#[test]
+fn metrics_refuse_an_unknown_agent_and_an_empty_agent_value() {
+    // #1948 AC2, refusal half: --agent must resolve to a real platform agent,
+    // and a present-but-empty value is refused without a lookup, mirroring the
+    // runs --agent-id refusal so both flags answer the same falsey class.
+    let agents = serde_json::to_string(&json!([
+        {"id": "22222222-2222-2222-2222-222222222222", "name": "other-agent", "channels": [{"kind": "slack", "address": "C0EXAMPLE2"}], "memory": false}
+    ]))
+    .unwrap();
+    let server = serve(move |request| {
+        if request.method == "GET" && request.path == "/agents" {
+            Response::json(200, &agents)
+        } else {
+            Response::json(500, r#"{"detail":"unexpected test request"}"#)
+        }
+    });
+
+    let output = query(
+        "local",
+        &["metrics", "--agent", "acme-bot"],
+        &server,
+        true,
+        false,
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "an unresolvable agent name must be a usage refusal\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value = one_stdout_object(&output);
+    assert_only_error_fix(&value);
+    assert!(
+        value["error"].as_str().unwrap().contains("acme-bot"),
+        "the error must name the unresolvable value: {value}"
+    );
+    let fix = value["fix"].as_str().unwrap();
+    assert!(
+        fix.contains("name") && fix.contains("agent id"),
+        "the fix must name what --agent accepts: {value}"
+    );
+
+    for raw in ["", "   "] {
+        let output = query("local", &["metrics", "--agent", raw], &server, true, false);
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "--agent {raw:?} must be a usage refusal\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_only_error_fix(&one_stdout_object(&output));
+    }
+    let lookups = server
+        .recorded()
+        .iter()
+        .filter(|request| request.path == "/agents")
+        .count();
+    assert_eq!(
+        lookups, 1,
+        "only the unknown-name case may consult the agent list; the empty refusals precede it"
+    );
+    assert!(
+        !server
+            .recorded()
+            .iter()
+            .any(|request| request.path.starts_with("/observability/metrics/")),
+        "no metrics query is dispatched for a refused --agent"
+    );
+}
+
+#[test]
+fn series_span_is_validated_against_the_point_cap_before_dispatch() {
+    // #1948 AC3: the 1,000-point series cap must be enforced before the
+    // upstream request, because the backend has already paid for the query by
+    // the time the response is buffered. The boundary control proves the guard
+    // is the point cap itself: exactly 1,000 hour buckets dispatch, 1,001 do
+    // not.
+    let series = json!({
+        "metric": "runs", "granularity": "hour", "start": START, "end": END,
+        "points": [{"ts": START, "value": 1.0}]
+    });
+    let body = serde_json::to_string(&series).unwrap();
+    let server = serve(move |request| {
+        if request.method == "GET" && request.path.starts_with("/observability/metrics/series?") {
+            Response::json(200, &body)
+        } else {
+            Response::json(500, r#"{"detail":"unexpected test request"}"#)
+        }
+    });
+
+    // The issue's repro shape: an hourly 1970 to 2026 window.
+    let output = query(
+        "local",
+        &[
+            "metrics",
+            "--metric",
+            "runs",
+            "--granularity",
+            "hour",
+            "--start",
+            "1970-01-01T00:00:00Z",
+            "--end",
+            "2026-01-01T00:00:00Z",
+        ],
+        &server,
+        true,
+        false,
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "an over-cap span is a runtime failure, the same class the post-hoc bound used\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value = one_stdout_object(&output);
+    assert_only_error_fix(&value);
+    assert!(
+        value["fix"]
+            .as_str()
+            .unwrap()
+            .contains("narrow --start/--end"),
+        "the pre-dispatch refusal keeps the typed bound's recovery: {value}"
+    );
+    assert!(
+        !value["error"].as_str().unwrap().contains("500"),
+        "the refusal is the CLI's own guard, not the server's answer: {value}"
+    );
+
+    // Boundary: exactly 1,000 hour buckets is at the cap, not above it.
+    // 1970-01-01T00:00:00Z + 1000h = 1970-02-11T16:00:00Z.
+    let output = query(
+        "local",
+        &[
+            "metrics",
+            "--metric",
+            "runs",
+            "--granularity",
+            "hour",
+            "--start",
+            "1970-01-01T00:00:00Z",
+            "--end",
+            "1970-02-11T16:00:00Z",
+        ],
+        &server,
+        true,
+        false,
+    );
+    assert_success(&output, "at-cap hourly span dispatches");
+
+    // One bucket over the boundary is refused again.
+    let output = query(
+        "local",
+        &[
+            "metrics",
+            "--metric",
+            "runs",
+            "--granularity",
+            "hour",
+            "--start",
+            "1970-01-01T00:00:00Z",
+            "--end",
+            "1970-02-11T17:00:00Z",
+        ],
+        &server,
+        true,
+        false,
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert_only_error_fix(&one_stdout_object(&output));
+
+    // A --start with no --end is unbounded server-side (the API defaults end to
+    // now), so the CLI validates that shape against now as well.
+    let output = query(
+        "local",
+        &[
+            "metrics",
+            "--metric",
+            "runs",
+            "--granularity",
+            "hour",
+            "--start",
+            "1970-01-01T00:00:00Z",
+        ],
+        &server,
+        true,
+        false,
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert_only_error_fix(&one_stdout_object(&output));
+
+    // A fractional-second end past the cap boundary opens the boundary's
+    // bucket, so it is refused on the consumer path too (round 3).
+    let output = query(
+        "local",
+        &[
+            "metrics",
+            "--metric",
+            "runs",
+            "--granularity",
+            "hour",
+            "--start",
+            "1970-01-01T00:00:00Z",
+            "--end",
+            "1970-02-11T16:00:00.500Z",
+        ],
+        &server,
+        true,
+        false,
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert_only_error_fix(&one_stdout_object(&output));
+
+    // A fractional pre-epoch start floors down at nanosecond precision, so
+    // this cap-length window touches 1,001 buckets (round 5).
+    let output = query(
+        "local",
+        &[
+            "metrics",
+            "--metric",
+            "runs",
+            "--granularity",
+            "hour",
+            "--start",
+            "1969-12-31T23:59:59.500Z",
+            "--end",
+            "1970-02-11T16:00:00Z",
+        ],
+        &server,
+        true,
+        false,
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert_only_error_fix(&one_stdout_object(&output));
+
+    // The API's fromisoformat accepts date-only values the strict RFC 3339
+    // parser rejects, so the guard parses them too instead of forwarding the
+    // span unprevalidated (scope review). The same applies to an
+    // offset-bearing minute-truncated timestamp.
+    let output = query(
+        "local",
+        &[
+            "metrics",
+            "--metric",
+            "runs",
+            "--granularity",
+            "hour",
+            "--start",
+            "1970-01-01T00:00Z",
+            "--end",
+            "2026-01-01T00:00Z",
+        ],
+        &server,
+        true,
+        false,
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert_only_error_fix(&one_stdout_object(&output));
+
+    let series_calls = server
+        .recorded()
+        .iter()
+        .filter(|request| request.path.starts_with("/observability/metrics/series?"))
+        .count();
+    assert_eq!(
+        series_calls, 1,
+        "only the at-cap span may reach the API; every over-cap refusal precedes dispatch"
     );
 }
 

--- a/cli/tests/observability_query.rs
+++ b/cli/tests/observability_query.rs
@@ -1357,14 +1357,101 @@ fn series_span_is_validated_against_the_point_cap_before_dispatch() {
     assert_eq!(output.status.code(), Some(1));
     assert_only_error_fix(&one_stdout_object(&output));
 
+    // Compact ±HHMM is API-accepted (datetime.fromisoformat) and must not
+    // skip the pre-dispatch cap (code review).
+    let output = query(
+        "local",
+        &[
+            "metrics",
+            "--metric",
+            "runs",
+            "--granularity",
+            "hour",
+            "--start",
+            "1970-01-01T00:00:00+0000",
+            "--end",
+            "2026-01-01T00:00:00+0000",
+        ],
+        &server,
+        true,
+        false,
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert_only_error_fix(&one_stdout_object(&output));
+
+    // Sibling path: the same query function serves cluster. At-cap still
+    // dispatches; over-cap still does not.
+    let output = query(
+        "cluster",
+        &[
+            "metrics",
+            "--metric",
+            "runs",
+            "--granularity",
+            "hour",
+            "--start",
+            "1970-01-01T00:00:00Z",
+            "--end",
+            "2026-01-01T00:00:00Z",
+        ],
+        &server,
+        true,
+        false,
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "cluster over-cap span must refuse before dispatch\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_only_error_fix(&one_stdout_object(&output));
+    let output = query(
+        "cluster",
+        &[
+            "metrics",
+            "--metric",
+            "runs",
+            "--granularity",
+            "hour",
+            "--start",
+            "1970-01-01T00:00:00Z",
+            "--end",
+            "1970-02-11T16:00:00Z",
+        ],
+        &server,
+        true,
+        false,
+    );
+    assert_success(&output, "cluster at-cap hourly span dispatches");
+    let output = query(
+        "cluster",
+        &[
+            "metrics",
+            "--metric",
+            "runs",
+            "--granularity",
+            "hour",
+            "--start",
+            "1970-01-01T00:00:00Z",
+            "--end",
+            "1970-02-11T17:00:00Z",
+        ],
+        &server,
+        true,
+        false,
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert_only_error_fix(&one_stdout_object(&output));
+
     let series_calls = server
         .recorded()
         .iter()
         .filter(|request| request.path.starts_with("/observability/metrics/series?"))
         .count();
     assert_eq!(
-        series_calls, 1,
-        "only the at-cap span may reach the API; every over-cap refusal precedes dispatch"
+        series_calls, 2,
+        "only the at-cap span may reach the API at each tier; every over-cap refusal precedes dispatch"
     );
 }
 


### PR DESCRIPTION
## Summary

Observability query verbs no longer forward an empty `--agent-id`, no longer treat a human agent name as a trace-name contains filter, and no longer send an over-cap series window to Langfuse. Empty or whitespace filters exit 2 with a `fix` before any HTTP request. `--agent` resolves name or id to the documented `agent-<id>` token. The 1,000-point series cap is enforced on the requested span before dispatch; the post-dispatch bound remains as a backstop.

## Related issue

Closes #1948

## Fix pin verification

Fix pin: cli/tests/observability_query.rs::runs_refuse_an_empty_or_whitespace_agent_id_before_http

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin, runner turn loop, ACI event, or skill eval/check is reached. The skill observability leaf's unavailable contract is unchanged. | | |
| local | Required | CLI verb output, exit code, and `--json` shape changed for `local`/`cluster observability runs` and `metrics`. | fake | `cd cli && cargo test --test observability_query` against commit `b844c7472`: 21 passed. Empty `--agent-id` exits 2 with zero HTTP. `--agent acme-bot` sends `agent=agent-11111111-...` and returns nonzero metrics from a mock that zeros any other filter. Over-cap hourly 1970-2026, compact `+0000`, and cluster siblings refuse with one at-cap dispatch per tier (two total). Pre-fix, the same four new tests failed: empty id hit the mock 500 (exit 3), name filter returned zeros, over-cap dispatched exit 0. |
| local-release | n/a | No released binary identity, install path, version pin, or release compose change. | | |
| cluster | n/a | No chart, RBAC, securityContext, NetworkPolicy, sandbox claim, or init container change. Cluster query leaves share the same CLI path and are covered by the binary tests above. | | |
| live provider | n/a | No model routing, credential resolution, provider auth, or token/cost accounting change. | | |
| external integration | n/a | No third-party API shape change. Langfuse query dicts and platform routes are unchanged; the CLI now sends the token the API already documents. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Done-check

- [x] Tests present and green: `observability_query` 21 passed; `series_span_guard` 5 passed; `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
- [x] Agent-router Code Reviewer completed (review 480 changes-requested, review 484 approve) with file:line spec-vs-impl evidence.
- [x] Agent-router Scope Reviewer completed (review 481 PASS) with every non-trivial hunk mapped to an AC.
- [x] Sibling-path parity: local and cluster share `observability::query`; empty-id, name resolution, and series-cap controls run on both leaves.
- [x] Guard demonstration: empty/whitespace `--agent-id` and `--agent` exit 2 with no HTTP; over-cap spans exit 1 with no series request.
- [x] Train check: v0.9.0 milestone maps to `next`; worktree cut from `origin/next` `0a9b64f4d`.
- [x] Discovery-surface proof: defect was observed by executing the CLI (local); proven on the built binary against a wire-level HTTP peer.
- N/A failing-tests-first / delegated-executor / consolidation / security / deployed E2E / re-fix: quick tier; no security scale-up; no prior merged fix of this symptom on `next`.

## Checklist

- [x] Tests pass for the area I touched.
- [x] Docs updated if behavior changed. Help already names `--agent-id` and `--agent`; refusals carry `error`/`fix`. No clap surface change, so the command manifest is unchanged.
- [x] An ADR is not required: no wire shape, route signature, or frozen contract change.

Abandoned branch `task/1948-observability-query-defects` was recovery material only and was not modified.
