### PR TITLE
Move the fix pin gate off the Python critical path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,11 +22,10 @@ jobs:
     name: Python (ruff + mypy + pytest)
     runs-on: ubuntu-latest
     # A job-level block REPLACES the workflow-level one, so `contents: read` is
-    # repeated here. `issues: read` is what lets the fix pin gate read the
-    # labels of the closed issues a pull request names, through the Issues API.
+    # repeated here. The Issues scope that used to sit alongside it followed the
+    # fix pin gate into its own job; the suite never read issue labels.
     permissions:
       contents: read
-      issues: read
     env:
       CI_REQUIRE_VALKEY_TESTS: "1"
     steps:
@@ -206,45 +205,124 @@ jobs:
             exit 1
           fi
           echo "Python pytest selection matched $expected"
-      # Build ONLY when the declaration parser would invoke the curie binary.
-      # tools/fix-pin-ci/check.py reaches it at exactly one place, the
-      # `curie dev verify-fix-pin` call, and only once `declaration.selector` is
-      # set; `n/a`, no declaration, a near-miss marker like `Fix-pin:`, HTML
-      # comments in the pull request template, and the bug-without-declaration
-      # rejection all return before touching it.
-      #
-      # `#2228` gated cargo with `contains(..., 'Fix pin:')`. That is true for
-      # every pull request that keeps the default template, because the template
-      # embeds those exact bytes inside `<!-- -->`. The probe reuses
-      # `_declaration` so a commented example cannot trigger a cold
-      # `cargo build --release` inside the longest job on the graph, and a live
-      # selector line cannot skip it.
-      #
-      # `n/a` used to pay that extra build as a safe over-match. The parser does
-      # not invoke curie for `n/a`, so the probe reports needed=false. This
-      # stays a direct build inside the required Python status: no `needs`, no
-      # downloaded artifact, no Cargo cache.
+      - name: Dump dev stack logs on failure
+        if: ${{ failure() && steps.python-runtime.outputs.pytest == 'true' }}
+        run: docker compose -f compose.dev.yaml logs --no-color --tail=200
+
+  fix-pin:
+    name: Fix pin verification
+    runs-on: ubuntu-latest
+    # #2230 measured the Python job as the sole critical path. On run
+    # 34528877480 it was 26.4 minutes, and two of its steps were this gate: a
+    # cold 251s `cargo build --release` plus a 127s verification, both appended
+    # AFTER the 1048s pytest that neither of them depends on.
+    #
+    # #2228 stopped that build on pull requests that declare nothing. It did
+    # not stop it for the ones that do, and this repository REQUIRES a
+    # `Fix pin:` selector on every pull request closing a `bug` labelled issue,
+    # so the declaring majority still paid all 6.3 minutes in series behind the
+    # suite. Run 34528877480 is one of those: the build ran, for 251s.
+    #
+    # Nothing here is waste in itself, so this does not delete a step, it moves
+    # them off the path. They are unchanged, including the direct cargo build:
+    # a `rust` selector makes verify-fix-pin.sh run `cargo test` out of
+    # CARGO_TARGET_DIR, so that build warms the directory the verification then
+    # compiles in, and is not merely producing the binary the check invokes.
+    # Swapping it for the artifact rust-build already uploads would leave a
+    # rust selector to compile from cold, which is why it stays a direct build.
+    # The comment it carried about living "inside the required Python status"
+    # is now met by this job being its own required status.
+    #
+    # The dev stack is the one addition, and it is a correctness fix, not a
+    # speed one. verify-fix-pin.sh runs `uv run pytest <selector>` for a
+    # `python` selector; for an integration selector that dials Postgres and
+    # Valkey. Inside the Python job the stack was already up and the gate
+    # inherited it. Split out, it has to boot its own or those selectors fail
+    # for the environment rather than for the pin.
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      # `issues: read` is what lets this gate read the labels of the closed
+      # issues a pull request names, through the Issues API.
+      issues: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # verify-fix-pin.sh resolves HEAD and adds a detached worktree at it,
+          # and the gate diffs against the base, so the full history is needed.
+          fetch-depth: 0
+          persist-credentials: false
+      # Retry eligibility (#1106): this step's whole job is to ACQUIRE a
+      # third-party tool, so it may be wrapped. The verification below is this
+      # repository's own gate and is deliberately not.
+      - name: Install uv
+        id: install_uv
+        continue-on-error: true
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: "3.13"
+      - name: Back off before retrying Install uv
+        if: steps.install_uv.outcome == 'failure'
+        run: |
+          echo "Install uv failed on attempt 1 of 2, retrying in 15 seconds"
+          sleep 15
+      - name: Install uv (retry)
+        if: steps.install_uv.outcome == 'failure'
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: "3.13"
+      - name: Sync workspace
+        run: uv sync
+      # Everything below the probe is gated on it, so a pull request that
+      # declares nothing, or declares `n/a`, still costs only the probe. That
+      # is #2228's win, preserved: the parser does not reach the binary for
+      # those, so no build, no Helm, and no compose stack is paid for them.
       - name: Decide whether the current curie binary is needed
         id: fix-pin-curie
