### PR TITLE
Make two parametrized cases collect deterministically

### DIFF
--- a/.github/workflows/xdist-characterise.yaml
+++ b/.github/workflows/xdist-characterise.yaml
@@ -1,0 +1,151 @@
+# Draw the boundary #2230 could not draw from three samples.
+#
+# The parallelism comment on #2230 ran `uv run pytest -n 4 --dist loadfile`
+# three times on a 12 core laptop. Two attempts failed, on two DIFFERENT tests,
+# which is the worst shape a sample can have: it says a boundary exists without
+# saying where. The comment named what would fix that, and this is the first
+# item, run the suite many times and collect every test that ever fails, plus
+# the third item, do it on a CI runner rather than a laptop.
+#
+# It is deliberately not on `pull_request` or `push` to a release branch. It
+# runs the whole suite twenty times over and is an investigation, not a gate.
+# The branch pattern is the trigger so it can run before it is on a release
+# branch, since `workflow_dispatch` only offers workflows already on the
+# default branch.
+name: Xdist characterisation
+
+on:
+  push:
+    branches: ["task/xdist-characterise*"]
+
+permissions:
+  contents: read
+
+jobs:
+  attempt:
+    name: Parallel attempt ${{ matrix.attempt }}
+    runs-on: ubuntu-latest
+    strategy:
+      # Every attempt is a sample. One that fails must not cancel the rest, or
+      # the run answers "at least one failed" instead of "here is the set".
+      fail-fast: false
+      matrix:
+        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                  11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      # Retry eligibility (#1106): acquiring a third-party tool may be wrapped.
+      - name: Install uv
+        id: install_uv
+        continue-on-error: true
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: "3.13"
+      - name: Back off before retrying Install uv
+        if: steps.install_uv.outcome == 'failure'
+        run: |
+          echo "Install uv failed on attempt 1 of 2, retrying in 15 seconds"
+          sleep 15
+      - name: Install uv (retry)
+        if: steps.install_uv.outcome == 'failure'
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: "3.13"
+      - name: Sync workspace
+        run: uv sync
+      # The same stack the Python job boots, because the contention this is
+      # looking for is largely contention over it.
+      - name: Start dev stack
+        run: |
+          docker compose -f compose.dev.yaml up -d \
+            postgres valkey clickhouse rustfs rustfs-init \
+            langfuse-web langfuse-worker otel-collector
+          docker compose -f compose.dev.yaml up -d --wait --wait-timeout 300 \
+            postgres valkey clickhouse rustfs \
+            langfuse-web langfuse-worker otel-collector
+      - name: Wait for Langfuse to serve
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:23000/api/public/health >/dev/null 2>&1; then
+              echo "Langfuse ready after attempt ${i}"; exit 0
+            fi
+            sleep 3
+          done
+          echo "Langfuse did not become ready within 180s"; exit 1
+      - name: Migrate the shared database
+        working-directory: apps/api
+        run: uv run alembic upgrade head
+      - name: Record the runner's real core count
+        run: |
+          echo "nproc=$(nproc)"
+          free -g || true
+      # `-n 4` matches the runner, and `--dist loadfile` is what #2230
+      # measured, so this extends that data rather than starting a new series.
+      #
+      # A failing attempt is the measurement, and this step is deliberately NOT
+      # wrapped to hide that. `continue-on-error` on a step that runs this
+      # repository's tests is the exact pattern the retry gate exists to refuse,
+      # and it is refused here too. It is also unnecessary: pytest writes the
+      # junit file whether the suite passed or failed, the upload below is
+      # `always()`, and the aggregate job is `always()`. So a red attempt leg
+      # still contributes its data, and reads as what it is.
+      - name: Parallel suite
+        env:
+          CI_REQUIRE_VALKEY_TESTS: "1"
+        run: |
+          uv run pytest -n 4 --dist loadfile -q \
+            --junitxml "junit-${{ matrix.attempt }}.xml"
+      - name: Upload this attempt's report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: junit-${{ matrix.attempt }}
+          path: junit-${{ matrix.attempt }}.xml
+          if-no-files-found: warn
+
+  aggregate:
+    name: Characterisation
+    runs-on: ubuntu-latest
+    needs: attempt
+    # `attempt` legs are expected to fail; that is the data. Without always()
+    # the aggregate never runs on exactly the runs worth aggregating.
+    if: always()
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Install uv
+        id: install_uv
+        continue-on-error: true
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: "3.13"
+      - name: Back off before retrying Install uv
+        if: steps.install_uv.outcome == 'failure'
+        run: |
+          echo "Install uv failed on attempt 1 of 2, retrying in 15 seconds"
+          sleep 15
+      - name: Install uv (retry)
+        if: steps.install_uv.outcome == 'failure'
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: "3.13"
+      - name: Download every attempt's report
+        uses: actions/download-artifact@v7
+        with:
+          pattern: junit-*
+          path: reports
+      - name: Union the failures across attempts
+        run: |
+          uv run python tools/xdist-characterise/aggregate.py \
+            --reports reports \
+            --json characterisation.json | tee "$GITHUB_STEP_SUMMARY"
+      - name: Upload the characterisation
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: characterisation
+          path: characterisation.json
+          if-no-files-found: error

