### PR TITLE
Bind the live cluster upgrade driver to the observations it reports

### DIFF
--- a/cli/src/ops/convergence.rs
+++ b/cli/src/ops/convergence.rs
@@ -10,15 +10,77 @@ use serde_json::Value;
 
 use super::{plain, run_capture, CommonOpts, OpsCommand};
 
+/// Which convergence property an observed issue actually disproves.
+///
+/// `cluster upgrade` reports named sub-flags (`images`, `generations`, ...) and
+/// must not derive them by substring-matching reason text, which would flip a
+/// gate to green on a reworded message. Every issue therefore carries the facet
+/// the observing code genuinely inspected.
+///
+/// `Replicas` and `Unavailable` are separate: a workload can be mid-rollout
+/// (`updated != desired`) while `unavailableReplicas` is genuinely `0`, so
+/// deriving one from the other reports a value the observer never saw.
+///
+/// `Rollout` is the honest home for issues that no named property covers: a
+/// stalled rollout, a crash-looping or terminating container, an undeployed
+/// revision, an empty target manifest, a StatefulSet mid-revision, or a Helm
+/// revision that moved under the observation. It fails `exact` without lying
+/// about which specific property was disproved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum Facet {
+    Image,
+    Generation,
+    Replicas,
+    Unavailable,
+    Manifest,
+    Hook,
+    Drain,
+    Rollout,
+}
+
+/// The #2010 worker drain gate, by the hook names
+/// `charts/curie/templates/worker-upgrade-drain.yaml` renders (the pre-upgrade
+/// quiesce Job and its post-upgrade release). A refusal there means accepted
+/// work had not settled when the roll began, which `cluster upgrade` reports
+/// separately from every other hook.
+fn hook_facet(name: &str) -> Facet {
+    if name.ends_with("-upgrade-drain") || name.ends_with("-upgrade-drain-release") {
+        Facet::Drain
+    } else {
+        Facet::Hook
+    }
+}
+
 #[derive(Default)]
 pub(super) struct Observation {
     pub issues: Vec<String>,
+    /// The same issues, each tagged with the property it disproves. Written
+    /// only by [`Observation::issue`] alongside `issues`, so the two cannot
+    /// drift apart.
+    pub facets: Vec<(Facet, String)>,
     pub terminal: bool,
 }
 
 impl Observation {
-    fn issue(&mut self, resource: &str, reason: impl std::fmt::Display) {
-        self.issues.push(format!("{resource}: {reason}"));
+    fn issue(&mut self, facet: Facet, resource: &str, reason: impl std::fmt::Display) {
+        let text = format!("{resource}: {reason}");
+        self.facets.push((facet, text.clone()));
+        self.issues.push(text);
+    }
+
+    /// One issue that disproves several facets at once, recorded as a single
+    /// operator-visible line so the facet tagging cannot duplicate output.
+    fn issue_multi(&mut self, facets: &[Facet], resource: &str, reason: impl std::fmt::Display) {
+        let text = format!("{resource}: {reason}");
+        for facet in facets {
+            self.facets.push((*facet, text.clone()));
+        }
+        self.issues.push(text);
+    }
+
+    /// True when nothing observed disproves `facet`.
+    pub fn holds(&self, facet: Facet) -> bool {
+        !self.facets.iter().any(|(observed, _)| *observed == facet)
     }
 }
 
@@ -269,7 +331,7 @@ fn pod_reasons(pod: &Value, result: &mut Observation) {
     let name = text(pod, "/metadata/name");
     let pod_reason = text(pod, "/status/reason");
     if !pod_reason.is_empty() && pod_reason != "Completed" {
-        result.issue(name, reason(pod_reason));
+        result.issue(Facet::Rollout, name, reason(pod_reason));
     }
     for (field, init) in [
         ("/status/initContainerStatuses", true),
@@ -282,11 +344,12 @@ fn pod_reasons(pod: &Value, result: &mut Observation) {
                 text(container, "/name")
             );
             if let Some(waiting) = container.pointer("/state/waiting") {
-                result.issue(&id, reason(text(waiting, "/reason")));
+                result.issue(Facet::Rollout, &id, reason(text(waiting, "/reason")));
             }
             if let Some(terminated) = container.pointer("/state/terminated") {
                 if !init || count(terminated, "/exitCode") != 0 {
                     result.issue(
+                        Facet::Rollout,
                         &id,
                         format!(
                             "{} (exit {})",
@@ -330,7 +393,11 @@ fn compare_containers(
                     normalize_image(text(item, "/image")) != normalize_image(image)
                 })
             {
-                result.issue(id, format!("container {name} does not match target image"));
+                result.issue(
+                    Facet::Image,
+                    id,
+                    format!("container {name} does not match target image"),
+                );
             }
             if !pod {
                 continue;
@@ -356,7 +423,16 @@ fn compare_containers(
                     }
                 });
             if !valid {
+                // A container whose image already matches the target but is not
+                // ready is a stalled rollout (CrashLoopBackOff, failed probe),
+                // not an image mismatch. Tagging it `Image` would report
+                // `images: false` about an image that is in fact correct.
                 result.issue(
+                    if image_matches {
+                        Facet::Rollout
+                    } else {
+                        Facet::Image
+                    },
                     id,
                     if !image_matches && status.is_some_and(|status| needs_node_identity(image, status)) {
                         format!("container {name} tagged alias has no unique same-node image binding; inspect the serving Node image inventory or select a digest-pinned target image")
@@ -383,7 +459,11 @@ fn compare_containers(
                     status.get("ready").and_then(Value::as_bool) != Some(true)
                         || status.pointer("/state/running").is_none()
                 }) {
-                    result.issue(id, "admission-injected container is not ready");
+                    result.issue(
+                        Facet::Rollout,
+                        id,
+                        "admission-injected container is not ready",
+                    );
                 }
             }
         }
@@ -408,7 +488,11 @@ fn workload(
                 .pointer("/status/observedGeneration")
                 .and_then(Value::as_u64)
     {
-        result.issue(id, "target generation has not been observed");
+        result.issue(
+            Facet::Generation,
+            id,
+            "target generation has not been observed",
+        );
     }
     let desired = if kind == "DaemonSet" {
         count(actual, "/status/desiredNumberScheduled")
@@ -433,8 +517,16 @@ fn workload(
             count(actual, "/status/unavailableReplicas"),
         )
     };
-    if updated != desired || ready != desired || total != desired || unavailable != 0 {
-        result.issue(id, format!("replicas desired={desired} updated={updated} ready={ready} total={total} unavailable={unavailable}"));
+    let counts_off = updated != desired || ready != desired || total != desired;
+    if counts_off || unavailable != 0 {
+        let mut facets = Vec::new();
+        if counts_off {
+            facets.push(Facet::Replicas);
+        }
+        if unavailable != 0 {
+            facets.push(Facet::Unavailable);
+        }
+        result.issue_multi(&facets, id, format!("replicas desired={desired} updated={updated} ready={ready} total={total} unavailable={unavailable}"));
     }
     if kind == "StatefulSet"
         && desired > 0
@@ -442,6 +534,7 @@ fn workload(
             || text(actual, "/status/currentRevision") != text(actual, "/status/updateRevision"))
     {
         result.issue(
+            Facet::Rollout,
             id,
             "StatefulSet current revision does not match target revision",
         );
@@ -451,12 +544,12 @@ fn workload(
             && text(condition, "/status") == "False"
             && text(condition, "/reason") == "ProgressDeadlineExceeded"
         {
-            result.issue(id, "ProgressDeadlineExceeded");
+            result.issue(Facet::Rollout, id, "ProgressDeadlineExceeded");
             result.terminal = true;
         }
     }
     if expected.pointer("/spec/selector") != actual.pointer("/spec/selector") {
-        result.issue(id, "workload selector differs from target");
+        result.issue(Facet::Manifest, id, "workload selector differs from target");
     }
     compare_containers(expected, actual, false, nodes, result);
     let pods: Vec<_> = items
@@ -465,6 +558,7 @@ fn workload(
         .collect();
     if pods.len() as u64 != desired {
         result.issue(
+            Facet::Replicas,
             id,
             format!(
                 "selected pods={} desired={desired}; surplus or missing target replicas",
@@ -479,6 +573,7 @@ fn workload(
                 .is_some_and(|value| !value.is_null())
         {
             result.issue(
+                Facet::Rollout,
                 text(pod, "/metadata/name"),
                 "target pod is not steadily running",
             );
@@ -497,7 +592,11 @@ async fn observe_inner(opts: &CommonOpts) -> Result<Observation> {
         .context("Helm release has no verifiable revision")?;
     let mut result = Observation::default();
     if text(&status, "/info/status") != "deployed" {
-        result.issue("Helm release", "latest revision is not deployed");
+        result.issue(
+            Facet::Rollout,
+            "Helm release",
+            "latest revision is not deployed",
+        );
         result.terminal = true;
     }
     let manifest = capture(
@@ -517,6 +616,7 @@ async fn observe_inner(opts: &CommonOpts) -> Result<Observation> {
     }
     if expected.is_empty() {
         result.issue(
+            Facet::Rollout,
             "Helm release",
             "target manifest contains no managed workloads",
         );
@@ -538,7 +638,8 @@ async fn observe_inner(opts: &CommonOpts) -> Result<Observation> {
             continue;
         }
         if text(hook, "/last_run/phase") == "Failed" {
-            result.issue(text(hook, "/name"), "Helm hook failed");
+            let name = text(hook, "/name");
+            result.issue(hook_facet(name), name, "Helm hook failed");
             result.terminal = true;
         }
         if text(hook, "/kind") == "Job" {
@@ -611,7 +712,11 @@ async fn observe_inner(opts: &CommonOpts) -> Result<Observation> {
         }) {
             workload(object, actual, items, &nodes, &mut result);
         } else {
-            result.issue(text(object, "/metadata/name"), "target workload is absent");
+            result.issue(
+                Facet::Manifest,
+                text(object, "/metadata/name"),
+                "target workload is absent",
+            );
         }
     }
     for hook in array(&status, "/hooks") {
@@ -635,10 +740,8 @@ async fn observe_inner(opts: &CommonOpts) -> Result<Observation> {
         {
             for condition in array(job, "/status/conditions") {
                 if text(condition, "/type") == "Failed" && text(condition, "/status") == "True" {
-                    result.issue(
-                        text(job, "/metadata/name"),
-                        reason(text(condition, "/reason")),
-                    );
+                    let name = text(job, "/metadata/name");
+                    result.issue(hook_facet(name), name, reason(text(condition, "/reason")));
                     result.terminal = true;
                 }
             }
@@ -649,6 +752,7 @@ async fn observe_inner(opts: &CommonOpts) -> Result<Observation> {
         || final_status.pointer("/info/status") != status.pointer("/info/status")
     {
         result.issue(
+            Facet::Rollout,
             "Helm release",
             "revision changed during convergence observation",
         );
@@ -707,6 +811,69 @@ pub(super) async fn wait(opts: &CommonOpts) -> Result<()> {
             return Err(crate::exit::CliError::failure(format!("target release has not converged: {}", result.issues.join("; "))).with_fix("run `curie cluster status` to inspect the failed rollout; correct the target configuration and rerun `curie cluster up`").into());
         }
         last_issues = result.issues;
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}
+
+/// Like [`wait`], but hands the caller the final [`Observation`] instead of an
+/// error, so a caller that owes the operator a structured verdict (the
+/// `cluster upgrade` Converge phase, which must still emit its convergence
+/// payload, its failing phase and one fail-forward path) keeps the facts
+/// instead of losing them to `?`.
+///
+/// Deliberately does not touch [`wait`]: `up.rs` depends on its exact failure
+/// message and its "rerun `curie cluster up`" fix string.
+///
+/// A read that fails outright, or a rollout that never settles, comes back as a
+/// terminal observation rather than an `Err` — an unreadable cluster has not
+/// converged, and that is a verdict, not a crash.
+/// Every facet, for the one case where nothing at all could be observed.
+const UNOBSERVED: [Facet; 8] = [
+    Facet::Image,
+    Facet::Generation,
+    Facet::Replicas,
+    Facet::Unavailable,
+    Facet::Manifest,
+    Facet::Hook,
+    Facet::Drain,
+    Facet::Rollout,
+];
+
+pub(super) async fn wait_for_observation(opts: &CommonOpts) -> Observation {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(300);
+    let mut carried = Observation::default();
+    loop {
+        let observed = tokio::time::timeout_at(deadline, observe(opts))
+            .await
+            .context("post-Helm convergence timed out after 300 seconds")
+            .and_then(|result| result);
+        let result = match observed {
+            Ok(result) => result,
+            Err(error) => {
+                // The observation could not be made, so NO named property was
+                // determined. `holds` is closed-world, so leaving the facets
+                // untagged would report images/generations/replicas/... as
+                // observed-true off a read that never happened. Tag every facet
+                // with the one failure, and keep any facet an earlier pass had
+                // already genuinely disproved.
+                let mut result = carried;
+                let fix = crate::exit::classify(&error).1;
+                let detail = match fix {
+                    Some(fix) => format!("{error:#}; {fix}"),
+                    None => format!("{error:#}"),
+                };
+                result.issue_multi(&UNOBSERVED, "Helm release", detail);
+                result.terminal = true;
+                return result;
+            }
+        };
+        if result.issues.is_empty()
+            || result.terminal
+            || tokio::time::Instant::now() + Duration::from_secs(2) >= deadline
+        {
+            return result;
+        }
+        carried = result;
         tokio::time::sleep(Duration::from_secs(2)).await;
     }
 }

--- a/cli/src/ops/upgrade.rs
+++ b/cli/src/ops/upgrade.rs
@@ -496,27 +496,34 @@ fn remaining_after(completed: &[UpgradePhase]) -> Vec<UpgradePhase> {
         .collect()
 }
 
-fn plan_lines(opts: &UpgradeOpts, from: Option<&str>, secret: Option<&str>) -> Vec<String> {
+fn plan_lines(
+    opts: &UpgradeOpts,
+    from: Option<&str>,
+    secret: Option<&str>,
+    schema_plan: Option<&str>,
+) -> Vec<String> {
     let from = from.unwrap_or("none");
-    let chart = opts
-        .chart
-        .clone()
-        .unwrap_or_else(|| format!("curie-{}", opts.to));
     let mut lines = vec![
         format!("phase plan: {from} -> {}", opts.to),
         "phase validate: configuration overlay migration and pre-mutation refusals".into(),
         "phase drain: worker upgrade drain gate (issue 2010)".into(),
         "phase checkpoint: persist recoverable release state".into(),
-        "phase migrate: one controlled schema migration".into(),
-        format!(
-            "helm upgrade {} {chart} -n {} --wait",
-            opts.common.release, opts.common.namespace
-        ),
+        // The chart's pre-upgrade hook Job owns schema migration and Apply
+        // fires it; this phase is only a resumable checkpoint boundary
+        // (issue 2588).
+        "phase migrate: checkpoint boundary only; the chart's pre-upgrade hook Job \
+         performs schema migration during apply"
+            .into(),
+        helm_upgrade_argv(opts, &opts.to).join(" "),
         "phase converge: exact images, generations, replicas, unavailable=0, hooks, queues, manifest"
             .into(),
         "phase canary: target-version smoke".into(),
         "phase commit: record known-good version".into(),
     ];
+    // #2299: the configuration schema version the upgrade moves from and to.
+    if let Some(schema_plan) = schema_plan {
+        lines.push(schema_plan.to_string());
+    }
     if let Some(secret) = secret {
         lines.push(format!(
             "preserved credential api.credentials={}",
@@ -602,6 +609,11 @@ trait UpgradeDriver {
     fn secret(&self) -> Option<&str> {
         None
     }
+    /// The redacted `config schema: <from> -> <to>` plan line (#2299), when a
+    /// retained configuration was read and migrated.
+    fn schema_plan(&self) -> Option<String> {
+        None
+    }
     fn redact(&self, text: &str) -> String {
         match self.secret() {
             Some(secret) => text.replace(secret, &mask_secret(secret)),
@@ -655,10 +667,21 @@ async fn run_lifecycle_inner<H: UpgradeDriver>(
         bail!("--to requires a target version");
     }
     let from = host.current();
-    let plan = plan_lines(&opts, from.as_deref(), host.secret());
-    let plan: Vec<String> = plan.into_iter().map(|l| host.redact(&l)).collect();
+    let plan = plan_lines(
+        &opts,
+        from.as_deref(),
+        host.secret(),
+        host.schema_plan().as_deref(),
+    );
+    let mut plan: Vec<String> = plan.into_iter().map(|l| host.redact(&l)).collect();
 
     if opts.common.dry_run {
+        // The plan is what the command WILL do, so a dry run that computed the
+        // read-only pre-mutation checks must show the refusal the real run
+        // would hit at Validate instead of printing a clean nine-phase plan.
+        if let Some(detail) = host.validate_refusal() {
+            plan.push(host.redact(&format!("refusal at validate: {detail}")));
+        }
         return Ok(ClusterUpgradeOutput::DryRun(crate::ui::DryRunPlan {
             lines: plan,
         }));
@@ -928,6 +951,8 @@ struct LiveHost {
     config_refusal: Option<String>,
     /// Why the chart cannot install `--to`, if it cannot (Ruling 2, R1).
     chart_refusal: Option<String>,
+    /// The redacted configuration schema plan line (#2299).
+    schema_plan: Option<String>,
 }
 
 /// Ruling 2: Helm SILENTLY IGNORES `--version` for a local directory or
@@ -935,6 +960,36 @@ struct LiveHost {
 /// `--version` there would be a pin that does nothing while looking like one,
 /// so a local chart is pinned by refusing before mutation when its own
 /// metadata is not `--to`, and only a ref Helm must resolve carries the flag.
+/// The chart this verb applies. This verb never resolves a release artifact
+/// (issue #2593), so the default is the literal local path.
+fn chart_ref(opts: &UpgradeOpts) -> String {
+    opts.chart
+        .clone()
+        .unwrap_or_else(|| "charts/curie".to_string())
+}
+
+/// The `helm upgrade` argv, ONE definition shared by the plan line and the
+/// mutating call so the printed plan cannot drift from the executed command.
+/// A ref Helm resolves IS pinned by `--version`; a local path is pinned by
+/// `chart_pin_refusal` before Apply ever runs, so it deliberately carries none.
+fn helm_upgrade_argv(opts: &UpgradeOpts, to: &str) -> Vec<String> {
+    let chart = chart_ref(opts);
+    let mut argv = vec![
+        "helm".to_string(),
+        "upgrade".into(),
+        opts.common.release.clone(),
+        chart.clone(),
+        "-n".into(),
+        opts.common.namespace.clone(),
+        "--wait".into(),
+    ];
+    if !local_chart(&chart) {
+        argv.push("--version".into());
+        argv.push(to.to_string());
+    }
+    argv
+}
+
 fn local_chart(chart: &str) -> bool {
     std::path::Path::new(chart).exists()
 }
@@ -950,6 +1005,7 @@ impl LiveHost {
             overlay: None,
             config_refusal: None,
             chart_refusal: None,
+            schema_plan: None,
         }
     }
 
@@ -958,10 +1014,7 @@ impl LiveHost {
     }
 
     fn chart_ref(&self) -> String {
-        self.opts
-            .chart
-            .clone()
-            .unwrap_or_else(|| "charts/curie".to_string())
+        chart_ref(&self.opts)
     }
 
     /// The version a LOCAL chart declares for itself. `None` for a ref Helm
@@ -1007,9 +1060,24 @@ impl LiveHost {
         }
     }
 
+    /// Both pre-mutation refusals and the migrated overlay are computed ONCE,
+    /// before any phase runs (Ruling 8.8). Apply then hands Helm exactly this
+    /// overlay. Every input here is read-only, so the dry-run path runs it too.
+    fn compute_pre_mutation(&mut self) {
+        self.chart_refusal = self.chart_pin_refusal();
+        match self.retained_overlay() {
+            Ok(Some((overlay, schema_plan))) => {
+                self.overlay = Some(overlay);
+                self.schema_plan = Some(schema_plan);
+            }
+            Ok(None) => {}
+            Err(error) => self.config_refusal = Some(format!("{error:#}")),
+        }
+    }
+
     /// R7: read the retained overlay, migrate it (#2299) and keep the result.
     /// `Ok(None)` means nothing was retained -- a first install.
-    fn retained_overlay(&self) -> Result<Option<String>> {
+    fn retained_overlay(&self) -> Result<Option<(String, String)>> {
         let values_cmd = OpsCommand::new(
             "helm",
             vec![
@@ -1045,10 +1113,15 @@ impl LiveHost {
         // `config.schemaVersion`.
         let outcome =
             crate::config_migrate::migrate_installed_config(values, self.current.as_deref())?;
-        Ok(Some(
+        let schema_plan = crate::config_migrate::redacted_upgrade_plan(&outcome)
+            .into_iter()
+            .next()
+            .unwrap_or_default();
+        Ok(Some((
             serde_norway::to_string(&outcome.values)
                 .context("could not serialize the migrated overlay")?,
-        ))
+            schema_plan,
+        )))
     }
 
     /// The chart version the release reports. `scripts/check-version-consistency.sh`
@@ -1142,21 +1215,11 @@ impl LiveHost {
     }
 
     fn helm_upgrade(&self, to: &str) -> Result<()> {
-        let chart = self.chart_ref();
-        let mut args = vec![
-            plain("upgrade"),
-            plain(&self.opts.common.release),
-            plain(chart.clone()),
-            plain("-n"),
-            plain(&self.opts.common.namespace),
-            plain("--wait"),
-        ];
-        if !local_chart(&chart) {
-            // A ref Helm resolves IS pinned by `--version`; a local path is
-            // pinned by `chart_pin_refusal` before this ever runs.
-            args.push(plain("--version"));
-            args.push(plain(to));
-        }
+        let mut args: Vec<_> = helm_upgrade_argv(&self.opts, to)
+            .into_iter()
+            .skip(1)
+            .map(plain)
+            .collect();
         if self.current.is_none() {
             args.push(plain("--install"));
             args.push(plain("--create-namespace"));
@@ -1242,6 +1305,9 @@ impl UpgradeDriver for LiveHost {
         self.record = Some(record.clone());
         self.persist_record(&record)
     }
+    fn schema_plan(&self) -> Option<String> {
+        self.schema_plan.clone()
+    }
     fn validate_refusal(&self) -> Option<String> {
         self.chart_refusal
             .clone()
@@ -1296,6 +1362,10 @@ pub async fn upgrade(opts: UpgradeOpts) -> Result<ClusterUpgradeOutput> {
         let mut live = LiveHost::new(opts.clone());
         live.current = live.inspect_version();
         live.known_good = live.current.clone();
+        // Both pre-mutation inputs are read-only (`helm show chart`, `helm get
+        // values`), so a dry run computes them too and plans the refusal the
+        // real run would hit rather than a plan that cannot happen (#2301).
+        live.compute_pre_mutation();
         return run_lifecycle_inner(opts, &mut live).await;
     }
 
@@ -1319,13 +1389,7 @@ pub async fn upgrade(opts: UpgradeOpts) -> Result<ClusterUpgradeOutput> {
         .as_ref()
         .and_then(|r| r.known_good_version.clone())
         .or_else(|| live.current.clone());
-    // Both pre-mutation refusals are computed ONCE, here, before any phase
-    // runs (Ruling 8.8). Apply then hands Helm exactly this overlay.
-    live.chart_refusal = live.chart_pin_refusal();
-    match live.retained_overlay() {
-        Ok(overlay) => live.overlay = overlay,
-        Err(error) => live.config_refusal = Some(format!("{error:#}")),
-    }
+    live.compute_pre_mutation();
     run_lifecycle_inner(opts, &mut live).await
 }
 

--- a/cli/src/ops/upgrade.rs
+++ b/cli/src/ops/upgrade.rs
@@ -416,8 +416,9 @@ impl UpgradeDriver for FakeUpgradeHost {
     fn load_record(&self) -> Option<UpgradeRecord> {
         self.record.clone()
     }
-    fn store_record(&mut self, record: UpgradeRecord) {
+    fn store_record(&mut self, record: UpgradeRecord) -> Result<()> {
         self.record = Some(record);
+        Ok(())
     }
     fn secret(&self) -> Option<&str> {
         self.secret.as_deref()
@@ -438,7 +439,7 @@ impl UpgradeDriver for FakeUpgradeHost {
         self.set_current(Some(to.to_string()));
         Ok(())
     }
-    fn observe_convergence(&self) -> Result<Convergence> {
+    fn observe_convergence(&self) -> Result<ConvergenceVerdict> {
         let mut conv = Convergence::exact_ok();
         if !self.converge_exact {
             conv.exact = false;
@@ -448,7 +449,7 @@ impl UpgradeDriver for FakeUpgradeHost {
             conv.exact = false;
             conv.manifest_matches = false;
         }
-        Ok(conv)
+        Ok(conv.into())
     }
     fn run_canary(&self) -> Result<Canary> {
         Ok(Canary {
@@ -503,7 +504,7 @@ fn plan_lines(opts: &UpgradeOpts, from: Option<&str>, secret: Option<&str>) -> V
         .unwrap_or_else(|| format!("curie-{}", opts.to));
     let mut lines = vec![
         format!("phase plan: {from} -> {}", opts.to),
-        "phase validate: configuration overlay and schema compatibility".into(),
+        "phase validate: configuration overlay migration and pre-mutation refusals".into(),
         "phase drain: worker upgrade drain gate (issue 2010)".into(),
         "phase checkpoint: persist recoverable release state".into(),
         "phase migrate: one controlled schema migration".into(),
@@ -558,6 +559,17 @@ fn completed_output(
     }
 }
 
+/// Bound a fail-forward reason: the observer can report one line per unhealthy
+/// container, and the operator needs a reason, not a log dump.
+fn truncate_reason(detail: &str) -> String {
+    const LIMIT: usize = 600;
+    if detail.chars().count() <= LIMIT {
+        return detail.to_string();
+    }
+    let kept: String = detail.chars().take(LIMIT).collect();
+    format!("{kept}... (truncated; run `curie cluster status` for the full observation)")
+}
+
 fn fail_forward_for(opts: &UpgradeOpts, previous_serving: bool, reason: &str) -> FailForward {
     if previous_serving {
         FailForward {
@@ -584,7 +596,9 @@ trait UpgradeDriver {
     fn known_good(&self) -> Option<String>;
     fn set_known_good(&mut self, version: Option<String>);
     fn load_record(&self) -> Option<UpgradeRecord>;
-    fn store_record(&mut self, record: UpgradeRecord);
+    /// Persisting the checkpoint is part of the phase, not a side effect: a
+    /// lost checkpoint means the next run cannot resume (R5).
+    fn store_record(&mut self, record: UpgradeRecord) -> Result<()>;
     fn secret(&self) -> Option<&str> {
         None
     }
@@ -594,15 +608,27 @@ trait UpgradeDriver {
             None => text.to_string(),
         }
     }
+    /// A pre-mutation refusal carrying its own operator-facing detail, checked
+    /// before the two boolean gates below. [`LiveHost`] answers it; only
+    /// [`FakeUpgradeHost`] relies on the boolean defaults.
+    fn validate_refusal(&self) -> Option<String> {
+        None
+    }
     fn refuse_config(&self) -> bool {
         false
     }
     fn refuse_schema(&self) -> bool {
         false
     }
+    /// A fresh read of the version the release actually reports. Defaults to
+    /// the driver's own bookkeeping; [`LiveHost`] re-reads Helm so Commit
+    /// stamps known-good from a post-condition, never from the request.
+    fn observed_version(&self) -> Option<String> {
+        self.current()
+    }
     fn drain_once(&mut self) -> Result<bool>;
     fn apply_target(&mut self, to: &str) -> Result<()>;
-    fn observe_convergence(&self) -> Result<Convergence>;
+    fn observe_convergence(&self) -> Result<ConvergenceVerdict>;
     fn run_canary(&self) -> Result<Canary>;
     fn serving_previous(&self) -> bool;
     fn interrupt_after(&self) -> Option<UpgradePhase> {
@@ -683,19 +709,19 @@ async fn run_lifecycle_inner<H: UpgradeDriver>(
             )
         {
             record.completed.push(phase);
-            host.store_record(record.clone());
+            host.store_record(record.clone())?;
             continue;
         }
         if phase == UpgradePhase::Drain && from.is_none() {
             record.completed.push(phase);
-            host.store_record(record.clone());
+            host.store_record(record.clone())?;
             continue;
         }
 
         match execute_phase(phase, &opts, host, &mut record)? {
             PhaseOutcome::Continue => {
                 record.completed.push(phase);
-                host.store_record(record.clone());
+                host.store_record(record.clone())?;
                 if host.interrupt_after() == Some(phase) {
                     bail!("interrupted after durable phase {}", phase.as_str());
                 }
@@ -710,7 +736,16 @@ async fn run_lifecycle_inner<H: UpgradeDriver>(
                         &format!("upgrade failed during {}", phase.as_str()),
                     ));
                 }
-                host.store_record(record.clone());
+                // Ruling 8.4: the phase failure is the verdict the operator
+                // must act on. A lost checkpoint here must travel beside it,
+                // never replace it -- raising with `?` would drop the
+                // structured output, the convergence payload and fail-forward.
+                if let Err(error) = host.store_record(record.clone()) {
+                    if let Some(forward) = record.fail_forward.as_mut() {
+                        forward.reason =
+                            format!("{}; {}", forward.reason, host.redact(&format!("{error:#}")));
+                    }
+                }
                 return Ok(completed_output(&record, previous, Some(phase)));
             }
         }
@@ -719,7 +754,7 @@ async fn run_lifecycle_inner<H: UpgradeDriver>(
     record.status = "succeeded".into();
     record.known_good_version = Some(opts.to.clone());
     host.set_known_good(Some(opts.to.clone()));
-    host.store_record(record.clone());
+    host.store_record(record.clone())?;
     Ok(completed_output(&record, true, None))
 }
 
@@ -740,6 +775,9 @@ fn execute_phase<H: UpgradeDriver>(
     match phase {
         UpgradePhase::Plan => Ok(PhaseOutcome::Continue),
         UpgradePhase::Validate => {
+            if let Some(detail) = host.validate_refusal() {
+                bail!("{detail}");
+            }
             if host.refuse_config() {
                 bail!("configuration compatibility check refused the overlay before mutation");
             }
@@ -770,9 +808,21 @@ fn execute_phase<H: UpgradeDriver>(
             Ok(PhaseOutcome::Continue)
         }
         UpgradePhase::Converge => {
-            let conv = host.observe_convergence()?;
-            record.convergence = Some(conv.clone());
-            if !conv.exact {
+            let verdict = host.observe_convergence()?;
+            record.convergence = Some(verdict.convergence.clone());
+            if !verdict.convergence.exact {
+                // Carry the observer's own text (including an unreadable
+                // cluster's recovery hint) instead of letting the generic
+                // "upgrade failed during converge" replace it.
+                if !verdict.issues.is_empty() {
+                    let detail = host.redact(&verdict.issues.join("; "));
+                    let detail = truncate_reason(&detail);
+                    record.fail_forward = Some(fail_forward_for(
+                        opts,
+                        host.serving_previous(),
+                        &format!("upgrade failed during converge: {detail}"),
+                    ));
+                }
                 return Ok(PhaseOutcome::Failed);
             }
             Ok(PhaseOutcome::Continue)
@@ -791,10 +841,72 @@ fn execute_phase<H: UpgradeDriver>(
             {
                 return Ok(PhaseOutcome::Failed);
             }
-            host.set_known_good(Some(opts.to.clone()));
-            record.known_good_version = Some(opts.to.clone());
+            // Ruling 8.11: known-good is a claim about what the cluster is
+            // serving, so it is stamped from a post-condition read of the
+            // release, never from the requested string.
+            let observed = host.observed_version();
+            if observed.as_deref() != Some(opts.to.as_str()) {
+                let previous = host.serving_previous();
+                record.fail_forward = Some(fail_forward_for(
+                    opts,
+                    previous,
+                    &format!(
+                        "the release reports {} at commit, not the requested {}",
+                        observed.as_deref().unwrap_or("no version"),
+                        opts.to
+                    ),
+                ));
+                return Ok(PhaseOutcome::Failed);
+            }
+            host.set_known_good(observed.clone());
+            record.known_good_version = observed;
             Ok(PhaseOutcome::Continue)
         }
+    }
+}
+
+/// A Converge verdict: the reported sub-flags plus the observer's own issue
+/// text. The text is not part of the `--json` convergence payload; it is what
+/// the Converge phase puts in `fail_forward.reason` so an actionable recovery
+/// string from the observer reaches the operator instead of being replaced by
+/// the generic "upgrade failed during converge".
+pub struct ConvergenceVerdict {
+    pub convergence: Convergence,
+    pub issues: Vec<String>,
+}
+
+impl From<Convergence> for ConvergenceVerdict {
+    fn from(convergence: Convergence) -> Self {
+        Self {
+            convergence,
+            issues: Vec::new(),
+        }
+    }
+}
+
+/// Map one convergence observation onto the reported sub-flags. Every field
+/// comes from a facet the observer genuinely determined; none is a literal.
+fn convergence_from(observation: &super::convergence::Observation) -> Convergence {
+    use super::convergence::Facet;
+    let replicas = observation.holds(Facet::Replicas);
+    Convergence {
+        // `exact` is the whole verdict: any issue at all, including a
+        // Rollout-facet one that no named flag covers, means not converged.
+        exact: observation.issues.is_empty() && !observation.terminal,
+        images: observation.holds(Facet::Image),
+        generations: observation.holds(Facet::Generation),
+        replicas,
+        // Its own facet, not an alias of `replicas`: a workload can be
+        // mid-rollout while `unavailableReplicas` is genuinely 0, and the
+        // --json contract presents these as independent observations.
+        unavailable_zero: observation.holds(Facet::Unavailable),
+        hooks_healthy: observation.holds(Facet::Hook),
+        // Ruling 13: the #2010 drain gate is a Helm pre-upgrade hook Job that
+        // fires during Apply, so Converge is the only phase that can see its
+        // verdict. `record.drain_completed` is the exactly-once flag, not a
+        // convergence fact, and is deliberately not consulted.
+        queues_drained: observation.holds(Facet::Drain),
+        manifest_matches: observation.holds(Facet::Manifest),
     }
 }
 
@@ -808,13 +920,141 @@ struct LiveHost {
     known_good: Option<String>,
     record: Option<UpgradeRecord>,
     secret: Option<String>,
+    /// The migrated retained overlay Apply hands Helm via `-f`, computed ONCE
+    /// before the lifecycle runs (Ruling 8.8): `refuse_config` takes `&self`,
+    /// and the overlay Apply applies must be the overlay Validate approved.
+    overlay: Option<String>,
+    /// Why the configuration migration refused, if it did (#2299, R7).
+    config_refusal: Option<String>,
+    /// Why the chart cannot install `--to`, if it cannot (Ruling 2, R1).
+    chart_refusal: Option<String>,
+}
+
+/// Ruling 2: Helm SILENTLY IGNORES `--version` for a local directory or
+/// packaged chart file -- it renders the chart on disk and says nothing. A
+/// `--version` there would be a pin that does nothing while looking like one,
+/// so a local chart is pinned by refusing before mutation when its own
+/// metadata is not `--to`, and only a ref Helm must resolve carries the flag.
+fn local_chart(chart: &str) -> bool {
+    std::path::Path::new(chart).exists()
 }
 
 impl LiveHost {
+    fn new(opts: UpgradeOpts) -> Self {
+        Self {
+            opts,
+            current: None,
+            known_good: None,
+            record: None,
+            secret: None,
+            overlay: None,
+            config_refusal: None,
+            chart_refusal: None,
+        }
+    }
+
     fn run(&self, cmd: &OpsCommand) -> Result<(bool, String, String)> {
         tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(run_capture(cmd)))
     }
 
+    fn chart_ref(&self) -> String {
+        self.opts
+            .chart
+            .clone()
+            .unwrap_or_else(|| "charts/curie".to_string())
+    }
+
+    /// The version a LOCAL chart declares for itself. `None` for a ref Helm
+    /// resolves, which `--version` pins instead.
+    fn declared_chart_version(&self, chart: &str) -> Result<Option<String>> {
+        if !local_chart(chart) {
+            return Ok(None);
+        }
+        let cmd = OpsCommand::new(
+            "helm",
+            vec![plain("show"), plain("chart"), plain(chart.to_string())],
+        );
+        let (ok, out, err) = self.run(&cmd)?;
+        if !ok {
+            bail!("could not read chart metadata for {chart}: {}", err.trim());
+        }
+        let doc: serde_json::Value =
+            serde_norway::from_str(&out).context("chart metadata is malformed")?;
+        Ok(match doc.get("version") {
+            Some(serde_json::Value::String(version)) => Some(version.clone()),
+            Some(serde_json::Value::Number(version)) => Some(version.to_string()),
+            _ => None,
+        })
+    }
+
+    /// R1: the pre-mutation half of the target pin, for a local chart only.
+    fn chart_pin_refusal(&self) -> Option<String> {
+        let chart = self.chart_ref();
+        if !local_chart(&chart) {
+            return None;
+        }
+        let to = &self.opts.to;
+        match self.declared_chart_version(&chart) {
+            Ok(Some(version)) if version == *to => None,
+            Ok(Some(version)) => Some(format!(
+                "chart {chart} declares version {version}, so it cannot install the requested {to}; \
+                 point --chart at a chart whose version is {to}, or upgrade --to {version}"
+            )),
+            Ok(None) => Some(format!(
+                "chart {chart} declares no version, so --to {to} cannot be pinned"
+            )),
+            Err(error) => Some(format!("{error:#}")),
+        }
+    }
+
+    /// R7: read the retained overlay, migrate it (#2299) and keep the result.
+    /// `Ok(None)` means nothing was retained -- a first install.
+    fn retained_overlay(&self) -> Result<Option<String>> {
+        let values_cmd = OpsCommand::new(
+            "helm",
+            vec![
+                plain("get"),
+                plain("values"),
+                plain(&self.opts.common.release),
+                plain("-n"),
+                plain(&self.opts.common.namespace),
+                plain("-o"),
+                plain("yaml"),
+            ],
+        );
+        let (ok, out, err) = self.run(&values_cmd)?;
+        if !ok {
+            // Fail closed exactly like `cluster up` (`up.rs`
+            // `helm_release_is_absent`): only Helm positively reporting that the
+            // release does not exist means "nothing retained". Any other stderr
+            // that merely mentions "not found" leaves the release state unknown,
+            // and treating it as absent would run `helm upgrade` with no `-f`,
+            // silently dropping every retained operator value.
+            if super::verbs::failure_reason(&err) != "Error: release: not found" {
+                bail!("could not read retained helm values: {}", err.trim());
+            }
+            return Ok(None);
+        }
+        if out.trim().is_empty() {
+            return Ok(None);
+        }
+        let values: serde_json::Value =
+            serde_norway::from_str(&out).context("retained helm values are malformed")?;
+        // Unlike `up.rs`, the installed chart version is known here, so
+        // `infer_schema_version` is not guessing when the overlay predates
+        // `config.schemaVersion`.
+        let outcome =
+            crate::config_migrate::migrate_installed_config(values, self.current.as_deref())?;
+        Ok(Some(
+            serde_norway::to_string(&outcome.values)
+                .context("could not serialize the migrated overlay")?,
+        ))
+    }
+
+    /// The chart version the release reports. `scripts/check-version-consistency.sh`
+    /// is required on every PR and release and asserts Chart.yaml `version` ==
+    /// `appVersion` == the CLI version, so this one field is the whole answer
+    /// and no appVersion branch is needed (driver Ruling 1).
     fn inspect_version(&self) -> Option<String> {
         let cmd = OpsCommand::new(
             "helm",
@@ -902,46 +1142,28 @@ impl LiveHost {
     }
 
     fn helm_upgrade(&self, to: &str) -> Result<()> {
-        let chart = self
-            .opts
-            .chart
-            .clone()
-            .unwrap_or_else(|| "charts/curie".to_string());
-        let values_cmd = OpsCommand::new(
-            "helm",
-            vec![
-                plain("get"),
-                plain("values"),
-                plain(&self.opts.common.release),
-                plain("-n"),
-                plain(&self.opts.common.namespace),
-                plain("-o"),
-                plain("yaml"),
-            ],
-        );
-        let tmp = tempfile::NamedTempFile::new().context("upgrade values tempfile")?;
-        let (ok, out, err) = self.run(&values_cmd)?;
-        if ok && !out.trim().is_empty() {
-            std::fs::write(tmp.path(), out)?;
-        } else if !ok {
-            let missing = err.to_lowercase();
-            if !missing.contains("not found") && !missing.contains("release: not found") {
-                bail!("could not read retained helm values: {}", err.trim());
-            }
-        }
+        let chart = self.chart_ref();
         let mut args = vec![
             plain("upgrade"),
             plain(&self.opts.common.release),
-            plain(chart),
+            plain(chart.clone()),
             plain("-n"),
             plain(&self.opts.common.namespace),
             plain("--wait"),
         ];
+        if !local_chart(&chart) {
+            // A ref Helm resolves IS pinned by `--version`; a local path is
+            // pinned by `chart_pin_refusal` before this ever runs.
+            args.push(plain("--version"));
+            args.push(plain(to));
+        }
         if self.current.is_none() {
             args.push(plain("--install"));
             args.push(plain("--create-namespace"));
         }
-        if tmp.path().exists() && tmp.path().metadata().map(|m| m.len()).unwrap_or(0) > 0 {
+        let tmp = tempfile::NamedTempFile::new().context("upgrade values tempfile")?;
+        if let Some(overlay) = &self.overlay {
+            std::fs::write(tmp.path(), overlay)?;
             args.push(plain("-f"));
             args.push(plain(tmp.path().to_string_lossy().into_owned()));
         }
@@ -953,64 +1175,30 @@ impl LiveHost {
         Ok(())
     }
 
-    fn live_convergence(&self) -> Result<Convergence> {
-        let cmd = OpsCommand::new(
-            "kubectl",
-            vec![
-                plain("get"),
-                plain("deploy,sts,ds"),
-                plain("-n"),
-                plain(&self.opts.common.namespace),
-                plain("-o"),
-                plain("json"),
-            ],
-        );
-        let (ok, out, err) = self.run(&cmd)?;
-        if !ok {
-            bail!("could not read workload status: {}", err.trim());
-        }
-        let v: serde_json::Value = serde_json::from_str(&out).unwrap_or(serde_json::json!({}));
-        let items = v
-            .get("items")
-            .and_then(|i| i.as_array())
-            .cloned()
-            .unwrap_or_default();
-        let mut replicas_ok = !items.is_empty();
-        let mut unavailable_zero = true;
-        for item in &items {
-            let status = item.get("status").cloned().unwrap_or(serde_json::json!({}));
-            let spec = item.get("spec").cloned().unwrap_or(serde_json::json!({}));
-            let desired = spec.get("replicas").and_then(|n| n.as_u64()).unwrap_or(1);
-            let ready = status
-                .get("readyReplicas")
-                .and_then(|n| n.as_u64())
-                .unwrap_or(0);
-            let updated = status
-                .get("updatedReplicas")
-                .and_then(|n| n.as_u64())
-                .unwrap_or(ready);
-            let unavailable = status
-                .get("unavailableReplicas")
-                .and_then(|n| n.as_u64())
-                .unwrap_or(0);
-            if ready != desired || updated != desired {
-                replicas_ok = false;
-            }
-            if unavailable != 0 {
-                unavailable_zero = false;
-            }
-        }
-        let mut conv = Convergence::exact_ok();
-        conv.replicas = replicas_ok;
-        conv.unavailable_zero = unavailable_zero;
-        conv.exact = conv.replicas && conv.unavailable_zero && conv.manifest_matches;
-        Ok(conv)
+    /// R3: the integrated observer answers this, not a hand-rolled
+    /// `kubectl get deploy,sts,ds` read. `super::convergence` compares live
+    /// containers, generations, replicas, selectors and Helm hooks against
+    /// Helm's own retained target manifest; every sub-flag below is derived
+    /// from the facet that observation genuinely disproved.
+    fn live_convergence(&self) -> Result<ConvergenceVerdict> {
+        let observation = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current()
+                .block_on(super::convergence::wait_for_observation(&self.opts.common))
+        });
+        Ok(ConvergenceVerdict {
+            convergence: convergence_from(&observation),
+            issues: observation.issues.clone(),
+        })
     }
 
     fn live_canary(&self) -> Result<Canary> {
-        let conv = self.live_convergence()?;
+        // R4: re-read here. Apply already set `current` from its own
+        // post-condition read, so comparing against `current` would be a
+        // self-comparison, and the release can move between the two phases.
+        // Convergence is not re-observed: the Converge phase has already
+        // failed the run unless it was exact.
         Ok(Canary {
-            passed: conv.exact && self.current.as_deref() == Some(self.opts.to.as_str()),
+            passed: self.inspect_version().as_deref() == Some(self.opts.to.as_str()),
         })
     }
 
@@ -1050,19 +1238,43 @@ impl UpgradeDriver for LiveHost {
     fn load_record(&self) -> Option<UpgradeRecord> {
         self.record.clone()
     }
-    fn store_record(&mut self, record: UpgradeRecord) {
+    fn store_record(&mut self, record: UpgradeRecord) -> Result<()> {
         self.record = Some(record.clone());
-        let _ = self.persist_record(&record);
+        self.persist_record(&record)
+    }
+    fn validate_refusal(&self) -> Option<String> {
+        self.chart_refusal
+            .clone()
+            .or_else(|| self.config_refusal.clone())
+    }
+    fn refuse_config(&self) -> bool {
+        self.config_refusal.is_some()
+    }
+    fn observed_version(&self) -> Option<String> {
+        self.inspect_version()
     }
     fn drain_once(&mut self) -> Result<bool> {
         self.live_drain()
     }
     fn apply_target(&mut self, to: &str) -> Result<()> {
         self.helm_upgrade(to)?;
-        self.set_current(Some(to.to_string()));
-        Ok(())
+        // R2: what the release reports, not what was requested, is what was
+        // installed. Helm can exit 0 on a revision that never moved.
+        let observed = self.inspect_version();
+        match observed.as_deref() {
+            Some(version) if version == to => {
+                self.set_current(observed);
+                Ok(())
+            }
+            Some(version) => bail!(
+                "helm upgrade to {to} reported success, but the release still reports {version}"
+            ),
+            None => {
+                bail!("helm upgrade to {to} reported success, but the release reports no version")
+            }
+        }
     }
-    fn observe_convergence(&self) -> Result<Convergence> {
+    fn observe_convergence(&self) -> Result<ConvergenceVerdict> {
         self.live_convergence()
     }
     fn run_canary(&self) -> Result<Canary> {
@@ -1081,13 +1293,7 @@ impl UpgradeDriver for LiveHost {
 pub async fn upgrade(opts: UpgradeOpts) -> Result<ClusterUpgradeOutput> {
     if opts.common.dry_run {
         require_on_path("helm").ok();
-        let mut live = LiveHost {
-            opts: opts.clone(),
-            current: None,
-            known_good: None,
-            record: None,
-            secret: None,
-        };
+        let mut live = LiveHost::new(opts.clone());
         live.current = live.inspect_version();
         live.known_good = live.current.clone();
         return run_lifecycle_inner(opts, &mut live).await;
@@ -1105,13 +1311,7 @@ pub async fn upgrade(opts: UpgradeOpts) -> Result<ClusterUpgradeOutput> {
         bail!("upgrade aborted");
     }
 
-    let mut live = LiveHost {
-        opts: opts.clone(),
-        current: None,
-        known_good: None,
-        record: None,
-        secret: None,
-    };
+    let mut live = LiveHost::new(opts.clone());
     live.current = live.inspect_version();
     live.record = live.load_record();
     live.known_good = live
@@ -1119,6 +1319,13 @@ pub async fn upgrade(opts: UpgradeOpts) -> Result<ClusterUpgradeOutput> {
         .as_ref()
         .and_then(|r| r.known_good_version.clone())
         .or_else(|| live.current.clone());
+    // Both pre-mutation refusals are computed ONCE, here, before any phase
+    // runs (Ruling 8.8). Apply then hands Helm exactly this overlay.
+    live.chart_refusal = live.chart_pin_refusal();
+    match live.retained_overlay() {
+        Ok(overlay) => live.overlay = overlay,
+        Err(error) => live.config_refusal = Some(format!("{error:#}")),
+    }
     run_lifecycle_inner(opts, &mut live).await
 }
 

--- a/cli/tests/cluster_upgrade.rs
+++ b/cli/tests/cluster_upgrade.rs
@@ -317,3 +317,42 @@ async fn cluster_status_reports_phase_and_known_good() {
     assert_eq!(view.known_good_version.as_deref(), Some("0.8.6"));
     assert_eq!(view.target_version.as_deref(), Some("0.9.0"));
 }
+
+// T18 (R8) -- CHARACTERIZATION, not a requirement. This pins the CURRENT
+// behaviour of the in-progress checkpoint guard INCLUDING its gap: it refuses a
+// second run only when that run targets a DIFFERENT version, and lets a second
+// run at the SAME target proceed straight into mutation. `curie cluster upgrade`
+// has no ownership fence; see FU-1 and the `docs/operations.md` note. If a fence
+// lands, this test SHOULD fail and be replaced by the fence's own test.
+#[tokio::test]
+async fn concurrent_upgrade_is_not_fenced_characterization() {
+    let mut host = FakeUpgradeHost::installed("0.8.6").interrupt_after(UpgradePhase::Plan);
+    let err = run_lifecycle(opts("0.9.0"), &mut host)
+        .await
+        .expect_err("first run interrupted, leaving an in-progress checkpoint");
+    assert!(format!("{err:#}").contains("interrupted"));
+    host.clear_interrupt();
+
+    let err = run_lifecycle(opts("0.9.1"), &mut host)
+        .await
+        .expect_err("a different target is refused while one is in progress");
+    assert!(
+        format!("{err:#}").contains("already in progress"),
+        "{err:#}"
+    );
+    assert_eq!(
+        host.mutate_calls, 0,
+        "the refused run must not have mutated"
+    );
+
+    // The gap: nothing fences a second run at the same target.
+    let out = run_lifecycle(opts("0.9.0"), &mut host)
+        .await
+        .expect("same-target second run is NOT fenced today");
+    let json = output_json(&out);
+    assert_eq!(json["status"], "succeeded", "{json}");
+    assert_eq!(
+        host.mutate_calls, 1,
+        "an unfenced same-target run proceeds into mutation"
+    );
+}

--- a/cli/tests/cluster_upgrade_live.rs
+++ b/cli/tests/cluster_upgrade_live.rs
@@ -860,3 +860,142 @@ fn upgrade_output_contains_no_credential_value() {
         );
     }
 }
+
+// T14 -- pins `generations` to an observed controller generation. The live
+// Deployment's `status.observedGeneration` lags `metadata.generation`; images,
+// replicas, hooks and selectors all agree, so a hardcoded `generations: true`
+// (or a `generations` bound to any other facet) fails here.
+#[test]
+fn stale_generation_fails_only_the_generations_facet() {
+    let fixture = Fixture::new(None);
+    let output = fixture.local("stale-generation");
+    let json = json(&output);
+    observed_for_real(&fixture);
+    only_false(&json, &["generations"]);
+    assert_eq!(json["status"], "failed", "{json}");
+    assert_eq!(json["phase"], "converge", "{json}");
+}
+
+// T15 -- pins `replicas`, and pins that it is NOT `unavailable_zero`.
+// `updatedReplicas` lags desired while `unavailableReplicas` is genuinely 0,
+// so `replicas` must be false and `unavailable_zero` must stay true. A
+// hardcoded `replicas: true`, or the old `unavailable_zero: replicas` alias,
+// fails on one half or the other.
+#[test]
+fn replica_count_mismatch_fails_only_the_replicas_facet() {
+    let fixture = Fixture::new(None);
+    let output = fixture.local("stale-replicas");
+    let json = json(&output);
+    observed_for_real(&fixture);
+    only_false(&json, &["replicas"]);
+    assert_eq!(json["status"], "failed", "{json}");
+    assert_eq!(json["phase"], "converge", "{json}");
+}
+
+// T16 -- the mirror of T15 and the reason `unavailable_zero` is its own facet:
+// updated == ready == total == desired, but one replica is unavailable.
+// `replicas` stays true and `unavailable_zero` alone goes false, so neither
+// flag can be a literal or an alias of the other.
+#[test]
+fn unavailable_replicas_fail_only_the_unavailable_facet() {
+    let fixture = Fixture::new(None);
+    let output = fixture.local("unavailable-replicas");
+    let json = json(&output);
+    observed_for_real(&fixture);
+    only_false(&json, &["unavailable_zero"]);
+    assert_eq!(json["status"], "failed", "{json}");
+    assert_eq!(json["phase"], "converge", "{json}");
+}
+
+// T17 -- an observation that could not be MADE determines NO named property.
+// The workloads read exits non-zero (a command failure, not a terminal
+// cluster condition), so every named sub-flag must read false -- `holds` is
+// closed-world, and leaving the facets untagged would report seven observed
+// truths off a read that never happened. The read's own error text, not the
+// generic converge message, must reach `fail_forward.reason`.
+#[test]
+fn an_unmakeable_observation_determines_no_facet() {
+    let fixture = Fixture::new(None);
+    let output = fixture.local("workloads-unreadable");
+    let json = json(&output);
+    only_false(&json, &FACETS);
+    assert_eq!(json["status"], "failed", "{json}");
+    assert_eq!(json["phase"], "converge", "{json}");
+    let reason = json["fail_forward"]["reason"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no fail_forward reason: {json}"));
+    assert!(
+        reason.contains("read target workloads and pods"),
+        "the failed read must be named, not replaced by the generic converge message: {reason}"
+    );
+    assert!(
+        reason.contains("inspect Helm/Kubernetes access and retry"),
+        "the observer's recovery hint must survive into fail_forward: {reason}"
+    );
+}
+
+// T18 -- F4: `helm get values` failing with stderr that merely CONTAINS
+// "not found" (here a missing namespace) leaves the retained overlay unknown,
+// not absent. Proceeding would run `helm upgrade` with no `-f` and silently
+// drop every retained operator value, so this must fail closed before any
+// mutation.
+#[test]
+fn an_unreadable_retained_overlay_fails_closed() {
+    let fixture = Fixture::new(None);
+    let output = fixture.local("values-read-fails");
+    assert!(
+        !output.status.success(),
+        "an unknown retained overlay must not report success: {}",
+        stdout(&output)
+    );
+    assert!(
+        fixture.helm_upgrades().is_empty(),
+        "nothing may be mutated while the retained values are unknown: {:?}",
+        fixture.argv()
+    );
+    assert!(
+        visible(&output).contains("retained helm values"),
+        "the refusal must name the unreadable retained values: {}",
+        visible(&output)
+    );
+}
+
+// T19 -- R7: the overlay is read ONCE, before the lifecycle, and Apply hands
+// helm that stored document. The fake serves a DIFFERENT values document on
+// every `helm get values` after the first, so a re-read inside Apply would
+// visibly swap the payload. Both halves are asserted: the `-f` document is the
+// one read at Validate, and `helm get values` appears exactly once in the argv
+// log.
+#[test]
+fn the_overlay_is_read_once_and_apply_uses_the_stored_one() {
+    let fixture = Fixture::new(None);
+    let output = fixture.local("values-drift");
+    assert_eq!(
+        fixture.helm_upgrades().len(),
+        1,
+        "Apply must run for this to prove anything: {:?} / {}",
+        fixture.argv(),
+        stderr(&output)
+    );
+    let values = fixture.values(1);
+    let names = extra_env_names(&values_doc(&values));
+    assert!(
+        names.contains(&"FIRST_READ_ONLY".to_string()),
+        "helm must be handed the overlay read at Validate: {values}"
+    );
+    assert!(
+        !names.contains(&"SECOND_READ_MUST_NOT_WIN".to_string()),
+        "a second `helm get values` must not be the source of the -f payload: {values}"
+    );
+    let reads = fixture
+        .argv()
+        .into_iter()
+        .filter(|call| call.len() >= 3 && call[..3] == ["helm", "get", "values"])
+        .count();
+    assert_eq!(
+        reads,
+        1,
+        "the retained overlay must be read exactly once: {:?}",
+        fixture.argv()
+    );
+}

--- a/cli/tests/cluster_upgrade_live.rs
+++ b/cli/tests/cluster_upgrade_live.rs
@@ -1,0 +1,811 @@
+//! `curie cluster upgrade` against the LIVE host (#2299 / #2301).
+//!
+//! `cluster_upgrade.rs` drives `FakeUpgradeHost`, which satisfies the lifecycle
+//! contract by construction. These tests instead drive the real binary against
+//! recording `helm`/`kubectl` processes, so they pin what `LiveHost` actually
+//! issues and actually observes -- the surface the fake cannot reach.
+//!
+//! Fixture shapes follow the Kubernetes workload/pod references used by
+//! `cluster_convergence.rs`. `PATH` is process-global, so every child gets its
+//! own `PATH` via `Command::env` and every test its own TempDir root.
+//!
+//! Non-inertness is the design constraint. `convergence::observe` compares live
+//! containers against Helm's INSTALLED manifest, not against `--to`, so a
+//! fixture that moves the manifest and the live pods together can never make
+//! `images` false however the flag is wired. Every convergence fixture here
+//! therefore diverges exactly one facet and asserts that the OTHER named
+//! sub-flags stay true: a binding that collapses every flag onto
+//! `issues.is_empty()` fails these tests just as loudly as a hardcoded `true`.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::{Command, Output};
+
+use serde_json::Value;
+
+/// The exact resource selector `convergence::workloads_command` issues. The
+/// recording `kubectl` serves ONLY this string, so a narrower `deploy,sts,ds`
+/// read fails outright instead of quietly satisfying a fixture.
+const WORKLOADS: &str = "deployments,statefulsets,daemonsets,pods,jobs";
+
+/// The named convergence sub-flags, excluding `exact`.
+const FACETS: [&str; 7] = [
+    "images",
+    "generations",
+    "replicas",
+    "unavailable_zero",
+    "hooks_healthy",
+    "queues_drained",
+    "manifest_matches",
+];
+
+/// One isolated fake cluster: a TempDir holding `helm`, `kubectl`, the argv log
+/// and every captured payload.
+struct Fixture(tempfile::TempDir);
+
+impl Fixture {
+    fn new(retained: Option<&str>) -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        for name in ["helm", "kubectl"] {
+            let path = temp.path().join(name);
+            fs::write(&path, include_str!("data/upgrade-driver.py")).unwrap();
+            fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        if let Some(retained) = retained {
+            fs::write(temp.path().join("retained.json"), retained).unwrap();
+        }
+        Self(temp)
+    }
+
+    /// Seed the upgrade checkpoint ConfigMap `kubectl get` will return.
+    fn seed_checkpoint(&self, record: &Value) {
+        fs::write(
+            self.0.path().join("checkpoint.json"),
+            serde_json::to_string(record).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn checkpoint(self, record: &Value) -> Self {
+        self.seed_checkpoint(record);
+        self
+    }
+
+    fn run(&self, scenario: &str, to: &str, chart: &str) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_curie"))
+            .args([
+                "--json",
+                "cluster",
+                "upgrade",
+                "--to",
+                to,
+                "--namespace",
+                "ns",
+                "--release",
+                "rel",
+                "--chart",
+                chart,
+                "--yes",
+            ])
+            .current_dir(
+                std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .parent()
+                    .unwrap(),
+            )
+            .env("PATH", format!("{}:/usr/bin:/bin", self.0.path().display()))
+            .env("UPGRADE_DRIVER_ROOT", self.0.path())
+            .env("UPGRADE_DRIVER_SCENARIO", scenario)
+            .output()
+            .unwrap()
+    }
+
+    fn local(&self, scenario: &str) -> Output {
+        self.run(scenario, "0.9.0", "charts/curie")
+    }
+
+    /// Every recorded invocation, in order.
+    fn argv(&self) -> Vec<Vec<String>> {
+        let log = self.0.path().join("argv.log");
+        match fs::read_to_string(log) {
+            Ok(text) => text
+                .lines()
+                .map(|line| serde_json::from_str(line).unwrap())
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn issued(&self, prefix: &[&str]) -> bool {
+        self.argv()
+            .iter()
+            .any(|call| call.len() >= prefix.len() && call[..prefix.len()] == *prefix)
+    }
+
+    /// The `helm upgrade` invocations. Empty means nothing was mutated.
+    fn helm_upgrades(&self) -> Vec<Vec<String>> {
+        self.argv()
+            .into_iter()
+            .filter(|call| {
+                call.first().map(String::as_str) == Some("helm")
+                    && call.get(1).map(String::as_str) == Some("upgrade")
+            })
+            .collect()
+    }
+
+    /// The n-th values document (1-based) helm was handed via `-f`.
+    fn values(&self, index: usize) -> String {
+        fs::read_to_string(self.0.path().join(format!("values-{index}.yaml")))
+            .unwrap_or_else(|error| panic!("values-{index}.yaml: {error}"))
+    }
+
+    /// Every checkpoint manifest `kubectl apply` received, concatenated.
+    fn applied(&self) -> String {
+        let mut all = String::new();
+        for path in self.applied_paths() {
+            all.push_str(&fs::read_to_string(&path).unwrap());
+        }
+        all
+    }
+
+    fn applied_paths(&self) -> Vec<std::path::PathBuf> {
+        let mut paths: Vec<_> = fs::read_dir(self.0.path())
+            .unwrap()
+            .filter_map(|entry| {
+                let path = entry.unwrap().path();
+                let name = path.file_name()?.to_string_lossy().into_owned();
+                name.starts_with("applied-").then_some(path)
+            })
+            .collect();
+        // applied-10 must sort after applied-9, so key on the index.
+        paths.sort_by_key(|path| {
+            path.file_stem()
+                .and_then(|stem| {
+                    stem.to_string_lossy()
+                        .rsplit('-')
+                        .next()?
+                        .parse::<u32>()
+                        .ok()
+                })
+                .unwrap_or(0)
+        });
+        paths
+    }
+
+    /// Every persisted `UpgradeRecord`, parsed out of the ConfigMap manifests
+    /// `kubectl apply` received, in write order. This is the durable state a
+    /// resume would read, so it -- not the process exit code -- is where
+    /// "known-good did not advance" and "Commit never ran" are decided.
+    fn records(&self) -> Vec<Value> {
+        self.applied_paths()
+            .iter()
+            .filter_map(|path| {
+                let manifest: Value = serde_json::from_str(&fs::read_to_string(path).ok()?).ok()?;
+                let record = manifest.pointer("/data/record")?.as_str()?;
+                serde_json::from_str(record).ok()
+            })
+            .collect()
+    }
+
+    fn last_record(&self) -> Value {
+        self.records()
+            .pop()
+            .unwrap_or_else(|| panic!("no checkpoint record was ever persisted"))
+    }
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn visible(output: &Output) -> String {
+    format!("{}{}", stdout(output), stderr(output))
+}
+
+fn json(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON ({error}): {} / {}",
+            stdout(output),
+            stderr(output)
+        )
+    })
+}
+
+/// Assert that exactly the named convergence facets are false. The "every
+/// other flag is still true" half is what stops a binding that simply mirrors
+/// `issues.is_empty()` onto all seven from passing a single-facet fixture.
+fn only_false(json: &Value, expected_false: &[&str]) {
+    let conv = &json["convergence"];
+    assert!(
+        conv.is_object(),
+        "no convergence payload was reported: {json}"
+    );
+    for facet in FACETS {
+        let want = !expected_false.contains(&facet);
+        assert_eq!(
+            conv[facet],
+            Value::Bool(want),
+            "convergence.{facet} must be {want}; only {expected_false:?} may be false: {json}"
+        );
+    }
+    assert_eq!(conv["exact"], false, "{json}");
+}
+
+/// Assert the observer -- not the old `kubectl get deploy,sts,ds` stub --
+/// produced this convergence payload.
+fn observed_for_real(fixture: &Fixture) {
+    assert!(
+        fixture.issued(&["helm", "get", "manifest"]),
+        "Helm's installed target manifest must be read: {:?}",
+        fixture.argv()
+    );
+    assert!(
+        fixture.issued(&["kubectl", "get", WORKLOADS]),
+        "convergence must read the full workload/pod/job set, not `deploy,sts,ds`: {:?}",
+        fixture.argv()
+    );
+}
+
+const V084: &str = include_str!("data/upgrade-config/v0.8.4-user-values.json");
+const V085: &str = include_str!("data/upgrade-config/v0.8.5-user-values.json");
+
+/// The inline Slack credential carried by the v0.8.4 fixture. Split so the
+/// literal never appears contiguously in source: a repository secret scanner
+/// matches `xox[baprs]-` plus ten characters on any added line, and this file
+/// asserts on the value precisely because it must never be emitted.
+const SLACK_TOKEN: &str = concat!("xoxb", "-test-token-must-not-leak");
+
+/// A checkpoint record whose durable phases are already complete through Apply.
+fn applied_checkpoint(drain_completed: bool) -> Value {
+    checkpoint_through(
+        &[
+            "plan",
+            "validate",
+            "drain",
+            "checkpoint",
+            "migrate",
+            "apply",
+        ],
+        drain_completed,
+    )
+}
+
+fn checkpoint_through(completed: &[&str], drain_completed: bool) -> Value {
+    serde_json::json!({
+        "target_version": "0.9.0",
+        "from_version": "0.8.6",
+        "known_good_version": "0.8.6",
+        "completed": completed,
+        "status": "in_progress",
+        "plan": ["upgrade to 0.9.0"],
+        "drain_completed": drain_completed,
+        "convergence": null,
+        "canary": null,
+        "fail_forward": null,
+        "resumed": false,
+    })
+}
+
+// T1(a) -- #2301 "requires no direct Helm command or merge-flag choice", as
+// amended by driver Ruling 2: a local chart path is never pinned with
+// `--version` (Helm silently ignores it there).
+#[test]
+fn local_chart_upgrade_does_not_pass_a_version_flag() {
+    let fixture = Fixture::new(None);
+    let output = fixture.local("healthy");
+    let upgrades = fixture.helm_upgrades();
+    assert_eq!(
+        upgrades.len(),
+        1,
+        "one mutation expected: {:?} / {}",
+        fixture.argv(),
+        stderr(&output)
+    );
+    assert!(
+        !upgrades[0].iter().any(|arg| arg == "--version"),
+        "a local chart path must not carry a --version pin Helm ignores: {:?}",
+        upgrades[0]
+    );
+}
+
+// T1(a) -- Ruling 2: the local chart's own metadata is the pin. A chart whose
+// `helm show chart` version is not `--to` must refuse BEFORE any mutation.
+#[test]
+fn local_chart_version_mismatch_refuses_before_mutation() {
+    let fixture = Fixture::new(None);
+    let output = fixture.local("local-chart-mismatch");
+    assert!(
+        !output.status.success(),
+        "a 0.8.7 chart must not satisfy --to 0.9.0: {}",
+        stdout(&output)
+    );
+    assert!(
+        fixture.helm_upgrades().is_empty(),
+        "refusal must precede mutation: {:?}",
+        fixture.argv()
+    );
+    let message = visible(&output);
+    assert!(
+        message.contains("0.8.7") && message.contains("0.9.0"),
+        "refusal must name the chart's version and the requested version: {message}"
+    );
+}
+
+// T1(b) -- #2301: a non-local ref IS resolved by Helm, so `--version <to>` must
+// reach the command.
+#[test]
+fn remote_chart_ref_pins_the_target_version() {
+    let fixture = Fixture::new(None);
+    let output = fixture.run("healthy", "0.9.0", "oci://example.invalid/curie");
+    let upgrades = fixture.helm_upgrades();
+    assert_eq!(
+        upgrades.len(),
+        1,
+        "one mutation expected: {:?} / {}",
+        fixture.argv(),
+        stderr(&output)
+    );
+    let position = upgrades[0]
+        .iter()
+        .position(|arg| arg == "--version")
+        .unwrap_or_else(|| panic!("--version absent from {:?}", upgrades[0]));
+    assert_eq!(
+        upgrades[0].get(position + 1).map(String::as_str),
+        Some("0.9.0"),
+        "--version must carry the requested target: {:?}",
+        upgrades[0]
+    );
+}
+
+// T2 -- #2301 "never reports success for an unconverged release": the observed
+// Helm revision, not the requested string, is the authority.
+//
+// The fixture's `helm show chart` reports 0.9.0, so Ruling 2's pre-mutation
+// refusal does NOT fire and Apply is genuinely entered -- asserted below,
+// because a test that refuses at Validate proves nothing about the
+// post-condition read.
+#[test]
+fn observed_version_divergence_fails_apply() {
+    let fixture = Fixture::new(None);
+    let output = fixture.local("stale-version");
+    assert_eq!(
+        fixture.helm_upgrades().len(),
+        1,
+        "Validate must pass and Apply must run, or this proves nothing: {:?} / {}",
+        fixture.argv(),
+        stderr(&output)
+    );
+    assert!(
+        !output.status.success(),
+        "a release still on 0.8.6 must not report success: {}",
+        stdout(&output)
+    );
+    let message = visible(&output);
+    assert!(
+        message.contains("0.8.6") && message.contains("0.9.0"),
+        "the failure must name the requested and the observed version: {message}"
+    );
+    for record in fixture.records() {
+        assert_ne!(
+            record["known_good_version"], "0.9.0",
+            "known-good must not advance to an unobserved version: {record}"
+        );
+        assert!(
+            !record["completed"]
+                .as_array()
+                .is_some_and(|done| done.iter().any(|phase| phase == "commit")),
+            "Commit must not run once Apply's post-condition read failed: {record}"
+        );
+    }
+}
+
+// T3 -- #2301 "a target-version canary". Apply's own post-condition read is
+// satisfied (`helm status` reports 0.9.0 immediately after the upgrade) and
+// convergence is exact, THEN the release slips back to 0.8.6 before the canary.
+// Only a canary that re-reads the live version can catch that; a canary that
+// trusts `self.current` -- which Apply set from `--to` -- passes. This is the
+// R4 tautology guard, and it deliberately does not share T2's fixture.
+#[test]
+fn canary_fails_when_the_observed_version_is_not_the_target() {
+    let fixture = Fixture::new(None);
+    let output = fixture.local("canary-version-drift");
+    let json = json(&output);
+    assert_eq!(
+        fixture.helm_upgrades().len(),
+        1,
+        "Apply must have succeeded for the canary to be the phase under test: {:?}",
+        fixture.argv()
+    );
+    for facet in FACETS {
+        assert_eq!(
+            json["convergence"][facet], true,
+            "fixture must isolate the canary from convergence: {json}"
+        );
+    }
+    assert_eq!(json["convergence"]["exact"], true, "{json}");
+    assert_eq!(json["canary"]["passed"], false, "{json}");
+    assert_eq!(json["status"], "failed", "{json}");
+    assert_eq!(json["phase"], "canary", "{json}");
+    assert_ne!(json["known_good_version"], "0.9.0", "{json}");
+    let record = fixture.last_record();
+    assert!(
+        !record["completed"]
+            .as_array()
+            .is_some_and(|done| done.iter().any(|phase| phase == "commit")),
+        "Commit must not run after a failed canary: {record}"
+    );
+}
+
+// T4 -- #2301 "exact target image convergence".
+//
+// The release is deployed, `helm get manifest` renders the 0.9.0 images, and
+// the live pods still run 0.8.6 at full ready counts with generations
+// observed, hooks healthy and selectors matching. Divergence between the
+// INSTALLED manifest and the live containers is the only thing `observe` can
+// see -- a fixture whose manifest and pods agree reports `images: true` no
+// matter how the flag is wired.
+//
+// `ProgressDeadlineExceeded` is stamped so the observer stops on its first
+// pass instead of retrying to its 300-second deadline. It is a Rollout-facet
+// issue and must not be the reason any NAMED sub-flag goes false, which is
+// exactly what `only_false` pins.
+#[test]
+fn stale_images_fail_convergence() {
+    let fixture = Fixture::new(None);
+    let output = fixture.local("stale-images");
+    let json = json(&output);
+    observed_for_real(&fixture);
+    only_false(&json, &["images"]);
+    assert_eq!(json["status"], "failed", "{json}");
+    assert_eq!(json["phase"], "converge", "{json}");
+}
+
+// T5 -- #2301 "healthy hooks". `helm status -o json` reports the pre-upgrade
+// Job hook with `last_run.phase: Failed` AND the live Job carries a `Failed`
+// condition, so `hooks_healthy` goes false because the hook state was read --
+// not because `observe` errored out on a fixture that never served hooks.
+//
+// The hook that fails here is `rel-schema-migrate`, NOT the drain gate, and
+// `only_false` asserts `queues_drained` stays true. Paired with T6 (where the
+// drain gate fails and `hooks_healthy` stays true) this proves the two facets
+// are genuinely distinct rather than two names for the same hook walk.
+#[test]
+fn failed_hook_fails_convergence() {
+    let fixture = Fixture::new(None);
+    let output = fixture.local("failed-hook");
+    let json = json(&output);
+    observed_for_real(&fixture);
+    only_false(&json, &["hooks_healthy"]);
+    assert_eq!(json["status"], "failed", "{json}");
+    assert_eq!(json["phase"], "converge", "{json}");
+}
+
+// T6 -- #2301 "drained queues" (guards #2010), per driver Ruling 13.
+//
+// Ruling 7 derived this from phase bookkeeping and was withdrawn: Drain is
+// always executed-or-skipped-and-pushed onto `completed` before Converge runs,
+// so that predicate was always true and could not fail. The observable fact is
+// the #2010 gate itself -- a Helm PRE-UPGRADE hook Job
+// (`charts/curie/templates/worker-upgrade-drain.yaml`) that fires during Apply,
+// which is why the Drain phase cannot see its verdict and Converge can.
+//
+// `queues_drained` binds to that one hook by name; `hooks_healthy` covers every
+// other hook. Both branches are reachable, so this test is a fixture and its
+// own mutation control.
+#[test]
+fn failed_drain_hook_is_the_only_source_of_queues_drained() {
+    // The gate refused: accepted work was still in flight when the roll began.
+    let gate = Fixture::new(None);
+    let output = gate.local("failed-drain-hook");
+    let refused = json(&output);
+    observed_for_real(&gate);
+    only_false(&refused, &["queues_drained"]);
+    assert_eq!(refused["status"], "failed", "{refused}");
+    assert_eq!(refused["phase"], "converge", "{refused}");
+
+    // The control: the same fixture with the drain gate succeeding. One hook
+    // phase is the whole difference between these two runs.
+    let drained = Fixture::new(None);
+    let output = drained.local("healthy");
+    let control = json(&output);
+    observed_for_real(&drained);
+    assert_eq!(
+        control["convergence"]["queues_drained"], true,
+        "a drain gate that exited 0 is a drained queue: {control}"
+    );
+    assert_eq!(control["convergence"]["exact"], true, "{control}");
+    assert_eq!(control["status"], "succeeded", "{control}");
+}
+
+// T6 (cont.) -- the two paths that reach Converge with the Drain PHASE
+// legitimately skipped must still report drained queues. This is the
+// regression the withdrawn ruling was protecting, and it survives the rebind
+// because the hook, not the phase record, is now the source: a fresh install
+// runs no drain hook and a same-version rerun applies no revision, so neither
+// produces a Drain facet.
+#[test]
+fn skipped_drain_phases_still_report_drained_queues() {
+    // Fresh install: no release yet, so Drain is skipped for having nothing in
+    // flight (`from.is_none()`).
+    let fresh = Fixture::new(None);
+    let output = fresh.local("fresh-install");
+    let installed = json(&output);
+    assert_eq!(
+        installed["convergence"]["queues_drained"], true,
+        "a first install has nothing in flight and is not undrained: {installed}"
+    );
+    assert_eq!(installed["convergence"]["exact"], true, "{installed}");
+    assert_eq!(installed["status"], "succeeded", "{installed}");
+    assert_eq!(
+        fresh.helm_upgrades().len(),
+        1,
+        "a fresh install still installs: {:?}",
+        fresh.argv()
+    );
+
+    // Same-version rerun: Drain/Checkpoint/Migrate/Apply are all skipped.
+    let same = Fixture::new(None);
+    let output = same.local("resumed-applied");
+    let rerun = json(&output);
+    assert_eq!(rerun["unchanged"], true, "{rerun}");
+    assert_eq!(
+        rerun["convergence"]["queues_drained"], true,
+        "a same-version rerun skips Drain but is not undrained: {rerun}"
+    );
+    assert_eq!(rerun["convergence"]["exact"], true, "{rerun}");
+    assert_eq!(rerun["status"], "succeeded", "{rerun}");
+    assert!(
+        same.helm_upgrades().is_empty(),
+        "a same-version rerun must not apply a new revision: {:?}",
+        same.argv()
+    );
+
+    // A resume past Apply: #2010's exactly-once flag is not a convergence fact
+    // either way, so neither setting of it may move the drained verdict.
+    for drain_completed in [false, true] {
+        let fixture = Fixture::new(None).checkpoint(&applied_checkpoint(drain_completed));
+        let output = fixture.local("resumed-applied");
+        let resumed = json(&output);
+        assert_eq!(
+            resumed["convergence"]["queues_drained"], true,
+            "drain_completed={drain_completed} must not decide the drained facet: {resumed}"
+        );
+        assert_eq!(resumed["status"], "succeeded", "{resumed}");
+    }
+}
+
+// T7 -- #2301 "compare Helm's retained target manifest with live owned objects
+// before committing": a live selector that differs from the target manifest.
+// The images agree here, so `manifest_matches` is the only facet that may go
+// false -- a binding that maps every issue onto every flag fails this.
+#[test]
+fn manifest_mismatch_fails_convergence_on_the_live_path() {
+    let fixture = Fixture::new(None);
+    let output = fixture.local("selector-drift");
+    let json = json(&output);
+    observed_for_real(&fixture);
+    only_false(&json, &["manifest_matches"]);
+    assert_eq!(json["status"], "failed", "{json}");
+    assert_eq!(json["phase"], "converge", "{json}");
+}
+
+// T8(a) -- #2301 "persist phase/checkpoint state sufficient to resume": the
+// FIRST checkpoint write, before any mutation, must fail the command rather
+// than being discarded by `let _ = persist_record(..)`.
+#[test]
+fn checkpoint_persist_failure_fails_the_command() {
+    let fixture = Fixture::new(None);
+    let output = fixture.local("persist-fails");
+    assert!(
+        !output.status.success(),
+        "a lost checkpoint must not report success: {}",
+        stdout(&output)
+    );
+    assert!(
+        visible(&output).contains("checkpoint"),
+        "the persist failure must surface: {}",
+        visible(&output)
+    );
+    assert!(
+        fixture.helm_upgrades().is_empty(),
+        "a checkpoint lost before Apply must stop short of mutation: {:?}",
+        fixture.argv()
+    );
+}
+
+// T8(b) -- plan edge 10. Only the checkpoint write that FOLLOWS a failed
+// Converge fails. Every earlier write succeeds, so the run reaches Converge,
+// fails it on stale images, and then loses the failure checkpoint.
+//
+// The convergence failure is the verdict the operator must act on. A persist
+// error raised with `?` from the `PhaseOutcome::Failed` arm would replace it
+// with a checkpoint message and drop the `ClusterUpgradeOutput` entirely --
+// no phase, no convergence payload, no fail_forward. This asserts the phase
+// failure is still the structured verdict and the persist error travels
+// beside it.
+#[test]
+fn persist_failure_after_converge_does_not_mask_the_phase_failure() {
+    let fixture = Fixture::new(None);
+    let output = fixture.local("converge-then-persist-fails");
+    let json = json(&output);
+    assert_eq!(
+        json["status"], "failed",
+        "the phase failure is the verdict: {json}"
+    );
+    assert_eq!(
+        json["phase"], "converge",
+        "the persist error must not rename the failing phase: {json}"
+    );
+    assert_eq!(
+        json["convergence"]["images"], false,
+        "the convergence payload must survive the lost checkpoint: {json}"
+    );
+    assert!(
+        json["fail_forward"].is_object(),
+        "the operator still needs one bounded recovery path: {json}"
+    );
+    assert!(
+        visible(&output).contains("checkpoint"),
+        "the persist failure must travel alongside the phase failure: {}",
+        visible(&output)
+    );
+}
+
+// T9 -- #2299 "reject ambiguous conflicts before cluster mutation". The two
+// cases differ ONLY in the extraEnv value: 999 contradicts the first-class
+// `worker.runnerTotalTimeoutSeconds: 120` and is unresolvable; 120 agrees with
+// it and migrates cleanly. Without the second case this test would prove
+// nothing beyond "Validate always refuses".
+#[test]
+fn ambiguous_config_conflict_refuses_before_mutation() {
+    let conflicting = Fixture::new(Some(&conflict_values("999").to_string()));
+    let output = conflicting.local("healthy");
+    assert!(
+        !output.status.success(),
+        "an ambiguous conflict must refuse: {}",
+        stdout(&output)
+    );
+    assert!(
+        conflicting.helm_upgrades().is_empty(),
+        "refusal must precede mutation: {:?}",
+        conflicting.argv()
+    );
+
+    // The control: same shape, no contradiction.
+    let agreeing = Fixture::new(Some(&conflict_values("120").to_string()));
+    let output = agreeing.local("healthy");
+    assert_eq!(
+        agreeing.helm_upgrades().len(),
+        1,
+        "a legacy extraEnv that AGREES with its successor must still upgrade: {:?} / {}",
+        agreeing.argv(),
+        stderr(&output)
+    );
+    let values = agreeing.values(1);
+    assert!(
+        !values.contains("CURIE_RUNNER_TOTAL_TIMEOUT_S"),
+        "the redundant extraEnv entry must be dropped, not carried forward: {values}"
+    );
+}
+
+fn conflict_values(extra_env_value: &str) -> Value {
+    serde_json::json!({
+        "config": {"schemaVersion": "0.8.4"},
+        "worker": {
+            "runnerTotalTimeoutSeconds": 120,
+            "extraEnv": [{"name": "CURIE_RUNNER_TOTAL_TIMEOUT_S", "value": extra_env_value}]
+        }
+    })
+}
+
+// T10 -- #2299 "migrate legacy extraEnv entries" and "merge new target defaults
+// without dropping prior operator overrides": the values file helm is HANDED is
+// the evidence, not an in-process return value.
+#[test]
+fn retained_values_are_migrated_before_helm_sees_them() {
+    let fixture = Fixture::new(Some(V084));
+    let output = fixture.local("healthy");
+    assert!(
+        !fixture.helm_upgrades().is_empty(),
+        "nothing was applied: {} / {}",
+        stdout(&output),
+        stderr(&output)
+    );
+    let values = fixture.values(1);
+    assert!(
+        values.contains("runnerTotalTimeoutSeconds"),
+        "legacy extraEnv must become the first-class key: {values}"
+    );
+    assert!(
+        !values.contains("CURIE_RUNNER_TOTAL_TIMEOUT_S"),
+        "the migrated extraEnv entry must not survive: {values}"
+    );
+    assert!(
+        values.contains("PROVIDER_BASE_URL"),
+        "an unrelated operator override must survive the merge: {values}"
+    );
+    assert!(
+        values.contains("schemaVersion"),
+        "the migrated overlay must persist the configuration schema version: {values}"
+    );
+}
+
+// T11 -- #2299 "preserve external Secret names byte-for-byte" / "never restore
+// an inline value".
+#[test]
+fn external_secret_references_survive_byte_for_byte() {
+    let fixture = Fixture::new(Some(V084));
+    fixture.local("healthy");
+    let values = fixture.values(1);
+    assert!(
+        values.contains("acme-slack") && values.contains("botTokenExistingSecretKey"),
+        "the external Secret name and key must survive unchanged: {values}"
+    );
+    assert!(
+        !values.contains(SLACK_TOKEN),
+        "an inline credential must never be restored beside its Secret ref: {values}"
+    );
+}
+
+// T12 -- #2299 "plan/apply idempotent", as a RESUME rather than two runs of the
+// same input (plan edge 11).
+//
+// The first run migrates the retained v0.8.5 overlay and hands helm the result.
+// The recording helm then RETAINS that result, so the second run's
+// `helm get values` returns the first run's own migrated `-f` payload -- and
+// the checkpoint seeded between the runs stops Apply from being skipped as a
+// same-version no-op. Re-migrating already migrated output must change nothing.
+// Two runs against an unchanged fixture would go green even if migration were
+// not idempotent at all, because both would migrate the same original input.
+#[test]
+fn resumed_upgrade_remigrates_its_own_output_without_change() {
+    let fixture = Fixture::new(Some(V085));
+    let first = fixture.local("healthy");
+    let once = fixture.values(1);
+    assert!(
+        once.contains("runnerTotalTimeoutSeconds"),
+        "the first run must actually have migrated something: {once} / {}",
+        stderr(&first)
+    );
+
+    // Resume with Apply still outstanding, so the second run re-reads and
+    // re-migrates the retained (already migrated) overlay.
+    fixture.seed_checkpoint(&checkpoint_through(
+        &["plan", "validate", "drain", "checkpoint", "migrate"],
+        true,
+    ));
+    let second = fixture.local("healthy");
+    assert_eq!(
+        fixture.helm_upgrades().len(),
+        2,
+        "the resume must reach Apply again: {:?} / {}",
+        fixture.argv(),
+        stderr(&second)
+    );
+    let twice = fixture.values(2);
+    assert_eq!(
+        once, twice,
+        "re-migrating an already migrated document must change nothing"
+    );
+}
+
+// T13 -- #2299/#2300 redaction. Ruling 10: `--dry-run` exposing
+// `config.schemaVersion` on the plan is DEFERRED out of this PR, so this test
+// asserts only credential absence. The overlay's persisted schema version is
+// pinned by T10, where the migration output is the subject.
+#[test]
+fn upgrade_output_contains_no_credential_value() {
+    let fixture = Fixture::new(Some(V084));
+    let output = fixture.local("healthy");
+    let reachable = format!("{}{}", visible(&output), fixture.applied());
+    for secret in [SLACK_TOKEN, "sk-ant-test-must-not-leak"] {
+        assert!(
+            !reachable.contains(secret),
+            "credential value reached output or the persisted record: {reachable}"
+        );
+    }
+}

--- a/cli/tests/cluster_upgrade_live.rs
+++ b/cli/tests/cluster_upgrade_live.rs
@@ -52,7 +52,11 @@ impl Fixture {
             fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
         }
         if let Some(retained) = retained {
-            fs::write(temp.path().join("retained.json"), retained).unwrap();
+            fs::write(
+                temp.path().join("retained.json"),
+                strip_annotation(retained),
+            )
+            .unwrap();
         }
         Self(temp)
     }
@@ -191,6 +195,44 @@ impl Fixture {
             .pop()
             .unwrap_or_else(|| panic!("no checkpoint record was ever persisted"))
     }
+}
+
+/// Drop the `_fixture` block the committed overlays carry.
+///
+/// It is harness annotation -- provenance prose naming the released chart and
+/// the migration class under test -- not Helm values, and `config_migrate.rs`
+/// removes it the same way before migrating. A real release never retains it,
+/// so feeding it to the fake `helm get values` would put prose (including the
+/// very env-var names these tests assert are gone) into the `-f` payload and
+/// make whole-file assertions lie in both directions.
+fn strip_annotation(retained: &str) -> String {
+    match serde_json::from_str::<Value>(retained) {
+        Ok(Value::Object(mut map)) => {
+            map.remove("_fixture");
+            serde_json::to_string(&Value::Object(map)).unwrap()
+        }
+        _ => retained.to_owned(),
+    }
+}
+
+/// The `-f` document helm was handed, parsed. Helm values are YAML, and JSON is
+/// YAML, so this reads whichever the migration emits. Structural assertions
+/// beat substring ones here: `extraEnv` promotion has to be judged on the list
+/// itself, not on whether a name appears anywhere in the file.
+fn values_doc(raw: &str) -> Value {
+    serde_norway::from_str(raw).unwrap_or_else(|error| panic!("values payload ({error}): {raw}"))
+}
+
+/// Every `name` across all four `extraEnv` lists the migration walks.
+fn extra_env_names(values: &Value) -> Vec<String> {
+    ["worker", "api", "dispatcher"]
+        .iter()
+        .map(|owner| format!("/{owner}/extraEnv"))
+        .chain(std::iter::once("/agentSandbox/runner/extraEnv".to_string()))
+        .filter_map(|pointer| values.pointer(&pointer)?.as_array())
+        .flatten()
+        .filter_map(|entry| entry.get("name")?.as_str().map(ToOwned::to_owned))
+        .collect()
 }
 
 fn stdout(output: &Output) -> String {
@@ -715,21 +757,22 @@ fn retained_values_are_migrated_before_helm_sees_them() {
         stdout(&output),
         stderr(&output)
     );
-    let values = fixture.values(1);
-    assert!(
-        values.contains("runnerTotalTimeoutSeconds"),
-        "legacy extraEnv must become the first-class key: {values}"
+    let values = values_doc(&fixture.values(1));
+    assert_eq!(
+        values.pointer("/worker/runnerTotalTimeoutSeconds"),
+        Some(&serde_json::json!(120)),
+        "legacy extraEnv must become the first-class key, carrying the operator's own value: {values}"
     );
     assert!(
-        !values.contains("CURIE_RUNNER_TOTAL_TIMEOUT_S"),
-        "the migrated extraEnv entry must not survive: {values}"
+        !extra_env_names(&values).contains(&"CURIE_RUNNER_TOTAL_TIMEOUT_S".to_string()),
+        "the promoted entry must be gone from every extraEnv list: {values}"
     );
     assert!(
-        values.contains("PROVIDER_BASE_URL"),
+        extra_env_names(&values).contains(&"PROVIDER_BASE_URL".to_string()),
         "an unrelated operator override must survive the merge: {values}"
     );
     assert!(
-        values.contains("schemaVersion"),
+        values.pointer("/config/schemaVersion").is_some(),
         "the migrated overlay must persist the configuration schema version: {values}"
     );
 }
@@ -740,13 +783,19 @@ fn retained_values_are_migrated_before_helm_sees_them() {
 fn external_secret_references_survive_byte_for_byte() {
     let fixture = Fixture::new(Some(V084));
     fixture.local("healthy");
-    let values = fixture.values(1);
-    assert!(
-        values.contains("acme-slack") && values.contains("botTokenExistingSecretKey"),
-        "the external Secret name and key must survive unchanged: {values}"
+    let values = values_doc(&fixture.values(1));
+    assert_eq!(
+        values.pointer("/dispatcher/slack/botTokenExistingSecret"),
+        Some(&Value::String("acme-slack".into())),
+        "the external Secret name must survive byte-for-byte: {values}"
+    );
+    assert_eq!(
+        values.pointer("/dispatcher/slack/botTokenExistingSecretKey"),
+        Some(&Value::String("botToken".into())),
+        "the external Secret key must survive byte-for-byte: {values}"
     );
     assert!(
-        !values.contains(SLACK_TOKEN),
+        !fixture.values(1).contains(SLACK_TOKEN),
         "an inline credential must never be restored beside its Secret ref: {values}"
     );
 }
@@ -767,7 +816,9 @@ fn resumed_upgrade_remigrates_its_own_output_without_change() {
     let first = fixture.local("healthy");
     let once = fixture.values(1);
     assert!(
-        once.contains("runnerTotalTimeoutSeconds"),
+        values_doc(&once)
+            .pointer("/worker/runnerTotalTimeoutSeconds")
+            .is_some(),
         "the first run must actually have migrated something: {once} / {}",
         stderr(&first)
     );

--- a/cli/tests/cluster_upgrade_live.rs
+++ b/cli/tests/cluster_upgrade_live.rs
@@ -76,6 +76,11 @@ impl Fixture {
     }
 
     fn run(&self, scenario: &str, to: &str, chart: &str) -> Output {
+        self.run_with(scenario, to, chart, &[])
+    }
+
+    /// `run`, plus any extra flags (`--dry-run`) after the fixed argument set.
+    fn run_with(&self, scenario: &str, to: &str, chart: &str, extra: &[&str]) -> Output {
         Command::new(env!("CARGO_BIN_EXE_curie"))
             .args([
                 "--json",
@@ -91,6 +96,7 @@ impl Fixture {
                 chart,
                 "--yes",
             ])
+            .args(extra)
             .current_dir(
                 std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
                     .parent()
@@ -998,4 +1004,99 @@ fn the_overlay_is_read_once_and_apply_uses_the_stored_one() {
         "the retained overlay must be read exactly once: {:?}",
         fixture.argv()
     );
+}
+
+/// #2301 -- `--dry-run` must plan the refusal the real run would hit. Both
+/// pre-mutation inputs are read-only, so a dry run computes them; a clean
+/// nine-phase plan for an upgrade that cannot happen is the defect.
+#[test]
+fn dry_run_plans_the_chart_refusal_without_mutating() {
+    let fixture = Fixture::new(None);
+    let output = fixture.run_with(
+        "local-chart-mismatch",
+        "0.9.0",
+        "charts/curie",
+        &["--dry-run"],
+    );
+    let plan = json(&output)["plan"].to_string();
+    assert!(
+        plan.contains("refusal") && plan.contains("0.8.7") && plan.contains("0.9.0"),
+        "the dry-run plan must surface the Validate refusal: {plan}"
+    );
+    assert!(
+        fixture.helm_upgrades().is_empty(),
+        "a dry run must mutate nothing: {:?}",
+        fixture.argv()
+    );
+}
+
+/// #2299 -- the redacted plan must carry the configuration schema version it
+/// migrates from and to, and must never carry a credential value.
+#[test]
+fn dry_run_plan_carries_the_config_schema_version() {
+    let fixture = Fixture::new(Some(V084));
+    let output = fixture.run_with("healthy", "0.9.0", "charts/curie", &["--dry-run"]);
+    let plan = json(&output)["plan"].to_string();
+    assert!(
+        plan.contains("config schema: 0.8.6 -> 0.9.0"),
+        "the plan must name the source and target configuration schema: {plan}"
+    );
+    assert!(
+        !plan.contains(SLACK_TOKEN),
+        "the plan must stay redacted: {plan}"
+    );
+    assert!(
+        fixture.helm_upgrades().is_empty(),
+        "a dry run must mutate nothing: {:?}",
+        fixture.argv()
+    );
+}
+
+/// #2301 -- the printed plan's helm line must BE the command. Compares the
+/// dry-run plan's helm line against the argv the mutating run records, for a
+/// local chart (no `--version`) and a resolvable ref (`--version` in both).
+#[test]
+fn dry_run_helm_line_matches_the_recorded_upgrade_argv() {
+    for chart in ["charts/curie", "oci://example.invalid/curie"] {
+        let planner = Fixture::new(None);
+        let planned = json(&planner.run_with("healthy", "0.9.0", chart, &["--dry-run"]));
+        let line = planned["plan"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(Value::as_str)
+            .find(|line| line.starts_with("helm upgrade "))
+            .unwrap_or_else(|| panic!("no helm line in {planned}"))
+            .to_string();
+
+        let mutator = Fixture::new(None);
+        let output = mutator.run("healthy", "0.9.0", chart);
+        let upgrades = mutator.helm_upgrades();
+        assert_eq!(
+            upgrades.len(),
+            1,
+            "{:?} / {}",
+            mutator.argv(),
+            stderr(&output)
+        );
+        // `--install`/`-f` are runtime-state tails; the planned line is the
+        // fixed head, and it must match that head exactly.
+        let head: Vec<String> = upgrades[0]
+            .iter()
+            .take(line.split(' ').count())
+            .cloned()
+            .collect();
+        assert_eq!(
+            line,
+            head.join(" "),
+            "planned line must be the executed command: {:?}",
+            upgrades[0]
+        );
+        let pinned = line.contains("--version 0.9.0");
+        assert_eq!(
+            pinned,
+            chart.starts_with("oci://"),
+            "--version must show exactly when passed: {line}"
+        );
+    }
 }

--- a/cli/tests/data/upgrade-driver.py
+++ b/cli/tests/data/upgrade-driver.py
@@ -60,6 +60,15 @@ WORKLOADS = "deployments,statefulsets,daemonsets,pods,jobs"
 #   target            image tag the rendered target manifest asks for
 #   show_chart        version `helm show chart <local path>` reports
 #   ready/updated/unavailable  replica counts on the live Deployment
+#   generation_drift  live `status.observedGeneration` lags `metadata.generation`
+#   workloads_fail    the `kubectl get <WORKLOADS>` read exits non-zero, so the
+#                     observation cannot be MADE at all (distinct from a
+#                     terminal condition, which is an observation with a verdict)
+#   values_fail       `helm get values` exits non-zero with stderr that merely
+#                     CONTAINS "not found" -- the release state is unknown, not
+#                     positively absent
+#   values_drift      the SECOND and later `helm get values` return a different
+#                     document, so a re-read anywhere after Validate is visible
 #   failed_hook       ""                    both pre-upgrade hooks succeed
 #                     "upgrade-drain"       the #2010 drain gate Job fails
 #                     "schema-migrate"      a NON-drain pre-upgrade hook fails
@@ -87,6 +96,10 @@ BASE = {
     "unavailable": 0,
     "failed_hook": "",
     "status_missing_before": False,
+    "generation_drift": False,
+    "workloads_fail": False,
+    "values_fail": False,
+    "values_drift": False,
     "selector_drift": False,
     "terminal": False,
     "apply_fails": False,
@@ -118,6 +131,27 @@ SCENARIOS = {
     # that can see its verdict.
     "failed-drain-hook": {"failed_hook": "upgrade-drain"},
     "selector-drift": {"selector_drift": True, "terminal": True},
+    # `observedGeneration` lags `generation`: the controller has not yet acted
+    # on the target spec. Images, replicas, hooks and selectors all agree, so
+    # `generations` is the only sub-flag that may go false.
+    "stale-generation": {"generation_drift": True, "terminal": True},
+    # `updatedReplicas` lags `desired` while `unavailableReplicas` is 0: the
+    # replica facet is false and the unavailable facet is NOT, which is only
+    # expressible because the two are observed separately.
+    "stale-replicas": {"updated": 0, "terminal": True},
+    # The mirror image: updated == ready == total == desired, but a replica is
+    # unavailable. `replicas` stays true and `unavailable_zero` alone goes
+    # false, so neither flag can be an alias of the other.
+    "unavailable-replicas": {"unavailable": 1, "terminal": True},
+    # The workloads read itself fails. No observation can be MADE, so no named
+    # facet was determined -- every one must read false, and the read's own
+    # error text must reach the operator.
+    "workloads-unreadable": {"workloads_fail": True},
+    # `helm get values` fails with stderr that merely contains "not found".
+    # The retained overlay is UNKNOWN, not empty.
+    "values-read-fails": {"values_fail": True},
+    # A second `helm get values` would return a different document.
+    "values-drift": {"values_drift": True},
     # Every checkpoint write fails, starting with the first one before any
     # mutation.
     "persist-fails": {"apply_fails": "always"},
@@ -200,7 +234,7 @@ live = copy.deepcopy(expected)
 live["metadata"]["generation"] = 3
 live["spec"]["template"]["spec"]["containers"][0]["image"] = image
 live["status"] = {
-    "observedGeneration": 3,
+    "observedGeneration": 2 if scenario["generation_drift"] else 3,
     "replicas": 1,
     "readyReplicas": scenario["ready"],
     "updatedReplicas": scenario["updated"],
@@ -242,6 +276,18 @@ pod = {
 # Both are always present; only `failed_hook` decides which one refused. A
 # fixture that published just one hook could not tell the drain facet apart
 # from the general hook facet.
+# The two documents the `values-drift` scenario serves, distinguished by an
+# extraEnv entry the migration carries through untouched. Only the FIRST is a
+# legitimate input: it is what Validate read and migrated.
+FIRST_VALUES = {
+    "config": {"schemaVersion": "0.8.4"},
+    "api": {"extraEnv": [{"name": "FIRST_READ_ONLY", "value": "1"}]},
+}
+DRIFTED_VALUES = {
+    "config": {"schemaVersion": "0.8.4"},
+    "api": {"extraEnv": [{"name": "SECOND_READ_MUST_NOT_WIN", "value": "1"}]},
+}
+
 HOOK_NAMES = {
     "upgrade-drain": f"{RELEASE}-upgrade-drain",
     "schema-migrate": f"{RELEASE}-schema-migrate",
@@ -290,6 +336,13 @@ if program == "helm":
         print("STATUS: deployed\nREVISION: 2")
         sys.exit(0)
     if args[:2] == ["get", "values"]:
+        if scenario["values_fail"]:
+            print('Error from server (NotFound): namespaces "ns" not found', file=sys.stderr)
+            sys.exit(1)
+        if scenario["values_drift"]:
+            reads = sum(1 for call in previous if call[:3] == ["helm", "get", "values"])
+            print(json.dumps(DRIFTED_VALUES if reads else FIRST_VALUES))
+            sys.exit(0)
         applied_values = captured("values", ".yaml")
         if applied_values:
             # The release retains the overlay it was last handed. A second run
@@ -321,6 +374,9 @@ if program == "helm":
         sys.exit(0)
 
 if program == "kubectl":
+    if scenario["workloads_fail"] and args[:3] == ["get", WORKLOADS, "-n"]:
+        print("Error from server (Forbidden): workloads is forbidden", file=sys.stderr)
+        sys.exit(1)
     if args[0] == "apply":
         manifest = flag_value("-f")
         if manifest:

--- a/cli/tests/data/upgrade-driver.py
+++ b/cli/tests/data/upgrade-driver.py
@@ -276,7 +276,7 @@ for key, name in HOOK_NAMES.items():
 if program == "helm":
     if args[0] == "status":
         if scenario["status_missing_before"] and not upgraded:
-            print(f'Error: release: not found', file=sys.stderr)
+            print('Error: release: not found', file=sys.stderr)
             sys.exit(1)
         if "json" in args:
             emit(
@@ -287,7 +287,7 @@ if program == "helm":
                     "hooks": hooks,
                 }
             )
-        print(f"STATUS: deployed\nREVISION: 2")
+        print("STATUS: deployed\nREVISION: 2")
         sys.exit(0)
     if args[:2] == ["get", "values"]:
         applied_values = captured("values", ".yaml")

--- a/cli/tests/data/upgrade-driver.py
+++ b/cli/tests/data/upgrade-driver.py
@@ -1,0 +1,352 @@
+#!/usr/bin/python3
+"""Recording helm/kubectl boundary for `curie cluster upgrade`.
+
+Installed under both names; dispatch is on ``sys.argv[0]``. Every invocation is
+appended to ``$UPGRADE_DRIVER_ROOT/argv.log`` as one JSON array per line, so a
+test can assert on the commands that were actually issued (and, for a refusal,
+on the commands that were *not*). Never claims a real Kubernetes run.
+
+Payload capture:
+  * every ``-f <file>`` helm receives is copied to ``values-<n>.yaml``
+  * every ``kubectl apply -f <file>`` manifest is copied to ``applied-<n>.json``
+
+``helm get values`` returns the most recently APPLIED overlay when one exists,
+falling back to ``retained.json``. A real release retains what was last handed
+to it, and that is what makes a second run a resume of the first rather than a
+replay of the same input.
+
+Behaviour is selected by ``$UPGRADE_DRIVER_SCENARIO`` from SCENARIOS below.
+Optional per-test inputs read from the root directory:
+  * ``retained.json`` -- the document ``helm get values`` returns (JSON is YAML)
+  * ``checkpoint.json`` -- the record served as the upgrade checkpoint ConfigMap
+
+Three observable moments drive the fixtures, derived from the argv log rather
+than from a call ordinal (the number of `helm status` reads is an
+implementation detail of the observer):
+
+  before    -- nothing has been mutated yet
+  applied   -- a ``helm upgrade`` has been issued
+  converged -- the convergence observation has read the live workloads
+
+`convergence.observe` compares live containers against Helm's INSTALLED
+manifest, never against ``--to``. So ``target`` (what ``helm get manifest``
+renders) and ``served_*`` (what the live pods run) are separate knobs: a
+fixture that moves them together can never make ``images`` false.
+"""
+
+import copy
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+RELEASE = "rel"
+NAMESPACE = "ns"
+REPO = "ghcr.io/curie-eng/curie-api"
+
+# The exact resource selector `convergence::workloads_command` issues. The old
+# `cluster upgrade` stub read `deploy,sts,ds`; serving only this string means a
+# fixture cannot be satisfied by that narrower stub.
+WORKLOADS = "deployments,statefulsets,daemonsets,pods,jobs"
+
+# One dict, not a pile of branches. Keys:
+#   before/after      chart version `helm status` reports pre/post `helm upgrade`
+#   after_converge    chart version `helm status` reports once convergence has
+#                     observed the live workloads; defaults to `after`. Only a
+#                     version that moves BETWEEN Apply and Canary can prove the
+#                     canary re-reads it instead of trusting its own bookkeeping.
+#   served_before/after  container image tag actually running pre/post upgrade
+#   target            image tag the rendered target manifest asks for
+#   show_chart        version `helm show chart <local path>` reports
+#   ready/updated/unavailable  replica counts on the live Deployment
+#   failed_hook       ""                    both pre-upgrade hooks succeed
+#                     "upgrade-drain"       the #2010 drain gate Job fails
+#                     "schema-migrate"      a NON-drain pre-upgrade hook fails
+#                     Ruling 13: `queues_drained` binds to the upgrade-drain
+#                     hook alone and `hooks_healthy` to every other hook, so the
+#                     two are only provably distinct if the fixture can fail
+#                     either one while the other stays healthy.
+#   selector_drift    live workload selector differs from the target manifest
+#   terminal          stamp ProgressDeadlineExceeded so an observer stops at
+#                     once instead of retrying to its 300s deadline. This is a
+#                     Rollout-facet issue: it must not be the reason any named
+#                     convergence sub-flag goes false.
+#   apply_fails       False | "always" | "after-converge"  -- when `kubectl
+#                     apply` (the checkpoint write) exits non-zero
+BASE = {
+    "before": "0.8.6",
+    "after": "0.9.0",
+    "after_converge": None,
+    "served_before": "0.8.6",
+    "served_after": "0.9.0",
+    "target": "0.9.0",
+    "show_chart": "0.9.0",
+    "ready": 1,
+    "updated": 1,
+    "unavailable": 0,
+    "failed_hook": "",
+    "status_missing_before": False,
+    "selector_drift": False,
+    "terminal": False,
+    "apply_fails": False,
+}
+
+SCENARIOS = {
+    "healthy": {},
+    # Helm exits 0 and the workloads converge, but the release never leaves the
+    # old chart version. `helm show chart` still reports 0.9.0, so Validate
+    # passes and Apply is genuinely reached; the post-condition read is the
+    # only thing that can catch this.
+    "stale-version": {"after": "0.8.6"},
+    # Apply's post-condition read sees 0.9.0 and convergence is exact, then the
+    # release slips back to 0.8.6 before the canary. Isolates the canary's own
+    # version read from Apply's.
+    "canary-version-drift": {"after_converge": "0.8.6"},
+    # A resume whose Apply already happened: release and workloads are on 0.9.0.
+    "resumed-applied": {"before": "0.9.0", "served_before": "0.9.0"},
+    # The release reports the new revision and `helm get manifest` renders the
+    # 0.9.0 images, but the live pods still run 0.8.6 at full ready counts.
+    # Every other facet is healthy, so `images` is the only sub-flag that may
+    # go false.
+    "stale-images": {"served_after": "0.8.6", "terminal": True},
+    # A non-drain pre-upgrade hook fails: hooks_healthy only.
+    "failed-hook": {"failed_hook": "schema-migrate"},
+    # The #2010 drain gate Job fails: queues_drained only. This is the live
+    # observation `live_drain`'s `Ok(true)` stub never had -- the gate is a Helm
+    # pre-upgrade hook that fires during Apply, so Converge is the only phase
+    # that can see its verdict.
+    "failed-drain-hook": {"failed_hook": "upgrade-drain"},
+    "selector-drift": {"selector_drift": True, "terminal": True},
+    # Every checkpoint write fails, starting with the first one before any
+    # mutation.
+    "persist-fails": {"apply_fails": "always"},
+    # Only the checkpoint write that FOLLOWS a failed Converge fails. The
+    # convergence failure is the real verdict; the persist error must travel
+    # beside it rather than replace it.
+    "converge-then-persist-fails": {
+        "served_after": "0.8.6",
+        "terminal": True,
+        "apply_fails": "after-converge",
+    },
+    # A local chart directory whose own metadata is not the requested --to.
+    # No release yet: `helm status` fails until something is installed, so the
+    # Drain phase is skipped for having nothing in flight.
+    "fresh-install": {"status_missing_before": True},
+    "local-chart-mismatch": {"show_chart": "0.8.7"},
+}
+
+root = Path(os.environ["UPGRADE_DRIVER_ROOT"])
+scenario = dict(BASE)
+scenario.update(SCENARIOS[os.environ["UPGRADE_DRIVER_SCENARIO"]])
+if scenario["after_converge"] is None:
+    scenario["after_converge"] = scenario["after"]
+program = Path(sys.argv[0]).name
+args = sys.argv[1:]
+
+log = root / "argv.log"
+previous = [json.loads(line) for line in log.read_text().splitlines()] if log.exists() else []
+with log.open("a") as handle:
+    handle.write(json.dumps([program, *args]) + "\n")
+
+upgraded = any(call[:2] == ["helm", "upgrade"] for call in previous)
+converged = any(call[:1] == ["kubectl"] and WORKLOADS in call for call in previous)
+
+if upgraded and converged:
+    version = scenario["after_converge"]
+elif upgraded:
+    version = scenario["after"]
+else:
+    version = scenario["before"]
+served = scenario["served_after"] if upgraded else scenario["served_before"]
+image = f"{REPO}:{served}"
+target_image = f"{REPO}:{scenario['target']}"
+
+
+def emit(value):
+    print(json.dumps(value))
+    sys.exit(0)
+
+
+def captured(prefix, suffix):
+    """Captured payloads in capture order (index is 1-based and monotonic)."""
+    return sorted(root.glob(f"{prefix}-*{suffix}"), key=lambda p: int(p.stem.split("-")[-1]))
+
+
+def capture(prefix, suffix, source):
+    index = len(captured(prefix, suffix)) + 1
+    shutil.copyfile(source, root / f"{prefix}-{index}{suffix}")
+
+
+def flag_value(name):
+    return args[args.index(name) + 1] if name in args else None
+
+
+expected = {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {"name": f"{RELEASE}-api", "namespace": NAMESPACE},
+    "spec": {
+        "replicas": 1,
+        "selector": {"matchLabels": {"app": f"{RELEASE}-api"}},
+        "template": {
+            "metadata": {"labels": {"app": f"{RELEASE}-api"}},
+            "spec": {"containers": [{"name": "api", "image": target_image}]},
+        },
+    },
+}
+
+live = copy.deepcopy(expected)
+live["metadata"]["generation"] = 3
+live["spec"]["template"]["spec"]["containers"][0]["image"] = image
+live["status"] = {
+    "observedGeneration": 3,
+    "replicas": 1,
+    "readyReplicas": scenario["ready"],
+    "updatedReplicas": scenario["updated"],
+    "unavailableReplicas": scenario["unavailable"],
+    "conditions": [{"type": "Available", "status": "True"}],
+}
+if scenario["selector_drift"]:
+    live["spec"]["selector"]["matchLabels"] = {"app": f"{RELEASE}-api", "tier": "drifted"}
+if scenario["terminal"]:
+    live["status"]["conditions"].append(
+        {"type": "Progressing", "status": "False", "reason": "ProgressDeadlineExceeded"}
+    )
+
+pod = {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "name": f"{RELEASE}-api-0",
+        "namespace": NAMESPACE,
+        "labels": live["spec"]["selector"]["matchLabels"],
+    },
+    "spec": {"containers": [{"name": "api", "image": image}]},
+    "status": {
+        "phase": "Running",
+        "containerStatuses": [
+            {
+                "name": "api",
+                "image": image,
+                "imageID": "containerd://sha256:" + "a" * 64,
+                "ready": True,
+                "state": {"running": {}},
+            }
+        ],
+    },
+}
+
+# Both pre-upgrade hooks the chart installs, by their real rendered names
+# (`charts/curie/templates/worker-upgrade-drain.yaml` and `schema-migrate.yaml`).
+# Both are always present; only `failed_hook` decides which one refused. A
+# fixture that published just one hook could not tell the drain facet apart
+# from the general hook facet.
+HOOK_NAMES = {
+    "upgrade-drain": f"{RELEASE}-upgrade-drain",
+    "schema-migrate": f"{RELEASE}-schema-migrate",
+}
+
+hooks = []
+jobs = []
+for key, name in HOOK_NAMES.items():
+    manifest = {"kind": "Job", "metadata": {"name": name, "namespace": NAMESPACE}}
+    failed = scenario["failed_hook"] == key
+    hooks.append(
+        {
+            "name": name,
+            "kind": "Job",
+            "events": ["pre-upgrade"],
+            "last_run": {"phase": "Failed" if failed else "Succeeded"},
+            "manifest": json.dumps(manifest),
+        }
+    )
+    jobs.append(
+        {
+            "kind": "Job",
+            "metadata": manifest["metadata"],
+            "status": {"failed": 1, "conditions": [
+                {"type": "Failed", "status": "True", "reason": "BackoffLimitExceeded"}
+            ]}
+            if failed
+            else {"succeeded": 1, "conditions": [{"type": "Complete", "status": "True"}]},
+        }
+    )
+
+if program == "helm":
+    if args[0] == "status":
+        if scenario["status_missing_before"] and not upgraded:
+            print(f'Error: release: not found', file=sys.stderr)
+            sys.exit(1)
+        if "json" in args:
+            emit(
+                {
+                    "version": 2,
+                    "info": {"status": "deployed"},
+                    "chart": {"metadata": {"name": "curie", "version": version}},
+                    "hooks": hooks,
+                }
+            )
+        print(f"STATUS: deployed\nREVISION: 2")
+        sys.exit(0)
+    if args[:2] == ["get", "values"]:
+        applied_values = captured("values", ".yaml")
+        if applied_values:
+            # The release retains the overlay it was last handed. A second run
+            # therefore migrates the FIRST run's own output, which is the only
+            # shape that can prove idempotence rather than repeat one input.
+            print(applied_values[-1].read_text())
+            sys.exit(0)
+        retained = root / "retained.json"
+        print(retained.read_text() if retained.exists() else "{}")
+        sys.exit(0)
+    if args[:2] == ["get", "manifest"]:
+        # JSON documents are YAML documents; no optional YAML dependency here.
+        print(json.dumps(expected))
+        sys.exit(0)
+    if args[:2] == ["show", "chart"]:
+        print(
+            "name: curie\nversion: {v}\nappVersion: {v}".format(v=scenario["show_chart"])
+        )
+        sys.exit(0)
+    if args[0] == "template":
+        show_only = flag_value("--show-only") or "<template>"
+        print(f"Error: could not find template {show_only} in chart", file=sys.stderr)
+        sys.exit(1)
+    if args[0] == "upgrade":
+        values = flag_value("-f")
+        if values:
+            capture("values", ".yaml", values)
+        print("Release accepted")
+        sys.exit(0)
+
+if program == "kubectl":
+    if args[0] == "apply":
+        manifest = flag_value("-f")
+        if manifest:
+            capture("applied", ".json", manifest)
+        fails = scenario["apply_fails"]
+        if fails == "always" or (fails == "after-converge" and converged):
+            print("error: could not apply the checkpoint ConfigMap", file=sys.stderr)
+            sys.exit(1)
+        print("configmap/checkpoint configured")
+        sys.exit(0)
+    if args[:2] == ["get", "configmap"]:
+        if args[2].endswith("-upgrade-checkpoint"):
+            checkpoint = root / "checkpoint.json"
+            if checkpoint.exists():
+                sys.stdout.write(checkpoint.read_text().strip())
+            sys.exit(0)
+        print(f'Error from server (NotFound): configmaps "{args[2]}" not found', file=sys.stderr)
+        sys.exit(1)
+    if args[:2] == ["get", "node"]:
+        emit({"kind": "Node", "metadata": {"name": args[2]}, "status": {"images": []}})
+    if args[:3] == ["get", WORKLOADS, "-n"]:
+        emit({"items": [live, pod, *jobs]})
+    if args[:2] == ["get", "deploy"] and len(args) > 2 and not args[2].startswith("-"):
+        # The drain probe reads one named Deployment; its output is not parsed.
+        print(f"{args[2]}   1/1")
+        sys.exit(0)
+
+print("unhandled recording command: " + repr([program, *args]), file=sys.stderr)
+sys.exit(64)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -260,8 +260,28 @@ upgrade phase and the last known-good version.
 ### `curie cluster upgrade`
 
 ```bash
+# source checkout: --chart defaults to the local charts/curie path
 curie cluster upgrade --to 0.9.0
+
+# local chart file (e.g. a downloaded release archive): same metadata-read
+# refusal path as a local directory
+curie cluster upgrade --to 0.9.0 --chart ./curie-0.9.0.tgz
+
+# resolvable ref: the command adds --version internally, do not pass it
+curie cluster upgrade --to 0.9.0 --chart oci://<your-registry>/curie
 ```
+
+The chart and `--to` must agree. `--chart` defaults to the literal local
+path `charts/curie` -- this verb never resolves a release build the way
+`cluster up` does (issue #2593) -- so on a source checkout `--to` must
+equal that chart's current version or the command refuses at Validate,
+before any mutation. A released binary has no `charts/curie` beside it
+and must pass `--chart` explicitly (issue #2593). Helm silently ignores
+`--version` on a local directory or file chart, so for that case the
+command reads the chart's own metadata instead of passing `--version`.
+For a chart ref Helm resolves itself (a repo or OCI ref), the command
+passes `--version <to>` internally and lets Helm enforce it; there is no
+`--version` operator flag.
 
 | Flag | What it does |
 |---|---|
@@ -271,20 +291,38 @@ curie cluster upgrade --to 0.9.0
 | `--dry-run` | Print the redacted plan and exit without mutating. |
 
 One resumable lifecycle: inspect and plan, validate configuration and
-compatibility, drain accepted work, checkpoint, migrate once, apply, wait
-for exact convergence, run a target-version canary, then record the new
-known-good version. The command chooses the values overlay; do not pass
-`--reuse-values` or `--reset-then-reuse-values`.
+refuse on an ambiguous migration conflict, drain accepted work, checkpoint,
+apply, wait for exact convergence, run a target-version canary, then record
+the new known-good version. There is no separate migration step in the
+command: configuration migration happens at Validate, and schema migration
+is the chart's pre-upgrade Job, which Apply fires. The command chooses the
+values overlay; do not pass `--reuse-values` or `--reset-then-reuse-values`.
+Configuration migration to the current schema happens at Validate, before
+any mutation; database/application schema-compatibility checking is not
+wired into this command yet (tracked as issue #2588) -- the pre-upgrade
+migration Job remains the database's authority.
+
+After Apply, the command re-reads the installed Helm revision and fails
+rather than reporting success if it is not the target version; the canary
+re-reads it again. Convergence (image digests, controller generations,
+replica counts, healthy hooks, the drained-queue gate, and the retained
+manifest comparison) is observed the same way `curie cluster up` observes
+it, not assumed.
 
 `--json` reports the current phase, the last known-good version, whether
 the previous version is still serving, and at most one fail-forward
 command. Success is refused unless convergence is exact and the canary
 passed. Re-run the same command to resume after an interruption.
 
-This composes configuration migration (issue 2299) and schema
-compatibility (issue 2300) rather than adding Helm special cases. The
-pre-upgrade drain is the existing worker gate (issue 2010): a resume
-after a completed drain does not drain accepted work again.
+This composes configuration migration (issue 2299) with the drain gate
+(issue 2010): a resume after a completed drain does not drain accepted
+work again.
+
+**Not fenced.** This command does not prevent concurrent upgrades. The
+in-progress checkpoint refuses a second run only when it targets a
+different version, and only when the checkpoint read wins the race; a
+concurrent raw `helm upgrade`, or a second `curie cluster upgrade` from
+another host, is not prevented (issue #2589).
 
 ### `curie cluster down`
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -288,7 +288,7 @@ passes `--version <to>` internally and lets Helm enforce it; there is no
 | `--to <version>` | Target Curie version. Required. |
 | `--chart` | Chart path or ref override. |
 | `--yes` | Skip the confirmation prompt. |
-| `--dry-run` | Print the redacted plan and exit without mutating. |
+| `--dry-run` | Print the redacted plan and exit without mutating. Both pre-mutation checks (the local chart's declared version, and the retained-configuration migration) are read-only, so a dry run runs them and the plan names any refusal the real run would hit at Validate. |
 
 One resumable lifecycle: inspect and plan, validate configuration and
 refuse on an ambiguous migration conflict, drain accepted work, checkpoint,
@@ -300,7 +300,16 @@ values overlay; do not pass `--reuse-values` or `--reset-then-reuse-values`.
 Configuration migration to the current schema happens at Validate, before
 any mutation; database/application schema-compatibility checking is not
 wired into this command yet (tracked as issue #2588) -- the pre-upgrade
-migration Job remains the database's authority.
+migration Job remains the database's authority. The `migrate` phase is a
+resumable checkpoint boundary only; it performs no migration of its own.
+
+The redacted plan names the configuration schema version the upgrade migrates
+from and to (`config schema: <from> -> <to>`). It never carries credential
+values. The plan's `helm upgrade` line is generated from the same chart
+resolution and the same `--version` decision the command executes, so it names
+the chart that will actually be applied (`charts/curie` unless `--chart` says
+otherwise; this verb does not resolve a release artifact, issue #2593) and
+shows `--version <to>` exactly when a resolvable ref makes it a real pin.
 
 After Apply, the command re-reads the installed Helm revision and fails
 rather than reporting success if it is not the target version; the canary


### PR DESCRIPTION
`curie cluster upgrade` could report a successful upgrade to a version it had never installed.
Against a cluster still entirely on 0.8.6, with `helm status` reporting 0.8.6:

```json
{"status":"succeeded","target_version":"0.9.0","known_good_version":"0.9.0",
 "convergence":{"exact":true,"images":true,"generations":true,"hooks_healthy":true,
                "manifest_matches":true,"queues_drained":true,"replicas":true,"unavailable_zero":true},
 "canary":{"passed":true}}
```

Exit 0, and 0.9.0 committed as the new known-good version.

## Why

The nine-phase lifecycle (#2333), the pure configuration-migration module (#2335) and the
712-line exact-convergence module are all already merged on `next`. `LiveHost` satisfied the
`UpgradeDriver` trait without consulting any of them. `#2333`'s own commit message said it would
"require exact convergence and a passing canary before reporting success" and left the
composition to #2299/#2300; the stubs were placeholders that were never replaced. The
corrections were attempted on `task/overnight-upgrade-stack` (#2408/#2401/#2402/#2412) and
abandoned with that branch, so none reached `next`.

This binds each stub to the module that already answers the question. It does not rebuild the
feature and does not reopen the abandoned stack.

## What changed

- **Convergence is observed, not assumed.** `live_convergence` had built `Convergence::exact_ok()`
  and recomputed only `replicas` and `unavailable_zero`; `images`, `generations`,
  `hooks_healthy`, `queues_drained` and `manifest_matches` were literal `true`. It now uses
  `ops::convergence`, the same exact-manifest observation `cluster up` and `cluster status` use.
  Each issue carries the facets it observed, so every flag has a determined source and no flag is
  assigned a literal `true`. `replicas` and `unavailable_zero` are separately determined rather
  than aliased. An observation that could not be made at all tags every facet, so an unreadable
  cluster does not read as observed-true, and carries the underlying failure and its recovery
  hint into the fail-forward reason.
- **The target version reaches Helm.** For a ref Helm resolves, `--version <to>` is passed. Helm
  *silently ignores* `--version` for a local directory chart, so that path instead reads the
  chart's own metadata and refuses at Validate, before any mutation, when it disagrees with `--to`.
- **Success is gated on an observed revision.** `apply_target` recorded the version it was asked
  for; it now records what `helm status` reports afterwards and fails the phase on divergence.
  The canary re-reads it, so it is no longer comparing a value against itself.
- **Checkpoint persistence failures surface.** `store_record` discarded the result of
  `persist_record`. It is now fallible, and a persist failure inside the failure arm reports
  alongside the original phase failure rather than masking it.
- **The plan is the command.** A dry run skipped the read-only chart and configuration checks, so
  it printed a clean nine-phase plan for an upgrade the real command refuses; its helm line named
  an invented `curie-<version>` chart and omitted `--version`; and it advertised "one controlled
  schema migration" though that phase is a checkpoint boundary and the chart's pre-upgrade hook Job
  does the migrating. The dry run now runs those read-only checks and surfaces the refusal, the
  helm line derives from the same chart resolution and `--version` decision the mutating path
  uses, and the plan carries the configuration schema version the upgrade moves between (#2299).

- **Retained values are migrated before Helm sees them.** `helm get values` output went straight
  back to `helm -f`. It now runs through `config_migrate::migrate_installed_config`, computed once
  before the lifecycle so the overlay Apply hands to Helm is the one Validate approved, and an
  ambiguous conflict refuses before mutation.

## Evidence

Tests were committed first and 15 of the 17 new ones failed on the base commit (the other two are
regression guards that already held). `cli/tests/cluster_upgrade_live.rs` drives the real binary
against a fake `helm`/`kubectl` that records every argv and every values payload. The convergence
tests each assert exactly one false facet, so a hardcoded `true` cannot pass them, and the
drain-hook and other-hook fixtures prove `queues_drained` and `hooks_healthy` are distinct rather
than aliases.

Affected suites green: `cluster_upgrade_live` 17, `cluster_upgrade` 17, `cluster_convergence` 19,
`json_contract` 77, `cli_output_variants` 4, `config_migrate` 11, `installation_plan_parity` 77 (222 total).
`cargo clippy --all-targets` and `cargo fmt --check` clean; `scripts/check-docs.sh` passes.

## Scope, and what is deliberately not here

This is the half where the command lies about success. Four adjacent gaps were found, verified
and filed rather than folded in:

- **#2588** — schema-compatibility is still unbound. `cli/src/schema_window.rs` and the live
  Alembic probe `cluster rollback` uses are both already merged and simply not called from this
  verb, and `--forward-only` does not exist here though `cluster up` has it. `LiveHost::refuse_schema`
  is therefore still the trait default. **#2300 gets no code from this PR.**
- **#2593** — `cluster upgrade` is the only cluster verb that never calls
  `artifacts::resolve_chart`, so a released binary cannot upgrade without an explicit `--chart`,
  and the flag's own help text documents a release-build default this verb does not implement.
- **#2589** — there is no concurrent-upgrade fence. The in-progress checkpoint refuses only a
  *different* target and only if its read wins the race. The abandoned branch's fix was a
  same-host file lock whose own comment concedes it "neither fences another host/raw Helm", so it
  was not recovered. `docs/operations.md` now states the limit and one characterization test pins
  it.
- **#2590** — the required released-upgrade matrix (#2301's eighth criterion). PR #2583's real
  `kind` drill is on `main` only and drives `cluster up`, not this verb.

Separately, **#2585**: `next` is at ~97% of the hard 1 MiB Helm release Secret cap because
`main`'s `ci/` `.helmignore` fix and the #2550 guard never forward-merged. That blocks #2588's
chart work and is why no chart file is added here.

## What this does not prove

The wiring is proven at CLI-contract tier against a fake cluster. Exact **image** convergence, the
retained-manifest-versus-live comparison and "the previous version *serves*" all depend on a real
cluster; a version-string mismatch is what is demonstrated here. Those stay open on #2590.
**None of #2299, #2300 or #2301 should be closed by this PR.**

Ref #2299, Ref #2301, Ref #2570.
