### PR TITLE
Summarize verification phase timing from existing run state

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,7 @@ testpaths = [
     "tools/ci-release-target-parity/tests",
     "tools/restore-drill/tests",
     "tools/sre-contract/tests",
+    "tools/verification-timing/tests",
 ]
 
 [tool.ruff]

--- a/tools/verification-timing/README.md
+++ b/tools/verification-timing/README.md
@@ -61,10 +61,22 @@ over sparse data is honest about its own sample size: `observed_count` and
 `unknown_count` sit next to each other in every phase total, and a phase nobody
 measured reports `null` totals rather than a confident `0`.
 
-A malformed record — a negative duration, a non-numeric duration, a completion
-before its start, an unrecognised phase name — aborts the load naming the
-offending file and phase. It is never skipped silently, because a quietly
-dropped row is indistinguishable from a fast one.
+A malformed record aborts the load, naming the offending file and phase. It is
+never skipped silently, because a quietly dropped row is indistinguishable from
+a fast one. Rejected as malformed: a negative, non-numeric, non-finite
+(`NaN`/infinity) or unrepresentably large duration; a completion before its
+start; a date-only timestamp, which would make a guessed midnight look like a
+measured zero; a timestamp pair mixing a timezone-aware endpoint with a naive
+one, since the missing offset cannot be guessed; an unrecognised phase name; a
+corrupt `e2e` or `e2e.evidence` container, which would otherwise drop a whole
+file's rows from a combined summary; and an evidence entry missing any of
+`tier`, `command` or `commit`, whose absence would let unrelated candidates
+collapse into one duplicate group. An absent `e2e` key and an empty
+`"evidence": []` are not malformed — they simply contribute no rows.
+
+The `source` reported for each row and duplicate group is the state file's bare
+name, never its local absolute path; error messages keep the full path, because
+a diagnosis needs it.
 
 ## Running it
 

--- a/tools/verification-timing/README.md
+++ b/tools/verification-timing/README.md
@@ -1,0 +1,107 @@
+# verification-timing
+
+A lightweight, offline summary of how much wall-clock time the verification
+phases of an `/implement` run actually consumed. It reads the run-state files
+this repository already writes and reports what was measured.
+
+It is **not** an observability product, **not** a monitoring backend, and it
+performs **no** historical scan of its own. It has no runtime dependency, adds
+nothing to the shipped product, and reads only the files you hand it.
+
+## The optional `timings` block
+
+Each entry of `e2e.evidence` in a run-state file may carry an optional
+`timings` object. It is backward compatible: a run-state written without it
+loads fine and reports every phase as unknown.
+
+```json
+{
+  "tier": "skill",
+  "command": "uv run pytest tests/test_example.py",
+  "commit": "0000000000000000000000000000000000000000",
+  "timings": {
+    "startup": { "started_at": "2026-01-01T00:00:00Z", "completed_at": "2026-01-01T00:00:30Z" },
+    "tests": { "seconds": 44.0 },
+    "cleanup": { "seconds": 3.5 },
+    "retries": { "count": 1, "seconds": 12.0 },
+    "external_wait": null
+  }
+}
+```
+
+A phase records either `seconds`, or a `started_at`/`completed_at` pair, or
+both (they must agree to within one second, or the record is rejected). The
+five phases are:
+
+- **startup** — bringing the environment up before any test executes: image
+  pulls, stack boot, dependency install, fixture provisioning.
+- **tests** — executing the test command itself, and nothing else.
+- **cleanup** — tearing the environment back down afterwards.
+- **retries** — time spent re-running work that had already been attempted.
+  `count` is the number of retries and is aggregated separately from duration.
+- **external_wait** — blocked on something outside the run: a queued CI runner,
+  a third-party endpoint, a rate limit.
+
+`startup` is recorded separately from `tests` on purpose. Conflating the two is
+precisely what makes a savings claim unfalsifiable — a change that only moves
+work from one bucket to the other looks identical to a change that removes the
+work, and nobody can tell the difference from a single combined number.
+
+## Observed-only
+
+Missing historical timing **remains unknown**. The summarizer never backfills a
+guess: an unmeasured phase is reported as `{"seconds": null, "provenance":
+"unknown"}` and is excluded from every count, sum, median and percentile.
+Provenance is `timestamps` when the duration came from a timestamp pair,
+`seconds` when it came from a declared duration, and `unknown` when there was
+no measurement at all.
+
+Because unknown phases are counted as unknown rather than as zero, a summary
+over sparse data is honest about its own sample size: `observed_count` and
+`unknown_count` sit next to each other in every phase total, and a phase nobody
+measured reports `null` totals rather than a confident `0`.
+
+A malformed record — a negative duration, a non-numeric duration, a completion
+before its start, an unrecognised phase name — aborts the load naming the
+offending file and phase. It is never skipped silently, because a quietly
+dropped row is indistinguishable from a fast one.
+
+## Running it
+
+Summarize one file, or every `*.state.json` in a directory:
+
+```bash
+uv run python tools/verification-timing/summarize_timings.py path/to/run.state.json
+```
+
+The tool prints a deterministic JSON summary (`json.dumps(..., sort_keys=True,
+indent=2)`) and exits 0, or exits 2 and prints nothing to stdout if any input
+record is malformed.
+
+Its test suite:
+
+```bash
+uv run pytest tools/verification-timing/tests
+```
+
+## Three-stage evidence contract
+
+This tool is stage 1 of a staged pilot:
+
+- **Stage 1 (this change)** — measurement and reporting support. Focused checks
+  only.
+- **Stage 2** — a development-only approval integration slice. Focused checks
+  only.
+- **Stage 3** — the structured development command, the complete failure
+  scenarios, and the FULL assembled verification for all three diffs together,
+  run against the final combined candidate.
+
+Stages 1 and 2 carry an explicit verification **debt**. Each one runs focused
+test-first checks plus review, and neither is independently merge-ready on its
+own. The full applicable repository baseline and the union of the required
+tiers are owed by stage 3, run against the assembled candidate.
+
+This staging is a specific, maintainer-authorized exception for this one pilot.
+It changes no repository-wide verification mandate: the tier rules in
+`AGENTS.md` remain in force, and a fake result never substitutes for a required
+real tier.

--- a/tools/verification-timing/summarize_timings.py
+++ b/tools/verification-timing/summarize_timings.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import re
 import statistics
 import sys
 from collections.abc import Sequence
@@ -26,6 +27,13 @@ PHASE_FIELDS = frozenset({"seconds", "started_at", "completed_at", "count"})
 # larger means one of the two is describing a different span, and guessing which
 # one is authoritative would be exactly the invention this tool exists to refuse.
 AGREEMENT_TOLERANCE_SECONDS = 1.0
+# A timestamp with no time component is a date, not an instant. Accepting one
+# would let two identical dates subtract to a confident 0.0 seconds -- a guessed
+# midnight wearing the provenance of a real measurement.
+_TIME_COMPONENT = re.compile(r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}")
+# Identity fields. Without all three, unrelated candidates would collapse into
+# one duplicate group under a shared empty key.
+IDENTITY_FIELDS = ("tier", "command", "commit")
 
 
 class TimingRecordError(ValueError):
@@ -69,16 +77,25 @@ def _fail(source: Path, phase: str, reason: str) -> TimingRecordError:
     return TimingRecordError(f"{source}: phase '{phase}': {reason}")
 
 
