### PR TITLE
Gate the repository-toolchain proof in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1206,6 +1206,82 @@ jobs:
           docker rm -f curie-api-smoke || true
           docker network rm curie-ui-smoke-net || true
 
+  # #2611: the Python job never builds curie-runner, so every container leg of
+  # runner/tests/test_repo_toolchain_proof.py skips on that job. This is the
+  # missing half: it builds the runner image and runs the harness with
+  # CURIE_REPO_TOOLCHAIN_PROOF=required so an absent image is a failure
+  # rather than a skip. No `needs:` on the Python job -- the image build must
+  # not serialise behind the ~22 min suite (#2230).
+  #
+  # Runtime (stated for #2611): the `images` matrix runner leg is ~2 min
+  # cache-warm (104s on run 34590132629). This job repeats that build with
+  # `load: true` (read-only `scope=runner` cache, same as the smoke jobs) and
+  # then runs the harness (~39s locally in required mode, 14 passed). Wall
+  # clock grows only if this job exceeds Python.
+  #
+  # GHA-layer-cached off the same `scope=runner` the `images` matrix writes,
+  # read-only so the two writers do not contend. `load: true` because the
+  # harness `docker run`s the tag. The builder is created with `use: false`
+  # so the default `docker` driver stays current, matching the smoke jobs.
+  repo-toolchain-proof:
+    name: Repository toolchain proof (runner image)
+    runs-on: ubuntu-latest
+    env:
+      CURIE_REPO_TOOLCHAIN_PROOF: required
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: "3.13"
+      - name: Sync workspace
+        run: uv sync
+      - name: Required setting is present (negative control)
+        run: |
+          set -euo pipefail
+          if [ "${CURIE_REPO_TOOLCHAIN_PROOF}" != "required" ]; then
+            echo "CURIE_REPO_TOOLCHAIN_PROOF must be required so a missing image cannot skip; got ${CURIE_REPO_TOOLCHAIN_PROOF:-<empty>}" >&2
+            exit 1
+          fi
+      - name: Absent image fails in required mode (negative control)
+        env:
+          CURIE_RUNNER_IMAGE: curie-runner-absent-2611
+        run: |
+          set -euo pipefail
+          set +e
+          output=$(uv run pytest \
+            runner/tests/test_repo_toolchain_proof.py::test_dependency_install_succeeds_under_read_only_rootfs \
+            -q --tb=line 2>&1)
+          status=$?
+          set -e
+          printf '%s\n' "$output"
+          if [ "$status" -eq 0 ]; then
+            echo "required mode passed or skipped without the runner image" >&2
+            exit 1
+          fi
+          printf '%s\n' "$output" | grep -F "may not skip"
+      - name: Set up a cache-only buildx builder (named, NOT the default)
+        id: buildcache
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          use: false
+      - name: Build the runner image locally (gha layer cache)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: runner/Dockerfile
+          builder: ${{ steps.buildcache.outputs.name }}
+          tags: curie-runner
+          push: false
+          load: true
+          cache-from: type=gha,scope=runner
+      - name: Repository toolchain proof
+        env:
+          CURIE_PROOF_EVIDENCE_DIR: ${{ runner.temp }}/repo-toolchain-proof
+        run: uv run pytest runner/tests/test_repo_toolchain_proof.py -q --durations=25
+
   # FALSIFIABILITY gate for the committed eval suites (issue #619). This is NOT
   # an E2E test: it never runs a real agent or makes a model call. It boots the
   # runner's scripted FAKE model (offline, no credential, no network) -- a

--- a/release/authorize.py
+++ b/release/authorize.py
@@ -73,9 +73,10 @@ PASSING_CONCLUSIONS = {"success", "neutral"}
 # three language/test jobs, the generated-artifact drift checks, the
 # release-compose validation, every first-party image actually building
 # (including the worker-local overlay and the dispatcher's own import
