### PR TITLE
Record the cluster-tier and restart/handoff evidence for #2571

### DIFF
--- a/docs/guides/repository-toolchain-in-the-managed-sandbox.md
+++ b/docs/guides/repository-toolchain-in-the-managed-sandbox.md
@@ -82,7 +82,10 @@ completely, console scripts included. So the recipe is: **make the virtualenv
 where the repository already is.**
 
 The Kubernetes sandbox driver renders those same writable paths as `emptyDir`
-volumes, which are exec-able. A `/tmp` recipe would therefore pass on a cluster
+volumes, which are exec-able. That divergence is measured, not inferred: probing
+a cluster-tier sandbox on 2026-09-11 found `/tmp`, `/home/runner` and
+`/workspace` all exec-able, and the virtualenv's console scripts ran from every
+one of them. A `/tmp` recipe would therefore pass on a cluster
 and fail on local Compose — a difference that would only ever be discovered by
 whoever ran it locally last. `/workspace` is correct on both, so it is the only
 location this guide documents.
@@ -222,12 +225,12 @@ What the committed evidence does and does not cover.
 | Surface | Applicability | Evidence |
 |---|---|---|
 | local (Docker sandbox driver) | **Supported and proved.** | The proof harness runs every step in the real runner image under the driver's own isolation flags: vendored install, the documented check red → green → red across a fix and its revert, both negative controls, and a read-only-rootfs control. |
-| cluster (Kubernetes sandbox driver) | **Applies by posture, not proved here.** | The chart renders the same writable paths (`/tmp`, `/home/runner`) as `emptyDir`, and `/workspace` is the same mounted checkout, so the venv-in-`/workspace` recipe is posture-identical. No cluster-tier run is included in this evidence. |
+| cluster (Kubernetes sandbox driver) | **Supported and proved.** | Run on a kind cluster against the released `curie-runner:0.8.7` image on 2026-09-11: two independently claimed sandboxes each installed the dependency offline and ran the documented check red → green → red. See `ac5-cluster-evidence/`. |
 | live provider | **Not covered.** | The harness makes no model call. The recipe is about the toolchain, not the session. |
 | slack | **Not covered.** | No Slack external-integration run is included. The publication approval a Slack thread would carry is asserted statically here, not exercised. |
 | GitHub | **Boundary asserted statically.** | The credential handling in section 5 is read from the worker's workspace acquisition path and the publication tool's contract; no live human publication approval was exercised. |
-| Profile B against an enforcing NetworkPolicy | **Documented, not proved.** | Proving that a hand-written `--allow-web-egress` CIDR really admits PyPI requires a cluster with an enforcing NetworkPolicy. |
-| repeat in a newly acquired workspace, and after restart/handoff | **Open.** | Not demonstrated by this evidence. Treat it as unproved rather than as working. |
+| Profile B against an enforcing NetworkPolicy | **Refusal proved; admission not.** | Under the chart's fail-closed default, a live-registry install fails truthfully (`Network is unreachable`, exit 1) — but only after **~368 s**, pip's default retry budget. That a hand-written `--allow-web-egress` CIDR then *admits* PyPI is still unproved. |
+| repeat in a newly acquired workspace, and after restart/handoff | **Supported and proved.** | A second, independently claimed sandbox reproduced the whole recipe from the acquired head with no state carried over, producing its own distinct commits. An in-place container restart preserved the workspace, its three-commit history, the expected head and the credential-free origin. A *pod-replacing* handoff is still unproved: it would discard all `emptyDir` state and re-fetch the workspace from the signed archive. |
 
 Every container the harness starts is `--rm` and every workspace it creates is a
 temporary directory; it asserts observably that neither survives the run.

--- a/runner/tests/test_repo_toolchain_proof.py
+++ b/runner/tests/test_repo_toolchain_proof.py
@@ -930,7 +930,7 @@ _HONESTY_ROWS: tuple[tuple[str, str, str], ...] = (
     (
         "Profile B against an enforcing NetworkPolicy",
         r"profile\s*b.*(networkpolicy|network\s*policy|egress)",
-        r"not\s+proved|not\s+covered|open\b",
+        r"not\s+proved|not\s+covered|unproved|open\b",
     ),
     (
         "repeat in a new workspace / after restart or handoff",


### PR DESCRIPTION
Follow-up to #2595, which landed the recipe, the proof harness and the operator guide but left three applicability rows open because that run had no authorization to claim a live sandbox.

Those rows were closed interactively with the maintainer on a live kind cluster, against the **released** `ghcr.io/curie-eng/curie-runner:0.8.7` image, with the repository delivered by the product's own `workspace-init` signed-archive fetcher rather than staged by hand.

## What was proved

| Gate | Result |
|---|---|
| Cluster tier | Recipe installs offline and runs the documented check |
| AC 5 — newly acquired workspace | Second, independently claimed sandbox reproduced red → green → red from the acquired head with no state carried over, producing its own distinct commits — an independent execution, not a replay |
| AC 5 — restart/handoff | In-place container restart preserved the three-commit history, the expected head, the credential-free origin and the virtualenv |
| `noexec` divergence | `/tmp`, `/home/runner` and `/workspace` are all `emptyDir` and all exec-able at cluster tier, exactly as the guide predicted |

Negative evidence at cluster tier: wrong registry exit 1 in 8 s; missing toolchain exit 127; `git push` exit 128 with `gh` absent and zero credentials in `.git/config` or the environment.

## What deliberately stays open

- **Profile B admission.** The *refusal* under the chart's fail-closed default is now proved (exit 1, `Network is unreachable`) — but only after **~368 s**, pip's default retry budget. That a hand-written `--allow-web-egress` CIDR then *admits* PyPI is still unproved.
- **Pod-replacing handoff.** Only an in-place container restart was exercised. A pod replacement would discard all `emptyDir` state and re-fetch from the signed archive.
- Live provider, Slack, and human GitHub publication approval remain uncovered.

The guide-drift test caught the first draft of this change overclaiming on the Profile B row — which is the behaviour it exists for. Its marker is widened to accept `unproved` so the row must still admit what is missing.

## Findings worth their own tickets

1. `SandboxClaim.spec.env` reaches **only** the runner container; the template's init containers keep their own `valueFrom` entries, so a hand-written claim cannot stage a plugin bundle or a workspace. That staging is worker-side only.
2. NetworkPolicy **is** enforced on this kind cluster — an unlabeled pod could not reach `curie-rustfs:9000`.

## Checks

- `uv run pytest runner/tests/test_repo_toolchain_proof.py runner/tests/test_publish_verification_contract.py -q` → 13 passed (container legs included)
- `uv run ruff check .` → clean
- `bash scripts/check-docs.sh` → OK

## Cleanup

Both claims, the proof-owned SandboxTemplate and WarmPool, the upload pod and both S3 objects were deleted and verified gone. The install was not mutated: `curie-runner` template and pool resourceVersions unchanged, all 11 workload pods still Running.