### PR TITLE
Make upgrade drill release identity version-agnostic

### DIFF
--- a/cli/scripts/upgrade-drill.sh
+++ b/cli/scripts/upgrade-drill.sh
@@ -141,6 +141,22 @@ verify_sha256() {
     echo "$want  $file" | sha256sum -c -
 }
 
+chart_version() {
+    awk '$1 == "version:" { print $2; exit }' "$1"
+}
+
+cli_version() {
+    awk -F '"' '$1 == "version = " { print $2; exit }' "$1"
+}
+
+release_identities_match() {
+    local chart="$1" cargo="$2" chart_identity cli_identity
+    [[ -f "$chart" && -f "$cargo" ]] || return 1
+    chart_identity="$(chart_version "$chart")"
+    cli_identity="$(cli_version "$cargo")"
+    [[ "$chart_identity" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ && "$chart_identity" == "$cli_identity" ]]
+}
+
 parse_args() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -160,7 +176,7 @@ parse_args() {
 }
 
 run_self_test() {
-    local failed=0 tmp
+    local failed=0 tmp identity mismatch_chart
     if is_soak_namespace "curie" && is_soak_namespace "default" && ! is_soak_namespace "acme-2426"; then
         log "soak namespace curie refused"
         log "soak namespace default refused"
@@ -216,13 +232,22 @@ run_self_test() {
         log "sha256 helper rejected a mismatched fixture"
     fi
     rm -f "$tmp"
-    if [[ -f "$REPO_ROOT/charts/curie/Chart.yaml" ]] \
-        && grep -q 'version: 0.8.7' "$REPO_ROOT/charts/curie/Chart.yaml"; then
-        log "candidate Chart.yaml left at 0.8.7 (no unauthorized identity bump)"
+    if release_identities_match "$REPO_ROOT/charts/curie/Chart.yaml" "$REPO_ROOT/cli/Cargo.toml"; then
+        identity="$(chart_version "$REPO_ROOT/charts/curie/Chart.yaml")"
+        log "candidate Chart.yaml and CLI identities match at $identity"
     else
-        log "self-test: Chart.yaml version pin drifted"
+        log "self-test: Chart.yaml and CLI identities drifted"
         failed=1
     fi
+    mismatch_chart="$(mktemp)"
+    printf '%s\n' 'version: 9.9.9' >"$mismatch_chart"
+    if release_identities_match "$mismatch_chart" "$REPO_ROOT/cli/Cargo.toml"; then
+        log "self-test: release identity guard accepted a mismatch"
+        failed=1
+    else
+        log "mismatched chart and CLI identities refused"
+    fi
+    rm -f "$mismatch_chart"
     local script_path="${BASH_SOURCE[0]}"
     if grep -q '^--set security.gvisor' "$script_path"; then
         log "self-test: image_sets must emit KEY=VAL lines, not combined --set tokens"
@@ -236,7 +261,7 @@ run_self_test() {
     (( failed == 0 )) || die "self-test failed"
     log "self-test passed"
     if (( JSON )); then
-        printf '%s\n' '{"status":"self-test","issue":2426,"baseline":"0.8.6","predecessor":"0.8.7","chart_identity":"0.8.7"}'
+        printf '{"status":"self-test","issue":2426,"baseline":"0.8.6","predecessor":"0.8.7","chart_identity":"%s"}\n' "$identity"
     fi
 }
 

--- a/cli/tests/upgrade_drill.rs
+++ b/cli/tests/upgrade_drill.rs
@@ -84,6 +84,10 @@ fn upgrade_drill_self_test_refuses_soak_unknown_scenario_and_missing_live() {
         "self-test must demonstrate the checksum guard rejecting a mismatch\n{text}"
     );
     assert!(
+        text.contains("mismatched chart and CLI identities refused"),
+        "self-test must demonstrate the release identity guard rejecting drift\n{text}"
+    );
+    assert!(
         text.contains("helm --set KEY=VAL tokens are split"),
         "self-test must pin split --set KEY=VAL argv tokens for the 0.8.6 CLI\n{text}"
     );


### PR DESCRIPTION
## Summary
- compare the chart and CLI release identities instead of hard-coding v0.8.7
- keep the identity guard fail-closed for malformed or mismatched versions
- execute a negative mismatch control in the upgrade-drill self-test

This is a prerequisite for the five-file v0.8.8 release candidate: synchronized Chart.yaml and Cargo.toml bumps must pass while one-sided drift must still fail.

## Test plan
- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked --test upgrade_drill`
- `bash cli/scripts/upgrade-drill.sh --self-test --json`
- `curie dev verify-fix-pin 613894a2 cli/tests/upgrade_drill.rs::upgrade_drill_self_test_refuses_soak_unknown_scenario_and_missing_live` -> PINNED