### PR TITLE
Record what a pod-replacing sandbox handoff destroys

### DIFF
--- a/docs/guides/repository-toolchain-in-the-managed-sandbox.md
+++ b/docs/guides/repository-toolchain-in-the-managed-sandbox.md
@@ -90,6 +90,77 @@ and fail on local Compose — a difference that would only ever be discovered by
 whoever ran it locally last. `/workspace` is correct on both, so it is the only
 location this guide documents.
 
+### Nothing in the sandbox survives a pod replacement
+
+Read this before you have work worth losing.
+
+The recipe's writable paths are all `emptyDir` at cluster tier and tmpfs or a
+bind mount locally. None of them is storage. A restart that keeps the *pod* —
+the runner container dying and being restarted in place — preserves everything:
+the checkout, its history, the head, the origin, the virtualenv. A restart that
+replaces the **pod** preserves none of it.
+
+**On a pod replacement your workspace is reset to the head the platform
+published, and everything the sandbox produced is gone:**
+
+| | in-place container restart | pod replacement |
+|---|---|---|
+| repository present, credential-free origin | preserved | re-fetched, so present |
+| head | preserved | **reset to the archive head** |
+| commits made in the sandbox, not published | preserved | **lost** |
+| uncommitted edits and untracked files | preserved | **lost** |
+| the virtualenv, and anything under `/tmp` or `/home/runner` | preserved | **lost** |
+
+This is structural, not a gap to be fixed by being careful. A replacement pod
+re-materializes `/workspace` through `workspace-init`, which fetches the signed
+archive the trusted worker built from *its own* clone of the remote. Nothing
+anywhere captures a live sandbox's `/workspace` back into an archive, so there
+is no mechanism by which in-sandbox work could survive. `workspace-init` also
+erases `/workspace` before extracting, deliberately, so that an interrupted
+extraction can never be overlaid.
+
+Three ordinary things replace the pod, and only the first is obvious:
+
+- the late workspace handoff of ADR-0136, when a conversation acquires a
+  repository after it has already started;
+- suspend/resume (ADR-0003 suspend *is* pod deletion), and any eviction, node
+  drain or rescheduling — here the claim, the route and the session id are all
+  unchanged, so there is no claim-level event that says work was discarded;
+- any pod restart that is not an in-place container restart.
+
+So: **the only durable place for work is publication.** `publish_changes` is not
+a nicety at the end of a task, it is the step that makes the work exist outside a
+pod. Commit early if you like, but understand that a commit is not durability
+here — an unpublished commit dies with the pod exactly as an uncommitted edit
+does.
+
+One consequence worth knowing when a sandbox will not come back: the signed
+workspace reference is short-lived (five minutes by default). A pod recreated
+after it expires cannot re-fetch at all — `workspace-init` exits non-zero with
+`workspace-fetch: signed reference expired` and the pod sits in
+`Init:CrashLoopBackOff`. That is the platform failing closed rather than serving
+a stale workspace; recovery is a fresh claim, which the worker prepares with a
+new reference.
+
+### Is a persistent workspace volume the answer?
+
+Not today, and not one flag away. `SandboxClaim.spec.volumeClaimTemplates`
+exists in the CRD, but nothing in Curie sets it, and the shipped runner
+`SandboxTemplate` leaves `volumeClaimTemplatesPolicy` at its CRD default of
+`Disallowed` — a claim that asks for a volume is refused outright with
+`VolumeClaimTemplatesError`, creating neither pod nor PVC.
+
+Allowing it does not get you a persistent workspace either. With the policy
+flipped and a PVC bound at `/workspace`, the volume genuinely does survive a pod
+replacement — and `workspace-init` then wipes it on the new pod's first start,
+because its unconditional clean is what guarantees a partial extraction is never
+overlaid. Persisting the workspace would mean changing that, and trading away
+the property the wipe exists to provide.
+
+The platform's answer to durability is elsewhere and is already in the recipe:
+committed work becomes durable by publication, and conversation state survives
+in the replayed history the replacement runner boots from.
+
 ## 3. The recipe
 
 Two profiles. **Profile A is the default**, because it is the only one that