-def _number(value: object) -> float | None:
+def _number(source: Path, phase: str, value: object) -> float | None:
     # bool is an int subclass; a flag is never a duration.
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return None
-    return float(value)
+    try:
+        number = float(value)
+    except OverflowError as exc:
+        # A huge JSON integer has no float representation; it is not a duration.
+        raise _fail(source, phase, "seconds is too large to be a duration") from exc
+    if not math.isfinite(number):
+        raise _fail(source, phase, "seconds must be a finite number")
+    return number
 
 
 def _timestamp(source: Path, phase: str, field: str, value: object) -> datetime:
     if not isinstance(value, str):
         raise _fail(source, phase, f"{field} must be an ISO 8601 string")
+    if not _TIME_COMPONENT.match(value):
+        raise _fail(source, phase, f"{field} must carry a time component, not a date alone")
     try:
         return datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError as exc:
@@ -88,6 +105,15 @@ def _timestamp(source: Path, phase: str, field: str, value: object) -> datetime:
 def _string(source: Path, field: str, value: object) -> str:
     if not isinstance(value, str):
         raise TimingRecordError(f"{source}: evidence field '{field}' must be a string")
+    return value
+
+
+def _identity(source: Path, field: str, entry: dict[str, Any]) -> str:
+    if field not in entry:
+        raise TimingRecordError(f"{source}: evidence field '{field}' is required")
+    value = _string(source, field, entry[field]).strip()
+    if not value:
+        raise TimingRecordError(f"{source}: evidence field '{field}' must not be empty")
     return value
 
 
