### PR TITLE
Bound fail-closed live-registry pip installs to one retry

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,7 +40,10 @@ The rails are the actual control. Every agent runs inside them:
   explicitly-declared egress is permitted: DNS, the in-chart collector, RustFS
   (or `rustfs.egress` / `rustfs.stsEgress` when the object store is BYO),
   and inference when deployed, plus the operator's declared model API and MCP
-  hosts via `allowedEgress`.
+  hosts via `allowedEgress`. A live-registry pip install under that default is
+  a refusal, not a hang: ~368s on unconfigured pip (`curie-runner:0.8.7`,
+  2026-09-11); the runner image now ships `/etc/pip.conf` with `retries = 0`
+  so the same command fails on the first unreachable attempt.
 - **gVisor kernel isolation** via a RuntimeClass (`security.gvisor.mode`).
 - **Non-root runner containers** with a read-only root filesystem.
 - **Per-agent RBAC scoping** so one agent's secrets are isolated from another's. The chart ships a least-privilege baseline (a ServiceAccount with no bound Role and no mounted token); the control plane binds each agent's `resourceNames`-scoped Role when the agent is deployed.

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -1079,7 +1079,12 @@ sandbox and renders whenever an in-chart store is deployed.
 **Fail-closed egress.** `security.networkPolicy.allowedEgress` is EMPTY by
 default: a fresh install denies all egress except DNS until the operator declares
 where the model API and MCP endpoints live (`{cidr, ports}` entries). An unset
-allowlist never means allow-all. The BYO in-chart peers are not on that list
+allowlist never means allow-all. A live-registry `pip install` under that default
+is a truthful refusal (`Network is unreachable`, exit 1), not a hang: on
+`curie-runner:0.8.7` it took ~368s (pip's default retry budget across every
+resolved address). The runner image now ships `/etc/pip.conf` with `retries = 0`
+so the same command fails on the first unreachable attempt. See
+[Repository toolchain in the managed sandbox](../../docs/guides/repository-toolchain-in-the-managed-sandbox.md). The BYO in-chart peers are not on that list
 either, because each names one endpoint rather than a class of destinations: set
 `rustfs.egress` (and `rustfs.stsEgress` on the key-free path) so the sandbox
 bundle-fetch can reach S3 and STS, `otelCollector.egress` when the runner's

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,11 @@ git history (`git log -- docs/`).
   declarative data rather than code, and what is wired today.
 - [`operations.md`](operations.md): running a cluster install, plus
   operator-facing findings from early installs.
+- [`guides/repository-toolchain-in-the-managed-sandbox.md`](guides/repository-toolchain-in-the-managed-sandbox.md):
+  the supported recipe for installing a repository's dependencies and running
+  its checks inside a managed sandbox, including the measured fail-closed
+  live-registry refusal (~368s on unconfigured pip; the runner image now
+  ships `/etc/pip.conf` with `retries = 0`).
 - [`release-verification.md`](release-verification.md): what every release asset
   carries (checksums, signature, provenance, SBOM) and how to verify one before
   you run it, plus the patch-release rule that the cut names its defect trigger

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -26,6 +26,13 @@ harness, from a released binary or someone else's bundle.
   on what commands exist.** It is hidden from `--help`, and it is real.
 - `curie schema-index`: the committed, versioned JSON Schemas for every `--json`
   result, so you can check that a payload field exists before you trust it.
+- [Repository toolchain in the managed sandbox](guides/repository-toolchain-in-the-managed-sandbox.md):
+  installing a repository's dependencies and running its checks inside a
+  managed sandbox. A live-registry install under the chart's fail-closed
+  egress default is a refusal, not a hang: about 368 seconds on pip's
+  unconfigured retry budget (measured 2026-09-11 on curie-runner:0.8.7). The
+  runner image now ships /etc/pip.conf with retries = 0 so the same command
+  fails on the first unreachable attempt.
 
 ## Supported SRE bundle
 

--- a/docs/guides/repository-toolchain-in-the-managed-sandbox.md
+++ b/docs/guides/repository-toolchain-in-the-managed-sandbox.md
@@ -203,16 +203,37 @@ Both failure modes an operator actually meets are non-zero, terminating, and say
 what went wrong. Neither is ever reported as success, and under the publication
 contract the coder must report the failure and **not** publish.
 
-**Wrong or unreachable registry.** pip exhausts its retries and exits non-zero
-with the requirement named:
+**Wrong or unreachable registry.** pip exits non-zero and names the unsatisfied
+requirement:
 
 ```text
 ERROR: Could not find a version that satisfies the requirement <name> (from versions: none)
 ERROR: No matching distribution found for <name>
 ```
 
