### PR TITLE
Declare the v0.8.8 rollback schema window

### DIFF
--- a/cli/src/application_schema_windows.json
+++ b/cli/src/application_schema_windows.json
@@ -72,6 +72,10 @@
     "0.8.7": {
       "schema_min": "0001",
       "schema_head": "0039"
+    },
+    "0.8.8": {
+      "schema_min": "0001",
+      "schema_head": "0039"
     }
   }
 }

--- a/cli/tests/cluster_rollback_schema.rs
+++ b/cli/tests/cluster_rollback_schema.rs
@@ -27,6 +27,17 @@ fn v087_accepts_0039_and_refuses_an_unknown_newer_revision() {
     assert!(!live_in_window("0040", &window));
 }
 
+/// Release v0.8.8 carries the same Alembic head as v0.8.7. Pin both the
+/// accepted live head and the fail-closed boundary for an unknown successor.
+#[test]
+fn v088_accepts_0039_and_refuses_an_unknown_newer_revision() {
+    let window = window_for("0.8.8").expect("0.8.8 is catalogued");
+    assert_eq!(window.schema_min, "0001");
+    assert_eq!(window.schema_head, "0039");
+    assert!(live_in_window("0039", &window));
+    assert!(!live_in_window("0040", &window));
+}
+
 fn write_exec(dir: &Path, name: &str, body: &str) {
     let path = dir.join(name);
     fs::write(&path, body).expect("write fake executable");


### PR DESCRIPTION
## Summary

Declare v0.8.8's rollback schema window at the unchanged Alembic range `0001..0039`, and pin both the accepted head and fail-closed unknown-successor boundary. This unblocks the separate five-file v0.8.8 release preparation without mixing the prerequisite into that candidate.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | The change does not reach plugin packaging, runner turns, ACI events, or skill eval/check. | n/a | n/a |
| local | required | The versioned catalog controls the pre-mutation `curie cluster rollback` compatibility decision. | fake | `cargo test --locked --test cluster_rollback_schema v088_accepts_0039_and_refuses_an_unknown_newer_revision -- --exact` passed at `39db7314ea624e6c6d1247fe70132dc97431ee1c`; it accepts live `0039` and refuses unknown successor `0040`. |
| local-release | n/a | This prerequisite does not change released binary identity, install paths, Cargo/Chart versions, or release Compose. | n/a | n/a |
| cluster | n/a | The change does not reach chart templates, RBAC, NetworkPolicy, sandbox claims, or init containers; rollback's pre-mutation consumer is covered by deterministic Helm/kubectl integration tests. | n/a | n/a |
| live provider | n/a | The change does not reach model routing, credentials, tokens, cost, MCP, or coding-tool capability. | n/a | n/a |
| external integration | n/a | The change does not reach Slack, webhooks, connector OAuth, or a third-party API shape. | n/a | n/a |

- [x] Every required tier names its exact command, candidate commit, mode, and observed result.
- [x] The test has a positive `0039` control and a falsifiable `0040` negative control.
- [x] No required tier is left unproved.

## Verification

- `curie dev verify-fix-pin 39db7314ea624e6c6d1247fe70132dc97431ee1c cli/tests/cluster_rollback_schema.rs::v088_accepts_0039_and_refuses_an_unknown_newer_revision` - `PINNED`; the selected test passes on the fix and fails on its parent because v0.8.8 is absent.
- `cd cli && cargo fmt --check` - passed.
- `cd cli && cargo clippy --locked --all-targets -- -D warnings` - passed.
- `cd cli && CI_REQUIRE_VALKEY_TESTS=1 TEST_VALKEY_URL=<isolated endpoint> KUBECONFIG=/dev/null cargo test --locked` - passed, including 1,232 library tests, 67 binary tests, 56 chart assertion scripts, Valkey-backed integration tests, and all remaining Rust integration/doc tests. The isolated Valkey container was removed afterward.
- `git diff --check` - passed.
- `scripts/check-commit-messages.sh origin/main..HEAD` - passed.

## Checklist

- [x] Tests pass for the area touched.
- [x] Existing v0.8.7 regression coverage remains intact.
- [x] No prose or ADR change is needed; this is the next release entry in the established catalog contract.