@@ -251,7 +322,9 @@ What the committed evidence does and does not cover.
 | slack | **Not covered.** | No Slack external-integration run is included. The publication approval a Slack thread would carry is asserted statically here, not exercised. |
 | GitHub | **Boundary asserted statically.** | The credential handling in section 5 is read from the worker's workspace acquisition path and the publication tool's contract; no live human publication approval was exercised. |
 | Profile B against an enforcing NetworkPolicy | **Refusal proved; admission not.** | Under the chart's fail-closed default, a live-registry install fails truthfully (`Network is unreachable`, exit 1). Unconfigured pip on `curie-runner:0.8.7` took **~368 s**; the image now ships `/etc/pip.conf` with `retries = 0` so the same command fails on the first attempt (see section 6). That a hand-written `--allow-web-egress` CIDR then *admits* PyPI is still unproved. |
-| repeat in a newly acquired workspace, and after restart/handoff | **Supported and proved.** | A second, independently claimed sandbox reproduced the whole recipe from the acquired head with no state carried over, producing its own distinct commits. An in-place container restart preserved the workspace, its three-commit history, the expected head and the credential-free origin. A *pod-replacing* handoff is still unproved: it would discard all `emptyDir` state and re-fetch the workspace from the signed archive. |
+| repeat in a newly acquired workspace, and after an in-place restart | **Supported and proved.** | A second, independently claimed sandbox reproduced the whole recipe from the acquired head with no state carried over, producing its own distinct commits. An in-place container restart preserved the workspace, its three-commit history, the expected head and the credential-free origin. See `ac5-cluster-evidence/`. |
+| after a pod-replacing handoff | **Proved — and it discards everything the sandbox made.** | Exercised on a kind cluster on 2026-09-11 in both shapes: the ADR-0136 cold-claim handoff, and a pod deleted under an unchanged live claim. Both re-fetched the signed archive, so the repository and its credential-free origin came back — at the **archive head**, with the in-sandbox commit, the uncommitted edits, the untracked files and the virtualenv all gone. Recorded for operators under *Nothing in the sandbox survives a pod replacement*. See `pod-replacing-handoff-evidence/`. |
+| a persistent workspace volume | **Not the answer; not supported today.** | Nothing in Curie sets `SandboxClaim.spec.volumeClaimTemplates`, and the shipped template leaves the policy at the CRD default `Disallowed`, so such a claim is refused with no pod and no PVC. With the policy flipped, the PVC does survive the pod replacement and `workspace-init` wipes it anyway. A persistent workspace would require changing that wipe. |
 
 Every container the harness starts is `--rm` and every workspace it creates is a
 temporary directory; it asserts observably that neither survives the run.

--- a/docs/guides/repository-toolchain-in-the-managed-sandbox.md
+++ b/docs/guides/repository-toolchain-in-the-managed-sandbox.md
@@ -111,6 +111,9 @@ published, and everything the sandbox produced is gone:**
 | uncommitted edits and untracked files | preserved | **lost** |
 | the virtualenv, and anything under `/tmp` or `/home/runner` | preserved | **lost** |
 
+Put plainly: **uncommitted changes are lost, and so is any commit you made in
+the sandbox but never published.** Both die with the pod.
+
 This is structural, not a gap to be fixed by being careful. A replacement pod
 re-materializes `/workspace` through `workspace-init`, which fetches the signed
 archive the trusted worker built from *its own* clone of the remote. Nothing
@@ -119,14 +122,19 @@ is no mechanism by which in-sandbox work could survive. `workspace-init` also
 erases `/workspace` before extracting, deliberately, so that an interrupted
 extraction can never be overlaid.
 