-No `Successfully installed` line is printed. The step terminates well inside its
-timeout rather than hanging.
+No `Successfully installed` line is printed. Under the chart's fail-closed
+egress default the same command talking to real `pypi.org` is also a refusal
+(`Network is unreachable`, exit 1) — it is not a hang. What *looks* like a hang
+is pip's default retry budget: `retries=5` at a 15s socket timeout, across every
+resolved address.
+
+| What you ran | Where | Wall clock | What bounded it |
+|---|---|---|---|
+| `.venv/bin/pip install requests==2.32.3` (pip defaults) | live kind cluster, chart fail-closed egress, `curie-runner:0.8.7`, 2026-09-11 | **~368 s**, exit 1, `[Errno 101] Network is unreachable (pypi.org:443)` | pip default retries=5, not Curie |
+| wrong-but-reachable index (`--index-url https://192.0.2.1/simple`) | same cluster proof | **~8 s** | connection refused / TEST-NET |
+| missing toolchain (`poetry install`) | same cluster proof | **well under 1 s**, exit 127 | shell `command not found` |
+| `git push` to unreachable github.com | same cluster proof | **~135 s**, exit 128 | git's own HTTP retry |
+| default-index pip, `PIP_RETRIES=0` | local analog, `pypi.org` pinned to TEST-NET-1 so DNS "succeeds" and TCP sits on the socket timeout | **18.6 s** (venv + one 15s connect) | image `/etc/pip.conf` |
+| default-index pip, `PIP_RETRIES=0` | local analog, `--network none` (fails at DNS) | **2.8 s** | image `/etc/pip.conf` |
+
+The runner image now ships `/etc/pip.conf` with `timeout = 15` and `retries = 0`,
+copied after the image's own pip installs so a flaky registry during the *build*
+still gets pip's default retries. Workspace venvs created at runtime read that
+site-wide file, so the naive Profile B command — the one an agent actually types —
+fails on the first unreachable attempt instead of spending six minutes of a run
+budget discovering the same ENETUNREACH. Override with `--retries` / `PIP_RETRIES`
+when a reachable index is flaky. Released `curie-runner:0.8.7` does **not** carry
+this file; that is the image the 368s number was measured against.
 
 **Missing toolchain.** A check command whose toolchain the image does not carry
 fails immediately with a `command not found`-class error and a non-zero status —
@@ -229,7 +250,7 @@ What the committed evidence does and does not cover.
 | live provider | **Not covered.** | The harness makes no model call. The recipe is about the toolchain, not the session. |
 | slack | **Not covered.** | No Slack external-integration run is included. The publication approval a Slack thread would carry is asserted statically here, not exercised. |
 | GitHub | **Boundary asserted statically.** | The credential handling in section 5 is read from the worker's workspace acquisition path and the publication tool's contract; no live human publication approval was exercised. |
-| Profile B against an enforcing NetworkPolicy | **Refusal proved; admission not.** | Under the chart's fail-closed default, a live-registry install fails truthfully (`Network is unreachable`, exit 1) — but only after **~368 s**, pip's default retry budget. That a hand-written `--allow-web-egress` CIDR then *admits* PyPI is still unproved. |
+| Profile B against an enforcing NetworkPolicy | **Refusal proved; admission not.** | Under the chart's fail-closed default, a live-registry install fails truthfully (`Network is unreachable`, exit 1). Unconfigured pip on `curie-runner:0.8.7` took **~368 s**; the image now ships `/etc/pip.conf` with `retries = 0` so the same command fails on the first attempt (see section 6). That a hand-written `--allow-web-egress` CIDR then *admits* PyPI is still unproved. |
 | repeat in a newly acquired workspace, and after restart/handoff | **Supported and proved.** | A second, independently claimed sandbox reproduced the whole recipe from the acquired head with no state carried over, producing its own distinct commits. An in-place container restart preserved the workspace, its three-commit history, the expected head and the credential-free origin. A *pod-replacing* handoff is still unproved: it would discard all `emptyDir` state and re-fetch the workspace from the signed archive. |
 
 Every container the harness starts is `--rm` and every workspace it creates is a