-# smoke-test), and the two behavioral gates (eval falsifiability, the E2E
-# parity ladder) that ci.yaml's own comments describe as catching bug
-# classes no unit test does. Checks from other workflows (CodeQL, the
+# smoke-test), and the behavioral gates (eval falsifiability, the E2E
+# parity ladder, the repository-toolchain proof) that ci.yaml's own
+# comments describe as catching bug classes no unit test does. Checks
+# from other workflows (CodeQL, the
 # dependency/secret scanners, release.yaml's own jobs) are deliberately
 # excluded -- they matter, but are not what this gate is asserting about
 # *this* commit's CI.
@@ -123,6 +124,7 @@ REQUIRED_CHECK_NAMES = frozenset(
         "Build sre-bot-self-upgrade image (no push)",
         "Build worker-local overlay image (no push)",
         "Dispatcher image imports resolve",
+        "Repository toolchain proof (runner image)",
         "Eval falsifiability gate (fake model, offline)",
         "E2E parity ladder (skill + local, fake model)",
         "E2E parity ladder (local-release, fake model)",

--- a/runner/tests/test_repo_toolchain_proof.py
+++ b/runner/tests/test_repo_toolchain_proof.py
@@ -13,20 +13,18 @@ one of these tests goes red.
 
 Gating rules (see the plan's Edge cases):
 
-- no ``docker`` binary, or a binary with an unreachable daemon -> **skip**;
+- no ``docker`` binary, or a binary with an unreachable daemon -> **skip**,
+  unless ``CURIE_REPO_TOOLCHAIN_PROOF=required``, which **fails**;
 - the resolved runner image absent locally -> **skip** with a message naming
-  ``curie build``;
+  ``curie build``, unless required, which **fails**;
 - hardening disabled (``run_args()`` empty) -> **fail**, because a vacuous proof
   is worse than no proof.
 
-**What this module does NOT currently gate.** Those skips are real skips. The
-repository's Python CI job does not build ``curie-runner``, so on the merge gate
-every container leg here skips and only the static tests run. Until CI both
-builds the runner image and runs this module with
-``CURIE_REPO_TOOLCHAIN_PROOF=required``, **this module does not gate the merge**
-and must not be described as if it does. Setting that variable to ``required``
-converts an absent ``docker`` or an absent image from a skip into a failure, so
-a pipeline that intends to gate cannot silently degrade to a green skip.
+The Python job still does not build ``curie-runner``, so its collection of this
+module skips every container leg. Merge gating lives in the dedicated
+``repo-toolchain-proof`` CI job, which builds the runner image and runs this
+module with ``CURIE_REPO_TOOLCHAIN_PROOF=required``. An absent image or an
+absent Docker daemon then fails that job instead of skipping.
 
 Evidence JSON is written to ``CURIE_PROOF_EVIDENCE_DIR`` when that is set, and
 only otherwise to pytest's ``tmp_path`` (which pytest deletes, making it useless
@@ -257,6 +255,39 @@ def _evidence_dir(tmp_path: Path) -> Path:
     directory = Path(configured).expanduser()
     directory.mkdir(parents=True, exist_ok=True)
     return directory
+
+
+def test_required_mode_fails_when_the_runner_image_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Catches required mode degrading to a skip when the image is missing.
+
+    The dedicated CI job sets ``CURIE_REPO_TOOLCHAIN_PROOF=required`` so an
+    absent ``curie-runner`` cannot silently skip. If ``_unavailable`` starts
+    skipping again under that setting, this test goes red even while the
+    workflow YAML still says required.
+    """
+
+    monkeypatch.setenv(PROOF_MODE_ENV, "required")
+    monkeypatch.setattr(sys.modules[__name__], "RUNNER_IMAGE", "curie-runner-absent-2611")
+    with pytest.raises(AssertionError, match="may not skip"):
+        _require_runner_image()
+
+
+def test_without_required_a_missing_image_skips(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The contributor default: no image, no required flag, skip rather than fail.
+
+    The CI pin is what forbids this path on the merge gate. This test keeps
+    the skip path honest so a future change cannot make a missing image fail
+    for every local contributor.
+    """
+
+    monkeypatch.delenv(PROOF_MODE_ENV, raising=False)
+    monkeypatch.setattr(sys.modules[__name__], "RUNNER_IMAGE", "curie-runner-absent-2611")
+    with pytest.raises(pytest.skip.Exception, match="unavailable|not present locally"):
+        _require_runner_image()
 
 
 # --- pinning the unittest run itself ----------------------------------------

--- a/runner/tests/test_repo_toolchain_proof.py
+++ b/runner/tests/test_repo_toolchain_proof.py
@@ -45,6 +45,7 @@ import tempfile
 import time
 import uuid
 import zipfile
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
@@ -479,6 +480,61 @@ def _materialize_fixture_clone(root: Path) -> Path:
     return workspace
 
 
+def _force_rmtree(path: Path) -> None:
+    """Delete a tree that may contain files owned by the runner image uid.
+
+    The proof containers run as uid 1000. GitHub-hosted runners are uid 1001,
+    so a host ``rmtree`` hits ``PermissionError`` on the ``.venv`` the
+    container created: tempfile tries to chmod before unlink. Delete from a
+    root container instead, mounting the parent so only this path is removed.
+    """
+
+    path = path.resolve()
+    if not path.exists():
+        return
+    completed = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--user",
+            "0",
+            "--network",
+            "none",
+            "--entrypoint",
+            "rm",
+            "-v",
+            f"{path.parent}:{path.parent}",
+            RUNNER_IMAGE,
+            "-rf",
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    if path.exists():
+        shutil.rmtree(path, ignore_errors=True)
+    if path.exists():
+        raise AssertionError(
+            f"could not delete {path} (exit {completed.returncode}): "
+            f"{completed.stdout}\n{completed.stderr}"
+        )
+
+
+@contextmanager
+def _owned_tempdir(prefix: str):
+    """A ``TemporaryDirectory`` whose container-owned contents still delete."""
+
+    tmp = tempfile.TemporaryDirectory(prefix=prefix, ignore_cleanup_errors=True)
+    try:
+        yield tmp.name
+    finally:
+        _force_rmtree(Path(tmp.name))
+        tmp.cleanup()
+
+
 # --- 1. the red -> green -> red cycle ---------------------------------------
 
 
@@ -507,7 +563,7 @@ def test_seeded_defect_fails_then_fix_passes_then_revert_fails_again(tmp_path: P
     _require_fixture()
 
     evidence = Evidence()
-    with tempfile.TemporaryDirectory(prefix="curie-2571-cycle-") as root:
+    with _owned_tempdir(prefix="curie-2571-cycle-") as root:
         workspace = _materialize_fixture_clone(Path(root))
 
         install = evidence.record(
@@ -583,7 +639,7 @@ def test_dependency_install_succeeds_under_read_only_rootfs(tmp_path: Path) -> N
     _require_fixture()
 
     evidence = Evidence()
-    with tempfile.TemporaryDirectory(prefix="curie-2571-install-") as root:
+    with _owned_tempdir(prefix="curie-2571-install-") as root:
         workspace = _materialize_fixture_clone(Path(root))
 
         install = evidence.record(
@@ -656,7 +712,7 @@ def test_venv_console_scripts_run_from_workspace_but_not_from_tmpfs(tmp_path: Pa
     _require_non_vacuous_hardening()
 
     evidence = Evidence()
-    with tempfile.TemporaryDirectory(prefix="curie-2571-noexec-") as root:
+    with _owned_tempdir(prefix="curie-2571-noexec-") as root:
         workspace = Path(root) / "ws"
         workspace.mkdir()
         os.chmod(workspace, 0o777)
@@ -723,7 +779,7 @@ def test_unreachable_registry_fails_bounded_and_truthfully(tmp_path: Path) -> No
     _require_fixture()
 
     evidence = Evidence()
-    with tempfile.TemporaryDirectory(prefix="curie-2571-registry-") as root:
+    with _owned_tempdir(prefix="curie-2571-registry-") as root:
         workspace = _materialize_fixture_clone(Path(root))
         step = evidence.record(
             _run_in_sandbox(
@@ -761,7 +817,7 @@ def test_missing_toolchain_fails_bounded_and_truthfully(tmp_path: Path) -> None:
     _require_fixture()
 
     evidence = Evidence()
-    with tempfile.TemporaryDirectory(prefix="curie-2571-toolchain-") as root:
+    with _owned_tempdir(prefix="curie-2571-toolchain-") as root:
         workspace = _materialize_fixture_clone(Path(root))
         step = evidence.record(
             _run_in_sandbox(
@@ -811,7 +867,7 @@ def test_vendored_profile_needs_no_registry_egress(tmp_path: Path) -> None:
     )
 
     evidence = Evidence()
-    with tempfile.TemporaryDirectory(prefix="curie-2571-vendored-") as root:
+    with _owned_tempdir(prefix="curie-2571-vendored-") as root:
         workspace = _materialize_fixture_clone(Path(root))
 
         install = evidence.record(
@@ -909,7 +965,7 @@ def test_live_registry_profile_installs_a_third_party_pin(tmp_path: Path) -> Non
         pytest.skip("PyPI is unreachable from the sandbox network: connectivity probe failed")
 
     evidence = Evidence()
-    with tempfile.TemporaryDirectory(prefix="curie-2571-live-") as root:
+    with _owned_tempdir(prefix="curie-2571-live-") as root:
         workspace = _materialize_fixture_clone(Path(root))
         install = evidence.record(
             _run_in_sandbox(
@@ -1085,8 +1141,8 @@ def test_fixture_tree_is_not_collected() -> None:
 def test_no_container_or_tmpdir_survives_the_harness(tmp_path: Path) -> None:
     """Catches the harness leaking the resources it owns.
 
-    Every container is ``--rm`` and every workspace lives in a
-    ``TemporaryDirectory``. This asserts both properties observably: after a
+    Every container is ``--rm`` and every workspace lives in an
+    ``_owned_tempdir``. This asserts both properties observably: after a
     round trip, no container this PROCESS actually launched (across the whole
     module, not just this test's synthetic ``true`` leg) is listed (running or
     exited), and the temporary workspace path is gone.
@@ -1103,7 +1159,7 @@ def test_no_container_or_tmpdir_survives_the_harness(tmp_path: Path) -> None:
     _require_runner_image()
     _require_non_vacuous_hardening()
 
-    with tempfile.TemporaryDirectory(prefix="curie-2571-cleanup-") as root:
+    with _owned_tempdir(prefix="curie-2571-cleanup-") as root:
         workspace = Path(root) / "ws"
         workspace.mkdir()
         os.chmod(workspace, 0o777)
@@ -1129,6 +1185,34 @@ def test_no_container_or_tmpdir_survives_the_harness(tmp_path: Path) -> None:
     )
     leaked = set(survivors) & set(_LAUNCHED_CONTAINER_NAMES)
     assert not leaked, f"containers this process actually launched survived cleanup: {leaked}"
+
+
+def test_host_can_delete_a_workspace_the_container_wrote(tmp_path: Path) -> None:
+    """Catches GHA uid 1001 failing to rmtree a uid-1000 ``.venv``.
+
+    The managed runner is uid 1000. A GitHub-hosted runner is uid 1001. Files
+    the container writes into the bind-mounted workspace are then not chmod-able
+    by the host, and tempfile cleanup raises ``PermissionError`` -- which is
+    exactly how the first required-mode CI run went red after every proof
+    assertion had already passed.
+    """
+
+    _require_runner_image()
+    _require_non_vacuous_hardening()
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    os.chmod(workspace, 0o777)
+    step = _run_in_sandbox(
+        "write-venv",
+        f"python -m venv {WORKSPACE_MOUNT_PATH}/.venv",
+        workspace=workspace,
+    )
+    assert step.exit_status == 0, f"venv creation must succeed:\n{step.output}"
+    venv = workspace / ".venv"
+    assert venv.is_dir(), "the container must have written a venv the host can see"
+    _force_rmtree(venv)
+    assert not venv.exists(), "the host must be able to delete the container-owned venv"
 
 
 # --- 10. the stdlib wheel builder, checked structurally on the host ----------

--- a/runner/tests/test_repo_toolchain_proof_ci.py
+++ b/runner/tests/test_repo_toolchain_proof_ci.py
@@ -1,0 +1,150 @@
+"""CI pin for the repository-toolchain proof job (issue #2611).
+
+``runner/tests/test_repo_toolchain_proof.py`` skips every container leg when
+the runner image is absent. The Python job does not build that image, so those
+legs were a silent skip on the merge gate. This file pins the dedicated job
+that builds the image and sets ``CURIE_REPO_TOOLCHAIN_PROOF`` to required.
+
+The two negative controls are driven through the same assertion the real check
+uses, rather than testing a matcher in isolation: dropping the required
+setting, or building without loading the image into the daemon, fails the pin.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_YAML = REPO_ROOT / ".github" / "workflows" / "ci.yaml"
+JOB_ID = "repo-toolchain-proof"
+REQUIRED_ASSIGNMENT = "CURIE_REPO_TOOLCHAIN_PROOF: required"
+HARNESS = "runner/tests/test_repo_toolchain_proof.py"
+BUILD_STEP = "Build the runner image locally (gha layer cache)"
+PROOF_STEP = "Repository toolchain proof"
+ABSENT_IMAGE_STEP = "Absent image fails in required mode (negative control)"
+REQUIRED_STEP = "Required setting is present (negative control)"
+ABSENT_IMAGE = "curie-runner-absent-2611"
+
+
+def _workflow(raw: str | None = None) -> dict[str, Any]:
+    return yaml.safe_load(raw if raw is not None else CI_YAML.read_text())
+
+
+def assert_proof_job_gates(doc: dict[str, Any]) -> None:
+    """The contract the dedicated CI job must keep, or the #2571 skip returns."""
+
+    jobs = doc.get("jobs") or {}
+    assert JOB_ID in jobs, (
+        "ci.yaml must keep the repo-toolchain-proof job; without it the "
+        "container legs of test_repo_toolchain_proof.py skip on the merge gate"
+    )
+    job = jobs[JOB_ID]
+    assert isinstance(job, dict)
+
+    python = jobs.get("python") or {}
+    python_env = python.get("env") or {}
+    assert python_env.get("CURIE_REPO_TOOLCHAIN_PROOF") != "required", (
+        "the Python job must not set CURIE_REPO_TOOLCHAIN_PROOF=required; it "
+        "does not build curie-runner, so required mode would fail that job on "
+        "every run instead of gating in the dedicated job"
+    )
+
+    assert "needs" not in job, (
+        "repo-toolchain-proof must not serialise behind another job; it is "
+        "the parallel half of the Python suite"
+    )
+    assert "if" not in job, (
+        "a job-level if: makes a required check skip, which is not a pass (#1470)"
+    )
+
+    env = job.get("env") or {}
+    assert env.get("CURIE_REPO_TOOLCHAIN_PROOF") == "required", (
+        "CURIE_REPO_TOOLCHAIN_PROOF must be required so an absent image fails "
+        "this job instead of skipping"
+    )
+
+    steps = job.get("steps") or []
+    by_name = {step.get("name"): step for step in steps if step.get("name")}
+
+    assert REQUIRED_STEP in by_name, (
+        "the job must keep the negative control that the required setting is present"
+    )
+    assert ABSENT_IMAGE_STEP in by_name, (
+        "the job must keep the negative control that an absent image fails in required mode"
+    )
+    absent = by_name[ABSENT_IMAGE_STEP]
+    absent_env = absent.get("env") or {}
+    assert absent_env.get("CURIE_RUNNER_IMAGE") == ABSENT_IMAGE, (
+        "the absent-image control must inspect a tag this job never builds"
+    )
+    assert HARNESS in (absent.get("run") or ""), (
+        "the absent-image control must drive the real harness, not a stub"
+    )
+    assert "may not skip" in (absent.get("run") or ""), (
+        "the absent-image control must assert the required-mode failure, not any non-zero exit"
+    )
+
+    assert BUILD_STEP in by_name, f"ci.yaml lost the {BUILD_STEP!r} step"
+    build = by_name[BUILD_STEP]
+    build_with = build.get("with") or {}
+    assert build_with.get("file") == "runner/Dockerfile", (
+        "the job must build runner/Dockerfile, not some other image"
+    )
+    assert build_with.get("load") is True, (
+        "load must be true so the harness can docker-run the tag; a cache-only "
+        "build leaves the image absent and the required-mode pytest would fail "
+        "for the environment rather than for the recipe"
+    )
+    assert build_with.get("push") is False
+    assert "curie-runner" in str(build_with.get("tags")), (
+        "the built tag must match the harness default CURIE_RUNNER_IMAGE"
+    )
+    assert build_with.get("cache-from") == "type=gha,scope=runner"
+    assert "cache-to" not in build_with, (
+        "this job must not write the runner cache; the images matrix already "
+        "refreshes scope=runner, and a second writer only contends"
+    )
+
+    assert PROOF_STEP in by_name, f"ci.yaml lost the {PROOF_STEP!r} step"
+    proof = by_name[PROOF_STEP]
+    assert HARNESS in (proof.get("run") or ""), (
+        "the proof step must run test_repo_toolchain_proof.py"
+    )
+    proof_env = proof.get("env") or {}
+    step_mode = proof_env.get("CURIE_REPO_TOOLCHAIN_PROOF")
+    assert step_mode in (None, "required"), (
+        "the proof step must inherit the job-level required setting; a "
+        f"step-level override of {step_mode!r} would drop the gate"
+    )
+
+
+def test_ci_job_builds_the_runner_image_and_requires_the_harness() -> None:
+    assert_proof_job_gates(_workflow())
+
+
+def test_dropping_required_from_the_job_fails_the_pin() -> None:
+    """Negative control: the required setting cannot be dropped silently."""
+
+    raw = CI_YAML.read_text()
+    assert raw.count(REQUIRED_ASSIGNMENT) == 1, (
+        "the YAML assignment of CURIE_REPO_TOOLCHAIN_PROOF: required moved or "
+        "was duplicated; update this control so it still doctors the one job env"
+    )
+    doctored = _workflow(raw.replace(REQUIRED_ASSIGNMENT, "CURIE_REPO_TOOLCHAIN_PROOF: optional"))
+    with pytest.raises(AssertionError, match="required"):
+        assert_proof_job_gates(doctored)
+
+
+def test_a_build_that_does_not_load_the_image_fails_the_pin() -> None:
+    """Negative control: a cache-only build is an absent image on the job."""
+
+    doc = _workflow()
+    job = doc["jobs"][JOB_ID]
+    build = next(step for step in job["steps"] if step.get("name") == BUILD_STEP)
+    build["with"]["load"] = False
+    with pytest.raises(AssertionError, match="load"):
+        assert_proof_job_gates(doc)

--- a/tools/ci-retry-gate/tests/test_retry_eligibility.py
+++ b/tools/ci-retry-gate/tests/test_retry_eligibility.py
@@ -89,6 +89,12 @@ PROTECTED_STEPS = frozenset(
         ("ci.yaml", "ui", "Lint"),
         ("ci.yaml", "ui", "Command manifest is current"),
         ("ci.yaml", "commit-messages", "Check the PR's commit messages"),
+        (
+            "ci.yaml",
+            "repo-toolchain-proof",
+            "Absent image fails in required mode (negative control)",
+        ),
+        ("ci.yaml", "repo-toolchain-proof", "Repository toolchain proof"),
         # Security gates. Retrying any of these reruns a scan or a verification
         # against the very same tree or the very same asset set, so a second
         # attempt cannot recover anything and can only bury a true positive.


### PR DESCRIPTION
Add a parallel CI job that builds `curie-runner` and runs `runner/tests/test_repo_toolchain_proof.py` with `CURIE_REPO_TOOLCHAIN_PROOF=required`, so the container legs stop silently skipping on the Python job.

Negative controls:

- Removing the image fails. The job runs the harness against `curie-runner-absent-2611` before the build and requires the `may not skip` failure. Locally, required mode plus a missing image exits 1; without required the same case skips.
- Dropping `required` is caught. `test_dropping_required_from_the_job_fails_the_pin` doctors the workflow and fails the pin. A job-level step also asserts the env is `required`.

Runtime: cache-warm runner image ~104s (run 34590132629) plus ~39s harness (14 passed locally in required mode). The job has no `needs:` on Python (~22 min), so it does not serialise the critical path.

The job is named in `REQUIRED_CHECK_NAMES` for release authorization. It is not added to the GitHub ruleset.

Closes #2611