--- a/apps/api/tests/test_cluster_message_results.py
+++ b/apps/api/tests/test_cluster_message_results.py
@@ -243,7 +243,16 @@ def test_platform_get_reports_an_unwritten_valid_ref_as_absent(
         "../",
         "a/b",
         "550E8400-E29B-41D4-A716-446655440000",
-        str(uuid.uuid1()),
+        # A version 1 UUID: well formed, and not the canonical form this route
+        # accepts, which is the whole point of the case.
+        #
+        # It was `str(uuid.uuid1())`, evaluated at COLLECTION time (#2235). That
+        # gave the case a different node id on every run, so no `Fix pin:`
+        # selector could ever name it, and under xdist each worker collects at
+        # its own moment and pytest refuses the mismatch outright: "Different
+        # tests were collected between gw0 and gw3". A literal proves exactly
+        # the same thing about the route and stays nameable.
+        "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
     ],
 )
 def test_noncanonical_refs_are_refused_before_any_valkey_write(

--- a/apps/worker/tests/test_workspace.py
+++ b/apps/worker/tests/test_workspace.py
@@ -13,6 +13,7 @@ frozen ACI nor plugin-format contracts participate in this seam.
 
 from __future__ import annotations
 
+import gzip
 import hashlib
 import importlib
 import io
@@ -525,19 +526,29 @@ def test_worker_rehashes_private_object_before_delivery(workspace: Any, tmp_path
 
 
 def _tar_with_member(name: str, *, kind: str = "file", data: bytes = b"x") -> bytes:
+    """Build one hostile archive, byte for byte the same on every call.
+
+    `mode="w:gz"` writes a gzip header carrying the time it was written, and
+    these bytes are used as pytest parameter values. Under xdist each worker
+    collects at its own moment, so an unpinned header gives the same case a
+    different node id per worker and pytest refuses to run at all: "Different
+    tests were collected between gw0 and gw3". Pinning mtime makes the payload
+    a constant, which is what a fixture of hostile bytes should have been.
+    """
     raw = io.BytesIO()
-    with tarfile.open(fileobj=raw, mode="w:gz") as archive:
-        info = tarfile.TarInfo(name)
-        if kind == "symlink":
-            info.type = tarfile.SYMTYPE
-            info.linkname = "../../outside"
-            archive.addfile(info)
-        elif kind == "device":
-            info.type = tarfile.CHRTYPE
-            archive.addfile(info)
-        else:
-            info.size = len(data)
-            archive.addfile(info, io.BytesIO(data))
+    with gzip.GzipFile(fileobj=raw, mode="wb", mtime=0) as compressed:
+        with tarfile.open(fileobj=compressed, mode="w") as archive:
+            info = tarfile.TarInfo(name)
+            if kind == "symlink":
+                info.type = tarfile.SYMTYPE
+                info.linkname = "../../outside"
+                archive.addfile(info)
+            elif kind == "device":
+                info.type = tarfile.CHRTYPE
+                archive.addfile(info)
+            else:
+                info.size = len(data)
+                archive.addfile(info, io.BytesIO(data))
     return raw.getvalue()
 
 
@@ -549,6 +560,9 @@ def _tar_with_member(name: str, *, kind: str = "file", data: bytes = b"x") -> by
         (_tar_with_member("repo/link", kind="symlink"), "link"),
         (_tar_with_member("repo/device", kind="device"), "special"),
     ],
+    # Without these the node id is the raw gzip payload, which no `Fix pin:`
+    # selector can be typed to name even once the bytes are deterministic.
+    ids=["traversal", "absolute", "link", "special"],
 )
 def test_hostile_workspace_archive_is_rejected_before_init(
     workspace: Any, payload: bytes, reason: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
     "curie-wire-tolerance-gate",
     "curie-test-support",
     "pytest>=8.3",
+    "pytest-xdist>=3.6",
     "ruff>=0.16.2",
     "mypy>=2.3.0",
     "import-linter>=2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,7 @@ testpaths = [
     "tools/fix-pin-ci/tests",
     "tools/sdk-lock-gate/tests",
     "tools/p0-closes-ci/tests",
+    "tools/xdist-characterise/tests",
     "tools/ci-release-target-parity/tests",
     "tools/restore-drill/tests",
 ]