-Three ordinary things replace the pod, and only the first is obvious:
+Three ordinary things replace the pod, and the last is the one that catches
+people out:
 
 - the late workspace handoff of ADR-0136, when a conversation acquires a
   repository after it has already started;
-- suspend/resume (ADR-0003 suspend *is* pod deletion), and any eviction, node
-  drain or rescheduling — here the claim, the route and the session id are all
-  unchanged, so there is no claim-level event that says work was discarded;
-- any pod restart that is not an in-place container restart.
+- suspend and resume — ADR-0003 suspend *is* pod deletion, and resume does not
+  bring the pod back: it retires the suspended claim and creates a fresh one at
+  the next route generation, so the replacement is visible as a new claim;
+- eviction, node drain or any rescheduling, where the controller recreates the
+  pod beneath a claim that never changes. The claim, the route and the session
+  id all stay exactly as they were and only the pod's uid moves, so nothing at
+  claim level records that a workspace was discarded and rebuilt. This is the
+  one you will not be told about.
 
 So: **the only durable place for work is publication.** `publish_changes` is not
 a nicety at the end of a task, it is the step that makes the work exist outside a

--- a/docs/guides/repository-toolchain-in-the-managed-sandbox.md
+++ b/docs/guides/repository-toolchain-in-the-managed-sandbox.md
@@ -130,11 +130,12 @@ people out:
 - suspend and resume — ADR-0003 suspend *is* pod deletion, and resume does not
   bring the pod back: it retires the suspended claim and creates a fresh one at
   the next route generation, so the replacement is visible as a new claim;
-- eviction, node drain or any rescheduling, where the controller recreates the
-  pod beneath a claim that never changes. The claim, the route and the session
-  id all stay exactly as they were and only the pod's uid moves, so nothing at
-  claim level records that a workspace was discarded and rebuilt. This is the
-  one you will not be told about.
+- the pod going away beneath a claim that never changes. The claim, the route
+  and the session id all stay exactly as they were and only the pod's uid moves,
+  so nothing at claim level records that a workspace was discarded and rebuilt.
+  This is the one you will not be told about. It was exercised by deleting the
+  pod directly; an eviction, a node drain or any other rescheduling reaches the
+  same controller path, though this guide has not measured those individually.
 
 So: **the only durable place for work is publication.** `publish_changes` is not
 a nicety at the end of a task, it is the step that makes the work exist outside a
@@ -159,11 +160,17 @@ exists in the CRD, but nothing in Curie sets it, and the shipped runner
 `VolumeClaimTemplatesError`, creating neither pod nor PVC.
 
 Allowing it does not get you a persistent workspace either. With the policy
-flipped and a PVC bound at `/workspace`, the volume genuinely does survive a pod
-replacement — and `workspace-init` then wipes it on the new pod's first start,
-because its unconditional clean is what guarantees a partial extraction is never
-overlaid. Persisting the workspace would mean changing that, and trading away
-the property the wipe exists to provide.
+flipped and a PVC bound at `/workspace`, the claim binds and the sandbox comes
+up — and a pod replacement still lands on an empty-then-re-extracted workspace,
+with the PVC itself unchanged throughout (same uid, same volume).
+
+The wipe is what does it, and that is measured rather than inferred: the same
+PVC, replaced the same way but mounted into a pod carrying **no**
+`workspace-init`, keeps its contents across the replacement intact. Put the init
+container back and the contents go. Its first action is to empty `/workspace`
+before extracting, which is exactly what guarantees a partial extraction is
+never overlaid — so persisting the workspace means changing that, and trading
+away the property the wipe exists to provide.
 
 The platform's answer to durability is elsewhere and is already in the recipe:
 committed work becomes durable by publication, and conversation state survives
