### PR TITLE
Verify live package registry egress

### DIFF
--- a/docs/adr/0152-no-cidr-trusted-registries-preset.md
+++ b/docs/adr/0152-no-cidr-trusted-registries-preset.md
@@ -1,0 +1,117 @@
+# 152. Registry destinations are operator-declared, not a platform preset
+
+Date: 2026-09-11
+
+Status: Draft
+
+This Draft proposes to supersede, if accepted, only the package-manager preset
+commitment in
+[ADR-0075](0075-the-agent-proxy-credential-and-egress-boundary.md). That
+commitment is already conditional on FQDN capability. The proposal leaves
+ADR-0075's Agent Proxy, credential boundary, per-agent scoping, and audit intent
+unchanged.
+
+## Context
+
+ADR-0075 says Curie will ship a curated "trusted registries" bundle on top of
+FQDN-aware enforcement. Its ordering is sound: the preset is conditional on
+the FQDN capability. The open question is whether Curie should commit to
+maintaining a multi-registry bundle after that capability arrives.
+
+That bundle is a product and maintenance boundary of its own. Package managers
+cross registry, archive, distribution, redirect, mirror, and shared-hosting
+boundaries that change independently. One successful PyPI installation does
+not justify a maintained list for npm, PyPI, crates.io, apt archives, ghcr, and
+their peers.
+
+FQDN enforcement is not the system available today. The current NetworkPolicy
+boundary admits IP addresses and CIDRs. The named-provider option resolves a
+hostname during installation and stores `/32` routes, while arbitrary
+destinations require an operator-supplied `--allow-web-egress <CIDR>` value.
+
+An install-time DNS answer is an address snapshot. It does not constrain later
+traffic by hostname, and it can drift when a CDN changes addresses. Shared CDN
+addresses may also serve destinations outside the intended registry. Calling
+such a snapshot a trusted-registry or hostname boundary would overstate what
+the enforcement layer proves.
+
+The [managed-sandbox toolchain guide](../guides/repository-toolchain-in-the-managed-sandbox.md)
+therefore describes live registry dependencies as a known-imprecise fallback.
+The reproducible
+[registry-egress check](../../scripts/check-registry-egress.py) creates a
+disposable Calico kind cluster from the current chart, resolves live PyPI
+addresses into `/32` TCP/443 allowances, and exercises denied, admitted, and
+revoked pip and direct-TCP controls. Its generated output records the address
+snapshot and result of that invocation. A successful run proves that the
+selected addresses admitted the selected flow at that time; it does not prove a
+durable registry or domain boundary.
+
+## Decision
+
+**If accepted, Curie will not carry a standing commitment to ship a
+platform-maintained "trusted registries" preset, including after FQDN-aware
+enforcement arrives.** Under this proposal, operators declare the destinations
+their repositories require. Curie does not approximate a preset by resolving
+registries during installation, storing the resulting CIDRs, or describing
+those CIDRs as hostname-scoped enforcement.
+
+Bundled dependencies, with no live registry egress, remain the default managed
+sandbox strategy. Live registry dependencies remain available to operators who
+explicitly provide raw CIDRs through `--allow-web-egress`. Documentation and
+operator output identify that route as known-imprecise and subject to address
+drift. It is not a trusted-registries preset.
+
+A future platform-maintained preset requires a separate explicit decision. It
+must define the supported ecosystems and destinations, redirect and mirror
+behavior, ownership, update cadence, security review, compatibility policy,
+and live proof. The FQDN-aware proxy substrate still requires its own Accepted
+ADR, implementation, and live positive and negative enforcement checks. This
+proposal does not select the proxy topology, TLS behavior, domain matching
+rules, or any registry contents.
+
+If this Draft is accepted, it supersedes only ADR-0075's commitment to
+ship the package-manager preset after FQDN capability. ADR-0075's accepted
+direction for proxy-held credentials, separate destination and credential
+bindings, per-agent scoping, and complete audit events remains intact. While
+this ADR is Draft, ADR-0075 stays unchanged and Accepted, with no status or
+backlink edit.
+
+## Consequences and security limits
+
+- Operators retain an explicit live-registry escape hatch, but they must own
+  the selected CIDRs and refresh them when registry addressing changes.
+- A raw CIDR can admit unrelated services sharing an address or range. Curie
+  cannot make a comprehensive registry or domain claim for that path.
+- A narrow `/32` may fail closed after address rotation. A broader range may
+  reduce failures while admitting more destinations. Neither tradeoff creates
+  hostname enforcement.
+- Bundled dependencies avoid this boundary by construction and remain the
+  precise default for repository toolchains whose dependencies can be vendored.
+- Future FQDN proxy evidence must remain separate from current CIDR admission
+  evidence. A successful live-registry admission check cannot stand in for
+  proxy implementation or live proxy enforcement checks.
+- Operator-declared FQDN destinations become the package-manager path after the
+  proxy arrives. Curie does not own their completeness or freshness.
+- Any future curated preset must earn and maintain its own support boundary. It
+  is a reconsideration through a new decision, not an implied proxy feature.
+
+## Alternatives considered
+
+1. **Retain ADR-0075's existing conditional preset commitment.** Rejected
+   because FQDN enforcement makes domain lists possible but does not establish
+   which ecosystems, redirects, mirrors, distributions, or archive versions
+   Curie can maintain. The existing promise is conditional, but still broader
+   than the evidence and named ownership.
+2. **Ship a preset made from install-time `/32` resolutions.** Rejected because
+   it would label a temporary address snapshot as a hostname boundary and would
+   inherit CDN drift and shared-address exposure.
+3. **Ship and maintain broad registry CIDR lists.** Rejected because the lists
+   would be operationally brittle, broader than the named registries, and still
+   unable to prove which domain received traffic.
+4. **Remove live registry dependencies and require bundling everywhere.**
+   Rejected because an operator may knowingly accept the imprecision for a
+   repository that cannot bundle its toolchain dependencies. The raw CIDR
+   control makes that choice explicit.
+5. **Treat the future Agent Proxy as available now.** Rejected because
+   ADR-0075 deliberately leaves the substrate and TLS decision to a follow-up.
+   Architecture intent is not an implemented enforcement boundary.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -174,4 +174,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0143 | [A coding thread owns one fenced pull request lineage](0143-thread-owned-pull-request-lineage.md) | Accepted |
 | 0144 | [The cluster lifecycle admits before it mutates, and its pause authority is installation-scoped](0144-the-upgrade-lifecycle-admits-before-it-mutates.md) | Draft |
 | 0151 | [A permission-gate card shows a bundle-authored sentence; the machine summary stays the audit record](0151-bundle-authored-human-approval-summary.md) | Draft |