--- a/tools/ci-retry-gate/tests/test_retry_eligibility.py
+++ b/tools/ci-retry-gate/tests/test_retry_eligibility.py
@@ -46,6 +46,8 @@ RETRY_ALLOWLIST = frozenset(
         ("ci.yaml", "python", "Install uv"),
         ("ci.yaml", "fix-pin", "Install uv"),
         ("ci.yaml", "e2e-ladder-cluster", "Create the kind cluster"),
+        ("xdist-characterise.yaml", "attempt", "Install uv"),
+        ("xdist-characterise.yaml", "aggregate", "Install uv"),
         ("dependency-audit.yaml", "python-audit", "Install uv"),
         ("gitleaks.yaml", "gitleaks", "Pull the gitleaks image"),
         ("release.yaml", "build", "Set up Buildx"),
@@ -187,6 +189,12 @@ RUN_RETRY_EXEMPT: frozenset[tuple[str, str, str]] = frozenset(
         # becomes ready the step fails the job rather than papering over it.
         ("ci.yaml", "ui-image-smoke", "Start the stub API upstream"),
         ("ci.yaml", "ui-image-smoke", "Start the UI container"),
+        # The characterisation harness boots the same dev stack as the
+        # python job and polls the same unhealthchecked Langfuse web
+        # container. A readiness poll for an external service, and this
+        # workflow gates nothing: it is an investigation that records
+        # which tests fail under parallelism.
+        ("xdist-characterise.yaml", "attempt", "Wait for Langfuse to serve"),
     }
 )
 

