### PR TITLE
Make a claim that cannot stage the sandbox say so

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -498,6 +498,19 @@ jobs:
       # image-GCed node cannot cold-pull amazon/aws-cli (~418MB) inside the
       # 90s claim window. Compares the two rendered objects; a sandbox image
       # with no matching prewarm container fails.
+      # Prove every sandbox staging init container explains its no-op instead of
+      # taking it silently (issue #2612). A SandboxClaim spec.env entry with no
+      # containerName reaches the runner container only, so a hand-written claim
+      # leaves bundle-fetch/bundle-extract/workspace-init on the template's empty
+      # defaults: all three exit 0 having staged nothing and the runner
+      # crash-loops on an unrelated [manifest.missing]. The no-op stays (a warm
+      # pod has no ref) but must now name containerName as the fix, in the log of
+      # the container that took it.
+      - name: helm render assertions (claim env / init containers)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/claim-env-init-container-assertions.sh
+
       - name: helm render assertions (prewarm bundle-fetch images)
         run: |
           set -euo pipefail

--- a/apps/worker/tests/sandbox/test_claim_env_init_container_parity.py
+++ b/apps/worker/tests/sandbox/test_claim_env_init_container_parity.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
 from curie_worker.sandbox.k8s import (
     BUNDLE_INIT_CONTAINERS,
     BUNDLE_REF_ENV,
@@ -41,8 +42,23 @@ _TEMPLATE = _REPO / "charts/curie/templates/agent-sandbox.yaml"
 # and their env entries at twelve. Go-template control lines (`{{- if ... }}`)
 # never carry a `- name:` head, so an indentation scan reads the same structure a
 # render would without needing one.
-_INIT_CONTAINER = re.compile(r"^ {8}- name: ([a-z0-9][a-z0-9-]*)\s*$")
-_ENV_ENTRY = re.compile(r"^ {12}- name: (CURIE_[A-Z0-9_]+)\s*$")
+#
+# The scan FAILS CLOSED. A `- name:` head this file does not recognise -- a
+# quoted key, a different indentation, a templated name -- is an error, not an
+# absence. Treating it as an absence is how a newly consumed staging key would
+# sail past the very gate that advertises it cannot.
+_INIT_CONTAINER = re.compile(r"^ {8}- name: (\S+)\s*$")
+_ENV_ENTRY = re.compile(r"^ {12}- name: (\S+)\s*$")
+_ANY_NAME_HEAD = re.compile(r"^(\s*)- name:(.*)$")
+_PLAIN_NAME = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.-]*$")
+
+
+def _unquote(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value
+
+
 # The keys the worker targets per init container, from the worker's own
 # declaration. The chart is the other half of this contract.
 _TARGETED: dict[str, frozenset[str]] = {
@@ -62,13 +78,23 @@ _TARGETED: dict[str, frozenset[str]] = {
 _CHART_WIRED_ONLY: frozenset[str] = frozenset()
 
 
+class TemplateScanError(AssertionError):
+    """A `- name:` head in the init-container region this scanner cannot classify."""
+
+
 def _init_container_env() -> dict[str, set[str]]:
-    """Map each init container in the SandboxTemplate to the CURIE_ keys it declares."""
+    """Map each init container in the SandboxTemplate to the CURIE_ keys it declares.
+
+    Raises ``TemplateScanError`` on any `- name:` head inside the region that is
+    neither an init container at eight spaces nor an env entry at twelve. That
+    is the fail-closed half: an env declaration written in a shape this scanner
+    does not read must break the gate, not slip through it.
+    """
 
     found: dict[str, set[str]] = {}
     current: str | None = None
     in_init_containers = False
-    for line in _TEMPLATE.read_text(encoding="utf-8").splitlines():
+    for number, line in enumerate(_TEMPLATE.read_text(encoding="utf-8").splitlines(), 1):
         if line.strip() == "initContainers:":
             in_init_containers = True
             continue
@@ -76,16 +102,43 @@ def _init_container_env() -> dict[str, set[str]]:
             continue
         if line.strip() == "containers:":
             break
+        head = _ANY_NAME_HEAD.match(line)
+        if head is None:
+            continue
+
         match = _INIT_CONTAINER.match(line)
         if match:
-            current = match.group(1)
+            name = _unquote(match.group(1))
+            if not _PLAIN_NAME.match(name):
+                raise TemplateScanError(
+                    f"{_TEMPLATE}:{number}: init container name {name!r} is not a "
+                    "plain identifier this scanner can compare against the "
+                    "worker's containerName targets."
+                )
+            current = name
             found.setdefault(current, set())
             continue
-        if current is None:
-            continue
+
         env_match = _ENV_ENTRY.match(line)
-        if env_match:
-            found[current].add(env_match.group(1))
+        if env_match is None or current is None:
+            raise TemplateScanError(
+                f"{_TEMPLATE}:{number}: unreadable '- name:' declaration inside "
+                f"the init-container region: {line!r}. This gate only reads init "
+                "containers at eight-space and env entries at twelve-space "
+                "indentation; anything else is treated as a scan failure rather "
+                "than as an absent key, because an absence here would silently "
+                "un-gate a newly consumed staging key (#2612). Either write the "
+                "declaration in the shape above, or teach this scanner to read "
+                "the new one."
+            )
+        key = _unquote(env_match.group(1))
+        if not _PLAIN_NAME.match(key):
+            raise TemplateScanError(
+                f"{_TEMPLATE}:{number}: env name {key!r} is not a plain "
+                "identifier; this gate cannot tell whether the worker targets it."
+            )
+        if key.startswith("CURIE_"):
+            found[current].add(key)
     return found
 
 
@@ -120,3 +173,78 @@ def test_the_runner_and_the_worker_agree_on_the_bundle_init_container_names() ->
     from curie_runner.plugin import BUNDLE_INIT_CONTAINERS as RUNNER_BUNDLE_INIT
 
     assert RUNNER_BUNDLE_INIT == BUNDLE_INIT_CONTAINERS
+
+
+# --- the scanner's own fail-closed property ------------------------------------
+#
+# The gate above is only worth anything if a declaration it cannot read breaks
+# it. An earlier revision matched only bare, twelve-space `- name: CURIE_...`
+# heads and treated everything else as an absent key, so a quoted key or an
+# env list at another indentation slipped through the drift gate untargeted.
+
+
+def _scan(text: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, set[str]]:
+    stand_in = tmp_path / "agent-sandbox.yaml"
+    stand_in.write_text(text, encoding="utf-8")
+    monkeypatch.setitem(globals(), "_TEMPLATE", stand_in)
+    return _init_container_env()
+
+
+_ONE_CONTAINER = """
+      initContainers:
+        - name: bundle-fetch
+          env:
+{env}
+      containers:
+"""
+
+
+def test_a_quoted_env_key_is_read_not_ignored(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    found = _scan(
+        _ONE_CONTAINER.format(
+            env='            - name: "CURIE_BUNDLE_REF"\n              value: ""'
+        ),
+        monkeypatch,
+        tmp_path,
+    )
+    assert found == {"bundle-fetch": {"CURIE_BUNDLE_REF"}}
+
+
+def test_an_env_entry_at_an_unread_indentation_fails_the_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with pytest.raises(TemplateScanError, match="unreadable"):
+        _scan(
+            _ONE_CONTAINER.format(
+                env='              - name: CURIE_BUNDLE_REF\n                value: ""'
+            ),
+            monkeypatch,
+            tmp_path,
+        )
+
+
+def test_a_templated_env_name_fails_the_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A name the scanner cannot resolve statically is an error, not an absence."""
+    with pytest.raises(TemplateScanError, match="not a plain identifier"):
+        _scan(
+            _ONE_CONTAINER.format(
+                env='            - name: {{$key}}\n              value: ""'
+            ),
+            monkeypatch,
+            tmp_path,
+        )
+
+    # A templated name carrying a space does not even reach that check; it is
+    # rejected one step earlier, still closed.
+    with pytest.raises(TemplateScanError, match="unreadable"):
+        _scan(
+            _ONE_CONTAINER.format(
+                env='            - name: {{ $key }}\n              value: ""'
+            ),
+            monkeypatch,
+            tmp_path,
+        )

--- a/apps/worker/tests/sandbox/test_claim_env_init_container_parity.py
+++ b/apps/worker/tests/sandbox/test_claim_env_init_container_parity.py
@@ -1,0 +1,122 @@
+"""#2612: the claim's per-init-container targeting matches what the chart declares.
+
+A ``SandboxClaim`` env entry with no ``containerName`` is injected into the
+runner container only. Every ``CURIE_*`` value the SandboxTemplate's staging
+init containers bake as an empty default is therefore a key that MUST be
+repeated, per container, with an explicit ``containerName`` -- otherwise the
+init container keeps the empty default, takes its no-op path, exits 0, and the
+sandbox boots having staged nothing while every container reported success
+(issue #2612, observed on chart 0.8.7).
+
+``KubernetesSandboxClient.create_claim`` does that targeting today. What had no
+gate is the *correspondence*: the container names and the key set live in the
+worker's Python, the init containers live in the chart's Go template, and
+nothing failed when they drifted. Renaming an init container, adding a fourth
+staging init container, or teaching an existing one a new ``CURIE_*`` key
+regressed straight back to the silent no-op.
+
+This test reads the chart template as text rather than a Helm render, so it runs
+in the plain Python lane with no ``helm`` binary. The render-level proof (the
+no-op log line naming the fix) is
+``charts/curie/ci/claim-env-init-container-assertions.sh``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from curie_worker.sandbox.k8s import (
+    BUNDLE_INIT_CONTAINERS,
+    BUNDLE_REF_ENV,
+    WORKSPACE_INIT_CONTAINERS,
+    WORKSPACE_REF_ENV,
+    WORKSPACE_SHA256_ENV,
+)
+
+_REPO = Path(__file__).resolve().parents[4]
+_TEMPLATE = _REPO / "charts/curie/templates/agent-sandbox.yaml"
+
+# The init containers render at eight-space indentation inside `initContainers:`,
+# and their env entries at twelve. Go-template control lines (`{{- if ... }}`)
+# never carry a `- name:` head, so an indentation scan reads the same structure a
+# render would without needing one.
+_INIT_CONTAINER = re.compile(r"^ {8}- name: ([a-z0-9][a-z0-9-]*)\s*$")
+_ENV_ENTRY = re.compile(r"^ {12}- name: (CURIE_[A-Z0-9_]+)\s*$")
+# The keys the worker targets per init container, from the worker's own
+# declaration. The chart is the other half of this contract.
+_TARGETED: dict[str, frozenset[str]] = {
+    **{c: frozenset({BUNDLE_REF_ENV}) for c in BUNDLE_INIT_CONTAINERS},
+    **{
+        c: frozenset({WORKSPACE_REF_ENV, WORKSPACE_SHA256_ENV})
+        for c in WORKSPACE_INIT_CONTAINERS
+    },
+}
+
+# CURIE_ env an init container reads that is deliberately NOT claim-settable
+# (chart-wired from values or a Secret). Empty today: every CURIE_ key the
+# staging init containers read is claim-settable, and the endpoint, bucket and
+# credential env they also read are S3_*/AWS_*-prefixed and out of a claim's
+# reach by construction. It exists so a new key has to be classified on purpose
+# -- targeted by the worker, or declared worker-side here with its reason.
+_CHART_WIRED_ONLY: frozenset[str] = frozenset()
+
+
+def _init_container_env() -> dict[str, set[str]]:
+    """Map each init container in the SandboxTemplate to the CURIE_ keys it declares."""
+
+    found: dict[str, set[str]] = {}
+    current: str | None = None
+    in_init_containers = False
+    for line in _TEMPLATE.read_text(encoding="utf-8").splitlines():
+        if line.strip() == "initContainers:":
+            in_init_containers = True
+            continue
+        if not in_init_containers:
+            continue
+        if line.strip() == "containers:":
+            break
+        match = _INIT_CONTAINER.match(line)
+        if match:
+            current = match.group(1)
+            found.setdefault(current, set())
+            continue
+        if current is None:
+            continue
+        env_match = _ENV_ENTRY.match(line)
+        if env_match:
+            found[current].add(env_match.group(1))
+    return found
+
+
+def test_the_chart_declares_exactly_the_init_containers_the_worker_targets() -> None:
+    declared = set(_init_container_env())
+    assert declared, f"no init containers parsed out of {_TEMPLATE}"
+    assert declared == set(_TARGETED), (
+        "the SandboxTemplate's staging init containers and the worker's "
+        "containerName targets have drifted. A container the worker does not "
+        "target receives no claim env at all and silently stages nothing "
+        "(#2612).\n"
+        f"  chart  ({_TEMPLATE}): {sorted(declared)}\n"
+        f"  worker (curie_worker.sandbox.k8s): {sorted(_TARGETED)}"
+    )
+
+
+def test_every_claim_consumed_init_env_key_is_targeted_by_name() -> None:
+    for container, keys in sorted(_init_container_env().items()):
+        unreachable = keys - _TARGETED.get(container, frozenset()) - _CHART_WIRED_ONLY
+        assert not unreachable, (
+            f"init container {container!r} reads {sorted(unreachable)}, which "
+            "KubernetesSandboxClient.create_claim never copies with an explicit "
+            "containerName. A claim setting it reaches the runner only and the "
+            "staging silently no-ops (#2612). Either target the key in "
+            "curie_worker.sandbox.k8s.create_claim, or add it to "
+            "_CHART_WIRED_ONLY with the reason it is not claim-settable."
+        )
+
+
+def test_the_runner_and_the_worker_agree_on_the_bundle_init_container_names() -> None:
+    """The runner's operator-facing diagnosis names the same containers."""
+    from curie_runner.plugin import BUNDLE_INIT_CONTAINERS as RUNNER_BUNDLE_INIT
+
+    assert RUNNER_BUNDLE_INIT == BUNDLE_INIT_CONTAINERS

--- a/charts/curie/ci/claim-env-init-container-assertions.sh
+++ b/charts/curie/ci/claim-env-init-container-assertions.sh
@@ -26,7 +26,13 @@
 #       absent variable.
 #   (c) The old bare "skipping" wording, which said nothing about the cause, is
 #       gone from every staging init container.
-#   (d) NEGATIVE: an init container whose no-op branch drops the notice fails
+#   (d) BEHAVIORAL: each staging init container's rendered command is EXECUTED
+#       with an empty env, and its actual stdout must carry the notice. Static
+#       text matching alone is not enough -- commenting the logging statements
+#       out leaves the wording in the command string, so a text-only checker
+#       accepts the exact regression this script exists to prevent. Running the
+#       branch is the only assertion that cannot be satisfied by a comment.
+#   (e) NEGATIVE: an init container whose no-op branch drops the notice fails
 #       the same checker the default render uses.
 #
 # The chart/worker half of this contract -- that the worker copies each staging
@@ -126,7 +132,63 @@ python3 "$CHECKER" "workspace enabled" "$TMP/workspace.yaml" \
   bundle-fetch bundle-extract workspace-init \
   || fail "workspace render: staging init containers do not explain their no-op"
 
-echo "=== (d) NEGATIVE: a no-op branch that drops the notice must fail ==="
+echo "=== (d) BEHAVIORAL: run each no-op branch and read its real output ==="
+# Render against a temp bundle mount path so the containers' own pre-guard setup
+# (bundle-extract's `mkdir -p <mountPath>/current`) works outside a pod, then
+# execute each rendered command verbatim with an EMPTY env -- which is exactly
+# what an init container sees when the claim's staging entry never reached it.
+# workspace.mountPath is pinned by values.schema.json and needs no override:
+# workspace-init only constructs pathlib.Path objects before its guard, so it
+# never touches /workspace on the no-op path.
+RUNROOT="$TMP/run"
+mkdir -p "$RUNROOT/bundles"
+helm template rel "$CHART" --set agentSandbox.deploy=true \
+  --set agentSandbox.runner.workspace.enabled=true \
+  --set "agentSandbox.runner.bundleFetch.mountPath=$RUNROOT/bundles" \
+  --show-only "$SANDBOX_TPL" > "$TMP/runnable.yaml"
+
+EXTRACT="$TMP/extract.py"
+cat >"$EXTRACT" <<'PY'
+import sys
+import yaml
+
+path, name = sys.argv[1], sys.argv[2]
+for doc in yaml.safe_load_all(open(path)):
+    if doc and doc.get("kind") == "SandboxTemplate":
+        for c in doc["spec"]["podTemplate"]["spec"].get("initContainers") or []:
+            if c["name"] == name:
+                # argv after the interpreter: `/bin/sh -c <script>` or
+                # `python -c <script>`. The script is the last element.
+                sys.stdout.write(str(c["command"][-1]))
+                raise SystemExit(0)
+raise SystemExit(f"{path}: no init container named {name}")
+PY
+
+run_no_op() {
+  # $1 = container name, $2 = interpreter argv0, $3 = the env key it consumes
+  local name="$1" interpreter="$2" key="$3" script out
+  script="$TMP/$name.script"
+  python3 "$EXTRACT" "$TMP/runnable.yaml" "$name" > "$script" \
+    || fail "could not extract the rendered command for $name"
+  # env -i: no CURIE_* at all, the mis-shaped-claim condition exactly.
+  out="$(env -i PATH="$PATH" "$interpreter" "$script" 2>&1)" \
+    || fail "$name: its no-op path exited non-zero with an empty env: $out"
+  case "$out" in
+    *"containerName: $name"*) ;;
+    *) fail "$name: ran its no-op path and printed $(printf '%q' "$out") -- no 'containerName: $name' guidance in the REAL output. A notice that exists only in the command text (commented out, or after an early exit) does not help anyone reading kubectl logs." ;;
+  esac
+  case "$out" in
+    *"$key"*) ;;
+    *) fail "$name: its no-op output does not name $key" ;;
+  esac
+  echo "$name: executed its no-op path, stdout names $key and containerName: $name"
+}
+
+run_no_op bundle-fetch /bin/sh CURIE_BUNDLE_REF
+run_no_op bundle-extract /bin/sh CURIE_BUNDLE_REF
+run_no_op workspace-init python3 CURIE_WORKSPACE_REF
+
+echo "=== (e) NEGATIVE: a no-op branch that drops the notice must fail ==="
 python3 - "$TMP/workspace.yaml" "$TMP/mutant.yaml" <<'PY'
 import re
 import sys

--- a/charts/curie/ci/claim-env-init-container-assertions.sh
+++ b/charts/curie/ci/claim-env-init-container-assertions.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# Render-assertion: the sandbox staging init containers say WHY they staged
+# nothing (issue #2612).
+#
+# A SandboxClaim `spec.env` entry with no `containerName` is injected into the
+# runner container only -- `envVarsInjectionPolicy: Overrides` never reaches an
+# init container without one. So a hand-written claim carrying
+# CURIE_BUNDLE_REF / CURIE_WORKSPACE_REF / CURIE_WORKSPACE_SHA256 leaves
+# bundle-fetch, bundle-extract and workspace-init on the template's own empty
+# defaults. All three take their no-op path, exit 0, and the runner boots over
+# an empty plugin dir and crash-loops on [manifest.missing] -- observed live on
+# chart 0.8.7 while closing #2571 AC 5, with every container reporting success.
+#
+# The no-op itself is correct and must stay: a warm or unbound pod has no ref
+# and must not fail. What changes is that the no-op now NAMES the one mistake
+# that produces it, in the log of the container that took it, so the operator
+# reading `kubectl logs -c bundle-fetch` is told about `containerName` instead
+# of being told "skipping".
+#
+# Proves:
+#   (a) Every staging init container the SandboxTemplate renders emits the
+#       shared notice on its no-op path, naming its OWN container name and the
+#       env key it consumes.
+#   (b) The notice names `containerName` -- the actual fix -- not just the
+#       absent variable.
+#   (c) The old bare "skipping" wording, which said nothing about the cause, is
+#       gone from every staging init container.
+#   (d) NEGATIVE: an init container whose no-op branch drops the notice fails
+#       the same checker the default render uses.
+#
+# The chart/worker half of this contract -- that the worker copies each staging
+# key per init container with an explicit containerName, and that the container
+# names have not drifted -- is pinned in
+# apps/worker/tests/sandbox/test_claim_env_init_container_parity.py.
+#
+# Runnable locally (from anywhere) and from CI. Fails loudly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+SANDBOX_TPL=templates/agent-sandbox.yaml
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+CHECKER="$TMP/check.py"
+cat >"$CHECKER" <<'PY'
+import sys
+import yaml
+
+# container name -> the env key whose absence takes the no-op path.
+STAGING_INIT = {
+    "bundle-fetch": "CURIE_BUNDLE_REF",
+    "bundle-extract": "CURIE_BUNDLE_REF",
+    "workspace-init": "CURIE_WORKSPACE_REF",
+}
+
+
+def sandbox_init_containers(path):
+    with open(path) as fh:
+        for doc in yaml.safe_load_all(fh):
+            if doc and doc.get("kind") == "SandboxTemplate":
+                spec = doc["spec"]["podTemplate"]["spec"]
+                return {c["name"]: c for c in (spec.get("initContainers") or [])}
+    raise SystemExit(f"{path}: no SandboxTemplate rendered")
+
+
+def main(argv):
+    label, path = argv[1], argv[2]
+    expected = set(argv[3:])
+    rendered = sandbox_init_containers(path)
+    present = expected & set(rendered)
+    if present != expected:
+        raise SystemExit(
+            f"{label}: expected staging init containers {sorted(expected)}, "
+            f"rendered {sorted(rendered)}"
+        )
+    for name in sorted(present):
+        command = "\n".join(str(part) for part in rendered[name].get("command") or [])
+        key = STAGING_INIT[name]
+        if "containerName" not in command:
+            raise SystemExit(
+                f"{label}: init container {name!r} does not mention "
+                "'containerName' on its no-op path. A claim that set "
+                f"{key} would be told nothing about why staging was skipped "
+                "(#2612)."
+            )
+        if f"containerName: {name}" not in command:
+            raise SystemExit(
+                f"{label}: init container {name!r} does not name ITSELF as the "
+                "containerName to target; an operator copying the hint would "
+                "target the wrong container (#2612)."
+            )
+        if key not in command:
+            raise SystemExit(
+                f"{label}: init container {name!r} no-op notice does not name "
+                f"{key} (#2612)."
+            )
+        if "skipping bundle fetch" in command or "starting with an empty plugin dir" in command:
+            raise SystemExit(
+                f"{label}: init container {name!r} still carries the pre-#2612 "
+                "bare wording, which reports the no-op without its cause."
+            )
+    print(f"{label}: OK ({', '.join(sorted(present))})")
+
+
+if __name__ == "__main__":
+    main(sys.argv)
+PY
+
+echo "=== (a)(b)(c) default render: bundle staging init containers ==="
+helm template rel "$CHART" --set agentSandbox.deploy=true \
+  --show-only "$SANDBOX_TPL" > "$TMP/default.yaml"
+python3 "$CHECKER" "default values" "$TMP/default.yaml" bundle-fetch bundle-extract \
+  || fail "default render: staging init containers do not explain their no-op"
+
+echo "=== (a)(b)(c) workspace staging init container ==="
+helm template rel "$CHART" --set agentSandbox.deploy=true \
+  --set agentSandbox.runner.workspace.enabled=true \
+  --show-only "$SANDBOX_TPL" > "$TMP/workspace.yaml"
+python3 "$CHECKER" "workspace enabled" "$TMP/workspace.yaml" \
+  bundle-fetch bundle-extract workspace-init \
+  || fail "workspace render: staging init containers do not explain their no-op"
+
+echo "=== (d) NEGATIVE: a no-op branch that drops the notice must fail ==="
+python3 - "$TMP/workspace.yaml" "$TMP/mutant.yaml" <<'PY'
+import re
+import sys
+
+src, dest = sys.argv[1], sys.argv[2]
+text = open(src).read()
+# Strip the containerName guidance out of the rendered notice, leaving the
+# pre-#2612 shape: the no-op is reported, its cause is not.
+mutated = re.sub(
+    r"If you set CURIE_[A-Z_]+ on a SandboxClaim[^\"\n]*?containerName: [a-z-]+\.",
+    "skipping.",
+    text,
+)
+if mutated == text:
+    raise SystemExit("mutation did not apply: the notice wording moved")
+open(dest, "w").write(mutated)
+PY
+if python3 "$CHECKER" "mutant" "$TMP/mutant.yaml" bundle-fetch bundle-extract workspace-init \
+  > "$TMP/mutant.out" 2>&1; then
+  cat "$TMP/mutant.out" >&2
+  fail "NEGATIVE case passed: a no-op path with no containerName guidance was accepted"
+fi
+echo "mutant correctly rejected: $(head -1 "$TMP/mutant.out")"
+
+echo "ALL CLAIM-ENV INIT CONTAINER ASSERTIONS PASSED"

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -2079,3 +2079,18 @@ that cannot reach it. See that helper for the containment/family rules.
   {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/* ---- Claim-env no-op notice for the sandbox init containers (#2612) ----
+     Every staging init container below takes a silent no-op path when its own
+     env is empty, which is correct for a warm or unbound pod and WRONG-looking
+     for a hand-written SandboxClaim: a `spec.env` entry with no `containerName`
+     is injected into the runner container only, so the init container keeps the
+     template's baked empty default, logs "nothing to do", and exits 0. Every
+     container reported success and the runner then crash-looped on an unrelated
+     [manifest.missing]. The no-op stays a no-op -- the pod must still boot warm
+     -- but it now names the one mistake that produces it, in the log of the
+     container that took it.
+     Args: dict "key" <env var name> "container" <this init container's name>. */}}
+{{- define "curie.sandbox.claimEnvNoOpNotice" -}}
+no {{ .key }} in this container's env: nothing to stage. This is expected for a warm or unbound pod. If you set {{ .key }} on a SandboxClaim and expected staging, note that a spec.env entry with no containerName reaches the RUNNER container only -- repeat it with containerName: {{ .container }}.
+{{- end -}}