--- a/llms.txt
+++ b/llms.txt
@@ -10,6 +10,7 @@ The point of the three targets (`skill` in-process, `local` via docker compose, 
 * [docs/agent-install.md](docs/agent-install.md): an unattended release install, verification, and result reporting procedure for a coding agent.
 - [README.md](README.md): what Curie is, how to run it, and the target-by-target CLI walkthroughs.
 - [docs/agents.md](docs/agents.md): the verification contract for an agent driving Curie. The exact commands that prove an outcome, and the rule that a file existing or a string appearing in output is never evidence.
+- [docs/guides/repository-toolchain-in-the-managed-sandbox.md](docs/guides/repository-toolchain-in-the-managed-sandbox.md): the supported recipe for installing a repository's dependencies and running its checks in a managed sandbox. A fail-closed live-registry pip install is a refusal, not a hang: ~368s on unconfigured pip (curie-runner:0.8.7); the image now ships /etc/pip.conf with retries=0.
 - [docs/vision.md](docs/vision.md): the north star, who it is for, and the parity thesis new features are held against.
 
 ## The parity ladder (skill -> local -> cluster)

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -97,5 +97,10 @@ ENV PATH="/app/.venv/bin:$PATH"
 ENV CURIE_RUNNER_PORT=8080
 EXPOSE 8080
 
+# Runtime pip defaults (#2614). Copied after the image's own pip installs so a
+# flaky registry during the build still gets pip's default retries. Workspace
+# venvs created at runtime read this site-wide file.
+COPY runner/pip.conf /etc/pip.conf
+
 USER 1000:1000
 CMD ["python", "-m", "curie_runner"]

--- a/runner/pip.conf
+++ b/runner/pip.conf
@@ -1,0 +1,9 @@
+# Runtime pip defaults for the Curie runner sandbox (#2614).
+# pip's own retry budget (retries=5, 15s socket timeout per attempt, across
+# every resolved address) is what made a fail-closed live-registry install
+# take ~368s on curie-runner:0.8.7. retries=0 keeps the refusal to one
+# attempt per destination so a blocked install fails in seconds, not minutes.
+# Override with --retries / PIP_RETRIES when a reachable index is flaky.
+[global]
+timeout = 15
+retries = 0

--- a/runner/tests/test_dockerfile_registry_layer.py
+++ b/runner/tests/test_dockerfile_registry_layer.py
@@ -54,6 +54,7 @@ _COPY_SOURCES = (
     "packages/telemetry-schema",
     "runner",
     "runner/export_dependency_pins.py",
+    "runner/pip.conf",
 )
 
 # Patterns that would drop a COPY source wholesale. dockerignore last-match

--- a/runner/tests/test_repo_toolchain_proof.py
+++ b/runner/tests/test_repo_toolchain_proof.py
@@ -55,6 +55,8 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 FIXTURE_REPO = Path(__file__).resolve().parent / "fixtures" / "repo_toolchain"
 GUIDE = REPO_ROOT / "docs" / "guides" / "repository-toolchain-in-the-managed-sandbox.md"
+PIP_CONF = REPO_ROOT / "runner" / "pip.conf"
+DOCKERFILE = REPO_ROOT / "runner" / "Dockerfile"
 
 # --- product posture, imported rather than hardcoded -------------------------
 #
@@ -366,6 +368,7 @@ def _run_in_sandbox(
     network: str | None = "none",
     timeout: int = DEFAULT_TIMEOUT,
     workdir: str | None = None,
+    extra_run_args: list[str] | None = None,
 ) -> Step:
     """Run one shell script inside the runner image under the product posture.
 
@@ -375,6 +378,8 @@ def _run_in_sandbox(
     name = f"{CONTAINER_PREFIX}{uuid.uuid4().hex[:12]}"
     _LAUNCHED_CONTAINER_NAMES.append(name)
     argv = ["docker", "run", "--rm", "--name", name, *HARDENING_ARGS]
+    if extra_run_args:
+        argv += extra_run_args
     if network is not None:
         argv += ["--network", network]
     if workspace is not None:
@@ -717,6 +722,66 @@ def test_unreachable_registry_fails_bounded_and_truthfully(tmp_path: Path) -> No
     evidence.write(_evidence_dir(tmp_path) / "repo-toolchain-unreachable-registry-evidence.json")
 
 
+def test_default_index_blocked_egress_fails_on_the_image_retry_budget(
+    tmp_path: Path,
+) -> None:
+    """Catches a fail-closed live-registry install hanging on pip's default retries.
+
+    The cluster observation (#2614) was a default-index pip install under
+    NetworkPolicy ENETUNREACH that ran for ~368s because pip retried every
+    resolved address. The image ships ``/etc/pip.conf`` with ``retries = 0``
+    so that command fails on the first attempt.
+
+    Local analog: pin ``pypi.org`` to TEST-NET-1 so DNS "succeeds" and the TCP
+    connect sits on pip's 15s socket timeout instead of failing at name
+    resolution (``--network none``). Without the image pip.conf this takes
+    ~90s (5 attempts * 15s) and trips the 45s bound below.
+    """
+
+    _require_runner_image()
+    _require_non_vacuous_hardening()
+    _require_fixture()
+
+    evidence = Evidence()
+    with tempfile.TemporaryDirectory(prefix="curie-2614-blocked-") as root:
+        workspace = _materialize_fixture_clone(Path(root))
+        step = evidence.record(
+            _run_in_sandbox(
+                "install-default-index-blocked-egress",
+                INSTALL_LIVE,
+                workspace=workspace,
+                network=None,
+                timeout=45,
+                extra_run_args=[
+                    "--add-host",
+                    "pypi.org:192.0.2.1",
+                    "--add-host",
+                    "files.pythonhosted.org:192.0.2.1",
+                ],
+            )
+        )
+
+    assert step.exit_status != 0, (
+        f"a blocked default-index install must not report success:\n{step.output}"
+    )
+    assert step.duration_seconds < 30, (
+        f"the image pip.conf must fail the blocked install on the first attempt, "
+        f"not pip's default retry budget; observed {step.duration_seconds}s:\n"
+        f"{step.output}"
+    )
+    lowered = step.output.casefold()
+    assert (
+        "could not find a version that satisfies the requirement" in lowered
+        or "no matching distribution found" in lowered
+        or "network is unreachable" in lowered
+        or "timed out" in lowered
+        or "connection" in lowered
+    ), f"the failure text must truthfully name the blocked registry:\n{step.output}"
+    assert "successfully installed" not in lowered, "a failed install must never claim success"
+
+    evidence.write(_evidence_dir(tmp_path) / "repo-toolchain-blocked-default-index-evidence.json")
+
+
 def test_missing_toolchain_fails_bounded_and_truthfully(tmp_path: Path) -> None:
     """Catches a missing toolchain being swallowed into a silent pass.
 
@@ -1006,6 +1071,17 @@ def test_guide_documents_the_recipe_and_the_boundary() -> None:
     assert "command not found" in lowered or "not found" in lowered, (
         "bounded failure mode 2 (missing toolchain) must be shown"
     )
+    assert "368" in text, (
+        "the guide must record the measured fail-closed live-registry latency, "
+        "not describe it only as 'well inside its timeout'"
+    )
+    assert "/etc/pip.conf" in text and "retries = 0" in text, (
+        "the guide must name the image pip.conf that bounds the refusal"
+    )
+    assert "network is unreachable" in lowered, (
+        "the fail-closed default-index error must be shown, not only the "
+        "wrong-index 'no matching distribution' text"
+    )
 
     for tier in ("local", "cluster", "slack"):
         assert tier in lowered, f"the applicability matrix must cover the {tier} tier"
@@ -1015,6 +1091,31 @@ def test_guide_documents_the_recipe_and_the_boundary() -> None:
     # The docs gate bans raw line-coordinate citations anywhere in the file.
     assert not re.search(r"\.(?:py|rs|toml|yaml|md)(?::\d+|#L\d+)", text), (
         "the docs citation gate bans file:line citations; cite by path only"
+    )
+
+
+def test_runner_image_ships_fail_fast_pip_retries() -> None:
+    """Catches the image retry bound drifting back to pip's default of 5.
+
+    The 368s cluster refusal was pip's default retry budget. If /etc/pip.conf
+    loses ``retries = 0``, or the Dockerfile stops copying it, the naive
+    Profile B command hangs for minutes again and the guide's fail-fast claim
+    is false.
+    """
+
+    assert PIP_CONF.is_file(), f"the runner image pip.conf must exist at {PIP_CONF}"
+    conf = PIP_CONF.read_text()
+    assert re.search(r"^retries\s*=\s*0\s*$", conf, flags=re.MULTILINE), (
+        "runner/pip.conf must set retries = 0; a higher value reintroduces the "
+        f"multi-minute fail-closed install:\n{conf}"
+    )
+    assert re.search(r"^timeout\s*=\s*15\s*$", conf, flags=re.MULTILINE), (
+        f"runner/pip.conf must keep pip's 15s socket timeout explicit:\n{conf}"
+    )
+    dockerfile = DOCKERFILE.read_text()
+    assert "COPY runner/pip.conf /etc/pip.conf" in dockerfile, (
+        "the Dockerfile must install the pip.conf at the site-wide path "
+        "workspace venvs actually read"
     )
 
 


### PR DESCRIPTION
A live-registry install under the chart's fail-closed egress default was a
truthful refusal that still burned ~368 seconds of a run, bounded only by
pip's default retry budget. That reads as a hang.

The runner image now ships `/etc/pip.conf` with `timeout = 15` and
`retries = 0`, copied after the image's own pip installs so a flaky registry
during the build still gets pip's default retries. Workspace venvs created at
runtime read that site-wide file, so the naive Profile B command fails on the
first unreachable attempt.

Measured numbers recorded in the repository-toolchain guide (operators) and
in the agent verification contract / `llms.txt` (agents):

- fail-closed default-index pip on `curie-runner:0.8.7` (2026-09-11): ~368s, exit 1, Network is unreachable
- wrong-but-reachable index: ~8s
- missing toolchain: under 1s
- git push to unreachable github.com: ~135s
- image pip.conf analog (TEST-NET-1, DNS "succeeds"): 18.6s
- image pip.conf analog (`--network none`): 2.8s

Admission of PyPI through a hand-written `--allow-web-egress` CIDR remains
unproved.

Closes #2614