--- a/tools/xdist-characterise/aggregate.py
+++ b/tools/xdist-characterise/aggregate.py
@@ -1,0 +1,124 @@
+"""Union the tests that failed across repeated parallel runs of the suite.
+
+#2230's parallelism comment measured `-n 4` three times and found two different
+tests failing, one per run, and said so plainly: that is not one reproducible
+conflict, it is two points inside a boundary nobody has drawn. It then named
+what would make parallelism shippable, and the first item is this: run the
+suite many times and collect every test that EVER fails, rather than reasoning
+from a handful of samples.
+
+This reads the JUnit XML each attempt wrote and answers one question: which
+tests failed, and in how many of the attempts. A test that fails in every
+attempt is a real breakage under parallelism. A test that fails in two of
+twenty is the interesting kind, the one a three-sample study reports as a
+different test each time, and the one that has to be pinned rather than
+debugged away.
+
+Attempt count comes from the files present, not from a flag, so an attempt
+whose job died without uploading cannot silently deflate a rate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree
+
+
+def _test_id(case: ElementTree.Element) -> str:
+    """Rebuild the node id pytest would accept as a selector.
+
+    pytest's JUnit writer puts the source path in `file` and the dotted module
+    path in `classname`. `file` is the half that round-trips back into a
+    command line, so it is preferred; `classname` is the fallback for a writer
+    that omits it.
+    """
+    name = case.get("name", "")
+    path = case.get("file")
+    if path:
+        return f"{path}::{name}"
+    return f"{case.get('classname', '')}::{name}"
+
+
+def _failures(report: Path) -> set[str]:
+    """Every test in one attempt that failed or errored.
+
+    A skip is not a failure and a passing rerun does not erase one: this is the
+    per-attempt set that the union is built from.
+    """
+    try:
+        tree = ElementTree.parse(report)
+    except ElementTree.ParseError as error:
+        raise ValueError(f"{report} is not parsable JUnit XML: {error}") from error
+
+    failed: set[str] = set()
+    for case in tree.iter("testcase"):
+        if case.find("failure") is not None or case.find("error") is not None:
+            failed.add(_test_id(case))
+    return failed
+
+
+def characterise(reports: list[Path]) -> dict[str, Any]:
+    if not reports:
+        raise ValueError("no JUnit XML reports were found, so nothing can be characterised")
+
+    counts: dict[str, int] = defaultdict(int)
+    for report in sorted(reports):
+        for test in _failures(report):
+            counts[test] += 1
+
+    attempts = len(reports)
+    # Most failures first, then by node id, so a rerun of the same data prints
+    # the same report and a diff between two characterisations is readable.
+    ranked = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    return {
+        "attempts": attempts,
+        "flaky": [
+            {"test": test, "failed": count, "of": attempts}
+            for test, count in ranked
+        ],
+    }
+
+
+def _render(result: dict[str, Any]) -> str:
+    attempts = result["attempts"]
+    flaky = result["flaky"]
+    if not flaky:
+        return f"No test failed in any of the {attempts} attempts."
+
+    lines = [f"{len(flaky)} test(s) failed in at least one of {attempts} attempts:", ""]
+    for entry in flaky:
+        lines.append(f"  {entry['failed']:>3}/{attempts}  {entry['test']}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--reports",
+        type=Path,
+        required=True,
+        help="directory holding one JUnit XML file per attempt",
+    )
+    parser.add_argument("--json", type=Path, help="also write the result as JSON here")
+    arguments = parser.parse_args(argv)
+
+    reports = sorted(arguments.reports.rglob("*.xml"))
+    try:
+        result = characterise(reports)
+    except ValueError as error:
+        print(f"xdist characterisation error: {error}", file=sys.stderr)
+        return 1
+
+    print(_render(result))
+    if arguments.json:
+        arguments.json.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/xdist-characterise/aggregate.py
+++ b/tools/xdist-characterise/aggregate.py
@@ -44,11 +44,27 @@ def _test_id(case: ElementTree.Element) -> str:
     return f"{case.get('classname', '')}::{name}"
 
 
-def _failures(report: Path) -> set[str]:
-    """Every test in one attempt that failed or errored.
+def _is_collection_error(case: ElementTree.Element) -> bool:
+    """A worker that never got as far as running tests.
 
-    A skip is not a failure and a passing rerun does not erase one: this is the
-    per-attempt set that the union is built from.
+    When xdist workers disagree about what was collected, pytest refuses the
+    whole run and writes one entry per worker with no source file, named for
+    the worker rather than for a test. Counting those as failing tests is how
+    this tool first reported a total collection refusal as "4 flaky tests"
+    called `::gw0` through `::gw3`, which is precisely the misreading #2230
+    warned about: it makes a suite that never ran look like a suite with a
+    handful of loose tests.
+    """
+    return case.get("file") is None and case.find("error") is not None
+
+
+def _failures(report: Path) -> tuple[set[str], list[str]]:
+    """One attempt's failing tests, and the collection errors that voided it.
+
+    A skip is not a failure and a passing rerun does not erase one: the first
+    element is the per-attempt set that the union is built from. The second is
+    non-empty only when the attempt never ran, in which case its empty failure
+    set means "no evidence", not "nothing went wrong".
     """
     try:
         tree = ElementTree.parse(report)
@@ -56,10 +72,14 @@ def _failures(report: Path) -> set[str]:
         raise ValueError(f"{report} is not parsable JUnit XML: {error}") from error
 
     failed: set[str] = set()
+    collection_errors: list[str] = []
     for case in tree.iter("testcase"):
+        if _is_collection_error(case):
+            collection_errors.append(case.get("name", "?"))
+            continue
         if case.find("failure") is not None or case.find("error") is not None:
             failed.add(_test_id(case))
-    return failed
+    return failed, collection_errors
 
 
 def characterise(reports: list[Path]) -> dict[str, Any]:
@@ -67,18 +87,27 @@ def characterise(reports: list[Path]) -> dict[str, Any]:
         raise ValueError("no JUnit XML reports were found, so nothing can be characterised")
 
     counts: dict[str, int] = defaultdict(int)
+    never_ran = 0
     for report in sorted(reports):
-        for test in _failures(report):
+        failed, collection_errors = _failures(report)
+        if collection_errors:
+            never_ran += 1
+            continue
+        for test in failed:
             counts[test] += 1
 
     attempts = len(reports)
-    # Most failures first, then by node id, so a rerun of the same data prints
-    # the same report and a diff between two characterisations is readable.
+    ran = attempts - never_ran
+    # The denominator is the attempts that actually ran. Dividing by every
+    # attempt would report a test that failed both of the two usable runs as
+    # 2/20, which reads as rare when it is in fact universal.
     ranked = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
     return {
         "attempts": attempts,
+        "ran": ran,
+        "never_ran": never_ran,
         "flaky": [
-            {"test": test, "failed": count, "of": attempts}
+            {"test": test, "failed": count, "of": ran}
             for test, count in ranked
         ],
     }