@@ -114,7 +140,7 @@ def _parse_phase(source: Path, phase: str, raw: object) -> tuple[PhaseTiming, in
     declared = raw.get("seconds")
     seconds: float | None = None
     if declared is not None:
-        seconds = _number(declared)
+        seconds = _number(source, phase, declared)
         if seconds is None:
             raise _fail(source, phase, "seconds must be a number")
         if seconds < 0:
@@ -126,6 +152,13 @@ def _parse_phase(source: Path, phase: str, raw: object) -> tuple[PhaseTiming, in
             raise _fail(source, phase, "started_at and completed_at must both be present")
         started = _timestamp(source, phase, "started_at", raw["started_at"])
         completed = _timestamp(source, phase, "completed_at", raw["completed_at"])
+        if (started.tzinfo is None) != (completed.tzinfo is None):
+            # Never guess the missing zone: the offset could be anything.
+            raise _fail(
+                source,
+                phase,
+                "started_at and completed_at must both be timezone-aware or both naive",
+            )
         measured = (completed - started).total_seconds()
         if measured < 0:
             raise _fail(source, phase, "completed_at precedes started_at")
@@ -170,10 +203,12 @@ def _parse_entry(source: Path, entry: object) -> TimingRecord:
             retry_count = count
 
     return TimingRecord(
-        source=str(source),
-        tier=_string(source, "tier", entry.get("tier", "")),
-        command=_string(source, "command", entry.get("command", "")),
-        commit=_string(source, "commit", entry.get("commit", "")),
+        # Only the bare file name reaches the summary; a local absolute path is
+        # an environment detail, and error messages keep the full path instead.
+        source=source.name,
+        tier=_identity(source, "tier", entry),
+        command=_identity(source, "command", entry),
+        commit=_identity(source, "commit", entry),
         mode=_string(source, "mode", entry.get("mode", "")),
         outcome=_string(source, "outcome", entry.get("outcome", "")),
         timings=timings,
@@ -188,10 +223,16 @@ def _load_file(path: Path) -> list[TimingRecord]:
         raise TimingRecordError(f"{path}: could not be read as JSON: {exc}") from exc
     if not isinstance(document, dict):
         raise TimingRecordError(f"{path}: run-state must be a JSON object")
-    e2e = document.get("e2e") or {}
+    # Type-check before defaulting: `or {}` would turn `false` into a silent
+    # zero-row success, quietly dropping a corrupt file from a combined summary.
+    e2e = document.get("e2e", {})
+    if e2e is None:
+        e2e = {}
     if not isinstance(e2e, dict):
         raise TimingRecordError(f"{path}: run-state field 'e2e' must be an object")
-    evidence = e2e.get("evidence") or []
+    evidence = e2e.get("evidence", [])
+    if evidence is None:
+        evidence = []
     if not isinstance(evidence, list):
         raise TimingRecordError(f"{path}: run-state field 'e2e.evidence' must be a list")
     return [_parse_entry(path, entry) for entry in evidence]

--- a/tools/verification-timing/summarize_timings.py
+++ b/tools/verification-timing/summarize_timings.py
@@ -31,9 +31,7 @@ AGREEMENT_TOLERANCE_SECONDS = 1.0
 # would let two identical dates subtract to a confident 0.0 seconds -- a guessed
 # midnight wearing the provenance of a real measurement.
 _TIME_COMPONENT = re.compile(r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}")
-# Identity fields. Without all three, unrelated candidates would collapse into
-# one duplicate group under a shared empty key.
-IDENTITY_FIELDS = ("tier", "command", "commit")
+_SHAPES: dict[type, str] = {dict: "an object", list: "a list"}
 
 
 class TimingRecordError(ValueError):
@@ -77,10 +75,23 @@ def _fail(source: Path, phase: str, reason: str) -> TimingRecordError:
     return TimingRecordError(f"{source}: phase '{phase}': {reason}")
 
 
-def _number(source: Path, phase: str, value: object) -> float | None:
+def _container(source: Path, label: str, value: object, expected: type, default: Any) -> Any:
+    """Resolve an optional container: absent or null is the default, wrong type is fatal.
+
+    The type check comes before the default so that a corrupt value (``false``,
+    a string) aborts instead of collapsing into a silent empty success.
+    """
+    if value is None:
+        return default
+    if not isinstance(value, expected):
+        raise TimingRecordError(f"{source}: {label} must be {_SHAPES[expected]}")
+    return value
+
+
+def _number(source: Path, phase: str, value: object) -> float:
     # bool is an int subclass; a flag is never a duration.
     if isinstance(value, bool) or not isinstance(value, (int, float)):
-        return None
+        raise _fail(source, phase, "seconds must be a number")
     try:
         number = float(value)
     except OverflowError as exc:
@@ -111,38 +122,42 @@ def _string(source: Path, field: str, value: object) -> str:
 def _identity(source: Path, field: str, entry: dict[str, Any]) -> str:
     if field not in entry:
         raise TimingRecordError(f"{source}: evidence field '{field}' is required")
+    # Without a non-empty identity, unrelated candidates would collapse into one
+    # duplicate group under a shared empty key.
     value = _string(source, field, entry[field]).strip()
     if not value:
         raise TimingRecordError(f"{source}: evidence field '{field}' must not be empty")
     return value
 
 
-def _parse_phase(source: Path, phase: str, raw: object) -> tuple[PhaseTiming, int | None]:
+def _retry_count(source: Path, raw: object) -> int | None:
+    """Read the retries count, which is a tally rather than a duration."""
+    if not isinstance(raw, dict) or "count" not in raw:
+        return None
+    count = raw["count"]
+    if isinstance(count, bool) or not isinstance(count, int):
+        raise _fail(source, "retries", "count must be an integer")
+    if count < 0:
+        raise _fail(source, "retries", "count must not be negative")
+    return count
+
+
+def _parse_phase(source: Path, phase: str, raw: object) -> PhaseTiming:
     if raw is None:
-        return PhaseTiming(None, "unknown"), None
+        return PhaseTiming(None, "unknown")
     if not isinstance(raw, dict):
         raise _fail(source, phase, "must be an object or null")
     unknown_fields = sorted(set(raw).difference(PHASE_FIELDS))
     if unknown_fields:
         raise _fail(source, phase, f"unknown fields: {', '.join(unknown_fields)}")
 
-    count: int | None = None
-    if "count" in raw:
-        if phase != "retries":
-            raise _fail(source, phase, "count is only meaningful on the retries phase")
-        raw_count = raw["count"]
-        if isinstance(raw_count, bool) or not isinstance(raw_count, int):
-            raise _fail(source, phase, "count must be an integer")
-        if raw_count < 0:
-            raise _fail(source, phase, "count must not be negative")
-        count = raw_count
+    if "count" in raw and phase != "retries":
+        raise _fail(source, phase, "count is only meaningful on the retries phase")
 
     declared = raw.get("seconds")
     seconds: float | None = None
     if declared is not None:
         seconds = _number(source, phase, declared)
-        if seconds is None:
-            raise _fail(source, phase, "seconds must be a number")
         if seconds < 0:
             raise _fail(source, phase, "seconds must not be negative")
 
@@ -163,44 +178,41 @@ def _parse_phase(source: Path, phase: str, raw: object) -> tuple[PhaseTiming, in
         if measured < 0:
             raise _fail(source, phase, "completed_at precedes started_at")
 
-    if seconds is not None and measured is not None:
-        if abs(seconds - measured) > AGREEMENT_TOLERANCE_SECONDS:
-            raise _fail(
-                source,
-                phase,
-                f"seconds ({seconds}) disagrees with the timestamp span ({measured})",
-            )
-        return PhaseTiming(measured, "timestamps"), count
+    if (
+        seconds is not None
+        and measured is not None
+        and abs(seconds - measured) > AGREEMENT_TOLERANCE_SECONDS
+    ):
+        raise _fail(
+            source,
+            phase,
+            f"seconds ({seconds}) disagrees with the timestamp span ({measured})",
+        )
+    # Timestamps win: they bound a real span, where a declared duration only
+    # asserts one.
     if measured is not None:
-        return PhaseTiming(measured, "timestamps"), count
+        return PhaseTiming(measured, "timestamps")
     if seconds is not None:
-        return PhaseTiming(seconds, "seconds"), count
+        return PhaseTiming(seconds, "seconds")
     # No measurement of any kind: stays unknown, never zero, and never inherits
     # a value from a sibling phase or a neighbouring row.
-    return PhaseTiming(None, "unknown"), count
+    return PhaseTiming(None, "unknown")
 
 
 def _parse_entry(source: Path, entry: object) -> TimingRecord:
     if not isinstance(entry, dict):
         raise TimingRecordError(f"{source}: evidence entries must be objects")
-    raw_timings = entry.get("timings")
-    if raw_timings is None:
-        raw_timings = {}
-    if not isinstance(raw_timings, dict):
-        raise TimingRecordError(f"{source}: evidence field 'timings' must be an object")
+    raw_timings: dict[str, Any] = _container(
+        source, "evidence field 'timings'", entry.get("timings"), dict, {}
+    )
     unknown_phases = sorted(set(raw_timings).difference(PHASES))
     if unknown_phases:
         raise TimingRecordError(
             f"{source}: phase '{unknown_phases[0]}': not a recognised verification phase"
         )
 
-    timings: dict[str, PhaseTiming] = {}
-    retry_count: int | None = None
-    for phase in PHASES:
-        timing, count = _parse_phase(source, phase, raw_timings.get(phase))
-        timings[phase] = timing
-        if count is not None:
-            retry_count = count
+    timings = {phase: _parse_phase(source, phase, raw_timings.get(phase)) for phase in PHASES}
+    retry_count = _retry_count(source, raw_timings.get("retries"))
 
     return TimingRecord(
         # Only the bare file name reaches the summary; a local absolute path is
@@ -223,18 +235,10 @@ def _load_file(path: Path) -> list[TimingRecord]:
         raise TimingRecordError(f"{path}: could not be read as JSON: {exc}") from exc
     if not isinstance(document, dict):
         raise TimingRecordError(f"{path}: run-state must be a JSON object")
-    # Type-check before defaulting: `or {}` would turn `false` into a silent
-    # zero-row success, quietly dropping a corrupt file from a combined summary.
-    e2e = document.get("e2e", {})
-    if e2e is None:
-        e2e = {}
-    if not isinstance(e2e, dict):
-        raise TimingRecordError(f"{path}: run-state field 'e2e' must be an object")
-    evidence = e2e.get("evidence", [])
-    if evidence is None:
-        evidence = []
-    if not isinstance(evidence, list):
-        raise TimingRecordError(f"{path}: run-state field 'e2e.evidence' must be a list")
+    e2e: dict[str, Any] = _container(path, "run-state field 'e2e'", document.get("e2e"), dict, {})
+    evidence: list[Any] = _container(
+        path, "run-state field 'e2e.evidence'", e2e.get("evidence"), list, []
+    )
     return [_parse_entry(path, entry) for entry in evidence]
 
 

--- a/tools/verification-timing/summarize_timings.py
+++ b/tools/verification-timing/summarize_timings.py
@@ -1,0 +1,309 @@
+"""Summarize observed verification phase durations from /implement run-state files.
+
+The summarizer reads the optional ``timings`` block on each ``e2e.evidence``
+entry of a ``.state.json`` run-state file and reports per-phase totals. It is
+observed-only: a phase that was never measured is reported as unknown and is
+excluded from every count, sum, median and percentile.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+PHASES = ("startup", "tests", "cleanup", "retries", "external_wait")
+PHASE_FIELDS = frozenset({"seconds", "started_at", "completed_at", "count"})
+# A ``seconds`` value and a timestamp pair are two independent measurements of
+# the same phase. Sub-second disagreement is clock and rounding noise; anything
+# larger means one of the two is describing a different span, and guessing which
+# one is authoritative would be exactly the invention this tool exists to refuse.
+AGREEMENT_TOLERANCE_SECONDS = 1.0
+
+
+class TimingRecordError(ValueError):
+    """A run-state timing record is malformed and cannot be trusted."""
+
+
+@dataclass(frozen=True)
+class PhaseTiming:
+    """One phase of one evidence row, with how its duration was established."""
+
+    seconds: float | None
+    provenance: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"seconds": self.seconds, "provenance": self.provenance}
+
+
+@dataclass(frozen=True)
+class TimingRecord:
+    """One evidence row, reduced to its structured, non-free-text fields."""
+
+    source: str
+    tier: str
+    command: str
+    commit: str
+    mode: str
+    outcome: str
+    timings: dict[str, PhaseTiming]
+    retry_count: int | None
+
+    @property
+    def identity(self) -> tuple[str, str, str]:
+        return (self.tier, self.command, self.commit)
+
+    @property
+    def sort_key(self) -> tuple[str, ...]:
+        return (self.command, self.commit, self.tier, self.mode, self.outcome, self.source)
+
+
+def _fail(source: Path, phase: str, reason: str) -> TimingRecordError:
+    return TimingRecordError(f"{source}: phase '{phase}': {reason}")
+
+
+def _number(value: object) -> float | None:
+    # bool is an int subclass; a flag is never a duration.
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _timestamp(source: Path, phase: str, field: str, value: object) -> datetime:
+    if not isinstance(value, str):
+        raise _fail(source, phase, f"{field} must be an ISO 8601 string")
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise _fail(source, phase, f"{field} is not a valid ISO 8601 timestamp") from exc
+
+
+def _string(source: Path, field: str, value: object) -> str:
+    if not isinstance(value, str):
+        raise TimingRecordError(f"{source}: evidence field '{field}' must be a string")
+    return value
+
+
+def _parse_phase(source: Path, phase: str, raw: object) -> tuple[PhaseTiming, int | None]:
+    if raw is None:
+        return PhaseTiming(None, "unknown"), None
+    if not isinstance(raw, dict):
+        raise _fail(source, phase, "must be an object or null")
+    unknown_fields = sorted(set(raw).difference(PHASE_FIELDS))
+    if unknown_fields:
+        raise _fail(source, phase, f"unknown fields: {', '.join(unknown_fields)}")
+
+    count: int | None = None
+    if "count" in raw:
+        if phase != "retries":
+            raise _fail(source, phase, "count is only meaningful on the retries phase")
+        raw_count = raw["count"]
+        if isinstance(raw_count, bool) or not isinstance(raw_count, int):
+            raise _fail(source, phase, "count must be an integer")
+        if raw_count < 0:
+            raise _fail(source, phase, "count must not be negative")
+        count = raw_count
+
+    declared = raw.get("seconds")
+    seconds: float | None = None
+    if declared is not None:
+        seconds = _number(declared)
+        if seconds is None:
+            raise _fail(source, phase, "seconds must be a number")
+        if seconds < 0:
+            raise _fail(source, phase, "seconds must not be negative")
+
+    measured: float | None = None
+    if raw.get("started_at") is not None or raw.get("completed_at") is not None:
+        if raw.get("started_at") is None or raw.get("completed_at") is None:
+            raise _fail(source, phase, "started_at and completed_at must both be present")
+        started = _timestamp(source, phase, "started_at", raw["started_at"])
+        completed = _timestamp(source, phase, "completed_at", raw["completed_at"])
+        measured = (completed - started).total_seconds()
+        if measured < 0:
+            raise _fail(source, phase, "completed_at precedes started_at")
+
+    if seconds is not None and measured is not None:
+        if abs(seconds - measured) > AGREEMENT_TOLERANCE_SECONDS:
+            raise _fail(
+                source,
+                phase,
+                f"seconds ({seconds}) disagrees with the timestamp span ({measured})",
+            )
+        return PhaseTiming(measured, "timestamps"), count
+    if measured is not None:
+        return PhaseTiming(measured, "timestamps"), count
+    if seconds is not None:
+        return PhaseTiming(seconds, "seconds"), count
+    # No measurement of any kind: stays unknown, never zero, and never inherits
+    # a value from a sibling phase or a neighbouring row.
+    return PhaseTiming(None, "unknown"), count
+
+
+def _parse_entry(source: Path, entry: object) -> TimingRecord:
+    if not isinstance(entry, dict):
+        raise TimingRecordError(f"{source}: evidence entries must be objects")
+    raw_timings = entry.get("timings")
+    if raw_timings is None:
+        raw_timings = {}
+    if not isinstance(raw_timings, dict):
+        raise TimingRecordError(f"{source}: evidence field 'timings' must be an object")
+    unknown_phases = sorted(set(raw_timings).difference(PHASES))
+    if unknown_phases:
+        raise TimingRecordError(
+            f"{source}: phase '{unknown_phases[0]}': not a recognised verification phase"
+        )
+
+    timings: dict[str, PhaseTiming] = {}
+    retry_count: int | None = None
+    for phase in PHASES:
+        timing, count = _parse_phase(source, phase, raw_timings.get(phase))
+        timings[phase] = timing
+        if count is not None:
+            retry_count = count
+
+    return TimingRecord(
+        source=str(source),
+        tier=_string(source, "tier", entry.get("tier", "")),
+        command=_string(source, "command", entry.get("command", "")),
+        commit=_string(source, "commit", entry.get("commit", "")),
+        mode=_string(source, "mode", entry.get("mode", "")),
+        outcome=_string(source, "outcome", entry.get("outcome", "")),
+        timings=timings,
+        retry_count=retry_count,
+    )
+
+
+def _load_file(path: Path) -> list[TimingRecord]:
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise TimingRecordError(f"{path}: could not be read as JSON: {exc}") from exc
+    if not isinstance(document, dict):
+        raise TimingRecordError(f"{path}: run-state must be a JSON object")
+    e2e = document.get("e2e") or {}
+    if not isinstance(e2e, dict):
+        raise TimingRecordError(f"{path}: run-state field 'e2e' must be an object")
+    evidence = e2e.get("evidence") or []
+    if not isinstance(evidence, list):
+        raise TimingRecordError(f"{path}: run-state field 'e2e.evidence' must be a list")
+    return [_parse_entry(path, entry) for entry in evidence]
+
+
+def _expand(target: Path) -> list[Path]:
+    if target.is_dir():
+        return sorted(target.glob("*.state.json"))
+    return [target]
+
+
+def load_records(targets: Sequence[Path | str]) -> list[TimingRecord]:
+    """Load every evidence row from the given run-state files or directories."""
+    records: list[TimingRecord] = []
+    for target in targets:
+        for path in _expand(Path(target)):
+            records.extend(_load_file(path))
+    return records
+
+
+def _percentile(values: list[float], fraction: float) -> float:
+    """Nearest-rank percentile over an already sorted, non-empty sample."""
+    rank = max(1, math.ceil(fraction * len(values)))
+    return values[rank - 1]
+
+
+def _phase_totals(records: Sequence[TimingRecord], phase: str) -> dict[str, Any]:
+    observed = sorted(
+        timing.seconds
+        for timing in (record.timings[phase] for record in records)
+        if timing.seconds is not None
+    )
+    unknown_count = len(records) - len(observed)
+    if not observed:
+        return {
+            "observed_count": 0,
+            "unknown_count": unknown_count,
+            "total_seconds": None,
+            "median_seconds": None,
+            "p90_seconds": None,
+        }
+    return {
+        "observed_count": len(observed),
+        "unknown_count": unknown_count,
+        "total_seconds": math.fsum(observed),
+        "median_seconds": statistics.median(observed),
+        "p90_seconds": _percentile(observed, 0.9),
+    }
+
+
+def _duplicate_groups(records: Sequence[TimingRecord]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str, str], list[TimingRecord]] = {}
+    for record in records:
+        grouped.setdefault(record.identity, []).append(record)
+    # Repeated (tier, command, commit) rows are reported as a group rather than
+    # collapsed: two runs of the same command are two observations, and merging
+    # them would silently discard one real measurement.
+    return [
+        {
+            "tier": tier,
+            "command": command,
+            "commit": commit,
+            "row_count": len(members),
+            "sources": sorted(member.source for member in members),
+        }
+        for (tier, command, commit), members in sorted(grouped.items())
+        if len(members) > 1
+    ]
+
+
+def summarize(records: Sequence[TimingRecord]) -> dict[str, Any]:
+    """Build the deterministic, observed-only summary for the loaded rows."""
+    ordered = sorted(records, key=lambda record: record.sort_key)
+    declared_retries = [record.retry_count for record in ordered if record.retry_count is not None]
+    return {
+        "row_count": len(ordered),
+        "rows": [
+            {
+                "source": record.source,
+                "tier": record.tier,
+                "command": record.command,
+                "commit": record.commit,
+                "mode": record.mode,
+                "outcome": record.outcome,
+                "timings": {phase: record.timings[phase].as_dict() for phase in PHASES},
+            }
+            for record in ordered
+        ],
+        "phase_totals": {phase: _phase_totals(ordered, phase) for phase in PHASES},
+        # No row declared a retry count, so the number of retries is unknown --
+        # which is not the same claim as "there were zero retries".
+        "retry_total_count": sum(declared_retries) if declared_retries else None,
+        "duplicate_groups": _duplicate_groups(ordered),
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("targets", nargs="+", type=Path, help="run-state files or directories")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        summary = summarize(load_records(args.targets))
+    except TimingRecordError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(summary, sort_keys=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verification-timing/tests/test_summarize_timings.py
+++ b/tools/verification-timing/tests/test_summarize_timings.py
@@ -380,3 +380,215 @@ def test_cli_exits_two_and_prints_no_summary_on_a_malformed_file(
     assert module.main([str(tmp_path)]) == 2
     captured = capsys.readouterr()
     assert captured.out.strip() == ""
+
+
+# --- Gaps found by adversarial cross-engine review -------------------------
+
+
+def _raw_state(tmp_path: Path, name: str, body: str) -> Path:
+    """Write a state file verbatim, so non-standard JSON literals survive."""
+    path = tmp_path / f"{name}.state.json"
+    path.write_text(body)
+    return path
+
+
+def _raw_entry(timings: str) -> str:
+    return (
+        '{"tier": "skill", "criterion": "synthetic criterion", '
+        f'"command": "{COMMAND}", "commit": "{COMMIT_A}", '
+        '"mode": "fake", "outcome": "pass", "observed": "OBSERVED_SENTINEL", '
+        '"negative": null, "teardown": null, "blocker": null, '
+        f'"timings": {timings}}}'
+    )
+
+
+def _raw_document(entry: str) -> str:
+    return (
+        '{"branch": "task/raw", "ticket": "1234", '
+        f'"commit": "{COMMIT_A}", "e2e": {{"evidence": [{entry}]}}}}'
+    )
+
+
+@pytest.mark.parametrize(
+    "literal",
+    [
+        pytest.param("NaN", id="nan"),
+        pytest.param("Infinity", id="infinity"),
+        pytest.param("-Infinity", id="negative-infinity"),
+        pytest.param("1e309", id="overflows-to-inf"),
+    ],
+)
+def test_non_finite_durations_are_rejected(tmp_path: Path, literal: str) -> None:
+    """A duration that is not a finite real number is not a measurement."""
+    module = _module()
+    path = _raw_state(
+        tmp_path,
+        "nonfinite",
+        _raw_document(_raw_entry(f'{{"seconds": {literal}}}')),
+    )
+
+    with pytest.raises(module.TimingRecordError) as excinfo:
+        module.summarize(module.load_records([path]))
+    assert str(path) in str(excinfo.value)
+
+
+def test_date_only_timestamps_are_rejected(tmp_path: Path) -> None:
+    """A guessed midnight must never become a measured zero."""
+    module = _module()
+    path = _state(
+        tmp_path,
+        "dateonly",
+        [_entry(timings={"tests": {"started_at": "2026-01-01", "completed_at": "2026-01-01"}})],
+    )
+
+    with pytest.raises(module.TimingRecordError) as excinfo:
+        module.summarize(module.load_records([path]))
+    assert str(path) in str(excinfo.value)
+
+
+def test_timestamps_with_a_time_component_still_work(tmp_path: Path) -> None:
+    """The date-only fix must not become a blanket rejection of timestamps."""
+    module = _module()
+    path = _state(
+        tmp_path,
+        "withtime",
+        [
+            _entry(
+                timings={
+                    "tests": {
+                        "started_at": "2026-01-01T00:00:00Z",
+                        "completed_at": "2026-01-01T00:01:00Z",
+                    }
+                }
+            )
+        ],
+    )
+    cell = _phase(module.summarize(module.load_records([path])), 0, "tests")
+
+    assert cell == {"seconds": 60.0, "provenance": "timestamps"}
+
+
+def _mixed_awareness_state(tmp_path: Path, name: str) -> Path:
+    return _state(
+        tmp_path,
+        name,
+        [
+            _entry(
+                timings={
+                    "tests": {
+                        "started_at": "2026-01-01T00:00:00Z",
+                        "completed_at": "2026-01-01T00:01:00",
+                    }
+                }
+            )
+        ],
+    )
+
+
+def test_mixed_timezone_awareness_is_a_record_error(tmp_path: Path) -> None:
+    """Naive versus aware must be diagnosed, not surface as an uncaught TypeError."""
+    module = _module()
+    path = _mixed_awareness_state(tmp_path, "mixedtz")
+
+    with pytest.raises(module.TimingRecordError) as excinfo:
+        module.summarize(module.load_records([path]))
+    assert str(path) in str(excinfo.value)
+
+
+def test_cli_exits_two_on_mixed_timezone_awareness(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    module = _module()
+    _mixed_awareness_state(tmp_path, "mixedtzcli")
+
+    assert module.main([str(tmp_path)]) == 2
+    assert capsys.readouterr().out.strip() == ""
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param('{"branch": "task/x", "ticket": "1234", "e2e": false}', id="e2e-not-object"),
+        pytest.param(
+            '{"branch": "task/x", "ticket": "1234", "e2e": {"evidence": {}}}',
+            id="evidence-not-list",
+        ),
+        pytest.param(
+            '{"branch": "task/x", "ticket": "1234", "e2e": {"evidence": "none"}}',
+            id="evidence-is-a-string",
+        ),
+    ],
+)
+def test_malformed_e2e_container_aborts(tmp_path: Path, body: str) -> None:
+    """A corrupt file must not silently drop its rows from a combined summary."""
+    module = _module()
+    path = _raw_state(tmp_path, "badcontainer", body)
+
+    with pytest.raises(module.TimingRecordError) as excinfo:
+        module.summarize(module.load_records([path]))
+    assert str(path) in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param('{"branch": "task/x", "ticket": "1234"}', id="e2e-absent"),
+        pytest.param(
+            '{"branch": "task/x", "ticket": "1234", "e2e": {"evidence": []}}',
+            id="evidence-empty-list",
+        ),
+    ],
+)
+def test_absent_or_empty_evidence_is_zero_rows_without_error(tmp_path: Path, body: str) -> None:
+    """Absent is not malformed: it contributes nothing and raises nothing."""
+    module = _module()
+    path = _raw_state(tmp_path, "emptyok", body)
+    summary = module.summarize(module.load_records([path]))
+
+    assert summary["rows"] == []
+    assert summary["duplicate_groups"] == []
+
+
+def test_absolute_paths_never_reach_the_summary(tmp_path: Path) -> None:
+    """The emitted source is the file's bare name, never its local absolute path."""
+    module = _module()
+    first = _state(tmp_path, "src1", [_entry(timings={"tests": {"seconds": 1.0}})])
+    second = _state(tmp_path, "src2", [_entry(timings={"tests": {"seconds": 2.0}})])
+    summary = module.summarize(module.load_records([first, second]))
+    rendered = json.dumps(summary)
+
+    assert str(tmp_path) not in rendered
+    assert "/" not in summary["rows"][0]["source"]
+    assert {row["source"] for row in summary["rows"]} == {first.name, second.name}
+    assert set(summary["duplicate_groups"][0]["sources"]) == {first.name, second.name}
+
+
+def test_error_messages_still_name_the_full_path(tmp_path: Path) -> None:
+    """Redaction is for the summary only; a diagnosis needs the real path."""
+    module = _module()
+    path = _state(tmp_path, "diagpath", [_entry(timings={"tests": {"seconds": -1.0}})])
+
+    with pytest.raises(module.TimingRecordError) as excinfo:
+        module.summarize(module.load_records([path]))
+    assert str(tmp_path) in str(excinfo.value)
+    assert str(path) in str(excinfo.value)
+
+
+@pytest.mark.parametrize("field", ["tier", "command", "commit"])
+@pytest.mark.parametrize("value", [None, "", "   "])
+def test_missing_provenance_identity_is_rejected(
+    tmp_path: Path, field: str, value: object
+) -> None:
+    """Empty identity would let unrelated candidates collapse into one duplicate group."""
+    module = _module()
+    entry = _entry(timings={"tests": {"seconds": 1.0}})
+    if value is None:
+        del entry[field]
+    else:
+        entry[field] = value
+    path = _state(tmp_path, "identity", [entry])
+
+    with pytest.raises(module.TimingRecordError) as excinfo:
+        module.summarize(module.load_records([path]))
+    assert str(path) in str(excinfo.value)
+    assert field in str(excinfo.value)

--- a/tools/verification-timing/tests/test_summarize_timings.py
+++ b/tools/verification-timing/tests/test_summarize_timings.py
@@ -410,26 +410,30 @@ def _raw_document(entry: str) -> str:
 
 
 @pytest.mark.parametrize(
-    "literal",
+    ("literal", "reason"),
     [
-        pytest.param("NaN", id="nan"),
-        pytest.param("Infinity", id="infinity"),
-        pytest.param("-Infinity", id="negative-infinity"),
-        pytest.param("1e309", id="overflows-to-inf"),
+        pytest.param("NaN", "seconds must be a finite number", id="nan"),
+        pytest.param("Infinity", "seconds must be a finite number", id="infinity"),
+        pytest.param("-Infinity", "seconds must be a finite number", id="negative-infinity"),
+        pytest.param("1e309", "seconds must be a finite number", id="overflows-to-inf"),
+        pytest.param("9" * 400, "seconds is too large to be a duration", id="unrepresentable-int"),
     ],
 )
-def test_non_finite_durations_are_rejected(tmp_path: Path, literal: str) -> None:
+def test_non_finite_durations_are_rejected(tmp_path: Path, literal: str, reason: str) -> None:
     """A duration that is not a finite real number is not a measurement."""
     module = _module()
     path = _raw_state(
         tmp_path,
         "nonfinite",
-        _raw_document(_raw_entry(f'{{"seconds": {literal}}}')),
+        _raw_document(_raw_entry(f'{{"tests": {{"seconds": {literal}}}}}')),
     )
 
     with pytest.raises(module.TimingRecordError) as excinfo:
         module.summarize(module.load_records([path]))
-    assert str(path) in str(excinfo.value)
+    message = str(excinfo.value)
+    assert str(path) in message
+    assert reason in message
+    assert "tests" in message
 
 
 def test_date_only_timestamps_are_rejected(tmp_path: Path) -> None:
@@ -576,9 +580,7 @@ def test_error_messages_still_name_the_full_path(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("field", ["tier", "command", "commit"])
 @pytest.mark.parametrize("value", [None, "", "   "])
-def test_missing_provenance_identity_is_rejected(
-    tmp_path: Path, field: str, value: object
-) -> None:
+def test_missing_provenance_identity_is_rejected(tmp_path: Path, field: str, value: object) -> None:
     """Empty identity would let unrelated candidates collapse into one duplicate group."""
     module = _module()
     entry = _entry(timings={"tests": {"seconds": 1.0}})

--- a/tools/verification-timing/tests/test_summarize_timings.py
+++ b/tools/verification-timing/tests/test_summarize_timings.py
@@ -1,0 +1,382 @@
+"""Executable contract for the offline verification-timing summarizer.
+
+The whole point of this tool is that it never guesses a timing. A phase that was
+not measured stays unmeasured all the way to the output: it is never zero, never
+interpolated, never borrowed from the neighbouring row or the neighbouring phase.
+These tests are written to fail loudly the moment a plausible-looking default
+sneaks in.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import random
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SUMMARIZER = REPO_ROOT / "tools" / "verification-timing" / "summarize_timings.py"
+
+COMMIT_A = "a" * 40
+COMMIT_B = "b" * 40
+COMMAND = "uv run pytest tests/test_example.py"
+OTHER_COMMAND = "uv run pytest tests/test_other.py"
+
+
+def _module() -> ModuleType:
+    specification = importlib.util.spec_from_file_location("curie_summarize_timings", SUMMARIZER)
+    assert specification is not None and specification.loader is not None
+    module = importlib.util.module_from_spec(specification)
+    sys.modules["curie_summarize_timings"] = module
+    specification.loader.exec_module(module)
+    return module
+
+
+def _entry(**overrides: object) -> dict:
+    entry: dict = {
+        "tier": "skill",
+        "criterion": "synthetic criterion",
+        "command": COMMAND,
+        "commit": COMMIT_A,
+        "mode": "fake",
+        "outcome": "pass",
+        "observed": "OBSERVED_SENTINEL",
+        "negative": "NEGATIVE_SENTINEL",
+        "teardown": "TEARDOWN_SENTINEL",
+        "blocker": "BLOCKER_SENTINEL",
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _state(tmp_path: Path, name: str, entries: list[dict], *, ticket: str = "1234") -> Path:
+    path = tmp_path / f"{name}.state.json"
+    path.write_text(
+        json.dumps(
+            {
+                "branch": f"task/{name}",
+                "ticket": ticket,
+                "commit": COMMIT_A,
+                "e2e": {"evidence": entries},
+            }
+        )
+    )
+    return path
+
+
+def _phase(summary: dict, index: int, phase: str) -> dict:
+    return summary["rows"][index]["timings"][phase]
+
+
+def test_phases_tuple_is_exact_and_ordered() -> None:
+    module = _module()
+    assert module.PHASES == ("startup", "tests", "cleanup", "retries", "external_wait")
+    assert isinstance(module.PHASES, tuple)
+
+
+def test_timing_record_error_is_a_value_error() -> None:
+    module = _module()
+    assert issubclass(module.TimingRecordError, ValueError)
+
+
+def test_unknown_phase_is_none_never_zero_and_never_borrowed(tmp_path: Path) -> None:
+    """Rule 1: observed-only. An unmeasured phase must not acquire a number."""
+    module = _module()
+    path = _state(
+        tmp_path,
+        "unknown",
+        [
+            _entry(timings={"startup": {"seconds": 12.5}, "tests": {"seconds": 44.0}}),
+            _entry(
+                commit=COMMIT_B,
+                timings={"startup": None, "tests": {"seconds": None}},
+            ),
+        ],
+    )
+    summary = module.summarize(module.load_records([path]))
+
+    for phase in ("startup", "tests"):
+        cell = _phase(summary, 1, phase)
+        assert cell["seconds"] is None, f"{phase} was filled in"
+        assert cell["seconds"] != 0.0
+        assert cell["provenance"] == "unknown"
+    # Absent keys behave exactly like explicit nulls, and never inherit a sibling.
+    for phase in ("cleanup", "retries", "external_wait"):
+        assert _phase(summary, 0, phase)["seconds"] is None
+        assert _phase(summary, 0, phase)["provenance"] == "unknown"
+
+
+def test_provenance_distinguishes_timestamps_seconds_and_unknown(tmp_path: Path) -> None:
+    module = _module()
+    path = _state(
+        tmp_path,
+        "provenance",
+        [
+            _entry(
+                timings={
+                    "startup": {
+                        "started_at": "2026-09-10T10:00:00Z",
+                        "completed_at": "2026-09-10T10:00:30Z",
+                    },
+                    "tests": {"seconds": 12.5},
+                }
+            )
+        ],
+    )
+    summary = module.summarize(module.load_records([path]))
+
+    assert _phase(summary, 0, "startup") == {"seconds": 30.0, "provenance": "timestamps"}
+    assert _phase(summary, 0, "tests") == {"seconds": 12.5, "provenance": "seconds"}
+    assert _phase(summary, 0, "cleanup")["provenance"] == "unknown"
+
+
+def test_startup_never_contributes_to_the_tests_total(tmp_path: Path) -> None:
+    """Rule 3: the two phases stay separate buckets, both directions."""
+    module = _module()
+    path = _state(
+        tmp_path,
+        "separation",
+        [_entry(timings={"startup": {"seconds": 100.0}, "tests": {"seconds": 7.0}})],
+    )
+    summary = module.summarize(module.load_records([path]))
+    totals = summary["phase_totals"]
+
+    assert tuple(totals) == module.PHASES
+    assert totals["startup"]["total_seconds"] == 100.0
+    assert totals["tests"]["total_seconds"] == 7.0
+    assert totals["tests"]["total_seconds"] != 107.0
+    assert totals["startup"]["observed_count"] == 1
+    assert totals["tests"]["observed_count"] == 1
+
+
+def test_phase_totals_are_none_when_nothing_was_observed(tmp_path: Path) -> None:
+    module = _module()
+    path = _state(tmp_path, "empty", [_entry(timings={"startup": {"seconds": 5.0}})])
+    totals = module.summarize(module.load_records([path]))["phase_totals"]["cleanup"]
+
+    assert totals["observed_count"] == 0
+    assert totals["unknown_count"] == 1
+    assert totals["total_seconds"] is None
+    assert totals["median_seconds"] is None
+    assert totals["p90_seconds"] is None
+
+
+def test_median_and_p90_use_the_observed_subset_only(tmp_path: Path) -> None:
+    """Rule 4: eleven observations 10..110 plus unknowns that must not drag it down."""
+    module = _module()
+    observed = [
+        _entry(
+            commit=COMMIT_A,
+            command=f"{COMMAND}::{index}",
+            timings={"tests": {"seconds": float(value)}},
+        )
+        for index, value in enumerate(range(10, 120, 10))
+    ]
+    unknown = [
+        _entry(commit=COMMIT_A, command=f"{COMMAND}::u{index}", timings={"tests": None})
+        for index in range(5)
+    ]
+    path = _state(tmp_path, "stats", observed + unknown)
+    totals = module.summarize(module.load_records([path]))["phase_totals"]["tests"]
+
+    assert totals["observed_count"] == 11
+    assert totals["unknown_count"] == 5
+    assert totals["total_seconds"] == pytest.approx(660.0)
+    assert totals["median_seconds"] == pytest.approx(60.0)
+    assert totals["p90_seconds"] == pytest.approx(100.0)
+
+
+def test_retry_counts_aggregate_and_stay_separate_from_duration(tmp_path: Path) -> None:
+    module = _module()
+    path = _state(
+        tmp_path,
+        "retries",
+        [
+            _entry(command=f"{COMMAND}::1", timings={"retries": {"count": 2, "seconds": 30.0}}),
+            _entry(command=f"{COMMAND}::2", timings={"retries": {"count": 3, "seconds": None}}),
+        ],
+    )
+    summary = module.summarize(module.load_records([path]))
+    totals = summary["phase_totals"]["retries"]
+
+    assert summary["retry_total_count"] == 5
+    assert totals["observed_count"] == 1
+    assert totals["unknown_count"] == 1
+    assert totals["total_seconds"] == pytest.approx(30.0)
+    assert _phase(summary, 1, "retries")["seconds"] is None
+
+
+def test_retry_total_count_is_none_when_no_row_declared_one(tmp_path: Path) -> None:
+    module = _module()
+    path = _state(tmp_path, "noretries", [_entry(timings={"tests": {"seconds": 1.0}})])
+    summary = module.summarize(module.load_records([path]))
+
+    assert summary["retry_total_count"] is None
+    assert summary["retry_total_count"] != 0
+
+
+def test_summary_is_byte_identical_regardless_of_input_order(tmp_path: Path) -> None:
+    module = _module()
+    paths = [
+        _state(
+            tmp_path,
+            f"det{index}",
+            [
+                _entry(
+                    commit=COMMIT_A,
+                    command=f"{COMMAND}::{index}",
+                    timings={"tests": {"seconds": float(index)}},
+                )
+            ],
+        )
+        for index in range(6)
+    ]
+    baseline = json.dumps(module.summarize(module.load_records(paths)), sort_keys=True)
+
+    shuffled = list(paths)
+    random.Random(1234).shuffle(shuffled)
+    assert shuffled != paths
+    assert json.dumps(module.summarize(module.load_records(shuffled)), sort_keys=True) == baseline
+
+
+def test_duplicates_are_grouped_but_never_merged_away(tmp_path: Path) -> None:
+    module = _module()
+    first = _state(tmp_path, "dup1", [_entry(timings={"tests": {"seconds": 1.0}})])
+    second = _state(tmp_path, "dup2", [_entry(timings={"tests": {"seconds": 2.0}})])
+    summary = module.summarize(module.load_records([first, second]))
+
+    assert len(summary["duplicate_groups"]) == 1
+    group = summary["duplicate_groups"][0]
+    sources = json.dumps(group)
+    assert first.name in sources and second.name in sources
+    assert len(summary["rows"]) == 2
+    assert {row["timings"]["tests"]["seconds"] for row in summary["rows"]} == {1.0, 2.0}
+
+
+def test_rows_differing_only_by_commit_are_not_duplicates(tmp_path: Path) -> None:
+    module = _module()
+    first = _state(
+        tmp_path, "uniq1", [_entry(commit=COMMIT_A, timings={"tests": {"seconds": 1.0}})]
+    )
+    second = _state(
+        tmp_path, "uniq2", [_entry(commit=COMMIT_B, timings={"tests": {"seconds": 1.0}})]
+    )
+    summary = module.summarize(module.load_records([first, second]))
+
+    assert summary["duplicate_groups"] == []
+    assert len(summary["rows"]) == 2
+
+
+@pytest.mark.parametrize(
+    "timings",
+    [
+        pytest.param({"tests": {"seconds": -1.0}}, id="negative-seconds"),
+        pytest.param(
+            {
+                "tests": {
+                    "started_at": "2026-09-10T10:00:30Z",
+                    "completed_at": "2026-09-10T10:00:00Z",
+                }
+            },
+            id="completed-before-started",
+        ),
+        pytest.param({"tests": {"seconds": "fast"}}, id="non-numeric-seconds"),
+        pytest.param({"retries": {"count": -1}}, id="negative-retry-count"),
+        pytest.param({"warmup": {"seconds": 1.0}}, id="unknown-phase-key"),
+        pytest.param(
+            {
+                "tests": {
+                    "seconds": 90.0,
+                    "started_at": "2026-09-10T10:00:00Z",
+                    "completed_at": "2026-09-10T10:00:30Z",
+                }
+            },
+            id="seconds-disagree-with-timestamps",
+        ),
+    ],
+)
+def test_malformed_records_raise_naming_the_source_path(tmp_path: Path, timings: dict) -> None:
+    module = _module()
+    path = _state(tmp_path, "bad", [_entry(timings=timings)])
+
+    with pytest.raises(module.TimingRecordError) as excinfo:
+        module.summarize(module.load_records([path]))
+    assert str(path) in str(excinfo.value)
+
+
+def test_seconds_agreeing_with_timestamps_within_one_second_is_accepted(tmp_path: Path) -> None:
+    module = _module()
+    path = _state(
+        tmp_path,
+        "agree",
+        [
+            _entry(
+                timings={
+                    "tests": {
+                        "seconds": 30.4,
+                        "started_at": "2026-09-10T10:00:00Z",
+                        "completed_at": "2026-09-10T10:00:30Z",
+                    }
+                }
+            )
+        ],
+    )
+    cell = _phase(module.summarize(module.load_records([path])), 0, "tests")
+    assert cell["seconds"] is not None
+    assert cell["seconds"] == pytest.approx(30.0, abs=1.0)
+
+
+def test_summary_carries_provenance_but_no_free_text(tmp_path: Path) -> None:
+    module = _module()
+    path = _state(tmp_path, "privacy", [_entry(timings={"tests": {"seconds": 3.0}})])
+    rendered = json.dumps(module.summarize(module.load_records([path])))
+
+    assert COMMIT_A in rendered
+    assert "skill" in rendered
+    assert COMMAND in rendered
+    for sentinel in (
+        "OBSERVED_SENTINEL",
+        "NEGATIVE_SENTINEL",
+        "TEARDOWN_SENTINEL",
+        "BLOCKER_SENTINEL",
+    ):
+        assert sentinel not in rendered
+
+
+def test_state_files_without_timings_load_and_are_all_unknown(tmp_path: Path) -> None:
+    module = _module()
+    path = _state(tmp_path, "legacy", [_entry(), _entry(commit=COMMIT_B)])
+    summary = module.summarize(module.load_records([path]))
+
+    assert len(summary["rows"]) == 2
+    for row in summary["rows"]:
+        for phase in module.PHASES:
+            assert row["timings"][phase] == {"seconds": None, "provenance": "unknown"}
+    assert all(summary["phase_totals"][phase]["observed_count"] == 0 for phase in module.PHASES)
+
+
+def test_cli_summarizes_a_directory_and_exits_zero(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    module = _module()
+    _state(tmp_path, "cli1", [_entry(command=f"{COMMAND}::1", timings={"tests": {"seconds": 1.0}})])
+    _state(tmp_path, "cli2", [_entry(command=OTHER_COMMAND, timings={"tests": {"seconds": 2.0}})])
+
+    assert module.main([str(tmp_path)]) == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert len(printed["rows"]) == 2
+
+
+def test_cli_exits_two_and_prints_no_summary_on_a_malformed_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    module = _module()
+    _state(tmp_path, "clibad", [_entry(timings={"tests": {"seconds": -5.0}})])
+
+    assert module.main([str(tmp_path)]) == 2
+    captured = capsys.readouterr()
+    assert captured.out.strip() == ""


### PR DESCRIPTION
## Summary

Adds a lightweight, offline summarizer over the `e2e.evidence` records this repository's `/implement` run-state files already carry, so verification cost can be measured per phase instead of estimated. It reports startup, test execution, cleanup, retries and external wait separately, and a phase nobody measured stays unknown all the way to the output rather than becoming a confident zero. That is the point: conflating startup with test execution, or backfilling a plausible default, is what makes a savings claim unfalsifiable.

New `timings` block on an evidence entry is optional and backward compatible — every existing run-state file loads and reports all phases unknown. No runtime product code is touched; the tool is stdlib-only and reads only the files it is handed.

This is stage 1 of a three-stage maintainer-authorized pilot. **It is not independently merge-ready.** Full applicable repository verification is explicitly deferred to stage 3 against the assembled three-PR candidate. See "Verification debt" below.

## Related issue

No issue; this lands from an authorized pilot plan.

## End-to-end verification

This change does not alter runtime behavior because it adds a contributor-only offline analysis tool plus its tests and documentation, and one `testpaths` line. It reaches no compose service, dispatcher, worker or API wiring, no `curie` verb output or `--json` shape, no released-binary identity or install path, no chart template, RBAC or sandbox claim, no model routing or credential resolution, and no third-party API. It is deliberately not exposed as a `curie` subcommand, since adding a verb surface would pull in the local tier for a stage whose scope is explicitly lightweight.

Scoped verification, all against `54f8c82`:

- `uv run pytest tools/verification-timing/tests` — 48 passed.
- `uv run ruff check .` — all checks passed. `uv run mypy` — success, no issues in 253 source files.
- `./scripts/check-docs.sh` — OK; every command the new README names resolves.
- Real historical run-state files (no `timings` block anywhere) summarize with every phase `null` / `unknown_count` populated and `total_seconds` null — never `0`.
- Guard demonstration, executed rather than read: negative, non-numeric, non-finite and unrepresentable durations; a completion before its start; date-only timestamps; mixed timezone awareness; an unrecognised phase; a malformed `e2e` or `evidence` container; and a missing or blank `tier`/`command`/`commit` each exit 2 with empty stdout and an error naming the file and the offending field. Negative controls: an absent `e2e` key and an explicit `"evidence": []` still load as zero rows without error, and a valid timestamp pair still yields its measured duration.
- Determinism: the same record set supplied in reversed order produces a byte-identical summary (matching sha256).
- Privacy: absolute input paths and the evidence free-text fields are absent from the summary; error messages still carry the full path for diagnosis.
- Test strength: deleting the finiteness check fails 4 tests, so that assertion is not vacuous.

## Reviews

Two cross-engine adversarial reviews (read-only, reviewer excluded the authoring engine).

- Code review (#492) returned six findings — non-finite durations entering the statistics, a date-only pair becoming a measured `0.0`, mixed timezone awareness crashing instead of reporting, a malformed container silently yielding zero rows, absolute paths in the output, and empty-string identity mis-grouping unrelated candidates. All six were reproduced by execution, pinned with 15 new tests, fixed, and re-verified by execution.
- Consolidation review (#493) of the behavior-preserving refactor confirmed acceptance/rejection, unknown handling, retry attribution, timestamp precedence and output fields are all preserved. Its one noted difference — which error surfaces first when several fields are invalid at once — is non-blocking.

Four quality passes (reuse, simplification, efficiency, altitude) ran over the file; reuse and efficiency came back clean, and the simplification and altitude findings were applied in the final commit.

## Verification debt

Stages 1 and 2 of this pilot run focused test-first checks plus review and complete their handoff as draft PRs. The full applicable repository baseline and the union of required tiers are owed by **stage 3**, run against the assembled candidate containing all three diffs. This staging is a specific maintainer-authorized exception for this pilot and changes no repository-wide verification mandate; the tier rules in `AGENTS.md` remain in force and no fake result substitutes for a required real tier.

## Known limitation

Row and duplicate-group `source` values are the state file's bare name, so two identically-named run-state files from different worktrees are indistinguishable in that field. Candidate provenance itself is unaffected — duplicate identity keys on commit, tier and command, never on `source`.

## Checklist

- [x] Tests pass for the area I touched.
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision — n/a, no architectural decision.