--- a/charts/curie/templates/agent-sandbox.yaml
+++ b/charts/curie/templates/agent-sandbox.yaml
@@ -317,7 +317,7 @@ spec:
               set -eu
               REF="${CURIE_BUNDLE_REF:-}"
               if [ -z "$REF" ]; then
-                echo "no CURIE_BUNDLE_REF; skipping bundle fetch"
+                echo {{ include "curie.sandbox.claimEnvNoOpNotice" (dict "key" "CURIE_BUNDLE_REF" "container" "bundle-fetch") | quote }}
                 exit 0
               fi
               {{- if include "curie.rustfs.staticCredentials" . }}
@@ -382,7 +382,7 @@ spec:
               DEST={{ $bf.mountPath }}/current
               mkdir -p "$DEST"
               if [ -z "$REF" ]; then
-                echo "no CURIE_BUNDLE_REF; starting with an empty plugin dir"
+                echo {{ include "curie.sandbox.claimEnvNoOpNotice" (dict "key" "CURIE_BUNDLE_REF" "container" "bundle-extract") | quote }}
                 exit 0
               fi
               ARCHIVE={{ $bf.mountPath }}/.bundle-archive
@@ -447,6 +447,7 @@ spec:
               destination = root / ".curie-workspace.tar.gz"
               stage = root / ".curie-stage"
               if not ref:
+                  print({{ include "curie.sandbox.claimEnvNoOpNotice" (dict "key" "CURIE_WORKSPACE_REF" "container" "workspace-init") | quote }}, flush=True)
                   sys.exit(0)
               # An init-container restart must never overlay a partial prior
               # extraction. The signed archive is fetched again after cleanup.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1103,11 +1103,74 @@ with anything. If such an approval expires, its message keeps its buttons.
 Edit or delete that Slack message by hand, or ignore it -- the approval itself
 is expired in the API either way, so a click on it cannot approve anything.
 
+## Which claim env reaches which sandbox container
+
+Almost nobody writes a `SandboxClaim` by hand -- the worker creates them. But
+reproducing a sandbox by hand is the normal way to build a proof, a bug repro,
+or a support investigation, and the claim's env has a shape that is easy to get
+wrong in a way that looks like success.
+
+A sandbox pod runs up to three staging **init containers** before the runner
+starts: `bundle-fetch` and `bundle-extract` pull the plugin bundle out of the
+object store into `CURIE_PLUGIN_DIR`, and `workspace-init` fetches and unpacks
+the repository workspace. Each one reads its own env.
+
+A `SandboxClaim` env entry carries an optional `containerName`. **An entry with
+no `containerName` is injected into the runner container only** -- the
+`envVarsInjectionPolicy: Overrides` on the SandboxTemplate governs which side
+wins for a container the entry names, not which containers it reaches. So an
+entry the init containers need must be repeated once per init container, each
+with an explicit `containerName`:
+
+```yaml
+spec:
+  env:
+    # Reaches the runner only -- correct for runner-side keys.
+    - name: CURIE_SESSION_ID
+      value: thread-42
+    # Staging keys must be repeated per init container.
+    - name: CURIE_BUNDLE_REF
+      value: bundles/my-agent-v7.tgz
+    - name: CURIE_BUNDLE_REF
+      value: bundles/my-agent-v7.tgz
+      containerName: bundle-fetch
+    - name: CURIE_BUNDLE_REF
+      value: bundles/my-agent-v7.tgz
+      containerName: bundle-extract
+```
+
+| Env | Claim-settable? | Who consumes it |
+|---|---|---|
+| `CURIE_BUNDLE_REF` | Yes -- runner **and** `containerName: bundle-fetch` **and** `containerName: bundle-extract` | The init pair fetches and extracts the bundle; the runner reads the ref only to diagnose a staging failure. |
+| `CURIE_WORKSPACE_REF` | Yes -- `containerName: workspace-init` only | `workspace-init`. Deliberately NOT injected into the runner: it is a short-lived signed URL and the claim is plaintext in etcd. |
+| `CURIE_WORKSPACE_SHA256` | Yes -- `containerName: workspace-init` only | `workspace-init`, to verify the fetched archive. |
+| `CURIE_SESSION_ID`, `CURIE_HISTORY_REF`, `CURIE_PLUGIN_DIR`, and the rest of the boot env | Yes -- runner, no `containerName` | The runner. |
+| `CURIE_CREDENTIALS` | **No.** Stripped off the claim by the worker | The runner, from the chart Secret's `secretKeyRef`. A claim env entry would persist it as plaintext in etcd. |
+| Per-agent connector secrets (the keys named by `CURIE_CONNECTOR_SECRET_KEYS`) | **No.** Stripped off the claim by the worker | The runner, from the per-agent SandboxTemplate's `secretKeyRef`. |
+| `S3_ENDPOINT`, `BUNDLE_BUCKET`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `AWS_*` | **No.** Chart-wired from values and Secrets | `bundle-fetch`. Not a per-claim decision. |
+
+**How the mistake shows up.** It does not look like a mistake. Every init
+container exits 0 -- an empty ref is its documented no-op path, which is what a
+warm or unbound pod needs. The claim reports `Pod is Running but not Ready`, and
+the runner crash-loops on `[manifest.missing]`, which reads like a broken
+bundle. Two things now name the real cause:
+
+- each staging init container logs, on its no-op path, that a `spec.env` entry
+  with no `containerName` reaches the runner only, and which `containerName` to
+  add (`kubectl logs <pod> -c bundle-fetch`);
+- the runner refuses to boot with `CURIE_BUNDLE_REF` set over an empty plugin
+  dir, and says so in those terms instead of blaming the bundle.
+
 ## Known gotchas
 
 Notes from the first installs of the chart on fresh clusters, kept for the
 next operator.
 