@@ -86,13 +115,32 @@ def characterise(reports: list[Path]) -> dict[str, Any]:
 
 def _render(result: dict[str, Any]) -> str:
     attempts = result["attempts"]
+    ran = result["ran"]
+    never_ran = result["never_ran"]
     flaky = result["flaky"]
-    if not flaky:
-        return f"No test failed in any of the {attempts} attempts."
 
-    lines = [f"{len(flaky)} test(s) failed in at least one of {attempts} attempts:", ""]
+    lines: list[str] = []
+    if never_ran:
+        lines += [
+            f"{never_ran} of {attempts} attempts never ran the suite: the workers "
+            "disagreed about what was collected, so pytest refused the run.",
+            "",
+            "That is a determinism defect in the test ids themselves, not "
+            "contention between tests, and it has to be fixed before any "
+            "statement about parallel flakiness means anything.",
+            "",
+        ]
+    if not ran:
+        lines.append("No attempt produced a usable result.")
+        return "\n".join(lines)
+
+    if not flaky:
+        lines.append(f"No test failed in any of the {ran} attempts that ran.")
+        return "\n".join(lines)
+
+    lines += [f"{len(flaky)} test(s) failed in at least one of {ran} attempts that ran:", ""]
     for entry in flaky:
-        lines.append(f"  {entry['failed']:>3}/{attempts}  {entry['test']}")
+        lines.append(f"  {entry['failed']:>3}/{ran}  {entry['test']}")
     return "\n".join(lines)
 
 