@@ -333,6 +340,14 @@ What the committed evidence does and does not cover.
 | repeat in a newly acquired workspace, and after an in-place restart | **Supported and proved.** | A second, independently claimed sandbox reproduced the whole recipe from the acquired head with no state carried over, producing its own distinct commits. An in-place container restart preserved the workspace, its three-commit history, the expected head and the credential-free origin. See `ac5-cluster-evidence/`. |
 | after a pod-replacing handoff | **Proved — and it discards everything the sandbox made.** | Exercised on a kind cluster on 2026-09-11 in both shapes: the ADR-0136 cold-claim handoff, and a pod deleted under an unchanged live claim. Both re-fetched the signed archive, so the repository and its credential-free origin came back — at the **archive head**, with the in-sandbox commit, the uncommitted edits, the untracked files and the virtualenv all gone. Recorded for operators under *Nothing in the sandbox survives a pod replacement*. See `pod-replacing-handoff-evidence/`. |
 | a persistent workspace volume | **Not the answer; not supported today.** | Nothing in Curie sets `SandboxClaim.spec.volumeClaimTemplates`, and the shipped template leaves the policy at the CRD default `Disallowed`, so such a claim is refused with no pod and no PVC. With the policy flipped, the PVC does survive the pod replacement and `workspace-init` wipes it anyway. A persistent workspace would require changing that wipe. |
+
+The `ac5-cluster-evidence/` and `pod-replacing-handoff-evidence/` records named
+above are the raw per-run artifacts of the two cluster runs — claim manifests,
+cluster version, and the measured before/after of each case. They are kept with
+the v0.9.0 queue contract under the maintainer's local `.projects/` tree, which
+this repository does not track, so you will not find them in a checkout. What
+they support is stated in full in the rows above; the citation is there to name
+the run, not to send you looking.
 
 Every container the harness starts is `--rm` and every workspace it creates is a
 temporary directory; it asserts observably that neither survives the run.