-        if: github.event_name == 'pull_request'
         run: >-
           python3 tools/fix-pin-ci/check.py
           --event "$GITHUB_EVENT_PATH"
           --needs-curie
       - name: Build the current curie binary for fix pin verification
-        if: >-
-          github.event_name == 'pull_request'
-          && steps.fix-pin-curie.outputs.needed == 'true'
+        if: steps.fix-pin-curie.outputs.needed == 'true'
         run: cargo build --release --locked --manifest-path cli/Cargo.toml
+      # A `chart` selector runs charts/curie/ci/<name>.sh, which needs Helm.
       - name: Install Helm for fix pin verification
-        if: >-
-          github.event_name == 'pull_request'
-          && steps.fix-pin-curie.outputs.needed == 'true'
+        if: steps.fix-pin-curie.outputs.needed == 'true'
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
         with:
           version: v3.16.4
+      # Same boot as the Python job: the first `up` starts the one-shot
+      # rustfs-init alongside the long-lived services, the second `--wait`s only
+      # on the long-lived ones because `--wait` reads rustfs-init's exit(0) as a
+      # failure.
+      - name: Start dev stack
+        if: steps.fix-pin-curie.outputs.needed == 'true'
+        run: |
+          docker compose -f compose.dev.yaml up -d \
+            postgres valkey clickhouse rustfs rustfs-init \
+            langfuse-web langfuse-worker otel-collector
+          docker compose -f compose.dev.yaml up -d --wait --wait-timeout 300 \
+            postgres valkey clickhouse rustfs \
+            langfuse-web langfuse-worker otel-collector
+      - name: Wait for Langfuse to serve
+        if: steps.fix-pin-curie.outputs.needed == 'true'
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:23000/api/public/health >/dev/null 2>&1; then
+              echo "Langfuse ready after attempt ${i}"; exit 0
+            fi
+            sleep 3
+          done
+          echo "Langfuse did not become ready within 180s"; exit 1
+      # A pinned worker binding test dials the shared default database and
+      # assumes the curie schema exists, exactly as it does under the Python
+      # job, so the same migration runs here.
+      - name: Migrate the shared database
+        if: steps.fix-pin-curie.outputs.needed == 'true'
+        working-directory: apps/api
+        run: uv run alembic upgrade head
       - name: Require declared fixes to be pinned by a changed test
-        if: github.event_name == 'pull_request'
         env:
           CARGO_TARGET_DIR: ${{ github.workspace }}/cli/target
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -254,7 +332,7 @@ jobs:
           --curie cli/target/release/curie
           --ref HEAD
       - name: Dump dev stack logs on failure
-        if: ${{ failure() && steps.python-runtime.outputs.pytest == 'true' }}
+        if: ${{ failure() && steps.fix-pin-curie.outputs.needed == 'true' }}
         run: docker compose -f compose.dev.yaml logs --no-color --tail=200
 
   rust:

--- a/tools/ci-retry-gate/tests/test_retry_eligibility.py
+++ b/tools/ci-retry-gate/tests/test_retry_eligibility.py
@@ -44,6 +44,7 @@ ACQUISITION_ACTIONS = frozenset(
 RETRY_ALLOWLIST = frozenset(
     {
         ("ci.yaml", "python", "Install uv"),
+        ("ci.yaml", "fix-pin", "Install uv"),
         ("ci.yaml", "e2e-ladder-cluster", "Create the kind cluster"),
         ("dependency-audit.yaml", "python-audit", "Install uv"),
         ("gitleaks.yaml", "gitleaks", "Pull the gitleaks image"),
@@ -160,6 +161,12 @@ SHELL_KEYWORDS = frozenset({"do", "done", "fi", "then", "else", "esac", "true", 
 RUN_RETRY_EXEMPT: frozenset[tuple[str, str, str]] = frozenset(
     {
         ("ci.yaml", "python", "Wait for Langfuse to serve"),
+        # The fix pin job boots the same dev stack as the python job,
+        # for the same reason and with the same readiness poll: Langfuse
+        # web has no compose healthcheck, so `--wait` returns while it is
+        # merely running. A readiness poll for an external service, not a
+        # retry of anything this repository builds or gates.
+        ("ci.yaml", "fix-pin", "Wait for Langfuse to serve"),
         # The candidate API has already rolled out; this only waits for the
         # temporary local port-forward to expose its external health state.
         (

--- a/tools/e2e-ci-selection/tests/test_python_pytest_selection.py
+++ b/tools/e2e-ci-selection/tests/test_python_pytest_selection.py
@@ -89,6 +89,17 @@ def _named_steps() -> dict[str, dict[str, Any]]:
     }
 
 
+def _fix_pin_named_steps() -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    job = workflow["jobs"]["fix-pin"]
+    assert isinstance(job, dict)
+    return job, {
+        step["name"]: step
+        for step in job["steps"]
+        if isinstance(step, dict) and isinstance(step.get("name"), str)
+    }
+
+
 def _string(step: dict[str, Any], key: str) -> str:
     value = step.get(key)
     return value if isinstance(value, str) else ""
@@ -281,25 +292,48 @@ def test_dump_logs_do_not_run_when_the_stack_never_started() -> None:
     assert "steps.python-runtime.outputs.pytest == 'true'" in condition
 
 
-def test_cargo_guard_if_is_unchanged() -> None:
+def test_the_fix_pin_gate_left_the_python_job() -> None:
+    """The suite's job must not carry the gate that used to run behind it.
+
+    This file's subject is what the pytest selector does and does not gate. The
+    fix pin steps were never gated on it, and now they are not even in the same
+    job, so the strongest statement here is absence: nothing that selects a
+    tier may reach them, because they are somewhere else.
+    """
     named = _named_steps()
+    for name in (
+        "Decide whether the current curie binary is needed",
+        "Build the current curie binary for fix pin verification",
+        "Install Helm for fix pin verification",
+        "Require declared fixes to be pinned by a changed test",
+    ):
+        assert name not in named, f"{name} must not run inside the Python job"
+
+
+def test_cargo_guard_if_is_unchanged() -> None:
+    job, named = _fix_pin_named_steps()
+    # The job carries the pull-request condition for every step in it.
+    assert _string(job, "if") == "github.event_name == 'pull_request'"
+
     probe = named["Decide whether the current curie binary is needed"]
     assert probe["id"] == "fix-pin-curie"
-    assert _string(probe, "if") == "github.event_name == 'pull_request'"
+    assert "if" not in probe, "the probe must decide for every pull request"
 
     cargo = named["Build the current curie binary for fix pin verification"]
     helm = named["Install Helm for fix pin verification"]
     needed = "steps.fix-pin-curie.outputs.needed == 'true'"
     for step in (cargo, helm):
         condition = _string(step, "if")
-        assert "github.event_name == 'pull_request'" in condition
         assert needed in condition
         assert "Fix pin:" not in condition
+        # No tier selector runs in this job, so this can only stay true.
         assert PYTEST_SELECTED not in condition
 
     gate = named["Require declared fixes to be pinned by a changed test"]
-    assert _string(gate, "if") == "github.event_name == 'pull_request'"
-    assert needed not in _string(gate, "if")
+    assert "if" not in gate, (
+        "the gate must still run for a body with no declaration, or the "
+        "bug-without-declaration rejection can never fire"
+    )
 
 
 def _pytest_aggregate_contract() -> tuple[str, dict[str, str]]:

--- a/tools/fix-pin-ci/tests/test_fix_pin_ci.py
+++ b/tools/fix-pin-ci/tests/test_fix_pin_ci.py
@@ -564,7 +564,27 @@ def _pull_request_only(step: dict[str, Any]) -> bool:
     return bool(PR_CONDITION.search(_string(step, "if")))
 
 
-def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() -> None:
+def _fix_pin_job() -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    document = _load_ci()
+    jobs = document.get("jobs")
+    assert isinstance(jobs, dict), "ci.yaml must declare jobs"
+    job = jobs.get("fix-pin")
+    assert isinstance(job, dict), "ci.yaml must retain the fix-pin job"
+    steps = job.get("steps")
+    assert isinstance(steps, list), "the fix pin job must retain steps"
+    return job, [step for step in steps if isinstance(step, dict)]
+
+
+def test_ci_keeps_the_required_python_status_and_keeps_the_fix_pin_gate_off_it() -> None:
+    """The suite and the gate are both required, and no longer in series.
+
+    They were one job. #2230 measured that job as the whole critical path, and
+    the gate sat behind the suite it does not depend on: a cold 251s cargo
+    build plus a 127s verification appended after 1048s of pytest. This asserts
+    the split, in both directions. The Python job must still be the unskippable
+    required suite, and it must no longer carry the gate; the gate must be its
+    own unskippable required job.
+    """
     document = _load_ci()
     trigger = _workflow_trigger(document)
     pull_request = trigger.get("pull_request")
@@ -582,13 +602,14 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
     assert job.get("name") == "Python (ruff + mypy + pytest)"
     assert "needs" not in job, "the required Python check must not be skippable"
 
-    # A job-level permissions block replaces the workflow-level one, so the job
-    # must grant both the checkout scope and the Issues scope the gate reads
-    # closed issue labels with.
     permissions = job.get("permissions")
     assert isinstance(permissions, dict), "the Python job must declare job level permissions"
     assert permissions.get("contents") == "read"
-    assert permissions.get("issues") == "read"
+    # The Issues scope followed the gate out. It was only ever there so the gate
+    # could read closed issue labels, and the suite has no use for it.
+    assert "issues" not in permissions, (
+        "the Python job must not keep the Issues scope the fix pin gate took with it"
+    )
 
     checkout_index = _single_step_index(
         steps,
@@ -612,9 +633,9 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
         "shared database migration",
     )
     # Matched on the prefix, not on equality. What this assertion is for is that
-    # the normal suite runs, unfiltered, before the gate; reporting flags like
-    # --durations do not bear on that, and pinning the exact string made a
-    # profiling flag look like a contract change.
+    # the normal suite runs, unfiltered; reporting flags like --durations do not
+    # bear on that, and pinning the exact string made a profiling flag look like
+    # a contract change.
     pytest_index = _single_step_index(
         steps,
         lambda step: _string(step, "run").strip().startswith("uv run pytest -q"),
@@ -628,12 +649,80 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
         "the Python suite must run unfiltered: only reporting flags may be added "
         f"to `uv run pytest -q`, got {pytest_command!r}"
     )
+    assert stack_index < migration_index < pytest_index
+
+    # The half that keeps the win. Nothing about the gate may drift back into
+    # the job whose length is the critical path.
+    assert not any(_is_fix_pin_gate(step) for step in steps), (
+        "the fix pin gate must not run inside the Python job again"
+    )
+    assert not any(_is_fix_pin_probe(step) for step in steps), (
+        "the fix pin probe must not run inside the Python job again"
+    )
+    assert not any(
+        "cargo" in _string(step, "run") for step in steps
+    ), "the Python job must not build Rust behind the suite"
+
+    diagnostic_index = _single_step_index(
+        steps,
+        lambda step: "docker compose -f compose.dev.yaml logs" in _string(step, "run"),
+        "failure stack diagnostic",
+    )
+    diagnostic_if = _string(steps[diagnostic_index], "if")
+    assert "failure()" in diagnostic_if
+    assert "steps.python-runtime.outputs.pytest == 'true'" in diagnostic_if
+    assert pytest_index < diagnostic_index
+
+
+def test_the_fix_pin_job_is_required_and_carries_the_whole_gate() -> None:
+    """Everything the gate needs must be in the job that now runs it."""
+    job, steps = _fix_pin_job()
+    assert "needs" not in job, "the required fix pin check must not be skippable"
+    assert _pull_request_only(job), (
+        "only a pull request carries the body this gate reads, so the job is "
+        "pull-request only and its steps no longer each repeat that condition"
+    )
+
+    permissions = job.get("permissions")
+    assert isinstance(permissions, dict), "the fix pin job must declare job level permissions"
+    assert permissions.get("contents") == "read"
+    assert permissions.get("issues") == "read", (
+        "the gate reads the labels of the closed issues a pull request names"
+    )
+
+    checkout = steps[
+        _single_step_index(
+            steps,
+            lambda step: _string(step, "uses") == "actions/checkout@v7",
+            "fix pin checkout",
+        )
+    ]
+    checkout_with = checkout.get("with")
+    assert isinstance(checkout_with, dict)
+    # verify-fix-pin.sh resolves HEAD and adds a detached worktree at it, and
+    # the gate diffs against the base.
+    assert checkout_with.get("fetch-depth") == 0
+    assert checkout_with.get("persist-credentials") is False
+
     probe_index = _single_step_index(steps, _is_fix_pin_probe, "fix pin cargo probe")
     gate_index = _single_step_index(steps, _is_fix_pin_gate, "fix pin caller")
-    gate = steps[gate_index]
-    assert _pull_request_only(gate), "the verifier must not run for pushes"
-    assert stack_index < migration_index < pytest_index < gate_index
 
+    probe = steps[probe_index]
+    assert probe.get("id") == "fix-pin-curie"
+    assert not _string(probe, "if"), (
+        "the probe must run for every pull request, including bodies with no "
+        "live selector; gating it on its own output would skip the decision"
+    )
+    assert shlex.split(_string(probe, "run")) == [
+        "python3",
+        "tools/fix-pin-ci/check.py",
+        "--event",
+        "$GITHUB_EVENT_PATH",
+        "--needs-curie",
+    ]
+    assert '--event "$GITHUB_EVENT_PATH"' in _string(probe, "run")
+
+    gate = steps[gate_index]
     gate_environment = gate.get("env")
     assert isinstance(gate_environment, dict)
     assert gate_environment.get("CARGO_TARGET_DIR") == "${{ github.workspace }}/cli/target"
@@ -650,21 +739,6 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
     ]
     assert '--event "$GITHUB_EVENT_PATH"' in _string(gate, "run")
 
-    probe = steps[probe_index]
-    assert _string(probe, "if") == "github.event_name == 'pull_request'", (
-        "the cargo probe must run for every pull request, including bodies with "
-        "no live selector; gating it on its own output would skip the decision"
-    )
-    assert probe.get("id") == "fix-pin-curie"
-    assert shlex.split(_string(probe, "run")) == [
-        "python3",
-        "tools/fix-pin-ci/check.py",
-        "--event",
-        "$GITHUB_EVENT_PATH",
-        "--needs-curie",
-    ]
-    assert '--event "$GITHUB_EVENT_PATH"' in _string(probe, "run")
-
     release_build_index = _single_step_index(
         steps,
         lambda step: _string(step, "run").strip()
@@ -678,19 +752,48 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
         and (step.get("with") or {}).get("version") == "v3.16.4",
         "pinned Helm setup",
     )
-    for index in (release_build_index, helm_index):
-        assert _pull_request_only(steps[index]), "selector tooling must not affect push runs"
-        assert pytest_index < index < gate_index
-    assert pytest_index < probe_index < release_build_index < helm_index < gate_index
+    assert probe_index < release_build_index < helm_index < gate_index
+
+    # The build stays direct. A `rust` selector makes verify-fix-pin.sh run
+    # `cargo test` out of CARGO_TARGET_DIR, so this build warms the directory
+    # the verification then compiles in; swapping it for rust-build's artifact
+    # would leave that selector to compile from cold.
     assert not any(
         _string(step, "uses") == "Swatinem/rust-cache@v2" for step in steps
-    ), "the Python job must build directly without a Cargo cache dependency"
+    ), "the fix pin job must build directly without a Cargo cache dependency"
     assert not any(
-        _string(step, "uses") == "actions/download-artifact@v8" for step in steps
-    ), "the Python job must not download its curie binary"
+        _string(step, "uses").startswith("actions/download-artifact") for step in steps
+    ), "the fix pin job must not download its curie binary"
     assert not any(
         "chmod +x cli/target/release/curie" in _string(step, "run") for step in steps
     ), "the direct Cargo build creates the executable"
+
+    # Inside the Python job the gate inherited a booted stack. A `python`
+    # selector naming an integration test dials Postgres and Valkey through
+    # `uv run pytest <selector>`, so the split job has to boot its own or those
+    # selectors fail for the environment rather than for the pin.
+    sync_index = _single_step_index(
+        steps,
+        lambda step: _string(step, "run").strip() == "uv sync",
+        "workspace sync",
+    )
+    stack_index = _single_step_index(
+        steps,
+        lambda step: "docker compose -f compose.dev.yaml up -d" in _string(step, "run"),
+        "dev stack startup",
+    )
+    migration_index = _single_step_index(
+        steps,
+        lambda step: "uv run alembic upgrade head" in _string(step, "run"),
+        "shared database migration",
+    )
+    assert sync_index < probe_index
+    assert helm_index < stack_index < migration_index < gate_index
+    for index in (stack_index, migration_index):
+        assert CARGO_NEEDED_GUARD in _string(steps[index], "if"), (
+            "a body with no live selector never reaches the verifier, so it "
+            "must not pay for a compose stack either"
+        )
 
     diagnostic_index = _single_step_index(
         steps,
@@ -699,7 +802,7 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
     )
     diagnostic_if = _string(steps[diagnostic_index], "if")
     assert "failure()" in diagnostic_if
-    assert "steps.python-runtime.outputs.pytest == 'true'" in diagnostic_if
+    assert CARGO_NEEDED_GUARD in diagnostic_if
     assert gate_index < diagnostic_index
 
 
@@ -721,8 +824,7 @@ def test_selector_tooling_builds_only_when_the_parser_would_invoke_curie() -> No
     reuse `_declaration` so a commented example cannot trigger the build, and
     a live `Fix pin: <selector>` line still cannot skip it.
     """
-    document = _load_ci()
-    _, steps = _python_job(document)
+    job, steps = _fix_pin_job()
 
     probe = steps[_single_step_index(steps, _is_fix_pin_probe, "fix pin cargo probe")]
     assert probe.get("id") == "fix-pin-curie"
@@ -742,7 +844,11 @@ def test_selector_tooling_builds_only_when_the_parser_would_invoke_curie() -> No
     ):
         step = steps[_single_step_index(steps, predicate, description)]
         condition = _string(step, "if")
-        assert PR_CONDITION.search(condition), f"{description} must stay pull-request only"
+        # The job carries the pull-request condition now, so the steps state
+        # only what is theirs: the parser's answer.
+        assert _pull_request_only(job), (
+            f"{description} must stay pull-request only"
+        )
         assert CARGO_NEEDED_GUARD in condition, (
             f"{description} must build only when the parser says the binary "
             f"is needed: {condition!r}"


### PR DESCRIPTION
## Summary

The Python job is the entire CI critical path. On run 34528877480 it ran 26.4 minutes while the next longest chain finished at 17.4, and two of its steps were the fix pin gate: a cold 251s `cargo build --release` plus a 127s verification, both appended after the 1048s pytest that neither of them depends on. That is 6.3 minutes in series for no ordering reason. #2228 removed that build for pull requests that declare nothing, but this repository requires a `Fix pin:` selector on every pull request closing a `bug` labelled issue, so the declaring majority still paid it in full. This moves the probe, the build, the Helm setup and the gate into a parallel `fix-pin` job. Nothing is deleted, because none of it was waste; it just stops being serialised behind an unrelated suite.

Two details are deliberate. The build stays direct, with no Cargo cache and no downloaded artifact, because a `rust` selector makes `verify-fix-pin.sh` run `cargo test` out of `CARGO_TARGET_DIR`: that build warms the directory the verification then compiles in, so reusing rust-build's artifact would leave that selector compiling from cold. And the new job boots the dev stack, which is the one behavioural addition and a correctness fix rather than a speed one. `verify-fix-pin.sh` runs `uv run pytest <selector>`, which for an integration selector dials Postgres and Valkey; inside the Python job the gate inherited a stack that was already up, so split out it has to boot its own. It stays behind the same probe, so a body with no live selector still pays nothing for it.

Expected effect: the Python job drops to roughly 20 minutes and the critical path becomes the E2E cluster chain at roughly 17. The remaining levers are the three decisions in #2230, which this does not touch.

## Required before this is enforcing again

`Fix pin verification` must be added to the Default ruleset's required status checks. The gate currently rides inside `Python (ruff + mypy + pytest)`, which is required; as its own job it is advisory until an administrator adds it. Adding it to the ruleset before this merges would block every open pull request on a check that does not exist yet, so the ordering is: merge, then add the check immediately.

## Related issue

Ref #2230

## Fix pin verification

## End-to-end verification

This change does not alter runtime behavior because it moves CI steps between jobs and adds no product code path. The moved steps are byte for byte the ones that ran before, and the only addition is the compose stack the gate previously inherited from the job it lived in.

Scoped verification, all against 75405c4f:

- `uv run pytest tools/ release/tests -q` gives 620 passed. This is the suite that owns the workflow contracts: `tools/fix-pin-ci` pins the gate's argv, its environment, its ordering and its guards; `tools/ci-retry-gate` enforces which steps may carry a retry; `tools/e2e-ci-selection` pins what the tier selector does and does not gate; `release/tests` pins the required check names.
- `uv run ruff check .` gives All checks passed, and `uv run mypy` gives Success: no issues found in 249 source files.
- `bash scripts/check-docs.sh` gives OK: the interface catalog is generated and drift-free.
- Falsifiable negative: the four contract tests that pinned the gate into the Python job failed first, naming the exact assertions, and were retargeted rather than removed. The new `test_the_fix_pin_gate_left_the_python_job` and the absence assertions in `test_ci_keeps_the_required_python_status_and_keeps_the_fix_pin_gate_off_it` fail if any of the four steps reappears in the Python job, so the change cannot silently revert.
- This pull request is itself the live check on the new job: it exercises the probe on a body with no `Fix pin:` selector, which is the path that must cost nothing.

## Checklist

- [x] Tests pass for the area I touched.
- [x] Docs updated if behavior changed. No behavior change; the reasoning lives in the workflow comments and the commit.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. Not one: `docs/adr/AGENTS.md` puts CI configuration and build plumbing outside the ADR requirement.