+| 0152 | [Registry destinations are operator-declared, not a platform preset](0152-no-cidr-trusted-registries-preset.md) | Draft |
 <!-- END GENERATED: adr-index -->

--- a/docs/guides/repository-toolchain-in-the-managed-sandbox.md
+++ b/docs/guides/repository-toolchain-in-the-managed-sandbox.md
@@ -178,10 +178,11 @@ in the replayed history the replacement runner boots from.
 
 ## 3. The recipe
 
-Two profiles. **Profile A is the default**, because it is the only one that
-satisfies "only the egress this repository needs" exactly.
+Two dependency strategies. **Bundled dependencies are the default**, because
+they are the only strategy that satisfies "only the egress this repository
+needs" exactly.
 
-### Profile A — vendored dependencies, no registry egress
+### Bundled dependencies — no registry egress
 
 Stage the dependency wheels into the workspace and install from there:
 
@@ -213,7 +214,7 @@ cd /workspace && /workspace/.venv/bin/python -m unittest discover -s tests -t . 
 Use the command the repository documents, not one you invented for it. That is
 also what the publication contract requires of the coder.
 
-### Profile B — live registry
+### Live registry dependencies
 
 ```sh
 python -m venv /workspace/.venv
@@ -229,9 +230,9 @@ section 4 before choosing it.
 default**, and entries are additive: nothing reaches a package registry until an
 operator says so.
 
-Profile A needs no entry at all.
+Bundled dependencies need no entry at all.
 
-Profile B needs pip to reach **both** `pypi.org` (the index) and
+Live registry dependencies need pip to reach **both** `pypi.org` (the index) and
 `files.pythonhosted.org` (the files). The only operator lever that can carry an
 arbitrary destination is:
 
@@ -249,10 +250,39 @@ CIDRs by hand.
 records that there is no package-manager story: enforcement is CIDR-based while
 registry hosts are CDN-fronted with rotating IPs. Any CIDR range you write for
 `pypi.org` or `files.pythonhosted.org` is therefore **broader than this
-repository needs, and it will drift** as the CDN's addressing changes. Profile B
-is a known-imprecise fallback. It is not a minimal allowlist, and this guide will
-not describe it as one. The "trusted registries" preset ADR-0075 contemplates is
-not implemented; there is no such flag or chart value today.
+repository needs, and it will drift** as the CDN's addressing changes. Live
+registry egress is a known-imprecise fallback. It is not a minimal allowlist,
+and this guide will not describe it as one. The "trusted registries" preset
+ADR-0075 contemplates is not implemented; there is no such flag or chart value
+today.
+
+[ADR-0152](../adr/0152-no-cidr-trusted-registries-preset.md) proposes removing
+the standing commitment to a platform-maintained registries preset, including
+after FQDN-aware enforcement arrives. It remains **Draft**: its proposed outcome
+is not accepted, and it does not supersede accepted ADR-0075 yet.
+
+The reproducible check requires Docker, kind, kubectl, Helm, and uv. Run it from
+the repository root with a new or empty output directory:
+
+```sh
+output_dir=$(mktemp -d)
+uv run python scripts/check-registry-egress.py \
+  --output-dir "$output_dir"
+```
+
+The check creates and cleans up its own disposable kind cluster with Calico,
+renders the current chart, resolves live PyPI DNS answers into IPv4 `/32`
+TCP/443 rules, and exercises `packaging==25.0` from a fresh virtualenv. Both pip
+and a direct TCP connect run denied → admitted → revoked; the named output
+directory receives the generated manifests and result record for that run.
+
+The September 11, 2026 verification observed `[1, 0, 1]` for both controls, and
+the admitted pip phase downloaded and imported version 25.0.
+[PR #2621](https://github.com/curie-eng/curie/pull/2621) records that historical
+verification. It proved refusal and admission for the recorded address
+snapshot. A CIDR snapshot is not a domain boundary or a trusted-registries
+preset, and later DNS answers may differ. The check does not exercise a
+controller claim, workspace acquisition, model call, or publication.
 
 **Edge case worth knowing before you need it:** `curie doctor` can recommend a
 `cluster up` re-run as remediation, and a re-run applies the allowlist it is
@@ -315,7 +345,7 @@ resolved address.
 The runner image now ships `/etc/pip.conf` with `timeout = 15` and `retries = 0`,
 copied after the image's own pip installs so a flaky registry during the *build*
 still gets pip's default retries. Workspace venvs created at runtime read that
-site-wide file, so the naive Profile B command — the one an agent actually types —
+site-wide file, so the naive live-registry command — the one an agent actually types —
 fails on the first unreachable attempt instead of spending six minutes of a run
 budget discovering the same ENETUNREACH. Override with `--retries` / `PIP_RETRIES`
 when a reachable index is flaky. Released `curie-runner:0.8.7` does **not** carry
@@ -327,7 +357,7 @@ for example `poetry: not found`. It is not swallowed into a silent pass.
 
 ## 7. Applicability
 
-What the committed evidence does and does not cover.
+What the documented checks do and do not cover.
 
 | Surface | Applicability | Evidence |
 |---|---|---|
@@ -336,7 +366,7 @@ What the committed evidence does and does not cover.
 | live provider | **Not covered.** | The harness makes no model call. The recipe is about the toolchain, not the session. |
 | slack | **Not covered.** | No Slack external-integration run is included. The publication approval a Slack thread would carry is asserted statically here, not exercised. |
 | GitHub | **Boundary asserted statically.** | The credential handling in section 5 is read from the worker's workspace acquisition path and the publication tool's contract; no live human publication approval was exercised. |
-| Profile B against an enforcing NetworkPolicy | **Refusal proved; admission not.** | Under the chart's fail-closed default, a live-registry install fails truthfully (`Network is unreachable`, exit 1). Unconfigured pip on `curie-runner:0.8.7` took **~368 s**; the image now ships `/etc/pip.conf` with `retries = 0` so the same command fails on the first attempt (see section 6). That a hand-written `--allow-web-egress` CIDR then *admits* PyPI is still unproved. |
+| Live registry dependencies against an enforcing NetworkPolicy | **Admission and refusal are reproducible for a CIDR snapshot.** | Run [`scripts/check-registry-egress.py`](../../scripts/check-registry-egress.py); it tests `packaging==25.0`. A CIDR snapshot is not a domain boundary and not a trusted-registries preset. |
 | repeat in a newly acquired workspace, and after an in-place restart | **Supported and proved.** | A second, independently claimed sandbox reproduced the whole recipe from the acquired head with no state carried over, producing its own distinct commits. An in-place container restart preserved the workspace, its three-commit history, the expected head and the credential-free origin. See `ac5-cluster-evidence/`. |
 | after a pod-replacing handoff | **Proved — and it discards everything the sandbox made.** | Exercised on a kind cluster on 2026-09-11 in both shapes: the ADR-0136 cold-claim handoff, and a pod deleted under an unchanged live claim. Both re-fetched the signed archive, so the repository and its credential-free origin came back — at the **archive head**, with the in-sandbox commit, the uncommitted edits, the untracked files and the virtualenv all gone. Recorded for operators under *Nothing in the sandbox survives a pod replacement*. See `pod-replacing-handoff-evidence/`. |
 | a persistent workspace volume | **Not the answer; not supported today.** | Nothing in Curie sets `SandboxClaim.spec.volumeClaimTemplates`, and the shipped template leaves the policy at the CRD default `Disallowed`, so such a claim is refused with no pod and no PVC. With the policy flipped, the PVC does survive the pod replacement and `workspace-init` wipes it anyway. A persistent workspace would require changing that wipe. |

--- a/runner/tests/test_repo_toolchain_proof.py
+++ b/runner/tests/test_repo_toolchain_proof.py
@@ -56,6 +56,7 @@ FIXTURE_REPO = Path(__file__).resolve().parent / "fixtures" / "repo_toolchain"
 GUIDE = REPO_ROOT / "docs" / "guides" / "repository-toolchain-in-the-managed-sandbox.md"
 PIP_CONF = REPO_ROOT / "runner" / "pip.conf"
 DOCKERFILE = REPO_ROOT / "runner" / "Dockerfile"
+REGISTRY_EGRESS_CHECK = REPO_ROOT / "scripts" / "check-registry-egress.py"
 
 # --- product posture, imported rather than hardcoded -------------------------
 #
@@ -830,7 +831,7 @@ def test_default_index_blocked_egress_fails_on_the_image_retry_budget(
     _require_fixture()
 
     evidence = Evidence()
-    with tempfile.TemporaryDirectory(prefix="curie-2614-blocked-") as root:
+    with _owned_tempdir(prefix="curie-2614-blocked-") as root:
         workspace = _materialize_fixture_clone(Path(root))
         step = evidence.record(
             _run_in_sandbox(
@@ -1063,8 +1064,8 @@ def test_live_registry_profile_installs_a_third_party_pin(tmp_path: Path) -> Non
 # --- 7. the guide cannot drift away from the harness ------------------------
 
 
-# The applicability matrix's honesty rows: each is a surface this evidence does
-# NOT prove. ``subject`` matches the row's first cell; ``marker`` is the
+# The applicability matrix's remaining honesty rows: each is a surface this
+# evidence does NOT prove. ``subject`` matches the row's first cell; ``marker`` is the
 # not-proved admission the row must still carry. Matched on concept plus marker
 # rather than verbatim prose, so rewording is fine and deletion or an upgrade to
 # "proved" is not.
@@ -1078,11 +1079,6 @@ _HONESTY_ROWS: tuple[tuple[str, str, str], ...] = (
         "GitHub publication approval",
         r"github",
         r"not\s+covered|not\s+proved|open\b|asserted\s+statically|statically",
-    ),
-    (
-        "Profile B against an enforcing NetworkPolicy",
-        r"profile\s*b.*(networkpolicy|network\s*policy|egress)",
-        r"not\s+proved|not\s+covered|unproved|open\b",
     ),
     (
         "a persistent workspace volume",
@@ -1170,7 +1166,7 @@ def _assert_guide_warns_about_pod_replacement_data_loss(text: str) -> None:
 
 
 def _assert_guide_discloses_what_is_not_proved(text: str) -> None:
-    """Pin the four applicability rows that admit what the evidence does not cover.
+    """Pin the remaining applicability rows that admit unproved surfaces.
 
     Catches the unpinned-rule class: a drift test that only greps for `local`,
     `cluster` and `slack` stays green after the honesty rows are deleted, which
@@ -1192,18 +1188,57 @@ def _assert_guide_discloses_what_is_not_proved(text: str) -> None:
         )
 
 
+def _assert_live_registry_egress_contract(text: str) -> None:
+    """Pin the reproducible live-registry check and its CIDR limits."""
+
+    rows = [
+        row
+        for row in text.splitlines()
+        if row.strip().startswith("|")
+        and re.search(
+            r"live\s+registry\s+dependencies.*(networkpolicy|network\s*policy|egress)",
+            row,
+            flags=re.IGNORECASE,
+        )
+    ]
+    assert len(rows) == 1, (
+        "the applicability matrix must carry exactly one live-registry enforcing-"
+        f"NetworkPolicy row; found {rows}"
+    )
+    row = rows[0].casefold()
+    for marker in (
+        "admission and refusal",
+        "cidr snapshot",
+        "packaging==25.0",
+        "scripts/check-registry-egress.py",
+        "not a domain boundary",
+        "not a trusted-registries preset",
+    ):
+        assert marker in row, (
+            f"the live-registry row must retain its contract and limit marker {marker!r}: "
+            f"{rows[0]}"
+        )
+
+    assert REGISTRY_EGRESS_CHECK.is_file(), (
+        f"the documented live-registry check must exist at {REGISTRY_EGRESS_CHECK}"
+    )
+    assert re.search(
+        r"python\s+scripts/check-registry-egress\.py\s+\\?\s*--output-dir\b",
+        text,
+    ), "the guide must carry the runnable check command with its output directory"
+
+
 def test_guide_documents_the_recipe_and_the_boundary() -> None:
     """Catches the guide drifting from what the harness actually proves, and the
     honesty rows being quietly deleted so the guide reads as proving more.
 
     The guide is the deliverable an operator follows; if it stops naming the
-    venv location, both egress profiles, the publication boundary, or the two
+    venv location, both dependency strategies, the publication boundary, or the two
     bounded-failure modes, the proof harness is proving something nobody is
     being told to do. And if the applicability matrix loses the rows that admit
     what is *not* proved -- the live provider, GitHub publication approval,
-    Profile B against an enforcing NetworkPolicy, and the persistent workspace
-    volume -- the guide overclaims. Deleting any one of those rows, or upgrading
-    it to a proved claim, now fails.
+    and the persistent workspace volume -- the guide overclaims. Live registry
+    egress has a separate reproducible contract with explicit CIDR limits.
 
     The restart/handoff row is no longer an honesty row: issue #2615 proved the
     pod-replacing path on a cluster. What replaces that pin is stricter, because
@@ -1221,9 +1256,9 @@ def test_guide_documents_the_recipe_and_the_boundary() -> None:
         "the guide must state the sandbox posture the recipe works within"
     )
     assert "--no-index" in text and "--find-links" in text, (
-        "Profile A's vendored install command must be copy-pasteable from the guide"
+        "the bundled-dependency install command must be copy-pasteable from the guide"
     )
-    assert "--allow-web-egress" in text, "Profile B's operator lever must be named"
+    assert "--allow-web-egress" in text, "the live-registry operator lever must be named"
     assert "0075" in text, "the guide must cite ADR-0075 for the egress imprecision"
     assert "no-new-privileges" in lowered or "cap-drop" in lowered or "cap_drop" in lowered
 
@@ -1258,6 +1293,7 @@ def test_guide_documents_the_recipe_and_the_boundary() -> None:
 
     _assert_guide_discloses_what_is_not_proved(text)
     _assert_guide_warns_about_pod_replacement_data_loss(text)
+    _assert_live_registry_egress_contract(text)
 
     # The docs gate bans raw line-coordinate citations anywhere in the file.
     assert not re.search(r"\.(?:py|rs|toml|yaml|md)(?::\d+|#L\d+)", text), (
@@ -1288,6 +1324,28 @@ def test_runner_image_ships_fail_fast_pip_retries() -> None:
         "the Dockerfile must install the pip.conf at the site-wide path "
         "workspace venvs actually read"
     )
+
+
+def test_live_registry_egress_contract_rejects_material_mutations() -> None:
+    """Prove deleting the row or overstating a CIDR snapshot makes the pin red."""
+
+    text = GUIDE.read_text()
+
+    without_row = "\n".join(
+        row
+        for row in text.splitlines()
+        if "Live registry dependencies against an enforcing" not in row
+    )
+    with pytest.raises(AssertionError):
+        _assert_live_registry_egress_contract(without_row)
+
+    overclaimed = text.replace(
+        "not a domain boundary and not a trusted-registries preset",
+        "a durable domain boundary and a trusted-registries preset",
+    )
+    assert overclaimed != text, "the mutation must alter the pinned live-registry row"
+    with pytest.raises(AssertionError):
+        _assert_live_registry_egress_contract(overclaimed)
 
 
 # --- 8. the deliberately-red fixture must never enter our own suite ---------

--- a/scripts/check-registry-egress.py
+++ b/scripts/check-registry-egress.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+"""Prove the chart's runner registry egress deny/admit/revoke boundary.
+
+This creates its own kind cluster and binds a chart-rendered SandboxTemplate to
+a probe Pod.  It intentionally does not run the sandbox controller, create a
+SandboxClaim, call a model, or prove a hostname-stable allowlist.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import datetime as dt
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+RUNNER_IMAGE = (
+    "ghcr.io/curie-eng/curie-runner@"
+    "sha256:c31e9f585d3f74a6a554b575042c0d71421de9603c038ced27ae5b393e0dc272"
+)
+KIND_IMAGE = "kindest/node@sha256:25a3504b2b340954595fa7a6ed1575ef2edadf5abd83c0776a4308b64bf47c93"
+CALICO_URL = "https://raw.githubusercontent.com/projectcalico/calico/v3.29.3/manifests/calico.yaml"
+CALICO_SHA256 = "9a575859428b822a224dedafc4238555b6b0f910f2abf12983f20f871860914e"
+PACKAGE = "packaging==25.0"
+
+
+class Check:
+    def __init__(self, output: Path, runner_image: str) -> None:
+        self.output = output
+        self.repo = Path(__file__).resolve().parent.parent
+        self.runner_image = runner_image
+        suffix = uuid.uuid4().hex[:10]
+        self.cluster = f"curie-registry-{suffix}"
+        self.release = f"registry-{suffix}"
+        self.namespace = self.release
+        self.pod = "registry-egress-probe"
+        self.commands: list[dict[str, Any]] = []
+        self.phases: dict[str, dict[str, int]] = {}
+        self.cluster_attempted = False
+        self.chart_sha256 = ""
+        self.temp: tempfile.TemporaryDirectory[str] | None = None
+        self.kubeconfig: Path | None = None
+
+    def write_json(self, name: str, value: Any) -> None:
+        (self.output / name).write_text(json.dumps(value, indent=2) + "\n")
+
+    def run(
+        self, name: str, args: list[str], timeout: int = 120, check: bool = True
+    ) -> subprocess.CompletedProcess[str]:
+        started = time.monotonic()
+        try:
+            result = subprocess.run(
+                args, cwd=self.repo, text=True, capture_output=True, timeout=timeout
+            )
+        except subprocess.TimeoutExpired as exc:
+            stdout = exc.stdout or ""
+            stderr = exc.stderr or ""
+            if isinstance(stdout, bytes):
+                stdout = stdout.decode(errors="replace")
+            if isinstance(stderr, bytes):
+                stderr = stderr.decode(errors="replace")
+            result = subprocess.CompletedProcess(
+                args, 124, stdout, stderr + f"\ntimeout after {timeout}s\n"
+            )
+        record = {
+            "name": name,
+            "command": args,
+            "exit_code": result.returncode,
+            "elapsed_seconds": round(time.monotonic() - started, 3),
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        }
+        self.commands.append(record)
+        self.write_json(f"command-{len(self.commands):02d}-{name}.json", record)
+        if check and result.returncode != 0:
+            raise RuntimeError(f"{name} exited {result.returncode}; see command log")
+        return result
+
+    def kubectl(self, *args: str) -> list[str]:
+        assert self.kubeconfig is not None
+        return ["kubectl", "--kubeconfig", str(self.kubeconfig), *args]
+
+    def render(self, values: Path, artifact: str) -> list[dict[str, Any]]:
+        result = self.run(
+            f"render-{artifact}",
+            [
+                "helm",
+                "template",
+                self.release,
+                "charts/curie",
+                "--namespace",
+                self.namespace,
+                "-f",
+                str(values),
+                "-s",
+                "templates/agent-sandbox.yaml",
+                "-s",
+                "templates/security-networkpolicy.yaml",
+                "-s",
+                "templates/priorityclass.yaml",
+            ],
+        )
+        (self.output / f"rendered-{artifact}.yaml").write_text(result.stdout)
+        return [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+
+    def probe(self, phase: str, ip: str) -> None:
+        tcp_code = (
+            "import socket,sys; s=socket.socket(); s.settimeout(3); "
+            "\ntry: s.connect((sys.argv[1],443)); print('TCP443_CONNECTED')"
+            "\nexcept OSError as e: print('TCP443_REFUSED',type(e).__name__); sys.exit(1)"
+        )
+        tcp = self.run(
+            f"tcp-{phase}",
+            self.kubectl(
+                "exec",
+                "-n",
+                self.namespace,
+                self.pod,
+                "-c",
+                "runner",
+                "--",
+                "python",
+                "-c",
+                tcp_code,
+                ip,
+            ),
+            timeout=15,
+            check=False,
+        )
+        venv = f"/workspace/.venv-{phase}"
+        pip_script = f"""set -eu
+python -m venv {venv}
+{venv}/bin/python -c "import importlib.util; assert importlib.util.find_spec('packaging') is None"
+set +e
+PIP_CONFIG_FILE=/dev/null {venv}/bin/python -m pip --isolated install \
+  --disable-pip-version-check --no-cache-dir --index-url https://pypi.org/simple \
+  --retries 0 --timeout 5 --only-binary=:all: --no-deps \
+  --report /workspace/report-{phase}.json {PACKAGE}
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  {venv}/bin/python -c "import packaging; assert packaging.__version__ == '25.0'"
+else
+  {venv}/bin/python -c "import importlib.util; assert importlib.util.find_spec('packaging') is None"
+fi
+exit "$rc"
+"""
+        pip = self.run(
+            f"pip-{phase}",
+            self.kubectl(
+                "exec",
+                "-n",
+                self.namespace,
+                self.pod,
+                "-c",
+                "runner",
+                "--",
+                "sh",
+                "-c",
+                pip_script,
+            ),
+            timeout=100,
+            check=False,
+        )
+        expected = 0 if phase == "admitted" else 1
+        self.phases[phase] = {
+            "tcp_exit_code": tcp.returncode,
+            "pip_exit_code": pip.returncode,
+        }
+        if tcp.returncode != expected or pip.returncode != expected:
+            raise AssertionError(
+                f"{phase}: expected TCP and pip exit {expected}, got "
+                f"{tcp.returncode} and {pip.returncode}"
+            )
+
+    def execute(self) -> None:
+        for tool in ("docker", "kind", "kubectl", "helm"):
+            if shutil.which(tool) is None:
+                raise RuntimeError(f"required executable not found: {tool}")
+        image_match = re.fullmatch(r"(.+)@(sha256:[0-9a-f]{64})", self.runner_image)
+        if not image_match:
+            raise ValueError("--runner-image must be an immutable sha256 image reference")
+        chart_hash = hashlib.sha256()
+        for path in sorted((self.repo / "charts/curie").rglob("*")):
+            if path.is_file():
+                relative = path.relative_to(self.repo).as_posix()
+                chart_hash.update(relative.encode() + b"\0" + path.read_bytes() + b"\0")
+        self.chart_sha256 = chart_hash.hexdigest()
+
+        self.temp = tempfile.TemporaryDirectory(prefix="curie-registry-egress-")
+        self.kubeconfig = Path(self.temp.name) / "kubeconfig"
+        kind_config = self.output / "kind.yaml"
+        kind_config.write_text(
+            "kind: Cluster\napiVersion: kind.x-k8s.io/v1alpha4\nnetworking:\n"
+            "  disableDefaultCNI: true\n  podSubnet: 192.168.0.0/16\n"
+            "nodes:\n  - role: control-plane\n"
+        )
+        calico = self.output / "calico.yaml"
+        with urllib.request.urlopen(CALICO_URL, timeout=30) as response:
+            calico.write_bytes(response.read())
+        digest = hashlib.sha256(calico.read_bytes()).hexdigest()
+        if digest != CALICO_SHA256:
+            raise AssertionError(f"Calico manifest digest mismatch: {digest}")
+
+        self.cluster_attempted = True
+        self.run(
+            "kind-create",
+            [
+                "kind",
+                "create",
+                "cluster",
+                "--name",
+                self.cluster,
+                "--image",
+                KIND_IMAGE,
+                "--config",
+                str(kind_config),
+                "--kubeconfig",
+                str(self.kubeconfig),
+            ],
+            timeout=360,
+        )
+        self.run("calico-apply", self.kubectl("apply", "-f", str(calico)), timeout=120)
+        self.run(
+            "calico-ready",
+            self.kubectl(
+                "rollout", "status", "daemonset/calico-node", "-n", "kube-system", "--timeout=300s"
+            ),
+            timeout=320,
+        )
+        self.run(
+            "nodes-ready",
+            self.kubectl("wait", "--for=condition=Ready", "nodes", "--all", "--timeout=300s"),
+            timeout=320,
+        )
+
+        base_values = {
+            "agentSandbox": {
+                "controller": {"deploy": False},
+                "runner": {
+                    "image": image_match.group(1),
+                    "digest": image_match.group(2),
+                    "bundleFetch": {"enabled": False},
+                    "serviceAccount": {"create": False},
+                },
+            },
+            "security": {"networkPolicy": {"allowedEgress": []}},
+        }
+        denied_values = self.output / "values-denied.yaml"
+        denied_values.write_text(yaml.safe_dump(base_values, sort_keys=False))
+        denied_docs = self.render(denied_values, "denied")
+        sandbox = next(doc for doc in denied_docs if doc.get("kind") == "SandboxTemplate")
+        if sandbox["spec"].get("networkPolicyManagement") != "Unmanaged":
+            raise AssertionError("SandboxTemplate is not bound to chart-managed NetworkPolicy")
+        self.write_json("sandbox-template.json", sandbox)
+
+        spec = copy.deepcopy(sandbox["spec"]["podTemplate"]["spec"])
+        runner = next(
+            container for container in spec["containers"] if container["name"] == "runner"
+        )
+        if runner["image"] != self.runner_image:
+            raise AssertionError(f"rendered runner image is not pinned: {runner['image']}")
+        runner["command"] = ["sleep", "3600"]
+        runner.pop("args", None)
+        for key in ("readinessProbe", "livenessProbe", "startupProbe"):
+            runner.pop(key, None)
+        spec["restartPolicy"] = "Never"
+        spec["automountServiceAccountToken"] = False
+        pod = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": self.pod,
+                "namespace": self.namespace,
+                "labels": sandbox["spec"]["podTemplate"]["metadata"]["labels"],
+            },
+            "spec": spec,
+        }
+        self.write_json("pod.json", pod)
+        policies = [doc for doc in denied_docs if doc.get("kind") == "NetworkPolicy"]
+        (self.output / "policies-denied.yaml").write_text(
+            yaml.safe_dump_all(policies, sort_keys=False)
+        )
+        classes = [doc for doc in denied_docs if doc.get("kind") == "PriorityClass"]
+        for item in classes:
+            item["value"] = int(float(item["value"]))
+        (self.output / "priorityclasses.yaml").write_text(
+            yaml.safe_dump_all(classes, sort_keys=False)
+        )
+
+        self.run("namespace-create", self.kubectl("create", "namespace", self.namespace))
+        self.run(
+            "priorityclasses-apply",
+            self.kubectl("apply", "-f", str(self.output / "priorityclasses.yaml")),
+        )
+        self.run(
+            "policies-apply",
+            self.kubectl(
+                "apply",
+                "-n",
+                self.namespace,
+                "-f",
+                str(self.output / "policies-denied.yaml"),
+            ),
+        )
+        self.run(
+            "pod-apply",
+            self.kubectl("apply", "-n", self.namespace, "-f", str(self.output / "pod.json")),
+        )
+        self.run(
+            "pod-ready",
+            self.kubectl(
+                "wait",
+                "--for=condition=Ready",
+                f"pod/{self.pod}",
+                "-n",
+                self.namespace,
+                "--timeout=300s",
+            ),
+            timeout=320,
+        )
+
+        dns_code = (
+            "import json,socket; h=['pypi.org','files.pythonhosted.org']; "
+            "print(json.dumps({x:sorted({r[4][0] for r in socket.getaddrinfo(x,443,"
+            "socket.AF_INET,socket.SOCK_STREAM)}) for x in h}))"
+        )
+        dns_result = self.run(
+            "dns",
+            self.kubectl(
+                "exec",
+                "-n",
+                self.namespace,
+                self.pod,
+                "-c",
+                "runner",
+                "--",
+                "python",
+                "-c",
+                dns_code,
+            ),
+            timeout=30,
+        )
+        answers = json.loads(dns_result.stdout)
+        if any(not answers.get(host) for host in ("pypi.org", "files.pythonhosted.org")):
+            raise AssertionError("both registry hostnames must have live IPv4 answers")
+        self.write_json("dns.json", {"hostnames": answers})
+        ips = sorted({ip for values in answers.values() for ip in values})
+        control_ip = ips[0]
+        self.probe("denied", control_ip)
+
+        admitted_values_data = copy.deepcopy(base_values)
+        admitted_values_data["security"]["networkPolicy"]["allowedEgress"] = [
+            {"cidr": f"{ip}/32", "ports": [{"protocol": "TCP", "port": 443}]} for ip in ips
+        ]
+        admitted_values = self.output / "values-admitted.yaml"
+        admitted_values.write_text(yaml.safe_dump(admitted_values_data, sort_keys=False))
+        admitted_docs = self.render(admitted_values, "admitted")
+        allow = next(
+            doc
+            for doc in admitted_docs
+            if doc.get("kind") == "NetworkPolicy"
+            and doc["metadata"]["name"].endswith("runner-allow-egress")
+        )
+        (self.output / "allow.yaml").write_text(yaml.safe_dump(allow, sort_keys=False))
+        self.run(
+            "allow-apply",
+            self.kubectl("apply", "-n", self.namespace, "-f", str(self.output / "allow.yaml")),
+        )
+        time.sleep(3)
+        self.probe("admitted", control_ip)
+        pip_report = self.run(
+            "pip-report-admitted",
+            self.kubectl(
+                "exec",
+                "-n",
+                self.namespace,
+                self.pod,
+                "-c",
+                "runner",
+                "--",
+                "cat",
+                "/workspace/report-admitted.json",
+            ),
+        )
+        (self.output / "pip-report-admitted.json").write_text(pip_report.stdout)
+        self.run(
+            "allow-delete",
+            self.kubectl("delete", "-n", self.namespace, "-f", str(self.output / "allow.yaml")),
+        )
+        time.sleep(3)
+        self.probe("revoked", control_ip)
+        live_pod = self.run(
+            "live-pod",
+            self.kubectl("get", "pod", self.pod, "-n", self.namespace, "-o", "json"),
+        )
+        (self.output / "live-pod.json").write_text(live_pod.stdout)
+        phase_order = ("denied", "admitted", "revoked")
+        if [self.phases[p]["pip_exit_code"] for p in phase_order] != [1, 0, 1]:
+            raise AssertionError("pip sequence was not [1, 0, 1]")
+        if [self.phases[p]["tcp_exit_code"] for p in phase_order] != [1, 0, 1]:
+            raise AssertionError("TCP sequence was not [1, 0, 1]")
+
+    def cleanup(self) -> None:
+        if not self.cluster_attempted:
+            return
+        assert self.kubeconfig is not None
+        deleted = self.run(
+            "kind-delete",
+            [
+                "kind",
+                "delete",
+                "cluster",
+                "--name",
+                self.cluster,
+                "--kubeconfig",
+                str(self.kubeconfig),
+            ],
+            timeout=180,
+            check=False,
+        )
+        inventory = self.run(
+            "kind-inventory-after",
+            ["kind", "get", "clusters"],
+            timeout=30,
+            check=False,
+        )
+        still_exists = self.cluster in inventory.stdout.splitlines()
+        if deleted.returncode != 0 or inventory.returncode != 0 or still_exists:
+            raise RuntimeError(f"cleanup failed for owned cluster {self.cluster}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="new or empty directory for manifests, command logs, and results",
+    )
+    parser.add_argument(
+        "--runner-image",
+        default=RUNNER_IMAGE,
+        help="public immutable runner image (default: release 0.8.7)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output = args.output_dir.expanduser().resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    if any(output.iterdir()):
+        print(f"output directory must be empty: {output}", file=sys.stderr)
+        return 2
+    check = Check(output, args.runner_image)
+    error: str | None = None
+    cleanup_error: str | None = None
+    try:
+        check.execute()
+    except Exception as exc:  # Keep partial evidence for diagnosis.
+        error = f"{type(exc).__name__}: {exc}"
+    finally:
+        try:
+            check.cleanup()
+        except Exception as exc:
+            cleanup_error = f"{type(exc).__name__}: {exc}"
+        if check.temp is not None:
+            check.temp.cleanup()
+        result = {
+            "status": "passed" if error is None and cleanup_error is None else "failed",
+            "completed_utc": dt.datetime.now(dt.UTC).isoformat(),
+            "cluster": check.cluster,
+            "runner_image": check.runner_image,
+            "chart_sha256": check.chart_sha256,
+            "kind_image": KIND_IMAGE,
+            "calico": {"url": CALICO_URL, "sha256": CALICO_SHA256},
+            "scope": "chart-rendered bound Pod only; no controller, claim, model, or publication",
+            "phases": check.phases,
+            "error": error,
+            "cleanup_error": cleanup_error,
+        }
+        check.write_json("results.json", result)
+    if error or cleanup_error:
+        print(error or cleanup_error, file=sys.stderr)
+        return 1
+    print(f"registry egress check passed; evidence: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Registry access is denied by default, but the guide previously lacked a reproducible check showing that configured egress permits a real package install. This PR adds a disposable kind/Calico check that renders the current chart, resolves PyPI addresses, and verifies denied → admitted → revoked behavior for both pip and direct TCP connections.

The guide now uses “Bundled dependencies” and “Live registry dependencies,” documents how to run the check, and explains the limits of CIDR allowances. Generated manifests and logs go to the caller’s output directory rather than into source control. The guide guard checks those documented limits and includes deletion and overclaim controls.

Draft ADR-0152 proposes operator-declared registry destinations instead of a standing platform-maintained preset commitment. ADR-0075 remains unchanged; this PR does not accept the proposal or implement a preset.

Ref #2613

Validation:

- Live PyPI check: pip and TCP denied/admitted/revoked exits `[1, 0, 1]`; admitted install imports `packaging==25.0`; disposable cluster cleanup verified.
- 21 container-proof and CI-guard tests passed with the current runner build.
- Ruff, configured mypy, and documentation checks passed; the command-timeout path preserves diagnostic output and returns 124.
- A CI-discovered cleanup fix uses the existing helper for container-owned virtualenv files.

Scope: chart-derived probe Pod on an enforcing cluster; no controller claim, model call, or publication flow. CIDR admission is an address snapshot, not hostname enforcement or a trusted-registry preset.

The requested external review retry was unavailable and was skipped with maintainer authorization. This PR remains unmerged; ADR acceptance is a separate decision.