--- a/runner/tests/test_repo_toolchain_proof.py
+++ b/runner/tests/test_repo_toolchain_proof.py
@@ -1094,14 +1094,37 @@ _HONESTY_ROWS: tuple[tuple[str, str, str], ...] = (
 
 _DATA_LOSS_WARNING_TERMS: tuple[tuple[str, str], ...] = (
     ("the pod-replacement case must be named", r"pod\s+replacement|pod-replacing"),
-    ("uncommitted work must be named as lost", r"uncommitted"),
     (
-        "an unpublished commit must be named as lost too, not just uncommitted edits",
-        r"unpublished\s+commit",
+        "uncommitted work must be asserted LOST, not merely mentioned",
+        r"uncommitted[^.|\n]{0,80}\b(lost|gone|discard\w*|erase\w*|wipe\w*)\b"
+        r"|\b(lost|gone|discard\w*|erase\w*|wipe\w*)\b[^.|\n]{0,80}uncommitted",
+    ),
+    (
+        "an unpublished commit must be asserted LOST too, not just uncommitted edits",
+        r"unpublished\s+commit[^.|\n]{0,80}\b(dies|lost|gone|discard\w*)\b",
     ),
     (
         "publication must be named as the durable answer",
         r"publish_changes",
+    ),
+)
+
+# A warning that says the opposite of what #2615 measured must never pass. These
+# are the shapes a softened rewrite actually takes -- "it survives", "it is
+# preserved", "it is kept" said of a pod replacement -- and each is a lie about
+# the recorded run.
+_DATA_LOSS_CONTRADICTIONS: tuple[tuple[str, str], ...] = (
+    (
+        "uncommitted work claimed to survive a replacement",
+        r"pod\s+replacement[^.|\n]{0,120}\b(preserv\w*|surviv\w*|keep\w*|kept|retain\w*)\b"
+        r"[^.|\n]{0,60}uncommitted"
+        r"|uncommitted[^.|\n]{0,80}\b(preserv\w*|surviv\w*|kept|retain\w*)\b"
+        r"[^.|\n]{0,60}pod\s+replacement",
+    ),
+    (
+        "publication declared unnecessary",
+        r"no\s+need\s+for\s+publish_changes|publish_changes\s+is\s+(not\s+)?"
+        r"(necessary|needed|required)",
     ),
 )
 
@@ -1115,6 +1138,12 @@ def _assert_guide_warns_about_pod_replacement_data_loss(text: str) -> None:
     *before* the recipe an operator is about to follow. A drift test that merely
     pinned the applicability row would stay green while the body warning was
     deleted -- the row is read after the fact, the warning is read in time.
+
+    Pinning the *subject words* alone is not enough either, and that is the
+    sharper trap: a rewrite saying a pod replacement **preserves** uncommitted
+    work names every required term while asserting the opposite of the measured
+    result. So each term is pinned to its loss relationship, and the inverted
+    claims are rejected outright as negative controls.
     """
 
     body = text.split("## 3. The recipe")[0]
@@ -1125,6 +1154,13 @@ def _assert_guide_warns_about_pod_replacement_data_loss(text: str) -> None:
             f"{label}: the pod-replacement data-loss warning must appear before "
             "the recipe. Deleting or softening it lets an operator follow the "
             "recipe without being told the workspace is not storage."
+        )
+    for label, pattern in _DATA_LOSS_CONTRADICTIONS:
+        assert not re.search(pattern, lowered), (
+            f"{label}: the guide now claims the opposite of what the #2615 "
+            "cluster run measured. A pod replacement re-fetches the signed "
+            "archive and discards every in-sandbox change; saying otherwise "
+            "invites exactly the data loss this warning exists to prevent."
         )
     assert re.search(r"in-place", lowered), (
         "the warning must distinguish an in-place container restart (which "

--- a/runner/tests/test_repo_toolchain_proof.py
+++ b/runner/tests/test_repo_toolchain_proof.py
@@ -1085,11 +1085,52 @@ _HONESTY_ROWS: tuple[tuple[str, str, str], ...] = (
         r"not\s+proved|not\s+covered|unproved|open\b",
     ),
     (
-        "repeat in a new workspace / after restart or handoff",
-        r"(restart|handoff|hand-off)",
-        r"open\b|not\s+proved|unproved|not\s+demonstrated",
+        "a persistent workspace volume",
+        r"persistent\s+workspace\s+volume",
+        r"not\s+the\s+answer|not\s+supported|not\s+proved|unproved|open\b",
     ),
 )
+
+
+_DATA_LOSS_WARNING_TERMS: tuple[tuple[str, str], ...] = (
+    ("the pod-replacement case must be named", r"pod\s+replacement|pod-replacing"),
+    ("uncommitted work must be named as lost", r"uncommitted"),
+    (
+        "an unpublished commit must be named as lost too, not just uncommitted edits",
+        r"unpublished\s+commit",
+    ),
+    (
+        "publication must be named as the durable answer",
+        r"publish_changes",
+    ),
+)
+
+
+def _assert_guide_warns_about_pod_replacement_data_loss(text: str) -> None:
+    """Pin the warning that stands between an operator and losing a day's work.
+
+    Issue #2615 proved that a pod-replacing handoff resets ``/workspace`` to the
+    published head and discards every in-sandbox commit, uncommitted edit and
+    virtualenv. That finding is only worth anything if the guide keeps saying so
+    *before* the recipe an operator is about to follow. A drift test that merely
+    pinned the applicability row would stay green while the body warning was
+    deleted -- the row is read after the fact, the warning is read in time.
+    """
+
+    body = text.split("## 3. The recipe")[0]
+    assert len(body) < len(text), "the warning must precede the recipe, not follow it"
+    lowered = body.casefold()
+    for label, pattern in _DATA_LOSS_WARNING_TERMS:
+        assert re.search(pattern, lowered), (
+            f"{label}: the pod-replacement data-loss warning must appear before "
+            "the recipe. Deleting or softening it lets an operator follow the "
+            "recipe without being told the workspace is not storage."
+        )
+    assert re.search(r"in-place", lowered), (
+        "the warning must distinguish an in-place container restart (which "
+        "preserves everything) from a pod replacement (which preserves none of "
+        "it); without the contrast the reader cannot tell which one they had"
+    )
 
 
 def _assert_guide_discloses_what_is_not_proved(text: str) -> None:
@@ -1124,9 +1165,15 @@ def test_guide_documents_the_recipe_and_the_boundary() -> None:
     bounded-failure modes, the proof harness is proving something nobody is
     being told to do. And if the applicability matrix loses the rows that admit
     what is *not* proved -- the live provider, GitHub publication approval,
-    Profile B against an enforcing NetworkPolicy, and repeat-after-restart/handoff
-    -- the guide overclaims. Deleting any one of those rows, or upgrading it to a
-    proved claim, now fails.
+    Profile B against an enforcing NetworkPolicy, and the persistent workspace
+    volume -- the guide overclaims. Deleting any one of those rows, or upgrading
+    it to a proved claim, now fails.
+
+    The restart/handoff row is no longer an honesty row: issue #2615 proved the
+    pod-replacing path on a cluster. What replaces that pin is stricter, because
+    what that proof found was a way to lose work -- the guide must keep warning,
+    before the recipe, that a pod replacement discards everything the sandbox
+    made.
     """
 
     assert GUIDE.is_file(), f"the operator guide must exist at {GUIDE}"
@@ -1174,6 +1221,7 @@ def test_guide_documents_the_recipe_and_the_boundary() -> None:
         assert tier in lowered, f"the applicability matrix must cover the {tier} tier"
 
     _assert_guide_discloses_what_is_not_proved(text)
+    _assert_guide_warns_about_pod_replacement_data_loss(text)
 
     # The docs gate bans raw line-coordinate citations anywhere in the file.
     assert not re.search(r"\.(?:py|rs|toml|yaml|md)(?::\d+|#L\d+)", text), (


### PR DESCRIPTION
Closes #2615.

#2571 AC 5 proved the benign half of "survives a restart/handoff": an in-place
container restart, where the workspace, its three-commit history, the expected
head, the credential-free origin and the virtualenv all survived. The
pod-replacing half was left unproved, and it is the half that decides whether
work is lost.

## What was exercised

On the `dark-factory` kind cluster against the released
`ghcr.io/curie-eng/curie-runner:0.8.7` image, with the repository delivered by
the product's own `workspace-init` signed-archive fetcher — both shapes of pod
replacement that actually occur:

1. **The ADR-0136 late workspace handoff** — cold-claim a candidate carrying the
   same session id, then retire the old claim (the shape of
   `SandboxSubstrate.handoff`). Pod uid `0dace47b` → `53b5cafb`.
2. **A pod deleted under an unchanged live claim** — eviction, node drain,
   rescheduling. Claim, route and session id all unchanged; pod uid
   `53b5cafb` → `dbdd1278`.

Before each, the sandbox held: a commit made inside it and never published
(`13315c9`), an uncommitted tracked edit, an untracked file, a virtualenv in
`/workspace`, and scratch under `/tmp` and `/home/runner`.

## What survives

Both shapes behave identically. The repository and its credential-free origin
come back, because `workspace-init` re-fetches the signed archive — **at the
archive head**. Everything the sandbox produced is gone: the in-sandbox commit
(commit count back to 1), the uncommitted edit, the untracked file, the
virtualenv, and both scratch files.

This is structural rather than a gap to tighten. The archive is built by the
trusted worker from *its own* clone of the remote at `base_sha`; nothing
anywhere captures a live sandbox's `/workspace` back into an archive, so there
is no mechanism by which in-sandbox work could survive.

Shape 2 is the dangerous one: the claim, the route and the session id never
change and only the pod's uid moves, so nothing at claim level records that a
workspace was discarded and rebuilt.

## Where an operator reads it

A new section sits in the sandbox-posture section, **before the recipe** —
"Nothing in the sandbox survives a pod replacement" — with a preserved-vs-lost
table, the plain statement that uncommitted changes and unpublished commits are
both lost, the three paths that replace a pod separated by what is observable
from each, and the conclusion that publication is the only durable place for
work.

## `SandboxClaim.spec.volumeClaimTemplates`

Assessed, and it is not the answer:

- **Nothing uses it today.** No `SandboxClaim` or `SandboxTemplate` in the repo
  sets it; the chart's four `volumeClaimTemplates` are the StatefulSets.
- **The shipped policy forbids it.** `volumeClaimTemplatesPolicy` is left at its
  CRD default `Disallowed`, and such a claim is refused outright with
  `VolumeClaimTemplatesError`, creating neither pod nor PVC.
- **Allowing it is still not enough.** With the policy flipped the claim binds,
  and a pod replacement still lands on an empty-then-re-extracted workspace with
  the PVC unchanged throughout. That the *wipe* causes this is measured, not
  inferred: the same PVC mounted into a pod carrying **no** `workspace-init`
  keeps its contents across the replacement intact. A persistent workspace means
  changing that clean, and trading away the property it provides.

## One operational finding

The signed workspace reference is short-lived (300 s by default). A pod
recreated after it expires cannot re-fetch at all: `workspace-init` exits 1 with
`workspace-fetch: signed reference expired` and the pod sits in
`Init:CrashLoopBackOff`. Failing closed is correct; having it written down is
what stops it being debugged as a mystery.

## Applicability matrix

The single unproved row is replaced by three: the in-place restart row (proved,
unchanged in substance), a pod-replacing-handoff row (proved, and recording what
it destroys), and a persistent-workspace-volume row (not the answer, not
supported today).

## Test changes

The `_HONESTY_ROWS` pin on the restart/handoff row is retired — the row is now
proved — and replaced with a stricter guard, since what the proof found was a
way to lose a day's work. The guide must keep the warning *ahead of the recipe*
and keep asserting the loss, not merely naming the subjects.

Adversarial review (router review 500, reviewer `codex`) caught that the first
version of this guard pinned vocabulary rather than the loss relationship, so a
rewrite claiming a pod replacement *preserves* uncommitted work would have
passed. Each term is now pinned to its loss relationship with inverted claims
rejected as negative controls. The same review caught the guide wrongly
grouping suspend/resume with the unchanged-claim case; `resume()` retires the
suspended claim and creates a fresh one, so its replacement *is* visible. Both
fixed in the second commit.

The `spec-vs-impl` and `scope-creep` reviewers then both passed (0 blocking, 0
creep). `spec-vs-impl` raised two places where the guide said slightly more than
the run had earned — the PVC persistence claim was a code-read attribution
presented as a measurement, and "eviction, node drain" was listed as exercised
when a direct pod delete is what happened. The third commit closes the first by
actually running the no-`workspace-init` control, and narrows the second to what
was measured.

Mutation-verified 6/6 red, including the reviewer's own attack string verbatim:
delete the section; soften uncommitted work to a bare mention; drop the
unpublished-commit clause; drop `publish_changes`; the inverted warning; upgrade
the persistent-volume row.

## Gates

- `uv run pytest runner/tests/ -q` → **1030 passed, 13 skipped**
- `uv run ruff check .` → clean
- `bash scripts/check-docs.sh` → OK

## Cleanup

Every cluster object this run created (5 claims, 3 SandboxTemplates, 3
SandboxWarmPools, 1 PVC, the upload helper pod, and the `s3://curie-bundles/h2615-proof/`
object) was deleted and verified gone. The install was not mutated: `curie-runner`
template and `curie-runner-pool` resourceVersions unchanged at 1053/1054, all 11
workload pods still Running.

The full evidence record is at
`.projects/release-realignment-2026-09-10/queue-contracts/curie-v090-repo-environment/pod-replacing-handoff-evidence/`,
local-only under the repo's `.projects/` convention, as `ac5-cluster-evidence/`
already is.