--- a/tools/xdist-characterise/tests/test_aggregate.py
+++ b/tools/xdist-characterise/tests/test_aggregate.py
@@ -1,0 +1,145 @@
+"""The union is the whole point, so these pin what it counts and what it ignores."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+AGGREGATE = REPO_ROOT / "tools" / "xdist-characterise" / "aggregate.py"
+
+
+def _module() -> ModuleType:
+    specification = importlib.util.spec_from_file_location("xdist_aggregate", AGGREGATE)
+    assert specification is not None and specification.loader is not None
+    module = importlib.util.module_from_spec(specification)
+    sys.modules["xdist_aggregate"] = module
+    specification.loader.exec_module(module)
+    return module
+
+
+def _report(directory: Path, name: str, cases: str) -> Path:
+    path = directory / name
+    path.write_text(f'<?xml version="1.0"?><testsuites><testsuite>{cases}</testsuite></testsuites>')
+    return path
+
+
+PASSING = (
+    '<testcase classname="apps.api.tests.test_a" file="apps/api/tests/test_a.py" '
+    'name="test_ok"/>'
+)
+FAILING = (
+    '<testcase classname="apps.api.tests.test_a" file="apps/api/tests/test_a.py" '
+    'name="test_flaky"><failure message="boom"/></testcase>'
+)
+ERRORING = (
+    '<testcase classname="apps.api.tests.test_b" file="apps/api/tests/test_b.py" '
+    'name="test_errored"><error message="teardown"/></testcase>'
+)
+SKIPPED = (
+    '<testcase classname="apps.api.tests.test_c" file="apps/api/tests/test_c.py" '
+    'name="test_skipped"><skipped message="no valkey"/></testcase>'
+)
+
+
+def test_a_test_that_fails_in_some_attempts_is_reported_with_its_rate(tmp_path: Path) -> None:
+    """The shape #2230 could not see from three samples: a partial failure rate."""
+    module = _module()
+    _report(tmp_path, "attempt-1.xml", PASSING + FAILING)
+    _report(tmp_path, "attempt-2.xml", PASSING + PASSING)
+    _report(tmp_path, "attempt-3.xml", PASSING + FAILING)
+
+    result = module.characterise(sorted(tmp_path.glob("*.xml")))
+
+    assert result["attempts"] == 3
+    assert result["flaky"] == [
+        {"test": "apps/api/tests/test_a.py::test_flaky", "failed": 2, "of": 3}
+    ]
+
+
+def test_errors_count_and_skips_do_not(tmp_path: Path) -> None:
+    """A teardown error is a failure under parallelism; a skip is not a signal."""
+    module = _module()
+    _report(tmp_path, "attempt-1.xml", ERRORING + SKIPPED)
+
+    result = module.characterise(sorted(tmp_path.glob("*.xml")))
+
+    assert [entry["test"] for entry in result["flaky"]] == [
+        "apps/api/tests/test_b.py::test_errored"
+    ]
+
+
+def test_the_attempt_count_comes_from_the_files_present(tmp_path: Path) -> None:
+    """An attempt whose job died uploads nothing, and must not deflate a rate.
+
+    Taking the denominator from a flag would report 1/20 for a test that failed
+    the only attempt that finished. Taking it from the files reports 1/1, which
+    is the honest statement of what was observed.
+    """
+    module = _module()
+    _report(tmp_path, "attempt-1.xml", FAILING)
+
+    result = module.characterise(sorted(tmp_path.glob("*.xml")))
+
+    assert result["attempts"] == 1
+    assert result["flaky"][0]["failed"] == 1
+
+
+def test_a_clean_sweep_reports_nothing(tmp_path: Path) -> None:
+    module = _module()
+    _report(tmp_path, "attempt-1.xml", PASSING)
+    _report(tmp_path, "attempt-2.xml", PASSING)
+
+    result = module.characterise(sorted(tmp_path.glob("*.xml")))
+
+    assert result["flaky"] == []
+    assert "No test failed" in module._render(result)
+
+
+def test_no_reports_is_an_error_not_an_empty_answer(tmp_path: Path) -> None:
+    """Zero uploads means the run broke, and must not read as "parallelism is safe"."""
+    module = _module()
+
+    with pytest.raises(ValueError, match="nothing can be characterised"):
+        module.characterise([])
+
+
+def test_ranking_puts_the_most_frequent_failure_first(tmp_path: Path) -> None:
+    module = _module()
+    rare = FAILING.replace("test_flaky", "test_rare")
+    _report(tmp_path, "attempt-1.xml", FAILING + rare)
+    _report(tmp_path, "attempt-2.xml", FAILING)
+
+    result = module.characterise(sorted(tmp_path.glob("*.xml")))
+
+    assert [entry["test"] for entry in result["flaky"]] == [
+        "apps/api/tests/test_a.py::test_flaky",
+        "apps/api/tests/test_a.py::test_rare",
+    ]
+
+
+def test_a_writer_that_omits_the_file_attribute_falls_back_to_classname(tmp_path: Path) -> None:
+    module = _module()
+    _report(
+        tmp_path,
+        "attempt-1.xml",
+        '<testcase classname="pkg.test_x" name="t"><failure/></testcase>',
+    )
+
+    result = module.characterise(sorted(tmp_path.glob("*.xml")))
+
+    assert result["flaky"][0]["test"] == "pkg.test_x::t"
+
+
+def test_unparsable_xml_names_the_file(tmp_path: Path) -> None:
+    """A truncated upload must fail loudly rather than be counted as a clean attempt."""
+    module = _module()
+    broken = tmp_path / "attempt-1.xml"
+    broken.write_text("<testsuites><testsuite>")
+
+    with pytest.raises(ValueError, match="attempt-1.xml is not parsable"):
+        module.characterise([broken])

--- a/tools/xdist-characterise/tests/test_aggregate.py
+++ b/tools/xdist-characterise/tests/test_aggregate.py
@@ -100,6 +100,67 @@ def test_a_clean_sweep_reports_nothing(tmp_path: Path) -> None:
     assert "No test failed" in module._render(result)
 
 