+- **A hand-written `SandboxClaim`'s `spec.env` reaches the runner container
+  only** unless each entry names a `containerName`. Staging a plugin bundle or a
+  workspace by hand therefore needs the entry repeated per init container --
+  see [Which claim env reaches which sandbox container](#which-claim-env-reaches-which-sandbox-container)
+  above. It used to fail silently: every init container exited 0 (#2612).
 - **The agent-sandbox controller is enabled by default.** The chart ships the
   agent-sandbox CRDs and deploys the vendored controller when
   `agentSandbox.controller.deploy=true`, which is the default. A cluster that

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1145,9 +1145,17 @@ spec:
 | `CURIE_WORKSPACE_REF` | Yes -- `containerName: workspace-init` only | `workspace-init`. Deliberately NOT injected into the runner: it is a short-lived signed URL and the claim is plaintext in etcd. |
 | `CURIE_WORKSPACE_SHA256` | Yes -- `containerName: workspace-init` only | `workspace-init`, to verify the fetched archive. |
 | `CURIE_SESSION_ID`, `CURIE_HISTORY_REF`, `CURIE_PLUGIN_DIR`, and the rest of the boot env | Yes -- runner, no `containerName` | The runner. |
-| `CURIE_CREDENTIALS` | **No.** Stripped off the claim by the worker | The runner, from the chart Secret's `secretKeyRef`. A claim env entry would persist it as plaintext in etcd. |
-| Per-agent connector secrets (the keys named by `CURIE_CONNECTOR_SECRET_KEYS`) | **No.** Stripped off the claim by the worker | The runner, from the per-agent SandboxTemplate's `secretKeyRef`. |
-| `S3_ENDPOINT`, `BUNDLE_BUCKET`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `AWS_*` | **No.** Chart-wired from values and Secrets | `bundle-fetch`. Not a per-claim decision. |
+| `CURIE_CREDENTIALS` | Don't. Worker-filtered, not schema-rejected | The runner, from the chart Secret's `secretKeyRef`. The worker strips this key off every claim it writes; a claim you write yourself is not filtered, and the value would sit in plaintext in etcd. |
+| Per-agent connector secrets (the keys named by `CURIE_CONNECTOR_SECRET_KEYS`) | Don't. Worker-filtered, not schema-rejected | The runner, from the per-agent SandboxTemplate's `secretKeyRef`. Same plaintext-in-etcd caveat. |
+| `S3_ENDPOINT`, `BUNDLE_BUCKET`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `AWS_*` | Don't. Chart-managed defaults | `bundle-fetch`. Wired from values and Secrets, not a per-claim decision. An explicitly targeted claim entry would override them under `Overrides`. |
+
+**Nothing on this list is enforced by the CRD.** The vendored `SandboxClaim`
+schema accepts any env name, and `envVarsInjectionPolicy: Overrides` means a
+claim entry that names a container wins over the template's own value for it.
+The "Don't" rows above are the worker's discipline and the chart's wiring, both
+of which a hand-written claim bypasses entirely. Treat them as what you must not
+do, not as what you cannot do -- in particular, a credential you put on a claim
+is persisted in plaintext in etcd and nothing will stop you.
 
 **How the mistake shows up.** It does not look like a mistake. Every init
 container exits 0 -- an empty ref is its documented no-op path, which is what a

--- a/runner/src/curie_runner/plugin.py
+++ b/runner/src/curie_runner/plugin.py
@@ -132,20 +132,33 @@ def _is_empty(root: Path) -> bool:
 
 
 def staging_no_op_detail(root: Path) -> str:
-    """The operator-facing diagnosis for a claim whose staging env never landed."""
+    """The operator-facing diagnosis for a ref that is set over an empty dir.
+
+    Deliberately worded as "the most common cause", not a proven one. What this
+    runner observes is missing content, and a mis-shaped claim is the only cause
+    of it the sandbox's own loud failures do not already rule out -- but it is
+    not the only cause reachable from outside that path. A claim that overrides
+    CURIE_PLUGIN_DIR away from the init pair's mount path, or ``run_check``
+    pointed at an arbitrary directory, both land here with the init containers
+    entirely innocent. Naming the likely cause and the ones to rule out is the
+    honest form of that.
+    """
 
     entries = ", ".join(
         f"{{name: {BUNDLE_REF_ENV}, value: <ref>, containerName: {container}}}"
         for container in BUNDLE_INIT_CONTAINERS
     )
     return (
-        f"{BUNDLE_REF_ENV} is set but no plugin bundle was staged at {root}: the "
-        "bundle-fetch/bundle-extract init containers took their no-op path, so "
-        "the ref never reached them. SandboxClaim spec.env entries that carry no "
-        "containerName are injected into the runner container ONLY. A "
-        "hand-written claim must repeat each staging entry once per init "
-        f"container, e.g. {entries}. See docs/operations.md, 'Which claim env "
-        "reaches which sandbox container'."
+        f"{BUNDLE_REF_ENV} is set but nothing was staged at {root}. The most "
+        "common cause is a SandboxClaim whose staging env never reached the "
+        "init containers: a spec.env entry that carries no containerName is "
+        "injected into the runner container ONLY, so bundle-fetch and "
+        "bundle-extract keep the SandboxTemplate's empty default and take their "
+        "no-op path. A hand-written claim must repeat each staging entry once "
+        f"per init container, e.g. {entries}. Other causes to rule out: a "
+        f"CURIE_PLUGIN_DIR that does not name the path the init pair extracts "
+        "into, and a plugin dir emptied after extraction. See "
+        "docs/operations.md, 'Which claim env reaches which sandbox container'."
     )
 
 

--- a/runner/src/curie_runner/plugin.py
+++ b/runner/src/curie_runner/plugin.py
@@ -7,11 +7,26 @@ valid bundle into the ``ClaudeAgentOptions.plugins`` shape (a local plugin
 config). An invalid bundle is a hard configuration error surfaced at startup, not
 a silent skip: a runner that booted with a broken bundle would answer with the
 wrong (empty) capability set.
+
+This module is also where the sandbox's bundle STAGING is proved, not just its
+content (#2612). ``CURIE_BUNDLE_REF`` is the object key the ``bundle-fetch`` /
+``bundle-extract`` init containers fetch and unpack into ``CURIE_PLUGIN_DIR``
+before this runner starts. A ``SandboxClaim`` written by hand puts that ref in
+``spec.env`` with no ``containerName``, and the substrate injects such an entry
+into the RUNNER container only -- the init containers keep the SandboxTemplate's
+own empty default, take their documented no-op path, and exit 0. The runner then
+boots with the ref set and an empty plugin dir and dies on ``[manifest.missing]``,
+which reads like a broken bundle rather than a claim that never staged one. So a
+ref that is set while nothing was staged is diagnosed here, by name, before the
+frozen validator gets a chance to mis-attribute it.
 """
 
 import json
+import os
+from collections.abc import Mapping
 from pathlib import Path
 
+from aci_protocol import BootEnv
 from claude_agent_sdk import SdkPluginConfig
 from plugin_format import (
     TOOL_POLICY_ENFORCEMENT,
@@ -21,6 +36,18 @@ from plugin_format import (
 )
 
 BUNDLE_CONFIG_NAME = "curie.bundle.json"
+
+# The boot key the bundle init containers consume. Read through BootEnv rather
+# than typed here, so a rename in the one declaration (#488, ADR-0049) cannot
+# leave this diagnosis watching a name nobody sets any more.
+BUNDLE_REF_ENV = BootEnv.env_key("bundle_ref")
+
+# The SandboxTemplate init containers that consume BUNDLE_REF_ENV
+# (charts/curie/templates/agent-sandbox.yaml). Named in the operator-facing
+# message below because the fix is to target them explicitly;
+# ``curie_worker.sandbox.k8s.BUNDLE_INIT_CONTAINERS`` is the worker's copy of the
+# same list and the two are pinned equal by the chart/worker parity test.
+BUNDLE_INIT_CONTAINERS = ("bundle-fetch", "bundle-extract")
 
 
 class PluginBundleError(RuntimeError):
@@ -92,18 +119,69 @@ def load_bundle_system_prompt(plugin_dir: str | None) -> str | None:
     return manifest.systemPrompt
 
 
-def load_plugins(plugin_dir: str | None) -> list[SdkPluginConfig]:
+def _is_empty(root: Path) -> bool:
+    """True when nothing was staged at ``root`` -- no directory, or no entries."""
+
+    try:
+        return not any(root.iterdir())
+    except (FileNotFoundError, NotADirectoryError):
+        return True
+    except OSError:
+        # Unreadable is not provably empty; leave the verdict to validate_bundle.
+        return False
+
+
+def staging_no_op_detail(root: Path) -> str:
+    """The operator-facing diagnosis for a claim whose staging env never landed."""
+
+    entries = ", ".join(
+        f"{{name: {BUNDLE_REF_ENV}, value: <ref>, containerName: {container}}}"
+        for container in BUNDLE_INIT_CONTAINERS
+    )
+    return (
+        f"{BUNDLE_REF_ENV} is set but no plugin bundle was staged at {root}: the "
+        "bundle-fetch/bundle-extract init containers took their no-op path, so "
+        "the ref never reached them. SandboxClaim spec.env entries that carry no "
+        "containerName are injected into the runner container ONLY. A "
+        "hand-written claim must repeat each staging entry once per init "
+        f"container, e.g. {entries}. See docs/operations.md, 'Which claim env "
+        "reaches which sandbox container'."
+    )
+
+
+def load_plugins(
+    plugin_dir: str | None, *, env: Mapping[str, str] | None = None
+) -> list[SdkPluginConfig]:
     """Validate the bundle at ``plugin_dir`` and return the SDK plugin config.
 
     Returns an empty list when no plugin dir is configured. Raises
     ``PluginBundleError`` with the aggregated validation issues when the bundle
-    exists but is malformed.
+    exists but is malformed, and with an explicit staging diagnosis when
+    ``CURIE_BUNDLE_REF`` is set but the init containers staged nothing (#2612).
+
+    ``env`` defaults to the process environment; it is a parameter so the
+    staging diagnosis is exercisable without mutating the interpreter's env.
     """
 
     if not plugin_dir:
         return []
 
     root = Path(plugin_dir)
+    # #2612: a set ref over an EMPTY plugin dir is a claim-shape fault, not a
+    # bundle fault. Diagnose it before validate_bundle reports [manifest.missing],
+    # which blames the bundle author for a directory nobody ever filled.
+    #
+    # The emptiness test is what keeps this precise, and it is only sound because
+    # every other staging failure is already loud: bundle-fetch runs `set -eu` and
+    # fails the pod when the object cannot be fetched, and bundle-extract FATALs
+    # when a ref is set with no archive present. So a runner that reached boot
+    # with the ref set and NOTHING in the dir has exactly one cause -- the init
+    # containers never saw the ref. A bundle that did extract but ships no
+    # manifest leaves files behind, so it keeps the frozen validator's verdict,
+    # which is the correct one for it.
+    source = os.environ if env is None else env
+    if source.get(BUNDLE_REF_ENV, "").strip() and _is_empty(root):
+        raise PluginBundleError(staging_no_op_detail(root))
     # Naming the enforcement contract is a statement that this build applies a
     # declared toolPolicy. Older runners omit it and safely refuse policy-bearing
     # bundles rather than starting them unfenced.

--- a/runner/tests/test_plugin.py
+++ b/runner/tests/test_plugin.py
@@ -90,3 +90,102 @@ def test_bundle_web_search_invalid_config_fails_closed(
     (tmp_path / "curie.bundle.json").write_text(body, encoding="utf-8")
     with pytest.raises(PluginBundleError, match=message):
         load_bundle_web_search_enabled(str(tmp_path))
+
+
+# --- #2612: a claim whose staging env never reached the init containers -------
+#
+# The silent no-op this pins: a hand-written SandboxClaim carrying
+# CURIE_BUNDLE_REF in spec.env with no containerName reaches the runner only.
+# bundle-fetch and bundle-extract keep the SandboxTemplate's empty default, take
+# their no-op path, exit 0, and the runner boots with the ref set over an empty
+# plugin dir. Before #2612 that surfaced as the frozen validator's
+# [manifest.missing], which blames the bundle. These tests fail if the
+# diagnosis regresses to that silent mis-attribution.
+
+
+def test_set_bundle_ref_with_nothing_staged_names_the_claim_shape(tmp_path: Path) -> None:
+    from curie_runner.plugin import BUNDLE_INIT_CONTAINERS, BUNDLE_REF_ENV
+
+    with pytest.raises(PluginBundleError) as excinfo:
+        load_plugins(str(tmp_path), env={BUNDLE_REF_ENV: "bundles/agent-v7.tgz"})
+
+    message = str(excinfo.value)
+    # The cause, not the symptom: the claim shape is named, every init container
+    # that needs targeting is named, and the misleading frozen-validator code is
+    # NOT what the operator is handed.
+    assert "containerName" in message
+    assert "spec.env" in message
+    for container in BUNDLE_INIT_CONTAINERS:
+        assert container in message
+    assert "manifest.missing" not in message
+
+
+def test_unset_bundle_ref_with_nothing_staged_stays_the_bundle_error(tmp_path: Path) -> None:
+    """No ref means no staging was ever asked for; the old error is correct."""
+    from curie_runner.plugin import BUNDLE_REF_ENV
+
+    with pytest.raises(PluginBundleError) as excinfo:
+        load_plugins(str(tmp_path), env={})
+    assert "containerName" not in str(excinfo.value)
+
+    # An empty or whitespace-only ref is the template's baked default, not an
+    # operator intent, and must not trip the diagnosis either.
+    with pytest.raises(PluginBundleError) as excinfo:
+        load_plugins(str(tmp_path), env={BUNDLE_REF_ENV: "   "})
+    assert "containerName" not in str(excinfo.value)
+
+
+def test_set_bundle_ref_with_a_staged_bundle_loads_normally() -> None:
+    """Staging worked: the ref is set AND a manifest is present. No diagnosis."""
+    from curie_runner.plugin import BUNDLE_REF_ENV
+
+    bundle = _FIXTURES / "valid_bundle"
+    plugins = load_plugins(str(bundle), env={BUNDLE_REF_ENV: "bundles/agent-v7.tgz"})
+    assert plugins == [{"type": "local", "path": str(bundle)}]
+
+
+def test_set_bundle_ref_with_a_staged_but_malformed_bundle_keeps_the_bundle_error() -> None:
+    """A manifest that exists but is wrong is a bundle fault, not a claim fault."""
+    from curie_runner.plugin import BUNDLE_REF_ENV
+
+    bundle = _FIXTURES / "bad_manifest_name"
+    with pytest.raises(PluginBundleError) as excinfo:
+        load_plugins(str(bundle), env={BUNDLE_REF_ENV: "bundles/agent-v7.tgz"})
+    assert "containerName" not in str(excinfo.value)
+
+
+def test_env_defaults_to_the_process_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The boot path calls load_plugins with no env; os.environ must be the source."""
+    from curie_runner.plugin import BUNDLE_REF_ENV
+
+    monkeypatch.setenv(BUNDLE_REF_ENV, "bundles/agent-v7.tgz")
+    with pytest.raises(PluginBundleError, match="containerName"):
+        load_plugins(str(tmp_path))
+
+
+def test_a_bundle_that_did_extract_but_ships_no_manifest_is_still_a_bundle_fault(
+    tmp_path: Path,
+) -> None:
+    """Files present means staging ran; the frozen validator's verdict is correct.
+
+    The emptiness test is what keeps the #2612 diagnosis from claiming every
+    manifest-less bundle is a mis-shaped claim.
+    """
+    from curie_runner.plugin import BUNDLE_REF_ENV
+
+    (tmp_path / "skills").mkdir()
+    with pytest.raises(PluginBundleError) as excinfo:
+        load_plugins(str(tmp_path), env={BUNDLE_REF_ENV: "bundles/agent-v7.tgz"})
+    assert "containerName" not in str(excinfo.value)
+
+
+def test_a_missing_plugin_dir_with_a_set_ref_is_diagnosed(tmp_path: Path) -> None:
+    """The init pair creates the dir; no dir at all is the same never-staged case."""
+    from curie_runner.plugin import BUNDLE_REF_ENV
+
+    with pytest.raises(PluginBundleError, match="containerName"):
+        load_plugins(
+            str(tmp_path / "absent"), env={BUNDLE_REF_ENV: "bundles/agent-v7.tgz"}
+        )


### PR DESCRIPTION
## What and why

A `SandboxClaim` `spec.env` entry with no `containerName` is injected into the runner container only. A hand-written claim carrying `CURIE_BUNDLE_REF`, `CURIE_WORKSPACE_REF` or `CURIE_WORKSPACE_SHA256` therefore leaves `bundle-fetch`, `bundle-extract` and `workspace-init` on the SandboxTemplate's own empty defaults. All three take their documented no-op path, exit 0, and the runner boots over an empty plugin dir and crash-loops on `[manifest.missing]`.

Observed live on chart 0.8.7 while closing #2571 AC 5: every init container reported success, the claim reported `Pod is Running but not Ready`, and nothing in any log named the cause.

## The decision

The issue offered two options: propagate the claim env to the init containers, or make the no-op loud.

Propagation is already done on the product path -- `KubernetesSandboxClient.create_claim` copies each staging key once per init container with an explicit `containerName`. What was missing was any signal on the hand-written path, and there is no in-cluster hook that can reject a mis-shaped claim without adding an admission policy that could hard-reject every worker claim if its CEL were subtly wrong. So this makes the no-op loud at both ends, and adds the gate that keeps the product path's propagation from silently drifting.

## Changes

- **Chart.** One shared `curie.sandbox.claimEnvNoOpNotice` helper renders each staging init container's no-op message: the env key it consumes, its own container name, and the fact that an entry with no `containerName` reaches the runner only. The no-op itself stays -- a warm or unbound pod has no ref and must not fail.
- **Runner.** `load_plugins` refuses to boot when `CURIE_BUNDLE_REF` is set over an **empty** plugin dir, with that same diagnosis, instead of letting the frozen validator blame the bundle. Bounded to emptiness because every other staging failure is already loud (`bundle-fetch` runs `set -eu`; `bundle-extract` FATALs on a set ref with no archive), so a bundle that did extract but ships no manifest keeps the validator's correct verdict.
- **Tests.** `apps/worker/tests/sandbox/test_claim_env_init_container_parity.py` pins the chart's staging init containers against the worker's `containerName` targets, and fails when an init container reads a `CURIE_` key the worker never copies by name -- the drift that regresses straight back to the silent no-op. `charts/curie/ci/claim-env-init-container-assertions.sh` proves the rendered notice at every staging container, with a negative case, and is wired into `helm-ci`.
- **Docs.** `docs/operations.md` gains "Which claim env reaches which sandbox container": the per-container table of what is claim-settable, what is worker-side only, and what is chart-wired, plus a Known gotchas pointer.

## Note on the signature change

`load_plugins` gains a keyword-only `env` parameter defaulting to `os.environ`, purely so the staging diagnosis is exercisable without mutating the interpreter's env. Both existing callers (`runner/src/curie_runner/check.py`, `runner/src/curie_runner/harness/claude.py`) are unchanged.

## Verification

```
uv run pytest runner/tests/test_plugin.py -q                                      # 18 passed
uv run pytest apps/worker/tests/sandbox apps/worker/tests/binding runner/tests packages/plugin-format -q
bash charts/curie/ci/claim-env-init-container-assertions.sh                        # ALL ASSERTIONS PASSED
helm lint charts/curie                                                            # 0 failed
bash scripts/check-docs.sh                                                        # OK
uv run ruff check . && uv run mypy runner/src/curie_runner/plugin.py
```

Mutation matrix -- every one of these fails a gate:

| Mutation | Caught by |
|---|---|
| rename `workspace-init` to `workspace-stage` | parity test (both assertions) |
| give `bundle-fetch` an untargeted `CURIE_*` key | parity test |
| give `workspace-init` an untargeted **quoted** key | parity test (fail-closed scan) |
| write an env entry at an indentation the scanner does not read | parity test (`TemplateScanError`) |
| comment out all three no-op notices | chart assertion, stage (d), on empty stdout |

The chart assertion does not rely on text matching alone: stage (d) renders against a temp bundle mount path, extracts each staging init container's rendered command, and **executes it under `env -i`** -- the mis-shaped-claim condition exactly -- then asserts the real stdout names its own `containerName` and its env key. A notice that exists only in the command string (commented out, or after an early exit) fails it. Stage (e) is the wording-strip negative control.

## Adversarial review

A cross-engine read-only review of the first commit raised four findings, all real and all fixed in `ad871d33`: the chart assertion matched command text rather than behaviour; the parity scanner treated an unreadable env declaration as an absent key; the runner's message asserted a cause it had not proved; and the docs implied the non-claim-settable rows were enforced when a hand-written claim bypasses the worker's filtering entirely.

Not verified here: a live cluster reproduction of the original #2571 AC 5 failure. The task contract for this run forbids any cluster mutation, so that gate is unavailable rather than passed. The chart-side evidence is the render assertion.

Closes #2612