+COLLECTION_ERROR = (
+    '<testcase classname="" name="gw0"><error message="Different tests were '
+    'collected between gw0 and gw3"/></testcase>'
+)
+
+
+def test_a_refused_run_is_not_reported_as_flaky_tests(tmp_path: Path) -> None:
+    """The regression that produced this code path.
+
+    Run 34541967865 failed all 20 attempts at collection, and the first version
+    of this tool rendered that as "4 test(s) failed", named `::gw0` through
+    `::gw3`. A total refusal to run read as a handful of loose tests, which is
+    the exact misreading #2230 cautions against.
+    """
+    module = _module()
+    _report(tmp_path, "attempt-1.xml", COLLECTION_ERROR)
+    _report(tmp_path, "attempt-2.xml", COLLECTION_ERROR)
+
+    result = module.characterise(sorted(tmp_path.glob("*.xml")))
+
+    assert result["never_ran"] == 2
+    assert result["ran"] == 0
+    assert result["flaky"] == []
+    rendered = module._render(result)
+    assert "never ran the suite" in rendered
+    assert "No attempt produced a usable result." in rendered
+
+
+def test_the_rate_divides_by_the_attempts_that_actually_ran(tmp_path: Path) -> None:
+    """A test failing both usable runs is 2/2, not 2/4.
+
+    Dividing by every attempt would print 2/4 for a test that failed every run
+    that got far enough to have an opinion, and 50% reads as flaky where 100%
+    reads as broken.
+    """
+    module = _module()
+    _report(tmp_path, "attempt-1.xml", FAILING)
+    _report(tmp_path, "attempt-2.xml", FAILING)
+    _report(tmp_path, "attempt-3.xml", COLLECTION_ERROR)
+    _report(tmp_path, "attempt-4.xml", COLLECTION_ERROR)
+
+    result = module.characterise(sorted(tmp_path.glob("*.xml")))
+
+    assert result["attempts"] == 4
+    assert result["ran"] == 2
+    assert result["flaky"] == [
+        {"test": "apps/api/tests/test_a.py::test_flaky", "failed": 2, "of": 2}
+    ]
+
+
+def test_a_real_test_error_still_counts(tmp_path: Path) -> None:
+    """Only a fileless error is a collection error; a real test's error counts."""
+    module = _module()
+    _report(tmp_path, "attempt-1.xml", ERRORING)
+
+    result = module.characterise(sorted(tmp_path.glob("*.xml")))
+
+    assert result["never_ran"] == 0
+    assert result["flaky"][0]["test"] == "apps/api/tests/test_b.py::test_errored"
+
+
 def test_no_reports_is_an_error_not_an_empty_answer(tmp_path: Path) -> None:
     """Zero uploads means the run broke, and must not read as "parallelism is safe"."""
     module = _module()

--- a/uv.lock
+++ b/uv.lock
@@ -973,6 +973,7 @@ dev = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "pytest" },
+    { name = "pytest-xdist" },
     { name = "pyyaml" },
     { name = "ruff" },
     { name = "types-pyyaml" },
@@ -1003,6 +1004,7 @@ dev = [
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.29" },
     { name = "opentelemetry-sdk", specifier = ">=1.44.0" },
     { name = "pytest", specifier = ">=8.3" },
+    { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", specifier = ">=0.16.2" },
     { name = "types-pyyaml", specifier = ">=6.0" },
@@ -1028,6 +1030,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/5d/5f8571bd5dedc80863191621ac4be001f3f3dd8315d2ec078705dab7dec1/durationpy-0.11.tar.gz", hash = "sha256:181898e1ae282e288f0a2291829656bf1b6b3aadf30a97993b85db4943642905", size = 3582, upload-time = "2026-08-26T13:56:00.991Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/c4/ebdf7837bc4ef6fd98cfb013c28855bb358467bf86c1af011bbc21e21df0/durationpy-0.11-py3-none-any.whl", hash = "sha256:a739fe2b8972c250ff72f8e2c488d18cf25f7b852f49ee76048775d5171df30c", size = 4133, upload-time = "2026-08-26T13:55:59.456Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -2227,6 +2238,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Two parametrized cases build their node id out of something that changes while collection is happening, and under xdist that is fatal rather than untidy: workers collect at different moments, disagree about what exists, and pytest refuses the whole run with "Different tests were collected between gw0 and gw3".

`test_noncanonical_refs_are_refused_before_any_valkey_write` took a parameter of `str(uuid.uuid1())`, evaluated at collection. That is #2235, found there as a case no `Fix pin:` selector could ever name. `test_hostile_workspace_archive_is_rejected_before_init` takes gzip bytes as parameter values, and `mode="w:gz"` writes the current time into the gzip header. The first becomes a literal version 1 UUID, the second pins gzip mtime and gets readable ids, so both node ids are now stable and nameable.

This also explains why #2230's measurement never hit it. The gzip header has one second resolution, so on a fast 12 core machine the workers collected inside the same second and agreed by luck. Four cores collect slowly enough to straddle the boundary, every time.

The pull request also adds the harness that found this, and `pytest-xdist` to the dev group. **It does not switch the suite to `-n 4`.** That is deliberate and is covered under sequencing below.

## Characterisation

#2230's parallelism comment measured `-n 4` three times on a laptop, saw two different tests fail, and said plainly that this is two points inside a boundary rather than one reproducible conflict. It then named what would make parallelism shippable, starting with running the suite many times on a CI runner and collecting every test that ever fails. That is what the harness does, and here is the result.

Run [34541967865](https://github.com/curie-eng/curie/actions/runs/34541967865), before these fixes: 20 of 20 attempts refused to run at all. No test data whatsoever.

Run [34542518036](https://github.com/curie-eng/curie/actions/runs/34542518036), after them: 20 of 20 ran, in 407s against 913s to 1048s serial. Four tests failed at least once.

| Failed | Test | |
| --- | --- | --- |
| 20/20 | `packages/test-support/tests/test_pytest_collection.py::test_all_test_directories_are_collected` | this pull request's own defect, fixed in it |
| 10/20 | `apps/api/tests/test_commitpoller.py::test_invalid_repo_full_name_is_skipped_without_blocking_valid_binding` | real |
| 4/20 | `apps/worker/tests/kernel/test_binding_integration.py::test_kill_interrupts_a_live_turn` | real |
| 1/20 | `apps/api/tests/test_publications.py::test_publication_credential_resolution_does_not_block_the_event_loop` | real |

The 1/20 is the point of doing this twenty times rather than three: a three sample study finds it one run in seven, which is exactly how a study lands on a different test each time. The three real ones are the set a follow-up would pin with `xdist_group`, and they are recorded here rather than acted on.

The 20/20 row is worth naming rather than hiding. `testpaths` did not list the harness's own test directory, so the suite never collected it and it passed only when run by explicit path. That is the defect class #2358 added the collection gate for, and the gate caught it on the first CI run that could see it.

## Sequencing, and why parallelism stops here

#2598 took the fix pin gate off the Python job, and on run [34541187675](https://github.com/curie-eng/curie/actions/runs/34541187675) that job went from 26.4 minutes to 17.5. It is now BELOW both E2E jobs in the same run: released chart upgrade at 19.2 and the cluster rung at 18.3. Python is no longer the critical path.

So parallelising the suite would not shorten what a contributor waits for, which is what this issue predicted from the start. It would cut total CI minutes, and it becomes worth landing the day the E2E floor moves. Until then the determinism fixes are worth having on their own account, because #2235 is a live defect in a gate this repository made mandatory, and the harness is worth having because rerunning it is now one push.

## Related issue

Closes #2235
Ref #2230

## Fix pin verification

## End-to-end verification

This change does not alter runtime behavior. It touches two test modules, `testpaths`, a dev-group dependency, and adds a workflow plus a tool that nothing in the product imports. No product source file is modified.

Scoped verification, all against eb1c6447:

- `uv run pytest tools/ release/tests -q` gives 631 passed, which includes the harness's own 11 tests and every workflow contract test.
- `uv run ruff check .` gives All checks passed, and `uv run mypy` gives Success: no issues found in 249 source files.
- Determinism, positively: `pytest --collect-only` on `apps/worker/tests/test_workspace.py` in two processes two seconds apart now yields byte identical node ids, `[traversal]`, `[absolute]`, `[link]`, `[special]`. Two seconds apart is the condition that broke the old gzip header.
- Falsifiable negative, and the strongest evidence here: run 34541967865 is the same harness against the unfixed tree, and it failed 20 of 20 attempts at collection. Run 34542518036 is the fixed tree, and it ran 20 of 20. The fix is pinned by a whole-suite before and after, not by an assertion.
- `packages/test-support/tests/test_pytest_collection.py` fails on this branch without the `testpaths` line and passes with it, confirmed serially.

The harness's own correctness is also pinned: it first rendered a total collection refusal as "4 test(s) failed" named `::gw0` through `::gw3`, making a suite that never ran look like a suite with a few loose tests. `test_a_refused_run_is_not_reported_as_flaky_tests` and `test_the_rate_divides_by_the_attempts_that_actually_ran` fail against that earlier behaviour.

## Note on the characterisation workflow

It triggers on pushes to `task/xdist-characterise*` and nothing else. It runs the whole suite twenty times and gates nothing, so it is kept off `pull_request` and off the release branches, and this pull request's own branch deliberately does not match the pattern. `workflow_dispatch` is not usable for it until it is on the default branch; once this merges, that becomes the better entry point and the trigger can narrow.

## Checklist

- [x] Tests pass for the area I touched.
- [x] Docs updated if behavior changed. No behavior change; the reasoning is in the test docstrings and the workflow comments.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. Not one: `docs/adr/AGENTS.md` puts CI configuration and build plumbing outside the ADR requirement.
