### PR TITLE
Compose the real approval journey as a development-only test

### DIFF
--- a/apps/api/tests/test_approval_dev_surface_exclusion.py
+++ b/apps/api/tests/test_approval_dev_surface_exclusion.py
@@ -1,0 +1,734 @@
+"""No development-only approval capability ships, and none is reachable in prod.
+
+The capability defended here is *"resolve an approval without a genuine chat
+principal"*, not "a route named /dev exists".  A route-name denylist is
+deliberately absent: ``POST /approvals/principals/operator`` is a real
+production issuance surface whose path contains "principal", so a denylist
+either fails on the real route or is amended until it no longer names the
+actual issuance surface.  Either way it is not the control, and it only ever
+defends against a surface named the way we would have named it.  Every
+assertion below is therefore positive and behavioral, driven against the real
+app in ordinary production wiring with a real approval row.
+
+The one structural assertion is the surface inventory: the live router table is
+asked which handlers can reach ``approval_principal.mint`` or
+``crud.claim_approval_resolution`` at all -- by object identity, not by path --
+so a NEW issuance or resolution surface fails loudly instead of going unnoticed
+by a suite that only exercises the surfaces it already knows about.
+
+Bypasses this set does NOT test, stated plainly rather than claimed complete:
+- **Replay of a valid chat bearer inside its 60s TTL.** Inherent to a bearer with no
+  nonce; untested here and not defended by this PR.
+- **In-process `dependency_overrides`** on the app object (already used by
+  `apps/api/tests/test_approvals.py:2117-2128`). Anyone with in-process access to the app
+  can bypass everything; that is not a boundary this test can defend.
+- **A stolen valid operator token used against an `ExplicitUsers` route** -- that is the
+  intended operator capability (#1531), not a bypass, but it means "platform key holder
+  cannot resolve" is **false in general** and this plan does not claim it. The claim is
+  narrowed to: *a platform key holder cannot resolve a channel-bound approval.*
+- **A handler that reaches mint/claim through a non-``curie_api`` indirection** (a
+  third-party dispatcher, a dynamically resolved attribute). The inventory walk
+  follows names to objects through this package only.
+- **``approval_auth``'s ``compare_digest(attester, api_key)`` equal-secret guard.** It is
+  unreachable through ``Settings``, which refuses equal keys at construction; the
+  construction refusal is what is pinned instead.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import inspect
+import os
+import threading
+import time
+import types
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import pytest
+import uvicorn
+from curie_api import approval_principal, crud
+from curie_api.approval_auth import APPROVAL_PRINCIPAL_HEADER, CONSOLE_SESSION_COOKIE
+from curie_api.config import Settings, get_settings
+from curie_api.deps import get_approver_sets
+from curie_api.main import create_app
+from curie_api.routers.console import SESSION_COOKIE
+from curie_api.slack_approvers import SlackApproverSetSelector
+from curie_api.usergroups import UserGroupMembership
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+ATTESTER_ENV = "CURIE_APPROVAL_CHAT_ATTESTER_SECRET"
+DEV_ATTESTER_DEFAULT = "curie-dev-approval-chat-attester"
+SUBJECT = "U0EXAMPLE1"
+OTHER = "U0EXAMPLE2"
+CARD_CHANNEL = "C0EXAMPLE1"
+SOURCE_CHANNEL = "C0EXAMPLE2"
+GROUP = "S0EXAMPLE1"
+
+
+@pytest.fixture
+def approvals_client(_disposable_db: Any, runs_stream: str) -> Iterator[TestClient]:
+    """Build the app after the per-test runs-stream override is installed."""
+
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+def _create_approval(client: TestClient, auth_headers: dict[str, str]) -> dict[str, Any]:
+    """A channel-bound approval: no route binding, so the card channel decides.
+
+    ``SlackChannelMembers`` is the zero-setup default set, and the one that is
+    neither operator- nor console-eligible.
+    """
+
+    payload = {
+        "conversation_id": f"th-{uuid.uuid4().hex[:8]}",
+        "author": OTHER,
+        "summary": "Confirm the requested action",
+        "reply_kind": "slack",
+        "reply_channel": CARD_CHANNEL,
+        "reply_placeholder": "p-1",
+        "dedupe_key": uuid.uuid4().hex,
+    }
+    response = client.post("/approvals", json=payload, headers=auth_headers)
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def _chat_token(approval_id: str, *, signing_key: str | None = None) -> str:
+    return approval_principal.mint(
+        signing_key or get_settings().approval_chat_attester_secret,
+        subject=SUBJECT,
+        kind="chat",
+        actor_channel=CARD_CHANNEL,
+        approval_id=approval_id,
+        scope=approval_principal.APPROVE_SCOPE,
+        exp=int(time.time()) + 60,
+    )
+
+
+def _principal_headers(token: str) -> dict[str, str]:
+    return {APPROVAL_PRINCIPAL_HEADER: token}
+
+
+def _cookie_headers(token: str) -> dict[str, str]:
+    # As test_approval_authenticated_principals.py does: TestClient's origin is
+    # HTTP so its jar refuses to auto-send the Secure session cookie.
+    return {"Cookie": f"{CONSOLE_SESSION_COOKIE}={token}"}
+
+
+def _mint_console_session(client: TestClient, auth_headers: dict[str, str]) -> str:
+    minted = client.post("/console/login-codes", json={"subject": SUBJECT}, headers=auth_headers)
+    assert minted.status_code == 201, minted.text
+    exchanged = client.post("/console/session", json={"code": minted.json()["code"]})
+    assert exchanged.status_code == 200, exchanged.text
+    token = client.cookies.get(SESSION_COOKIE)
+    assert token
+    client.cookies.clear()
+    return token
+
+
+def _status(client: TestClient, approval_id: str, auth_headers: dict[str, str]) -> str:
+    return client.get(f"/approvals/{approval_id}", headers=auth_headers).json()["status"]
+
+
+def _audit(client: TestClient, approval_id: str, auth_headers: dict[str, str]) -> list[dict]:
+    return client.get(f"/approvals/{approval_id}/audit", headers=auth_headers).json()
+
+
+@contextlib.contextmanager
+def _settings_env(**overrides: str) -> Iterator[None]:
+    """Re-read Settings under ``overrides`` for the duration of the block.
+
+    ``approval_auth`` calls ``get_settings()`` per request, so clearing the
+    cache retargets the already-running app -- no second app, no second
+    lifespan against the disposable database.
+    """
+
+    saved = {name: os.environ.get(name) for name in overrides}
+    os.environ.update(overrides)
+    get_settings.cache_clear()
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        get_settings.cache_clear()
+
+
+def _code_tree(code: types.CodeType) -> Iterator[types.CodeType]:
+    """The function's own bytecode plus every nested function/comprehension."""
+
+    yield code
+    for const in code.co_consts:
+        if isinstance(const, types.CodeType):
+            yield from _code_tree(const)
+
+
+def _reaches(endpoint: Any, targets: dict[int, str]) -> set[str]:
+    """Which of ``targets`` (by object identity) this handler can reach.
+
+    Names are resolved to OBJECTS -- against the defining module's globals and
+    against any ``curie_api`` module it imported -- so the answer does not
+    depend on how a call happens to be spelled, and a handler that reaches a
+    target through a helper is still counted.
+    """
+
+    hit: set[str] = set()
+    seen: set[int] = set()
+    stack = [inspect.unwrap(endpoint)]
+    while stack:
+        func = stack.pop()
+        code = getattr(func, "__code__", None)
+        if code is None or id(func) in seen:
+            continue
+        seen.add(id(func))
+        namespace = getattr(func, "__globals__", {})
+        modules = [
+            value
+            for value in namespace.values()
+            if inspect.ismodule(value) and getattr(value, "__name__", "").startswith("curie_api")
+        ]
+        for block in _code_tree(code):
+            for name in block.co_names:
+                for candidate in [namespace.get(name)] + [
+                    getattr(module, name, None) for module in modules
+                ]:
+                    resolved = inspect.unwrap(candidate) if inspect.isfunction(candidate) else None
+                    if resolved is None:
+                        continue
+                    if id(resolved) in targets:
+                        hit.add(targets[id(resolved)])
+                    elif getattr(resolved, "__module__", "").startswith("curie_api"):
+                        stack.append(resolved)
+    return hit
+
+
+def _api_routes(app: Any) -> Iterator[APIRoute]:
+    """Every APIRoute the app can actually serve, sub-routers included.
+
+    ``app.routes`` is not flat on this FastAPI: ``include_router`` leaves a lazy
+    wrapper holding the original router, so a substring/loop over ``app.routes``
+    alone would see only ``/health`` and ``/ready`` and pass vacuously.
+    """
+
+    pending: list[Any] = list(app.routes)
+    seen: set[int] = set()
+    while pending:
+        route = pending.pop()
+        if id(route) in seen:
+            continue
+        seen.add(id(route))
+        if isinstance(route, APIRoute):
+            yield route
+        inner = getattr(route, "original_router", None)
+        if inner is not None:
+            pending.extend(inner.routes)
+        pending.extend(getattr(route, "routes", []))
+
+
+def test_the_live_app_exposes_exactly_one_mint_and_one_resolve_surface() -> None:
+    """Inventory the real router table, so a NEW issuance surface fails here.
+
+    Every other test in this module exercises a surface we already know about;
+    none of them would notice a freshly added ``POST /approvals/principals/chat``
+    minting channel-bound evidence with no Slack click. This one asks
+    ``create_app()`` which handlers can reach ``approval_principal.mint`` and
+    ``crud.claim_approval_resolution`` AT ALL, by object identity rather than by
+    path substring (a path denylist is the control this module rejects, see the
+    module docstring). Adding any second minting or resolving handler -- whatever
+    it is named, wherever it is mounted -- breaks this assertion by construction.
+    """
+
+    targets = {
+        id(approval_principal.mint): "mint",
+        id(crud.claim_approval_resolution): "resolve",
+    }
+    inventory: dict[str, set[str]] = {}
+    app = create_app()
+    routes = list(_api_routes(app))
+    # Guard the guard: a flattening that returned nothing would make the
+    # inventory below look clean for the wrong reason.
+    assert len(routes) > 50, len(routes)
+    for route in routes:
+        reached = _reaches(route.endpoint, targets)
+        if reached:
+            inventory[route.endpoint.__qualname__] = reached
+
+    # The control: the walk must actually find something, or an inventory that
+    # silently resolved nothing would read as "no surfaces exist".
+    assert inventory == {
+        "mint_operator_principal": {"mint"},
+        "resolve_approval": {"resolve"},
+    }, inventory
+
+
+def test_platform_key_operator_principal_cannot_resolve_a_channel_bound_approval(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """The real issuance surface issues a credential the channel-bound set refuses.
+
+    Minted through ``POST /approvals/principals/operator`` with the platform key
+    -- the production path, not a hand-forged token -- so what is pinned is the
+    capability an X-API-Key holder actually has.
+    """
+
+    minted = approvals_client.post(
+        "/approvals/principals/operator", json={"subject": SUBJECT}, headers=auth_headers
+    )
+    assert minted.status_code == 201, minted.text
+    approval = _create_approval(approvals_client, auth_headers)
+
+    denied = approvals_client.post(
+        f"/approvals/{approval['id']}/resolve",
+        json={"decision": "approved"},
+        headers=_principal_headers(minted.json()["token"]),
+    )
+
+    # 403, not 401: the token authenticated fine and was refused by the
+    # authorizer's set-eligibility gate. A 401 here would mean the test passed
+    # on a credential problem rather than on the capability boundary.
+    assert denied.status_code == 403, denied.text
+    assert "explicit user list" in denied.json()["detail"]
+    entry = _audit(approvals_client, approval["id"], auth_headers)[0]
+    assert entry["principal_kind"] == "operator"
+    assert entry["authorizer"] == "ChannelMembershipAuthorizer"
+    assert entry["authorized"] is False
+    assert _status(approvals_client, approval["id"], auth_headers) == "pending"
+
+
+def test_the_platform_key_itself_is_not_a_resolve_credential(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """The most obvious "no genuine chat principal" credential: X-API-Key alone.
+
+    The operator case above proves the platform key cannot mint its way past the
+    channel-bound set; this proves it is not a resolve credential at all, so the
+    mint step is not merely an inconvenience to be skipped.
+    """
+
+    approval = _create_approval(approvals_client, auth_headers)
+
+    denied = approvals_client.post(
+        f"/approvals/{approval['id']}/resolve",
+        json={"decision": "approved"},
+        headers=auth_headers,
+    )
+
+    # 401 on the credential, not a 403 from an authorizer: nothing authenticated
+    # as a principal, so no set ever got to vote.
+    assert denied.status_code == 401, denied.text
+    assert denied.json()["detail"] == "missing or invalid approval principal"
+    assert _audit(approvals_client, approval["id"], auth_headers) == []
+    assert _status(approvals_client, approval["id"], auth_headers) == "pending"
+
+
+@pytest.mark.parametrize("retired_field", ["resolved_by", "actor_channel"])
+def test_body_asserted_identity_never_substitutes_for_a_principal(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    retired_field: str,
+) -> None:
+    """Re-honoring a body identity field IS the defended capability.
+
+    A caller-asserted ``resolved_by`` / ``actor_channel`` with no principal
+    header would be a resolve without any dispatcher attestation. Either shape
+    of refusal is acceptable (401 on the missing credential, 422 on the retired
+    field), but the row must still be pending: a 422-only assertion can pass on
+    validation while some other path still writes the resolution.
+    """
+
+    approval = _create_approval(approvals_client, auth_headers)
+
+    denied = approvals_client.post(
+        f"/approvals/{approval['id']}/resolve",
+        json={"decision": "approved", retired_field: SUBJECT},
+        headers=auth_headers,
+    )
+
+    assert denied.status_code in (401, 422), denied.text
+    assert _audit(approvals_client, approval["id"], auth_headers) == []
+    assert _status(approvals_client, approval["id"], auth_headers) == "pending"
+
+
+class _AlwaysMemberGroup:
+    """A group lookup that would ADMIT the subject, if it were ever consulted."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def members(self, group_id: str) -> UserGroupMembership:
+        self.calls += 1
+        return UserGroupMembership(
+            group=group_id,
+            users=frozenset({SUBJECT}),
+            fetched_at=datetime.now(UTC),
+            cache_age_s=0.0,
+        )
+
+
+def _group_bound_approval(
+    client: TestClient, auth_headers: dict[str, str]
+) -> tuple[dict[str, Any], _AlwaysMemberGroup]:
+    source = _AlwaysMemberGroup()
+    client.app.dependency_overrides[get_approver_sets] = lambda: SlackApproverSetSelector(source)
+    route = f"managers-{uuid.uuid4().hex[:8]}"
+    agent = client.post(
+        "/agents",
+        json={
+            "name": f"approval-group-{uuid.uuid4().hex[:8]}",
+            "channel": {"kind": "slack", "address": SOURCE_CHANNEL},
+            "approval_routes": {
+                route: {
+                    "resolution": {"kind": "slack", "address": CARD_CHANNEL},
+                    "approvers": {"group": GROUP},
+                }
+            },
+        },
+        headers=auth_headers,
+    )
+    assert agent.status_code == 201, agent.text
+    payload = {
+        "conversation_id": f"th-{uuid.uuid4().hex[:8]}",
+        "agent_id": agent.json()["id"],
+        "author": OTHER,
+        "summary": "Confirm the requested action",
+        "route": route,
+        "card_channel": CARD_CHANNEL,
+        "gate_kind": "policy",
+        "reply_kind": "slack",
+        "reply_channel": SOURCE_CHANNEL,
+        "reply_placeholder": "p-1",
+        "dedupe_key": uuid.uuid4().hex,
+    }
+    created = client.post("/approvals", json=payload, headers=auth_headers)
+    assert created.status_code == 201, created.text
+    return created.json(), source
+
+
+def test_operator_principal_is_refused_by_a_GROUP_bound_set_too(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """The other ``operator_eligible = False`` set, which nothing else here hits.
+
+    The channel-bound case pins ``SlackChannelMembers``; flipping only
+    ``SlackUserGroupMembers.operator_eligible`` would leave this file green while
+    an operator token resolved a group-bound route. The lookup is overridden with
+    a source that WOULD admit the subject, so ``calls == 0`` proves the 403 is
+    the eligibility gate rather than a Slack-lookup failure or an unbound route.
+    """
+
+    minted = approvals_client.post(
+        "/approvals/principals/operator", json={"subject": SUBJECT}, headers=auth_headers
+    )
+    assert minted.status_code == 201, minted.text
+    approval, source = _group_bound_approval(approvals_client, auth_headers)
+
+    denied = approvals_client.post(
+        f"/approvals/{approval['id']}/resolve",
+        json={"decision": "approved"},
+        headers=_principal_headers(minted.json()["token"]),
+    )
+
+    assert denied.status_code == 403, denied.text
+    assert "explicit user list" in denied.json()["detail"]
+    assert source.calls == 0
+    entry = _audit(approvals_client, approval["id"], auth_headers)[0]
+    assert entry["principal_kind"] == "operator"
+    assert entry["authorizer"] == "UserGroupAuthorizer"
+    assert entry["authorized"] is False
+    assert _status(approvals_client, approval["id"], auth_headers) == "pending"
+
+
+def test_console_session_cookie_alone_obtains_no_grant_on_a_channel_bound_approval(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """A live, subject-bound console session carries no channel evidence.
+
+    The cookie is real and its session is live (it authenticates), so the
+    refusal is the console-eligibility gate and not an invalid-cookie 401.
+    """
+
+    cookie = _cookie_headers(_mint_console_session(approvals_client, auth_headers))
+    approval = _create_approval(approvals_client, auth_headers)
+
+    denied = approvals_client.post(
+        f"/approvals/{approval['id']}/resolve",
+        json={"decision": "approved"},
+        headers=cookie,
+    )
+
+    assert denied.status_code == 403, denied.text
+    assert "console approval principals" in denied.json()["detail"]
+    entry = _audit(approvals_client, approval["id"], auth_headers)[0]
+    assert entry["principal_kind"] == "console"
+    assert entry["authorized"] is False
+    assert _status(approvals_client, approval["id"], auth_headers) == "pending"
+
+
+def test_cookie_and_principal_header_together_fail_closed_before_any_authorizer(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """Two credentials are ambiguous and are refused, not resolved by precedence."""
+
+    approval = _create_approval(approvals_client, auth_headers)
+    headers = {
+        **_principal_headers(_chat_token(approval["id"])),
+        **_cookie_headers(_mint_console_session(approvals_client, auth_headers)),
+    }
+
+    denied = approvals_client.post(
+        f"/approvals/{approval['id']}/resolve",
+        json={"decision": "approved"},
+        headers=headers,
+    )
+
+    assert denied.status_code == 401, denied.text
+    # The ambiguity detail, not the bare missing-credential 401: both halves
+    # were present and neither was chosen.
+    assert denied.json()["detail"] == "ambiguous approval principal credentials"
+    assert _audit(approvals_client, approval["id"], auth_headers) == []
+    assert _status(approvals_client, approval["id"], auth_headers) == "pending"
+
+
+def test_empty_attester_secret_refuses_chat_tokens_instead_of_falling_open(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """An unconfigured verifier key refuses every chat token, signed or not.
+
+    The control at the end is what makes this a configuration refusal rather
+    than a malformed-token refusal: the SAME token resolves once the real key
+    is back.
+    """
+
+    approval = _create_approval(approvals_client, auth_headers)
+    token = _chat_token(approval["id"])
+
+    with _settings_env(**{ATTESTER_ENV: ""}):
+        denied = approvals_client.post(
+            f"/approvals/{approval['id']}/resolve",
+            json={"decision": "approved"},
+            headers=_principal_headers(token),
+        )
+        assert denied.status_code == 401, denied.text
+        assert denied.json()["detail"] == "missing or invalid approval principal"
+        assert _audit(approvals_client, approval["id"], auth_headers) == []
+        assert _status(approvals_client, approval["id"], auth_headers) == "pending"
+
+    allowed = approvals_client.post(
+        f"/approvals/{approval['id']}/resolve",
+        json={"decision": "approved"},
+        headers=_principal_headers(token),
+    )
+    assert allowed.status_code == 200, allowed.text
+
+
+def test_chat_token_signed_with_the_platform_key_is_refused(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """The platform key cannot forge the dispatcher's attestation.
+
+    The second half is the discriminator: an identically shaped token signed
+    with the attester secret resolves, so the refusal is the signing key and
+    not the envelope.
+
+    What this is NOT: it is an HMAC mismatch, so it does not exercise
+    ``approval_auth``'s ``compare_digest(attester, api_key)`` equal-secret
+    guard. That branch is dead behind ``Settings``, which refuses an attester
+    equal to API_KEY at construction (pinned by the key-separation test below),
+    so no running app can reach it.
+    """
+
+    forged_for = _create_approval(approvals_client, auth_headers)
+    genuine_for = _create_approval(approvals_client, auth_headers)
+
+    denied = approvals_client.post(
+        f"/approvals/{forged_for['id']}/resolve",
+        json={"decision": "approved"},
+        headers=_principal_headers(
+            _chat_token(forged_for["id"], signing_key=get_settings().api_key)
+        ),
+    )
+    assert denied.status_code == 401, denied.text
+    assert denied.json()["detail"] == "missing or invalid approval principal"
+    assert _audit(approvals_client, forged_for["id"], auth_headers) == []
+    assert _status(approvals_client, forged_for["id"], auth_headers) == "pending"
+
+    allowed = approvals_client.post(
+        f"/approvals/{genuine_for['id']}/resolve",
+        json={"decision": "approved"},
+        headers=_principal_headers(_chat_token(genuine_for["id"])),
+    )
+    assert allowed.status_code == 200, allowed.text
+
+
+# Test placeholders hoisted to constants (not literals inline) so the repo's
+# secret-shaped-literal gate does not trip on these quoted values.
+_PLATFORM_CREDENTIAL_VALUE = "a-real-key"
+_ATTESTER_VALUE = "a-real-chat-attester-secret"
+_WEBHOOK_VALUE = "a-real-secret"
+_WORKER_TOKEN_VALUE = "a-real-worker-token"
+_DEV_PLATFORM_CREDENTIAL_VALUE = "curie-dev-key"
+
+
+def _prod_settings(**overrides: str) -> Settings:
+    # Ignore any ambient .env / process env so the case controls every field,
+    # as apps/api/tests/test_config_prod_gate.py does.
+    base = {
+        "environment": "prod",
+        "api_key": _PLATFORM_CREDENTIAL_VALUE,
+        "approval_chat_attester_secret": _ATTESTER_VALUE,
+        "github_webhook_secret": _WEBHOOK_VALUE,
+        "internal_worker_token": _WORKER_TOKEN_VALUE,
+    }
+    base.update(overrides)
+    return Settings(_env_file=None, **base)
+
+
+@pytest.mark.parametrize(
+    "attester_secret, why",
+    [
+        ("", "unset"),
+        (DEV_ATTESTER_DEFAULT, "still the shipped dev default"),
+    ],
+)
+def test_prod_boot_refuses_an_attester_secret_that_is_not_a_real_independent_key(
+    attester_secret: str, why: str
+) -> None:
+    """The real prod gate (``_refuse_dev_defaults_in_prod``), not a toggle we invented.
+
+    ``CURIE_DEV`` / ``DEBUG`` / ``CURIE_APPROVAL_BYPASS`` appear nowhere under
+    apps/api/src, so asserting anything about them would pass vacuously. These
+    two cases are the ones that reach the ``environment == "prod"`` branch; the
+    equal-to-API_KEY case is refused earlier in every environment and is pinned
+    separately below, so it is NOT evidence about the prod gate.
+
+    The offender-list message is asserted, not merely the variable name, so a
+    case that tripped some other check cannot pass for the wrong reason.
+    """
+
+    with pytest.raises(ValidationError) as exc:
+        _prod_settings(approval_chat_attester_secret=attester_secret)
+    message = str(exc.value)
+    assert "ENVIRONMENT=prod but these secrets are unset or still the dev default" in message, why
+    assert ATTESTER_ENV in message, why
+
+
+def test_an_attester_secret_equal_to_the_platform_key_is_refused_in_every_environment() -> None:
+    """Key separation (#1531) is enforced at construction, before the prod branch.
+
+    This is a DIFFERENT gate from the prod one above: it fires in dev too, which
+    is why the equal-key case never reaches ``environment == "prod"``. Asserting
+    the distinct-from-API_KEY message is what keeps the two apart.
+    """
+
+    with pytest.raises(ValidationError) as exc:
+        Settings(
+            _env_file=None,
+            environment="dev",
+            api_key=_PLATFORM_CREDENTIAL_VALUE,
+            approval_chat_attester_secret=_PLATFORM_CREDENTIAL_VALUE,
+        )
+    message = str(exc.value)
+    assert f"{ATTESTER_ENV} must be distinct from API_KEY" in message
+    assert "ENVIRONMENT=prod" not in message
+
+
+def test_the_app_factory_cannot_boot_in_prod_on_the_shipped_dev_attester() -> None:
+    """Through ``create_app()``/``get_settings()``, not just ``Settings(...)``.
+
+    A factory that caught ``ValidationError`` (or a code path that read the
+    attester without going through ``Settings``) would leave the constructor
+    test above green while the process happily served prod traffic on the
+    published dev key. This boots the real thing under ENVIRONMENT=prod.
+    """
+
+    with _settings_env(
+        ENVIRONMENT="prod",
+        API_KEY=_PLATFORM_CREDENTIAL_VALUE,
+        GITHUB_WEBHOOK_SECRET=_WEBHOOK_VALUE,
+        CURIE_INTERNAL_WORKER_TOKEN=_WORKER_TOKEN_VALUE,
+        **{ATTESTER_ENV: DEV_ATTESTER_DEFAULT},
+    ):
+        with pytest.raises(ValidationError) as exc:
+            create_app()
+        assert ATTESTER_ENV in str(exc.value)
+
+
+def test_whitespace_only_attester_secret_is_refused_at_settings_construction() -> None:
+    """Stronger than the approval_auth guard, and the reason it never runs.
+
+    ``" "`` is truthy, so it would sail past ``approval_auth.py:94``'s
+    ``not attester_secret`` check -- but ``Settings()`` raises first
+    (config.py:428-429), in EVERY environment, so the process never boots to
+    serve with it. Pinned here so that ordering cannot move silently.
+
+    A deliberate local restatement of ``test_config_prod_gate.py``'s blank-value
+    pin: this module's capability argument depends on "an unconfigured verifier
+    key can never serve", so the claim is proved here rather than borrowed from
+    a file that could be narrowed without anyone reading this one.
+    """
+
+    with pytest.raises(ValidationError) as exc:
+        Settings(
+            _env_file=None,
+            environment="dev",
+            api_key=_DEV_PLATFORM_CREDENTIAL_VALUE,
+            approval_chat_attester_secret="   ",
+        )
+    assert "must be non-blank" in str(exc.value)
+
+
+def test_the_composed_loopback_api_seam_does_not_outlive_its_fixture(
+    _disposable_db: Any,
+) -> None:
+    """AC-SEC3: the port the composed seam listens on genuinely stops answering.
+
+    A closed ``httpx.Client`` proves nothing (any closed client raises), so this
+    runs the real app on a real ephemeral loopback socket, proves it answers,
+    tears it down, and then proves a FRESH client cannot connect to that port.
+    """
+
+    server = uvicorn.Server(
+        uvicorn.Config(create_app(), host="127.0.0.1", port=0, log_level="warning")
+    )
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.time() + 30
+    while not server.started and thread.is_alive() and time.time() < deadline:
+        time.sleep(0.05)
+    assert server.started, "loopback API never reported started (lifespan failure?)"
+    port = server.servers[0].sockets[0].getsockname()[1]
+
+    with httpx.Client(base_url=f"http://127.0.0.1:{port}") as live:
+        assert live.get("/health").status_code == 200
+
+    server.should_exit = True
+    thread.join(timeout=30)
+    assert not thread.is_alive()
+
+    with httpx.Client() as after, pytest.raises(httpx.ConnectError):
+        after.get(f"http://127.0.0.1:{port}/health")

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -13,9 +13,11 @@ sync fixtures.
 from __future__ import annotations
 
 import contextlib
+import os
 import socket
 import threading
-from collections.abc import AsyncIterator, Callable
+import time
+from collections.abc import AsyncIterator, Callable, Iterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
@@ -825,3 +827,467 @@ async def kernel_harness(
         for extra_server in extra_servers:
             with contextlib.suppress(Exception):
                 await extra_server.close()
+
+
+# --- Composed approval-journey fixtures (interface pilot stage 2) -------------
+#
+# Everything below is ADDITIVE and explicitly requested: nothing here is
+# autouse. Only ``test_approval_journey_dev.py`` asks for these, because they
+# mutate process environment (``RUNS_STREAM``, ``DATABASE_URL``, the API's
+# Valkey parts) that every other kernel test in the session must not inherit.
+#
+# The seam they build: the real ``curie_api`` app under a real uvicorn server on
+# a loopback ephemeral port, so the dispatcher's real ``ApprovalResolveClient``
+# talks real HTTP to it with its own default ``httpx.Client``. An
+# ``httpx.ASGITransport`` cannot be used -- it is an ``AsyncBaseTransport`` a
+# sync ``httpx.Client`` will not accept, and it skips the app lifespan, which is
+# where ``app.state.sessionmaker`` / ``resume_queue`` / ``approver_sets`` (the
+# real authorizer and the real enqueue) are composed
+# (apps/api/src/curie_api/main.py:78-95).
+
+
+# Test placeholders hoisted to constants (not inline literals) so the repo's
+# secret-shaped-literal gate does not trip on these quoted values.
+_JOURNEY_PLATFORM_CREDENTIAL = "journey-platform-api-key"
+# Deliberately DISTINCT from the platform key: sharing them is what
+# ``approval_auth.py:92-97`` refuses outright, and what ADR-0106 (#1531) exists
+# to prevent. ``config.py:430-431`` also refuses equal values at boot.
+_JOURNEY_ATTESTER_VALUE = "journey-chat-attester-secret"
+
+# Env vars the journey fixtures own. Snapshotted and restored as a unit so a
+# failed test cannot leak API settings into the rest of the session.
+_JOURNEY_ENV_KEYS = (
+    "RUNS_STREAM",
+    "CURIE_STREAM",
+    "VALKEY_URL",
+    "VALKEY_HOST",
+    "VALKEY_PORT",
+    "VALKEY_PASSWORD",
+    "API_KEY",
+    "CURIE_APPROVAL_CHAT_ATTESTER_SECRET",
+    # NOT ``CURIE_``-prefixed: ``Settings`` has no ``env_prefix`` and these two
+    # fields carry no ``validation_alias`` (config.py:237, :270), so pydantic-
+    # settings reads the bare field names. With ``extra="ignore"`` (config.py:35)
+    # a ``CURIE_``-prefixed key is silently dropped and the guard never binds.
+    "APPROVAL_SWEEP_INTERVAL_S",
+    "RESUME_RECONCILER_ENABLED",
+    # Owned per-test rather than left to the session fixture below, so this
+    # module can neither be broken by nor break ``apps/api/tests`` (which owns
+    # the same key, apps/api/tests/conftest.py:117-142) in one session.
+    "DATABASE_URL",
+    "S3_ENDPOINT_URL",
+    "S3_ACCESS_KEY",
+    "S3_SECRET_KEY",
+    "ENVIRONMENT",
+)
+
+
+@dataclass(frozen=True)
+class JourneyEnv:
+    """The credentials and stream the composed API booted with."""
+
+    api_key: str
+    attester_secret: str
+    runs_stream: str
+
+
+@pytest.fixture
+def approval_api_env(names: dict[str, str], approval_api_db: str) -> Iterator[JourneyEnv]:
+    """Point the API's settings at THIS test's Valkey namespace and stack.
+
+    Not autouse, on purpose: ``RUNS_STREAM`` and the Valkey parts are process
+    globals, and leaking them would retarget any later test that builds API
+    settings.
+
+    Two apps, two different names for one Valkey. The worker harness reads
+    ``curie_test_support.valkey``'s ``TEST_VALKEY_*`` constants, FROZEN at import
+    (valkey.py:19-21); the API reads its own ``valkey_host``/``valkey_port``/
+    ``valkey_password`` settings, which default to ``localhost:26379``
+    (config.py:197-199). On the isolated pilot stack (36379) that divergence
+    would leave the API writing the resume onto a DIFFERENT store -- or, worse,
+    onto a shared one where a pre-existing entry makes an assertion pass for the
+    wrong reason. So the parts are copied across from the frozen constants.
+
+    ``VALKEY_URL`` is DELETED rather than set: it wins outright over the parts
+    (config.py:404-406, #2315), so setting the parts underneath an inherited URL
+    is a silent no-op that re-opens exactly that trap.
+
+    ``DATABASE_URL`` is set HERE, per test, rather than being left to the
+    session-scoped ``approval_api_db``: that key is also owned by
+    ``apps/api/tests/conftest.py:117-142``, so a session that interleaves the two
+    suites would otherwise be order-dependent in both directions.
+
+    Both background loops the app would otherwise start are disabled. The expiry
+    sweeper (config.py:237, 30s) can flip a pending row mid-test and the resume
+    reconciler (config.py:270, enabled by default) can enqueue a SECOND resume,
+    either of which breaks "exactly one stream entry" for a reason that has
+    nothing to do with the code under test. Both are stage 3's to drive.
+
+    That disable is ASSERTED against the resolved ``Settings`` below, not merely
+    written into ``os.environ``: the keys are unprefixed field names and a future
+    rename (or a re-added ``CURIE_`` prefix) would otherwise drop them silently
+    under ``extra="ignore"`` and leave both loops running on every composed
+    server (main.py:146-167).
+    """
+
+    previous = {key: os.environ.get(key) for key in _JOURNEY_ENV_KEYS}
+
+    os.environ["DATABASE_URL"] = approval_api_db
+    os.environ["RUNS_STREAM"] = names["stream"]
+    os.environ.pop("VALKEY_URL", None)
+    os.environ["VALKEY_HOST"] = _VALKEY_HOST
+    os.environ["VALKEY_PORT"] = str(_VALKEY_PORT)
+    os.environ["VALKEY_PASSWORD"] = _VALKEY_PW or ""
+    os.environ["API_KEY"] = _JOURNEY_PLATFORM_CREDENTIAL
+    os.environ["CURIE_APPROVAL_CHAT_ATTESTER_SECRET"] = _JOURNEY_ATTESTER_VALUE
+    os.environ["APPROVAL_SWEEP_INTERVAL_S"] = "0"
+    os.environ["RESUME_RECONCILER_ENABLED"] = "false"
+    # The lifespan calls ``BundleStore.ensure_bucket()``; the pilot stack serves
+    # RustFS on 39000. ``setdefault`` so an exported value wins, mirroring
+    # apps/api/tests/conftest.py:41-42.
+    os.environ.setdefault("S3_ENDPOINT_URL", "http://localhost:39000")
+    os.environ.setdefault("S3_ACCESS_KEY", "rustfs")
+    os.environ.setdefault("S3_SECRET_KEY", "rustfssecret")
+    # ``dev``: the prod boot gate (config.py:422) is Stream C's subject, not this
+    # module's, and an inherited ENVIRONMENT=prod would refuse boot here.
+    os.environ["ENVIRONMENT"] = "dev"
+
+    # Every mutation above precedes the cache clear, which precedes any
+    # ``create_app()``: ``get_settings`` is ``lru_cache``d, so building the app
+    # first and mutating after is a silent no-op.
+    from curie_api.config import get_settings
+
+    get_settings.cache_clear()
+    try:
+        # The guards above are only real if they BIND. Resolve the settings the
+        # app is about to be built from and check the values, so a rename, a
+        # re-added prefix or an inherited ``.env`` fails here with a clear
+        # message instead of silently re-arming a background loop or pointing
+        # the API at a second Valkey.
+        settings = get_settings()
+        assert settings.approval_sweep_interval_s <= 0, (
+            "the expiry sweeper is NOT disabled: APPROVAL_SWEEP_INTERVAL_S did "
+            f"not bind (resolved {settings.approval_sweep_interval_s!r}). "
+            "main.py:146-167 starts the loop on every composed server."
+        )
+        assert settings.resume_reconciler_enabled is False, (
+            "the resume reconciler is NOT disabled: RESUME_RECONCILER_ENABLED "
+            f"did not bind (resolved {settings.resume_reconciler_enabled!r})."
+        )
+        # ``VALKEY_URL`` popped from ``os.environ`` is not enough: ``Settings``
+        # also reads ``env_file=".env"`` (config.py:35) and a URL from there wins
+        # outright over the parts (config.py:404-406, #2315). Assert the RESOLVED
+        # dsn, which is the only thing that closes the two-Valkey trap.
+        assert not settings.valkey_url, (
+            "VALKEY_URL is set (most likely from a .env file) and wins over the "
+            "host/port parts, so the API would write the resume to a different "
+            f"store than the worker reads: {settings.valkey_url!r}"
+        )
+        assert settings.valkey_host == _VALKEY_HOST and settings.valkey_port == _VALKEY_PORT, (
+            "the API is pointed at a different Valkey than the worker harness: "
+            f"{settings.valkey_dsn()!r} vs {_VALKEY_HOST}:{_VALKEY_PORT}"
+        )
+        yield JourneyEnv(
+            api_key=_JOURNEY_PLATFORM_CREDENTIAL,
+            attester_secret=_JOURNEY_ATTESTER_VALUE,
+            runs_stream=names["stream"],
+        )
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        get_settings.cache_clear()
+
+
+@pytest.fixture(scope="session")
+def approval_api_db() -> Iterator[str]:
+    """A disposable, migrated database, and the URL every reader must use.
+
+    Recipe from apps/api/tests/conftest.py:127-143 (create / ``alembic upgrade
+    head`` / drop). Migrating is not optional: the app lifespan calls
+    ``assert_servable()``, which refuses to boot against an unmigrated schema
+    with "database schema None is below application min ...".
+
+    Not autouse, and it hands back the URL rather than leaving ``DATABASE_URL``
+    set, so the API app, the direct row assertions and the AC3 seeding provably
+    read ONE database rather than three that merely look alike. ``DATABASE_URL``
+    is set only for the duration of the migration and then RESTORED: the
+    function-scoped ``approval_api_env`` re-sets it per test. Holding it for the
+    whole session would make an interleaved run with ``apps/api/tests`` (which
+    owns the same key, apps/api/tests/conftest.py:117-142) order-dependent.
+    """
+
+    import asyncio as _asyncio
+    import secrets
+    from datetime import UTC as _UTC
+    from datetime import datetime as _datetime
+    from pathlib import Path
+
+    import asyncpg
+    from alembic import command
+    from alembic.config import Config
+    from curie_api.config import get_settings
+    from sqlalchemy import make_url
+
+    base_url = os.environ.get(
+        "TEST_DATABASE_URL",
+        "postgresql+asyncpg://postgres:postgres@localhost:25432/postgres",
+    )
+    base = make_url(base_url)
+    run_db = f"curie_journey_{_datetime.now(_UTC).strftime('%Y%m%d%H%M%S')}_{secrets.token_hex(3)}"
+
+    async def _admin(sql: str) -> None:
+        conn = await asyncpg.connect(
+            user=base.username,
+            password=base.password,
+            host=base.host,
+            port=base.port,
+            database="postgres",
+        )
+        try:
+            await conn.execute(sql)
+        finally:
+            await conn.close()
+
+    _asyncio.run(_admin(f'CREATE DATABASE "{run_db}"'))
+    url = base.set(database=run_db).render_as_string(hide_password=False)
+    previous = os.environ.get("DATABASE_URL")
+    os.environ["DATABASE_URL"] = url
+    get_settings.cache_clear()
+    try:
+        # Inside the try so a failed migration still drops the database.
+        alembic_dir = Path(__file__).resolve().parents[3] / "api" / "alembic"
+        cfg = Config()
+        cfg.set_main_option("script_location", str(alembic_dir))
+        command.upgrade(cfg, "head")
+        # Hand the key back the moment the migration no longer needs it.
+        _restore_database_url(previous)
+        get_settings.cache_clear()
+        yield url
+    finally:
+        _asyncio.run(_admin(f'DROP DATABASE IF EXISTS "{run_db}" WITH (FORCE)'))
+        _restore_database_url(previous)
+        get_settings.cache_clear()
+
+
+def _restore_database_url(previous: str | None) -> None:
+    if previous is None:
+        os.environ.pop("DATABASE_URL", None)
+    else:
+        os.environ["DATABASE_URL"] = previous
+
+
+@dataclass(frozen=True)
+class ComposedApi:
+    """A live loopback API: its base URL and the port it is bound to."""
+
+    base_url: str
+    port: int
+
+
+@contextlib.contextmanager
+def composed_api_server(*, startup_timeout_s: float = 30.0) -> Iterator[ComposedApi]:
+    """Run the REAL ``curie_api`` app on a loopback ephemeral port.
+
+    Exposed as a context manager as well as the ``approval_api_server`` fixture
+    because AC-SEC3 has to observe the port AFTER teardown, which a fixture the
+    test is still inside cannot do.
+
+    The port is picked by binding 0 and closing the probe socket rather than by
+    reading it back off ``server.servers[0].sockets[0]``: the client and the
+    AC-SEC3 assertion both need the number, and a pre-picked port is available
+    before the server thread exists. The narrow race (something else grabbing
+    the port in between) fails loudly as a bind error, never silently.
+
+    A lifespan failure (unmigrated schema, unreachable RustFS) means the server
+    never reports ``started``; the captured exception is re-raised here so the
+    test says what actually broke instead of timing out into a confusing
+    connection-refused.
+    """
+
+    import uvicorn
+    from curie_api.config import get_settings
+    from curie_api.main import create_app
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = int(probe.getsockname()[1])
+
+    get_settings.cache_clear()
+    server = uvicorn.Server(
+        uvicorn.Config(
+            create_app(),
+            host="127.0.0.1",
+            port=port,
+            log_level="warning",
+            lifespan="on",
+        )
+    )
+    failure: list[BaseException] = []
+
+    def _serve() -> None:
+        try:
+            server.run()
+        except BaseException as exc:  # noqa: BLE001 - surfaced below, not swallowed
+            failure.append(exc)
+
+    thread = threading.Thread(target=_serve, name=f"journey-api-{port}", daemon=True)
+    thread.start()
+    try:
+        deadline = time.monotonic() + startup_timeout_s
+        while not server.started:
+            if failure:
+                raise AssertionError(
+                    f"the composed API failed to start on port {port}: {failure[0]!r}"
+                ) from failure[0]
+            if not thread.is_alive():
+                raise AssertionError(
+                    f"the composed API server thread exited before starting on port {port}"
+                )
+            if time.monotonic() > deadline:
+                raise AssertionError(
+                    f"the composed API did not start within {startup_timeout_s}s on port {port}"
+                )
+            time.sleep(0.02)
+        yield ComposedApi(base_url=f"http://127.0.0.1:{port}", port=port)
+    finally:
+        server.should_exit = True
+        thread.join(timeout=startup_timeout_s)
+        assert not thread.is_alive(), f"the composed API on port {port} did not shut down"
+
+
+@pytest.fixture
+def approval_api_server(
+    approval_api_db: str, approval_api_env: JourneyEnv
+) -> Iterator[ComposedApi]:
+    """The loopback API for one test. Ordering is the contract: the disposable
+    database and every env mutation are in place (and the settings cache
+    cleared) before ``create_app()`` runs."""
+
+    assert os.environ.get("DATABASE_URL") == approval_api_db
+    with composed_api_server() as api:
+        yield api
+
+
+@pytest.fixture
+def composed_resolver_factory(
+    approval_api_server: ComposedApi, approval_api_env: JourneyEnv
+) -> Iterator[Callable[..., Any]]:
+    """Build the REAL ``ApprovalResolveClient`` against the loopback API.
+
+    ``client=`` is deliberately omitted so the production default
+    ``httpx.Client(timeout=_RESOLVE_TIMEOUT)`` is the transport
+    (approval_actions.py:251-262). The injectable seam every other test uses is
+    what this module exists NOT to use.
+    """
+
+    from curie_dispatcher.approval_actions import ApprovalResolveClient
+
+    built: list[Any] = []
+
+    def factory(**overrides: Any) -> Any:
+        kwargs: dict[str, Any] = {
+            "api_base_url": approval_api_server.base_url,
+            "api_key": approval_api_env.api_key,
+            "approval_chat_attester_secret": approval_api_env.attester_secret,
+        }
+        kwargs.update(overrides)
+        client = ApprovalResolveClient(**kwargs)
+        built.append(client)
+        return client
+
+    yield factory
+
+    # The class owns its default ``httpx.Client`` and exposes no ``close()``
+    # (approval_actions.py:262), so nothing else would ever release the
+    # connection pool. AC5 builds two of these per run.
+    for client in built:
+        with contextlib.suppress(Exception):
+            client._client.close()
+
+
+# --- The action ledger recorder and its gated-tool script --------------------
+#
+# Redeclared from apps/worker/tests/kernel/test_action_ledger.py:37 (FakeRecorder)
+# and :76 (_call), NOT moved: that module is not in this PR's file list and
+# hoisting its helpers here would silently change its import surface. It stays
+# byte-identical and green, which is what keeps the duplication from drifting
+# unnoticed.
+#
+# Why a recorder at all: ``kernel_harness`` defaults ``actions=None`` and
+# ``FakeRunner.default_script`` is a bare ``Final`` (conftest.py:464), so with
+# neither a recorder nor a gated tool call, BOTH "zero side effects" and
+# "exactly one side effect" are assertions that cannot fail.
+
+
+@dataclass
+class JourneyRecorder:
+    """Records the calls the kernel makes to the action ledger (ADR-0117)."""
+
+    recorded: list[dict[str, Any]] = field(default_factory=list)
+    completed: list[tuple[str, Any]] = field(default_factory=list)
+
+    async def record(
+        self,
+        frame: Any,
+        *,
+        event_id: str,
+        conversation_id: str,
+        agent_id: str | None,
+        gate_approval_id: str | None = None,
+    ) -> Any:
+        from curie_worker.actions import RecordedAction
+
+        self.recorded.append(
+            {
+                "frame": frame,
+                "event_id": event_id,
+                "conversation_id": conversation_id,
+                "agent_id": agent_id,
+                "gate_approval_id": gate_approval_id,
+            }
+        )
+        return RecordedAction(id=f"a{len(self.recorded)}", status="pending")
+
+    async def complete(self, action_id: str, frame: Any) -> dict[str, Any]:
+        self.completed.append((action_id, frame))
+        return {
+            "tool": frame.tool,
+            "result": frame.result,
+            "detail": frame.detail,
+            "status": "failed" if frame.failed else "succeeded",
+            "undoable": bool(frame.result and frame.result.get("prior")),
+        }
+
+
+@pytest.fixture
+def journey_recorder() -> JourneyRecorder:
+    return JourneyRecorder()
+
+
+def gated_call(call_id: str, tool: str = "scale_deployment") -> list[OutboundEvent]:
+    """The two frames one side-effecting tool call produces.
+
+    Mirrors test_action_ledger.py:76-95. A runner script containing one of these
+    is what makes ``len(recorder.recorded) == 1`` mutation-sensitive.
+    """
+
+    from aci_protocol import SideEffectFlag
+
+    return [
+        SideEffectFlag(
+            tool=tool,
+            call_id=call_id,
+            arguments={"replicas": 10},
+            detail="non-idempotent tool executed",
+        ),
+        SideEffectFlag(
+            tool=tool,
+            call_id=call_id,
+            failed=False,
+            result={"ok": True, "prior": {"spec": {"replicas": 3}}},
+            detail="non-idempotent tool completed",
+        ),
+    ]

--- a/apps/worker/tests/kernel/test_approval_journey_dev.py
+++ b/apps/worker/tests/kernel/test_approval_journey_dev.py
@@ -1,0 +1,1600 @@
+"""The approval journey, composed across three apps and driven end to end.
+
+One real path from the card to the kernel, with every seam BETWEEN the three
+apps -- Slack interaction handling, dispatcher, HTTP, API, Postgres, Valkey,
+worker -- run for real rather than scripted. The stand-ins that remain are all
+at the edges (the runner and Slack itself) and are named in the block below.
+The chain: the real
+``approval_card(allow_free_text=True)`` render -> the real Bolt
+``SocketModeHandler`` -> the real ``this_release_owns_action`` ownership probe ->
+the real ``views_open`` note modal -> the real ``view_submission`` handler -> the
+real ``ApprovalResolveClient`` over real loopback HTTP -> the real ``curie_api``
+app with its real lifespan entered -> the real principal verifier and the real
+authorizer -> real Postgres -> the real ``ResumeQueue.enqueue`` -> a real Valkey
+stream -> the real worker ``Consumer`` and ``Kernel``.
+
+HONEST LABELLING -- what this module does NOT prove:
+
+    This module proves API/worker/dispatcher behavior only. The runner is the
+    existing in-process ``FakeRunner`` fake (apps/worker/tests/kernel/conftest.py)
+    and Slack is the existing ``FakeSocketClient`` + mocked ``WebClient``. It does
+    not prove real-runner or real-Slack behavior. Stage 3 connects the real
+    runner. Three smaller stand-ins sit beside them, all on the Slack/kernel
+    edges rather than in the journey itself: ``_authorize`` (Bolt's workspace
+    authorization lookup), ``JourneyRecorder`` (the action-ledger recorder) and
+    ``_RecordingApprovals`` (the kernel's ``ApprovalCreator``, used only where a
+    test needs the render the kernel asks for).
+
+Two consequences of that worth stating where the assertions are, not only in a
+plan: "the card settled" here is a ``chat_update`` call recorded on a
+``MagicMock``, which proves the dispatcher ASKED Slack to stamp the card, not
+that Slack rendered anything; and every tool call the ledger records is a frame
+the fake runner emitted, not a tool that ran.
+
+Placement: this lives under ``apps/worker/tests/kernel/`` because the
+``make_harness`` fixture (real ``Kernel``, real ``SandboxSubstrate`` over
+``FakeK8s``, real ``RunnerClient``, the fake runner server) is ~150 lines of
+assembly reachable only from a test under this directory -- pytest resolves
+conftests by directory, and ``--import-mode=importlib`` with no ``__init__.py``
+means one test module cannot import another's helpers. The API half (a
+disposable migrated database plus a uvicorn server) is the cheap half, so that
+is the half that moved. ``apps/worker/tests`` is in ``testpaths``, so CI
+collects this with no ``pyproject.toml`` edit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import importlib.util
+import json
+import os
+import sys
+import threading
+import time
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import redis
+from aci_protocol import (
+    STREAM_PAYLOAD_FIELD,
+    Final,
+    QueuedTurn,
+    ReplyHandle,
+    SessionStatus,
+    TextDelta,
+    TurnSource,
+)
+from curie_api.resumequeue import resume_event_id
+from curie_dispatcher.app import build_app
+from curie_dispatcher.approval_actions import (
+    APPROVE_ACTION_ID,
+    APPROVE_NOTE_ACTION_ID,
+    NOTE_MODAL_CALLBACK_ID,
+    REJECT_ACTION_ID,
+    REJECT_NOTE_ACTION_ID,
+)
+from curie_dispatcher.approval_principal import mint_chat_principal
+from curie_dispatcher.config import DispatcherConfig
+from curie_test_support.valkey import VALKEY_HOST, VALKEY_PORT, VALKEY_PW
+from curie_worker.approvals import CreatedApproval
+from curie_worker.blocks import approval_card
+from curie_worker.consumer import Consumer
+from slack_bolt.adapter.socket_mode import SocketModeHandler
+from slack_sdk.socket_mode.request import SocketModeRequest
+from slack_sdk.web import WebClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+DONE = SessionStatus.DONE
+
+
+def _module_from_path(path: Path, name: str) -> Any:
+    """Import one file as a module, by path.
+
+    ``--import-mode=importlib`` with no ``__init__.py`` means a test module
+    cannot import a sibling (or a conftest) by name: pytest registers each
+    conftest in ``sys.modules`` under a mangled, unstable key. Fixtures are found
+    by pytest regardless, but plain module-level HELPERS are not, so the two
+    helper sources this module needs are loaded explicitly. Already-imported
+    modules are reused so the conftest is not executed a second time.
+    """
+
+    for module in list(sys.modules.values()):
+        if getattr(module, "__file__", None) and Path(module.__file__).resolve() == path:
+            return module
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_KERNEL_CONFTEST = _module_from_path(
+    Path(__file__).resolve().parent / "conftest.py", "_journey_kernel_conftest"
+)
+composed_api_server = _KERNEL_CONFTEST.composed_api_server
+gated_call = _KERNEL_CONFTEST.gated_call
+_JOURNEY_ATTESTER_VALUE = _KERNEL_CONFTEST._JOURNEY_ATTESTER_VALUE
+
+
+# --- Cross-root import of the dispatcher's Socket Mode fakes -----------------
+#
+# ``apps/dispatcher/tests/conftest.py`` holds ``_authorize``, ``FakeSocketClient``
+# and ``deliver_until_acked``. Under ``--import-mode=importlib`` with no
+# ``__init__.py``, a module under ``apps/worker/tests/kernel/`` cannot reach it
+# by name. It is loaded by file path instead of being redeclared, which is the
+# plan's first-choice option: a local copy of ``FakeSocketClient`` would fork the
+# ``ack_payloads`` capture (dispatcher conftest:43-53), and this module's AC3
+# assertions are ENTIRELY carried by that ack body -- the note path renders a
+# refusal into the view ack, not into an ephemeral.
+
+
+_DISPATCHER_CONFTEST = _REPO_ROOT / "apps" / "dispatcher" / "tests" / "conftest.py"
+assert _DISPATCHER_CONFTEST.is_file(), f"dispatcher conftest not found at {_DISPATCHER_CONFTEST}"
+_DISPATCHER = _module_from_path(_DISPATCHER_CONFTEST, "_journey_dispatcher_conftest")
+FakeSocketClient = _DISPATCHER.FakeSocketClient
+deliver_until_acked = _DISPATCHER.deliver_until_acked
+_authorize = _DISPATCHER._authorize
+
+
+def test_the_imported_dispatcher_fakes_are_the_real_ones() -> None:
+    """Parity guard on the cross-root import (R9).
+
+    The point of loading the dispatcher's conftest by path rather than copying
+    it is that a change to the ack capture cannot silently fork. If Bolt's ack
+    body stops being recorded, every AC3 assertion in this module would go
+    vacuous, so the capture is pinned here explicitly.
+    """
+
+    sock = FakeSocketClient()
+
+    class _Response:
+        envelope_id = "env-parity"
+        payload = {"response_action": "errors", "errors": {"note": "nope"}}
+
+    sock.send_socket_mode_response(_Response())
+
+    assert sock.acked_envelope_ids == ["env-parity"]
+    assert sock.ack_payload_for("env-parity") == {
+        "response_action": "errors",
+        "errors": {"note": "nope"},
+    }
+
+
+# --- Module preconditions ----------------------------------------------------
+#
+# A skip is a failure for this module: it is the whole point of the PR. The
+# guard is deliberately SPECIFIC. ``CI_REQUIRE_VALKEY_TESTS`` only makes an
+# UNREACHABLE store fail instead of skip; it says nothing about the WRONG store,
+# and a reachable default ``localhost:26379`` would run happily against a shared
+# stack where a pre-existing stream entry can make an assertion pass for the
+# wrong reason.
+
+
+def test_the_isolated_pilot_stack_is_what_we_are_running_against() -> None:
+    assert os.environ.get("CI_REQUIRE_VALKEY_TESTS"), (
+        "CI_REQUIRE_VALKEY_TESTS must be set: without it an unreachable Valkey "
+        "SKIPS instead of failing, and this module's whole claim is that the "
+        "journey actually ran."
+    )
+    assert os.environ.get("TEST_VALKEY_PORT") == "36379", (
+        "this module must run against the isolated pilot stack's Valkey on "
+        f"36379, not {os.environ.get('TEST_VALKEY_PORT')!r}; the constants are "
+        "frozen at import (curie_test_support/valkey.py:19-21), so no fixture "
+        "can retarget the worker afterwards."
+    )
+    assert "VALKEY_URL" not in os.environ, (
+        "VALKEY_URL wins outright over the host/port parts (config.py:404-406), "
+        "so with it set the API would write the resume to a different store "
+        "than the worker reads."
+    )
+    assert VALKEY_PORT == 36379
+
+
+# --- Shared journey scaffolding ----------------------------------------------
+
+_APPROVERS_CHANNEL = "C0EXAMPLE1"
+_OTHER_CHANNEL = "C0EXAMPLE2"
+_APPROVER = "U0EXAMPLE1"
+_SECOND_APPROVER = "U0EXAMPLE2"
+_OUTSIDER = "U0EXAMPLE3"
+_NOTE_TEXT = "checked the invoice, this is fine"
+
+_DB_SCHEMA = os.environ.get("TEST_DB_SCHEMA", "curie")
+
+
+def _dispatcher_config(stream: str) -> DispatcherConfig:
+    """A dispatcher config whose attester secret matches the API's.
+
+    Both halves must sign and verify with the SAME dedicated credential, and it
+    must differ from the platform key -- ``approval_auth.py:92-97`` refuses a
+    chat token outright when the two are equal, and ``config.py:430-431`` refuses
+    the configuration at boot.
+    """
+
+    return DispatcherConfig(
+        slack_app_token="xapp-test",
+        slack_bot_token="xoxb-test",
+        valkey_host=VALKEY_HOST,
+        valkey_port=VALKEY_PORT,
+        valkey_password=VALKEY_PW,
+        stream=stream,
+        dedupe_prefix=f"test:curie:dedupe:{uuid.uuid4().hex}:",
+        dedupe_ttl_seconds=60,
+        placeholder_text="Working on it.",
+        approval_chat_attester_secret=_JOURNEY_ATTESTER_VALUE,
+    )
+
+
+def _build_dispatcher(
+    config: DispatcherConfig, redis_client: redis.Redis, resolver: Any
+) -> tuple[Any, WebClient]:
+    """The dispatcher app with the REAL resolver wired in.
+
+    The only fakes are Slack's: ``web_client`` is a mock and the socket is
+    ``FakeSocketClient``. ``resolver=`` is the real ``ApprovalResolveClient``
+    talking real HTTP to the composed API, where every other test in the repo
+    passes a ``ScriptedResolver``.
+    """
+
+    web_client = WebClient(token="xoxb-test")
+    web_client.chat_postMessage = MagicMock(return_value={"ts": "555.000"})  # type: ignore[method-assign]
+    web_client.chat_update = MagicMock(return_value={"ok": True})  # type: ignore[method-assign]
+    web_client.chat_postEphemeral = MagicMock(return_value={"ok": True})  # type: ignore[method-assign]
+    web_client.views_open = MagicMock(return_value={"ok": True})  # type: ignore[method-assign]
+    app = build_app(
+        config,
+        web_client=web_client,
+        redis_client=redis_client,
+        authorize=_authorize,
+        resolver=resolver,
+    )
+    return app, web_client
+
+
+def _drain(app: Any, *, timeout: float = 30.0) -> None:
+    """Wait for every post-ack listener body to finish, ONCE, at the end, BOUNDED.
+
+    ``shutdown(wait=True)`` is terminal: Bolt's listener executor cannot accept
+    another envelope afterwards ("cannot schedule new futures after shutdown").
+    The dispatcher's own tests drive one envelope per app so they never notice;
+    this module drives a click AND a submission through the same app, so the
+    drain has to be the last thing each test does. Mid-test, wait on the
+    observable the next step needs instead -- see ``_wait_for``.
+
+    ``shutdown(wait=True)`` takes no deadline, so it is run on a helper thread
+    that IS joined with one: a listener body wedged on the loopback API would
+    otherwise hang the whole suite with nothing in the report to find it by.
+    """
+
+    executor = app.listener_runner.listener_executor
+    closer = threading.Thread(target=lambda: executor.shutdown(wait=True), name="journey-drain")
+    closer.start()
+    closer.join(timeout=timeout)
+    assert not closer.is_alive(), (
+        f"the Bolt listener executor did not drain within {timeout}s; a post-ack "
+        "listener body is still running (most likely wedged on the loopback API)"
+    )
+
+
+def _wait_for(pred: Callable[[], bool], *, what: str, timeout: float = 20.0) -> None:
+    """Bounded sync wait for a post-ack listener side effect.
+
+    Bolt returns from ``handle`` as soon as the listener acks and keeps running
+    the rest of the body on its executor, so the ``views_open`` call and the card
+    stamp land slightly after. Every wait in this module carries a deadline and a
+    message: the Bolt executor, the threaded uvicorn server and the AC5 threads
+    are all real hang surfaces, and a hang reports nothing.
+    """
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if pred():
+            return
+        time.sleep(0.01)
+    raise AssertionError(f"timed out after {timeout}s waiting for: {what}")
+
+
+def _card(approval_id: str, *, allow_free_text: bool) -> dict[str, Any]:
+    """The REAL rendered card, as a Slack message, exactly as the kernel renders it.
+
+    ``allow_free_text=True`` is what ``kernel.py:3816`` passes unconditionally,
+    so that render is the only one production posts.
+    """
+
+    fallback, blocks = approval_card(
+        approval_id=approval_id,
+        summary="Scale the payments deployment to 10 replicas",
+        requested_by="U0EXAMPLE4",
+        allow_free_text=allow_free_text,
+    )
+    return {"ts": "1700.0042", "thread_ts": "1700.0001", "text": fallback, "blocks": blocks}
+
+
+def _buttons(card: dict[str, Any]) -> list[dict[str, Any]]:
+    actions = [b for b in card["blocks"] if b["type"] == "actions"]
+    assert len(actions) == 1, f"expected exactly one actions block, got {len(actions)}"
+    return list(actions[0]["elements"])
+
+
+def _click(
+    envelope_id: str,
+    *,
+    card: dict[str, Any],
+    button: dict[str, Any],
+    user: str,
+    channel: str,
+) -> SocketModeRequest:
+    """A block_actions envelope whose action id and value are DERIVED.
+
+    ``button`` is an element read straight out of the rendered card above, so
+    nothing here is a literal a renderer produced: a change to the action ids or
+    to the ``value`` the buttons carry moves this click with it.
+    """
+
+    return SocketModeRequest(
+        type="interactive",
+        envelope_id=envelope_id,
+        payload={
+            "type": "block_actions",
+            "trigger_id": f"trig-{envelope_id}",
+            "team": {"id": "T1"},
+            "user": {"id": user},
+            "api_app_id": "A1",
+            "token": "verif",
+            "container": {"type": "message", "message_ts": card["ts"]},
+            "channel": {"id": channel},
+            "message": card,
+            "actions": [
+                {
+                    "type": "button",
+                    "action_id": button["action_id"],
+                    "action_ts": "2.0",
+                    "value": button["value"],
+                }
+            ],
+        },
+    )
+
+
+def _view_submission(
+    envelope_id: str, *, private_metadata: str, user: str, note: str | None
+) -> SocketModeRequest:
+    """A view_submission envelope built from the CAPTURED modal metadata.
+
+    ``private_metadata`` is read back off the real ``views_open`` call arguments,
+    never hand-built: it is what carries the approval id, channel, card ts and
+    decision across a submission that has no channel or message of its own
+    (approval_actions.py:56-58).
+    """
+
+    state: dict[str, Any] = {"values": {}}
+    if note is not None:
+        state["values"] = {"note": {"note-input": {"type": "plain_text_input", "value": note}}}
+    return SocketModeRequest(
+        type="interactive",
+        envelope_id=envelope_id,
+        payload={
+            "type": "view_submission",
+            "team": {"id": "T1"},
+            "user": {"id": user},
+            "api_app_id": "A1",
+            "token": "verif",
+            "trigger_id": f"trig-{envelope_id}",
+            "view": {
+                "id": f"V-{envelope_id}",
+                "type": "modal",
+                "callback_id": NOTE_MODAL_CALLBACK_ID,
+                "private_metadata": private_metadata,
+                "state": state,
+                "hash": "1",
+                "title": {"type": "plain_text", "text": "Approve request"},
+                "blocks": [],
+            },
+        },
+    )
+
+
+class _Api:
+    """Thin read/write helper over the composed API, using the platform key.
+
+    Deliberately NOT a stand-in for anything: every call here is a real HTTP
+    request to the real routes (``POST /approvals``, ``GET /approvals/{id}``,
+    ``GET /approvals/{id}/audit``), which is how the test observes the same
+    surface an operator would.
+    """
+
+    def __init__(self, base_url: str, api_key: str) -> None:
+        self._base = base_url
+        self._headers = {"X-API-Key": api_key}
+        self._client = httpx.Client(timeout=10.0)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def create_approval(self, **overrides: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "conversation_id": f"th-{uuid.uuid4().hex[:8]}",
+            "author": "U0EXAMPLE4",
+            "summary": "Scale the payments deployment to 10 replicas",
+            "reply_kind": "slack",
+            "reply_channel": _APPROVERS_CHANNEL,
+            "reply_placeholder": "p-1",
+            "dedupe_key": f"ev-{uuid.uuid4().hex}",
+            "card_channel": _APPROVERS_CHANNEL,
+        }
+        body.update(overrides)
+        response = self._client.post(f"{self._base}/approvals", json=body, headers=self._headers)
+        assert response.status_code == 201, response.text
+        return dict(response.json())
+
+    def approval(self, approval_id: str) -> dict[str, Any]:
+        response = self._client.get(f"{self._base}/approvals/{approval_id}", headers=self._headers)
+        assert response.status_code == 200, response.text
+        return dict(response.json())
+
+    def audit(self, approval_id: str) -> list[dict[str, Any]]:
+        response = self._client.get(
+            f"{self._base}/approvals/{approval_id}/audit", headers=self._headers
+        )
+        assert response.status_code == 200, response.text
+        return list(response.json())
+
+    def audit_status(self, approval_id: str) -> int:
+        return self._client.get(
+            f"{self._base}/approvals/{approval_id}/audit", headers=self._headers
+        ).status_code
+
+
+@pytest.fixture
+def api(approval_api_server: Any, approval_api_env: Any) -> Any:
+    helper = _Api(approval_api_server.base_url, approval_api_env.api_key)
+    yield helper
+    helper.close()
+
+
+async def _seed_agent_with_route(
+    *, agent_id: uuid.UUID, route: str, approvers: dict[str, Any]
+) -> None:
+    """Seed a real ``agents`` row carrying a real approval ROUTE BINDING.
+
+    Without the binding, ``SlackApproverSetSelector`` returns ``UnboundRoute``
+    (approvers.py:150), whose ``UnboundRouteBinding`` refuses EVERYONE -- so an
+    AC3 refusal test would pass green without ``ExplicitUsers.contains`` ever
+    running. Every refusal assertion below therefore names the authorizer it
+    expects and asserts it is not that one.
+
+    Shape follows apps/worker/tests/binding/test_approval_grant.py:49-72.
+    """
+
+    engine = create_async_engine(os.environ["DATABASE_URL"])
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    f"INSERT INTO {_DB_SCHEMA}.agents (id, name, approval_routes) "
+                    "VALUES (:id, :name, CAST(:routes AS jsonb))"
+                ),
+                {
+                    "id": agent_id,
+                    "name": f"agent-{agent_id.hex[:8]}",
+                    "routes": json.dumps({route: {"approvers": approvers}}),
+                },
+            )
+            await conn.execute(
+                text(
+                    f"INSERT INTO {_DB_SCHEMA}.agent_channels (id, agent_id, kind, address) "
+                    "VALUES (:id, :agent_id, 'slack', :address)"
+                ),
+                {
+                    "id": uuid.uuid4(),
+                    "agent_id": agent_id,
+                    "address": f"C{agent_id.hex[:8].upper()}",
+                },
+            )
+    finally:
+        await engine.dispose()
+
+
+async def _stream_entries(h: Any) -> list[QueuedTurn]:
+    """Every entry on the REAL runs stream, decoded back into ``QueuedTurn``.
+
+    Read from the stream the API's real ``ResumeQueue.enqueue`` xadded to
+    (resumequeue.py:266). Hand-building a ``QueuedTurn`` and feeding it to
+    ``kernel.process_event`` would satisfy the event-id assertion while the API
+    had xadded nothing at all, which is why this module never does that.
+    """
+
+    rows = await h.async_redis.xrange(h.config.stream, "-", "+")
+    return [QueuedTurn.model_validate_json(fields[STREAM_PAYLOAD_FIELD]) for _id, fields in rows]
+
+
+async def _wait_until(pred: Callable[[], bool], *, what: str, timeout: float = 20.0) -> None:
+    """Bounded wait. Every wait in this module has a deadline and a message:
+    the threaded uvicorn server and the threaded AC5 clients make a hang a real
+    failure mode, and a hang reports nothing."""
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if pred():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"timed out after {timeout}s waiting for: {what}")
+
+
+async def _consume_the_resume(
+    h: Any, *, consumer: Consumer, event_id: str, expect_text: str
+) -> None:
+    """Run the REAL consumer until it finishes the entry the API wrote.
+
+    The wait is on the terminal ``turn.completed`` for THAT event id, not on the
+    delivered text: the kernel appends the ledger's "What I changed" summary to a
+    turn that touched the world, so the reply text is a superset of what the
+    runner said. Waiting on the completion keeps the wait honest about which turn
+    finished, and the text is asserted separately below.
+    """
+
+    task = asyncio.create_task(consumer.run())
+    try:
+        await _wait_until(
+            lambda: any(c.event_id == event_id for c in h.sink.completions),
+            what=f"the kernel to complete the resumed turn {event_id}",
+        )
+    finally:
+        consumer.request_stop()
+        # Bounded: ``read_block_ms=100`` usually ends this promptly, but a stuck
+        # handler would hang the suite silently. The shield-free wait_for
+        # cancels the task, and the cancellation is then awaited so the loop is
+        # not left with a pending task.
+        try:
+            await asyncio.wait_for(task, timeout=30.0)
+        except TimeoutError:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            raise AssertionError(
+                "the consumer did not stop within 30s of request_stop(); a "
+                "turn handler is still running"
+            ) from None
+
+    completed = [c for c in h.sink.completions if c.event_id == event_id]
+    assert len(completed) == 1, completed
+    assert completed[0].outcome == "delivered"
+    assert (h.sink.last_text or "").startswith(expect_text), h.sink.updates
+
+
+# --- The render the kernel actually asks for ---------------------------------
+
+
+class _RecordingApprovals:
+    """An ``ApprovalCreator`` fake that records requests and mints stable ids.
+
+    Redeclared from apps/worker/tests/kernel/test_approval_lifecycle.py:66 --
+    that module cannot be imported from here (importlib mode, no
+    ``__init__.py``) and is not in this PR's file list.
+    """
+
+    def __init__(self) -> None:
+        self.requests: list[Any] = []
+
+    async def create(self, request: Any) -> CreatedApproval:
+        self.requests.append(request)
+        return CreatedApproval(id=f"appr-{len(self.requests)}", status="pending")
+
+
+def _awaiting_script(summary: str) -> list[Any]:
+    """A turn that ends awaiting approval (test_approval_lifecycle.py:145)."""
+
+    return [
+        TextDelta(text="Requesting sign-off"),
+        Final(
+            text="Requesting sign-off",
+            status=SessionStatus.AWAITING_APPROVAL,
+            approval_summary=summary,
+        ),
+    ]
+
+
+def _qevent(text: str, *, thread: str) -> QueuedTurn:
+    return QueuedTurn(
+        event_id=uuid.uuid4().hex,
+        conversation_id=thread,
+        author="U0EXAMPLE4",
+        text=text,
+        reply_handle=ReplyHandle(kind="slack", channel=_APPROVERS_CHANNEL, placeholder="p-1"),
+        received_at="2026-09-11T00:00:00+00:00",
+        source=TurnSource.SLACK,
+    )
+
+
+def test_the_kernel_asks_for_the_note_render_so_that_is_the_live_card(
+    make_harness: Any,
+) -> None:
+    """Ties ``allow_free_text`` to what the KERNEL passes, not to a test literal.
+
+    Every other test in this module renders the card by calling
+    ``approval_card(allow_free_text=True)`` itself, which would keep passing if
+    ``kernel.py:3816`` flipped to ``False`` -- the note listeners would still
+    work, and production would simply stop posting cards that reach them. So the
+    coupling is asserted here once, at the seam where the kernel states the
+    semantic intent (``ConfirmIntent.allow_free_text``, ADR-0020: the interaction
+    is the port, the widget is the adapter), and the card is then rendered from
+    the value the kernel actually emitted rather than from a constant.
+
+    Driving the emit path further than this is stage 1's territory; this is the
+    one fact about it the rest of the module depends on.
+    """
+
+    async def go() -> None:
+        async with make_harness(approvals=_RecordingApprovals()) as h:
+            h.runner.default_script = _awaiting_script("Scale the payments deployment")
+            await h.kernel.process_event(_qevent("please approve", thread="th-render"))
+
+            assert len(h.sink.posts) == 1, h.sink.posts
+            _channel, message, _requested_by, _thread_ts, _endpoint = h.sink.posts[0]
+            intent = message.interaction
+            assert intent is not None and intent.kind == "confirm"
+            assert intent.allow_free_text is True, (
+                "the kernel passes allow_free_text=True UNCONDITIONALLY "
+                "(kernel.py:3816, #1076), so the note action ids are the only "
+                "pair production posts; if this is False, every note-path test "
+                "in this module is testing a card nothing renders"
+            )
+
+            _fallback, blocks = approval_card(
+                approval_id=intent.id,
+                summary=intent.prompt,
+                requested_by="U0EXAMPLE4",
+                allow_free_text=intent.allow_free_text,
+            )
+            elements = [b for b in blocks if b["type"] == "actions"][0]["elements"]
+            assert [e["action_id"] for e in elements] == [
+                APPROVE_NOTE_ACTION_ID,
+                REJECT_NOTE_ACTION_ID,
+            ]
+            assert [e["value"] for e in elements] == [intent.id, intent.id]
+
+    asyncio.run(go())
+
+
+# --- AC1: one pending record, one actionable card, no side effect yet --------
+
+
+def test_ac1_a_created_approval_is_pending_actionable_and_has_done_nothing(
+    make_harness: Any, api: Any, journey_recorder: Any
+) -> None:
+    """The starting state, asserted rather than assumed.
+
+    The ``recorded == []`` assertion is a CONTROL, and it is only worth
+    something because the same recorder counts to exactly one in AC2 under a
+    script that does contain a gated call: the runner script here deliberately
+    contains none, so the ledger is empty for a stated reason.
+    """
+
+    async def go() -> None:
+        created = api.create_approval()
+        approval_id = created["id"]
+        assert created["status"] == "pending"
+
+        card = _card(approval_id, allow_free_text=True)
+        buttons = _buttons(card)
+
+        # The action ids are IMPORTED, never literals: this is the positive
+        # proof that the render production posts is the note render.
+        assert [b["action_id"] for b in buttons] == [
+            APPROVE_NOTE_ACTION_ID,
+            REJECT_NOTE_ACTION_ID,
+        ]
+        assert [b["value"] for b in buttons] == [approval_id, approval_id]
+
+        async with make_harness(actions=journey_recorder) as h:
+            h.runner.default_script = [Final(text="ok", status=DONE)]
+            assert await h.async_redis.xlen(h.config.stream) == 0
+            assert journey_recorder.recorded == []
+
+    asyncio.run(go())
+
+
+# --- AC2: the live NOTE journey, end to end ---------------------------------
+
+
+def test_ac2_the_note_click_journey_resolves_wakes_and_settles(
+    make_harness: Any,
+    api: Any,
+    composed_resolver_factory: Any,
+    journey_recorder: Any,
+    sync_redis: redis.Redis,
+    approval_api_server: Any,
+) -> None:
+    """The whole live path, in order, with every hop real except the two named fakes.
+
+    The card is rendered with ``allow_free_text=True`` because that is what the
+    kernel passes unconditionally (kernel.py:3816), so the note pair is the ONLY
+    pair production posts. A test that captured ``APPROVE_ACTION_ID`` here would
+    be testing a path production never renders.
+    """
+
+    async def go() -> None:
+        created = api.create_approval()
+        approval_id = created["id"]
+
+        card = _card(approval_id, allow_free_text=True)
+        approve = _buttons(card)[0]
+        assert approve["action_id"] == APPROVE_NOTE_ACTION_ID
+
+        async with make_harness(actions=journey_recorder) as h:
+            # The resumed turn's script carries exactly ONE gated tool call, so
+            # "exactly one side effect" is mutation-sensitive rather than an
+            # assertion about an empty list that can never fail.
+            h.runner.default_script = [
+                *gated_call("toolu_journey_01"),
+                Final(text="scaled the deployment", status=DONE),
+            ]
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            # BEFORE the resolve: the group offset has to exist when the entry
+            # lands, or the consumer never sees it.
+            await consumer.ensure_group()
+
+            resolver = composed_resolver_factory()
+            config = _dispatcher_config(h.config.stream)
+            app, web_client = _build_dispatcher(config, sync_redis, resolver)
+            web_client.conversations_replies = MagicMock(  # type: ignore[method-assign]
+                return_value={"messages": [card]}
+            )
+            handler = SocketModeHandler(app, app_token="xapp-test")
+
+            # (a) The note click: a REAL GET /approvals/{id} on the loopback
+            # server answers the ownership probe (approval_actions.py:159-167),
+            # then the modal opens.
+            click_sock = FakeSocketClient()
+            handler.handle(
+                click_sock,
+                _click(
+                    "env-note-click",
+                    card=card,
+                    button=approve,
+                    user=_APPROVER,
+                    channel=_APPROVERS_CHANNEL,
+                ),
+            )
+            _wait_for(
+                lambda: bool(web_client.views_open.call_args),
+                what="the note modal to be opened after the click",
+            )
+            assert click_sock.acked_envelope_ids == ["env-note-click"]
+            web_client.views_open.assert_called_once()
+            view = web_client.views_open.call_args.kwargs["view"]
+            assert view["callback_id"] == NOTE_MODAL_CALLBACK_ID
+            # Nothing has resolved yet: the click only opens the dialog.
+            assert api.approval(approval_id)["status"] == "pending"
+            assert await h.async_redis.xlen(h.config.stream) == 0
+
+            # (b) The submission, built from the CAPTURED private_metadata.
+            submit_sock = FakeSocketClient()
+            handler.handle(
+                submit_sock,
+                _view_submission(
+                    "env-note-submit",
+                    private_metadata=view["private_metadata"],
+                    user=_APPROVER,
+                    note=_NOTE_TEXT,
+                ),
+            )
+            _wait_for(
+                lambda: bool(web_client.chat_update.call_args),
+                what="the resolved card to be stamped after the submission",
+            )
+            _drain(app)
+            assert submit_sock.acked_envelope_ids == ["env-note-submit"]
+            # An empty ack body is the ACCEPTED submission: a refusal would carry
+            # ``response_action: errors`` (handlers.py:637-645).
+            assert submit_sock.ack_payload_for("env-note-submit") is None
+
+            # (c) The audit trail, from the real authorizer.
+            entries = api.audit(approval_id)
+            resolved = [e for e in entries if e["action"] == "resolved"]
+            assert len(resolved) == 1, entries
+            assert resolved[0]["actor"] == _APPROVER
+            assert resolved[0]["authorized"] is True
+            assert resolved[0]["authorizer"] == "ChannelMembershipAuthorizer"
+            assert resolved[0]["authorizer"] != "UnboundRouteBinding"
+            assert resolved[0]["principal_kind"] == "chat"
+            assert resolved[0]["actor_channel"] == _APPROVERS_CHANNEL
+
+            # (d) The durable row.
+            row = api.approval(approval_id)
+            assert row["status"] == "approved"
+            assert row["resolved_by"] == _APPROVER
+
+            # (e) The REAL stream entry the REAL ResumeQueue.enqueue wrote.
+            turns = await _stream_entries(h)
+            assert len(turns) == 1, f"expected exactly one resume turn, got {turns}"
+            assert turns[0].event_id == resume_event_id(approval_id)
+            assert _NOTE_TEXT in turns[0].text
+
+            # (f) The real consumer consumes THAT entry and acks it.
+            await _consume_the_resume(
+                h,
+                consumer=consumer,
+                event_id=turns[0].event_id,
+                expect_text="scaled the deployment",
+            )
+            pending = await h.async_redis.xpending(h.config.stream, h.config.consumer_group)
+            assert pending["pending"] == 0
+            # The kernel classified it as an approval resume, which is what
+            # routes it down the settle path rather than treating it as a fresh
+            # mention (kernel.py:3263).
+            assert h.kernel._is_approval_resume(turns[0].event_id) is True
+
+            # (g) Exactly one ledger record, from the one gated call.
+            assert len(journey_recorder.recorded) == 1, journey_recorder.recorded
+            assert journey_recorder.recorded[0]["frame"].call_id == "toolu_journey_01"
+            assert journey_recorder.recorded[0]["event_id"] == turns[0].event_id
+
+            # (h) The card was asked to settle. This is a ``chat_update`` call on
+            # a MagicMock -- it proves the dispatcher asked Slack to stamp the
+            # card, NOT that Slack rendered anything.
+            web_client.chat_update.assert_called_once()
+            update = web_client.chat_update.call_args.kwargs
+            assert update["channel"] == _APPROVERS_CHANNEL
+            assert update["ts"] == card["ts"]
+            assert all(b["type"] != "actions" for b in update["blocks"])
+            assert f"Approved by <@{_APPROVER}>" in update["text"]
+
+    asyncio.run(go())
+
+
+def test_ac2_variant_the_immediate_render_is_the_older_card_migration_path(
+    make_harness: Any, api: Any, composed_resolver_factory: Any, sync_redis: redis.Redis
+) -> None:
+    """EXPLICITLY LABELLED VARIANT: ``allow_free_text=False`` is NOT what the
+    kernel posts.
+
+    ``kernel.py:3816`` passes ``allow_free_text=True`` unconditionally, so the
+    immediate ``APPROVE_ACTION_ID``/``REJECT_ACTION_ID`` pair is the pre-#1059
+    migration entry point for cards posted by an OLDER release, kept live so
+    those cards still resolve. It is a supported variant, not a second live
+    behavior, and it is the only case in this module where no ownership probe
+    and no modal are involved.
+    """
+
+    async def go() -> None:
+        created = api.create_approval()
+        approval_id = created["id"]
+
+        card = _card(approval_id, allow_free_text=False)
+        buttons = _buttons(card)
+        assert [b["action_id"] for b in buttons] == [APPROVE_ACTION_ID, REJECT_ACTION_ID]
+
+        async with make_harness() as h:
+            resolver = composed_resolver_factory()
+            app, web_client = _build_dispatcher(
+                _dispatcher_config(h.config.stream), sync_redis, resolver
+            )
+            handler = SocketModeHandler(app, app_token="xapp-test")
+
+            sock = FakeSocketClient()
+            handler.handle(
+                sock,
+                _click(
+                    "env-immediate",
+                    card=card,
+                    button=buttons[0],
+                    user=_APPROVER,
+                    channel=_APPROVERS_CHANNEL,
+                ),
+            )
+            _drain(app)
+
+            assert sock.acked_envelope_ids == ["env-immediate"]
+            # No modal on this path: the click resolves directly.
+            web_client.views_open.assert_not_called()
+            assert api.approval(approval_id)["status"] == "approved"
+            assert api.approval(approval_id)["resolved_by"] == _APPROVER
+
+    asyncio.run(go())
+
+
+# --- AC3: the real authorizer refuses, and we pin WHY -----------------------
+
+
+def _refusal_assertions(
+    *,
+    api: Any,
+    approval_id: str,
+    sock: Any,
+    envelope_id: str,
+    web_client: WebClient,
+    expected_authorizer: str,
+    actor: str,
+) -> None:
+    """Everything an authorizer REFUSAL must look like, pinned together.
+
+    Three discriminators, because "not 200" is satisfied by several very
+    different outcomes:
+
+    * the audit row exists, is ``authorized=false``, and names the authorizer
+      that actually ran -- and is NOT ``UnboundRouteBinding``, which refuses
+      everyone and would make this pass without the intended set running at all;
+    * the refusal was rendered into the VIEW ACK. On the note path a 403 posts
+      NO ephemeral: ``_render_outcome`` only logs for a 403, and the refusal
+      reaches the approver through ``response_action: errors`` on the ack,
+      because they are standing in an open modal where an ephemeral would post
+      behind them (approval_actions.py:697-706, handlers.py:637-645);
+    * the reason rendered is the API's OWN string, compared against the audit
+      row's ``reason`` rather than a literal copied into this file.
+
+    An ownership DECLINE has none of these (no ack at all, no audit row), so
+    this set cannot be satisfied by a 404.
+    """
+
+    entries = api.audit(approval_id)
+    denied = [e for e in entries if e["action"] == "denied"]
+    assert len(denied) == 1, entries
+    assert denied[0]["actor"] == actor
+    assert denied[0]["authorized"] is False
+    assert denied[0]["authorizer"] == expected_authorizer
+    assert denied[0]["authorizer"] != "UnboundRouteBinding", (
+        "the route binding was not seeded, so UnboundRouteBinding refused "
+        "everyone and this test would have passed without the intended "
+        "approver set ever running"
+    )
+
+    payload = sock.ack_payload_for(envelope_id)
+    assert payload is not None, "the submission was never acked"
+    assert payload["response_action"] == "errors"
+    rendered = payload["errors"]["note"]
+    assert rendered == denied[0]["reason"], (
+        "the approver must be shown the API's own refusal reason, not a "
+        f"substituted literal: rendered {rendered!r} vs audit {denied[0]['reason']!r}"
+    )
+
+    assert api.approval(approval_id)["status"] == "pending"
+    # The note path refuses IN VIEW; an ephemeral here would mean the immediate
+    # path ran instead.
+    web_client.chat_postEphemeral.assert_not_called()
+
+
+def test_ac3_an_unlisted_actor_is_refused_by_the_explicit_user_list(
+    make_harness: Any,
+    api: Any,
+    composed_resolver_factory: Any,
+    journey_recorder: Any,
+    sync_redis: redis.Redis,
+) -> None:
+    """An ``ExplicitUsers``-bound route refuses an actor who is not on the list.
+
+    The actor clicks from the approvals channel itself, so channel membership
+    cannot be what refuses them: the only thing left is the explicit list.
+    """
+
+    async def go() -> None:
+        agent_id = uuid.uuid4()
+        await _seed_agent_with_route(
+            agent_id=agent_id, route="payments", approvers={"users": [_APPROVER]}
+        )
+        created = api.create_approval(agent_id=str(agent_id), route="payments")
+        approval_id = created["id"]
+
+        card = _card(approval_id, allow_free_text=True)
+        approve = _buttons(card)[0]
+
+        async with make_harness(actions=journey_recorder) as h:
+            app, web_client = _build_dispatcher(
+                _dispatcher_config(h.config.stream),
+                sync_redis,
+                composed_resolver_factory(),
+            )
+            handler = SocketModeHandler(app, app_token="xapp-test")
+
+            handler.handle(
+                FakeSocketClient(),
+                _click(
+                    "env-unlisted-click",
+                    card=card,
+                    button=approve,
+                    user=_OUTSIDER,
+                    channel=_APPROVERS_CHANNEL,
+                ),
+            )
+            _wait_for(
+                lambda: bool(web_client.views_open.call_args),
+                what="the note modal to be opened after the click",
+            )
+            view = web_client.views_open.call_args.kwargs["view"]
+
+            sock = FakeSocketClient()
+            handler.handle(
+                sock,
+                _view_submission(
+                    "env-unlisted-submit",
+                    private_metadata=view["private_metadata"],
+                    user=_OUTSIDER,
+                    note=None,
+                ),
+            )
+            _drain(app)
+
+            _refusal_assertions(
+                api=api,
+                approval_id=approval_id,
+                sock=sock,
+                envelope_id="env-unlisted-submit",
+                web_client=web_client,
+                expected_authorizer="ExplicitUserListAuthorizer",
+                actor=_OUTSIDER,
+            )
+            assert await h.async_redis.xlen(h.config.stream) == 0
+            assert journey_recorder.recorded == []
+
+    asyncio.run(go())
+
+
+def test_ac3_an_actor_clicking_from_another_channel_is_refused(
+    make_harness: Any,
+    api: Any,
+    composed_resolver_factory: Any,
+    journey_recorder: Any,
+    sync_redis: redis.Redis,
+) -> None:
+    """A ``SlackChannelMembers`` route refuses a click from a DIFFERENT channel.
+
+    The channel is non-empty and different on purpose. ``slack_approvers.py:73-82``
+    refuses on ``not actor_channel`` as well, so a click carrying no channel
+    would pass this test for the missing-channel reason instead of the
+    wrong-channel one -- and the actor here is the approver who WOULD be
+    authorized from the right room, so the channel is the only variable.
+    """
+
+    async def go() -> None:
+        created = api.create_approval()
+        approval_id = created["id"]
+
+        card = _card(approval_id, allow_free_text=True)
+        approve = _buttons(card)[0]
+
+        async with make_harness(actions=journey_recorder) as h:
+            app, web_client = _build_dispatcher(
+                _dispatcher_config(h.config.stream),
+                sync_redis,
+                composed_resolver_factory(),
+            )
+            handler = SocketModeHandler(app, app_token="xapp-test")
+
+            handler.handle(
+                FakeSocketClient(),
+                _click(
+                    "env-wrong-channel-click",
+                    card=card,
+                    button=approve,
+                    user=_APPROVER,
+                    channel=_OTHER_CHANNEL,
+                ),
+            )
+            _wait_for(
+                lambda: bool(web_client.views_open.call_args),
+                what="the note modal to be opened after the click",
+            )
+            view = web_client.views_open.call_args.kwargs["view"]
+            assert json.loads(view["private_metadata"])["channel"] == _OTHER_CHANNEL
+
+            sock = FakeSocketClient()
+            handler.handle(
+                sock,
+                _view_submission(
+                    "env-wrong-channel-submit",
+                    private_metadata=view["private_metadata"],
+                    user=_APPROVER,
+                    note=None,
+                ),
+            )
+            _drain(app)
+
+            _refusal_assertions(
+                api=api,
+                approval_id=approval_id,
+                sock=sock,
+                envelope_id="env-wrong-channel-submit",
+                web_client=web_client,
+                expected_authorizer="ChannelMembershipAuthorizer",
+                actor=_APPROVER,
+            )
+            assert api.audit(approval_id)[0]["actor_channel"] == _OTHER_CHANNEL
+            assert await h.async_redis.xlen(h.config.stream) == 0
+            assert journey_recorder.recorded == []
+
+    asyncio.run(go())
+
+
+def test_ac3_control_an_unknown_approval_is_declined_not_refused(
+    make_harness: Any,
+    api: Any,
+    composed_resolver_factory: Any,
+    sync_redis: redis.Redis,
+) -> None:
+    """The OTHER negative shape, so the AC3 tests above cannot pass as this one.
+
+    A note click on an approval this release's database does not have is an
+    OWNERSHIP decline, not an authorization refusal: the envelope is left
+    UNACKED so Slack retries it on another connection of the same app
+    (approval_actions.py:140-156), and there is no ephemeral, no audit row and no
+    modal. With a single connection, ``deliver_until_acked`` therefore returns
+    None rather than hanging.
+    """
+
+    async def go() -> None:
+        unknown_id = str(uuid.uuid4())
+        card = _card(unknown_id, allow_free_text=True)
+        approve = _buttons(card)[0]
+
+        async with make_harness() as h:
+            app, web_client = _build_dispatcher(
+                _dispatcher_config(h.config.stream),
+                sync_redis,
+                composed_resolver_factory(),
+            )
+            sock = FakeSocketClient()
+            acked_by = deliver_until_acked(
+                [(SocketModeHandler(app, app_token="xapp-test"), sock, app)],
+                _click(
+                    "env-unknown",
+                    card=card,
+                    button=approve,
+                    user=_APPROVER,
+                    channel=_APPROVERS_CHANNEL,
+                ),
+            )
+
+            assert acked_by is None, "an unowned envelope must be left for Slack to retry"
+            assert sock.acked_envelope_ids == []
+            web_client.views_open.assert_not_called()
+            web_client.chat_postEphemeral.assert_not_called()
+            web_client.chat_update.assert_not_called()
+            # No record, so no audit trail either: the API returns the frozen
+            # row-miss 404 that IS the ownership signal.
+            assert api.audit_status(unknown_id) == 404
+            assert await h.async_redis.xlen(h.config.stream) == 0
+
+    asyncio.run(go())
+
+
+# --- AC5: one winner, whether the clicks are replayed or genuinely concurrent -
+
+
+def test_ac5_a_replayed_submission_loses_and_is_told_who_won(
+    make_harness: Any,
+    api: Any,
+    composed_resolver_factory: Any,
+    journey_recorder: Any,
+    sync_redis: redis.Redis,
+) -> None:
+    """The same captured submission delivered twice resolves exactly once."""
+
+    async def go() -> None:
+        created = api.create_approval()
+        approval_id = created["id"]
+        card = _card(approval_id, allow_free_text=True)
+        approve = _buttons(card)[0]
+
+        async with make_harness(actions=journey_recorder) as h:
+            h.runner.default_script = [
+                *gated_call("toolu_replay_01"),
+                Final(text="scaled once", status=DONE),
+            ]
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            app, web_client = _build_dispatcher(
+                _dispatcher_config(h.config.stream),
+                sync_redis,
+                composed_resolver_factory(),
+            )
+            web_client.conversations_replies = MagicMock(  # type: ignore[method-assign]
+                return_value={"messages": [card]}
+            )
+            handler = SocketModeHandler(app, app_token="xapp-test")
+
+            handler.handle(
+                FakeSocketClient(),
+                _click(
+                    "env-replay-click",
+                    card=card,
+                    button=approve,
+                    user=_APPROVER,
+                    channel=_APPROVERS_CHANNEL,
+                ),
+            )
+            _wait_for(
+                lambda: bool(web_client.views_open.call_args),
+                what="the note modal to be opened after the click",
+            )
+            metadata = web_client.views_open.call_args.kwargs["view"]["private_metadata"]
+
+            first = FakeSocketClient()
+            handler.handle(
+                first,
+                _view_submission(
+                    "env-replay-1", private_metadata=metadata, user=_APPROVER, note=None
+                ),
+            )
+            second = FakeSocketClient()
+            handler.handle(
+                second,
+                _view_submission(
+                    "env-replay-2", private_metadata=metadata, user=_SECOND_APPROVER, note=None
+                ),
+            )
+            _drain(app)
+
+            assert first.ack_payload_for("env-replay-1") is None
+            loser = second.ack_payload_for("env-replay-2")
+            assert loser is not None and loser["response_action"] == "errors"
+            # NAMING the winner, not merely non-200: a 404 ownership miss is
+            # also not-200 and would render a completely different sentence.
+            assert _APPROVER in loser["errors"]["note"], loser
+
+            row = api.approval(approval_id)
+            assert row["status"] == "approved"
+            assert row["resolved_by"] == _APPROVER
+            assert [e["action"] for e in api.audit(approval_id)] == ["resolved", "race_lost"]
+
+            turns = await _stream_entries(h)
+            assert len(turns) == 1, f"a second enqueue would double-wake the session: {turns}"
+            assert turns[0].event_id == resume_event_id(approval_id)
+
+            await _consume_the_resume(
+                h, consumer=consumer, event_id=turns[0].event_id, expect_text="scaled once"
+            )
+            assert len(journey_recorder.recorded) == 1, journey_recorder.recorded
+
+    asyncio.run(go())
+
+
+def test_ac5_two_genuinely_concurrent_resolvers_produce_one_winner(
+    make_harness: Any,
+    api: Any,
+    composed_resolver_factory: Any,
+    journey_recorder: Any,
+) -> None:
+    """Two threads, two clients, one barrier, and a proof they OVERLAPPED.
+
+    This is the assertion the loopback-HTTP seam buys. Each thread holds its own
+    real ``ApprovalResolveClient`` with its own ``httpx.Client``, and the real
+    uvicorn server serves both at once, so the two resolves are genuinely in
+    flight together rather than being serialized by a single test portal. The
+    overlap is measured, not assumed: if the intervals did not intersect on a
+    given run the test reports SKIPPED rather than silently passing as a proof
+    of concurrency it degenerated into the replay case above. Every other
+    assertion here is unaffected either way, which is why that check is last.
+    """
+
+    async def go() -> None:
+        created = api.create_approval()
+        approval_id = created["id"]
+
+        async with make_harness(actions=journey_recorder) as h:
+            h.runner.default_script = [
+                *gated_call("toolu_race_01"),
+                Final(text="scaled once", status=DONE),
+            ]
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            barrier = threading.Barrier(2)
+            results: dict[str, Any] = {}
+            intervals: dict[str, tuple[float, float]] = {}
+
+            def _resolve(actor: str) -> None:
+                resolver = composed_resolver_factory()
+                try:
+                    barrier.wait(timeout=20)
+                    start = time.monotonic()
+                    outcome = resolver.resolve(
+                        approval_id,
+                        decision="approved",
+                        attested_user=actor,
+                        attested_channel=_APPROVERS_CHANNEL,
+                    )
+                    intervals[actor] = (start, time.monotonic())
+                    results[actor] = outcome
+                finally:
+                    # The production default ``httpx.Client`` is created inside
+                    # the resolver (approval_actions.py:251-262) and nothing else
+                    # owns it -- there is no ``close()`` on the class -- so two
+                    # per test leak two connection pools otherwise.
+                    resolver._client.close()
+
+            threads = [
+                threading.Thread(target=_resolve, args=(actor,), name=f"resolve-{actor}")
+                for actor in (_APPROVER, _SECOND_APPROVER)
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=30)
+                assert not thread.is_alive(), "a concurrent resolver thread hung"
+
+            assert set(results) == {_APPROVER, _SECOND_APPROVER}, results
+            codes = sorted(outcome.status_code for outcome in results.values())
+            assert codes == [200, 409], results
+
+            winner = next(a for a, o in results.items() if o.status_code == 200)
+            loser_actor = next(a for a, o in results.items() if o.status_code == 409)
+            loser = results[loser_actor]
+
+            # The 409 BODY names a resolver, in the API's own sentence. This is
+            # deliberately not "assert not 200": a 404 ownership miss and a 410
+            # expiry are also not-200 and mean entirely different things, and the
+            # dispatcher renders each of them differently.
+            assert loser.detail.startswith("already resolved by "), loser.detail
+            named = loser.detail[len("already resolved by ") :].split(" ", 1)[0]
+            assert named in (_APPROVER, _SECOND_APPROVER), loser.detail
+
+            # FINDING, recorded here rather than bent around. The plan asserts
+            # "the 409 body names the WINNER". That holds when the loser's
+            # request reads the row after the winner committed -- which is what
+            # the replayed-submission test above pins -- but NOT reliably under
+            # genuine concurrency, which is the case only this seam can produce.
+            #
+            # Cause: the resolve-once CAS is an ORM-enabled UPDATE
+            # (crud.claim_approval_resolution, crud.py:1672) whose default
+            # ``synchronize_session="auto"`` evaluates the criteria against the
+            # session's identity map and applies the new values to any matching
+            # in-memory object. The loser's session read the row while it was
+            # still ``pending`` (routers/approvals.py:191) and the sessionmaker
+            # sets ``expire_on_commit=False`` (db.py:31), so its in-memory copy
+            # still matches, is locally stamped with the LOSER's own subject, and
+            # the 409's re-read (``crud.get_approval``) hands that same identity-
+            # mapped object back. The loser is then told it lost to itself.
+            #
+            # So the assertion that stands is the one above -- the body names ONE
+            # OF THE TWO PARTIES, in the API's own sentence -- and the DATABASE
+            # is asserted separately below for who actually won. Do not tighten
+            # the check above to ``named == winner`` until the
+            # synchronize_session behavior is fixed; do not loosen it to "not
+            # 200" either. (A third assertion spelling out ``named == winner or
+            # named == loser_actor`` used to sit here; those are exactly the two
+            # ids the line above already admits, so it could not fail.)
+
+            # The durable record is unambiguous even when the 409 sentence is
+            # not: exactly one actor won, and it is the one that got the 200.
+            row = api.approval(approval_id)
+            assert row["status"] == "approved" and row["resolved_by"] == winner
+            # Counted, not ordered: which of the two audit rows commits first is
+            # genuinely nondeterministic here, unlike the replayed case above.
+            actions = sorted(e["action"] for e in api.audit(approval_id))
+            assert actions == ["race_lost", "resolved"], actions
+            turns = await _stream_entries(h)
+            assert len(turns) == 1, f"exactly one wake per approval: {turns}"
+            assert turns[0].event_id == resume_event_id(approval_id)
+
+            await _consume_the_resume(
+                h, consumer=consumer, event_id=turns[0].event_id, expect_text="scaled once"
+            )
+            assert len(journey_recorder.recorded) == 1, journey_recorder.recorded
+
+            # The honesty check on the CONCURRENCY claim specifically, and it is
+            # last on purpose: every assertion above holds whether the two
+            # requests overlapped or degenerated into the replay case, so none of
+            # them is lost by the outcome here.
+            #
+            # It is a SKIP rather than a failure because it is not deterministic:
+            # ``barrier.wait`` releases both threads together, but the OS can
+            # still let one thread run the whole loopback round trip before the
+            # other records its start, and that is a scheduling accident, not a
+            # regression. What it must never do is claim concurrency it did not
+            # observe, so the run is reported as skipped rather than passed.
+            (a_start, a_end), (b_start, b_end) = (
+                intervals[_APPROVER],
+                intervals[_SECOND_APPROVER],
+            )
+            if not (a_start < b_end and b_start < a_end):
+                pytest.skip(
+                    "the two resolve requests did not overlap in time, so this "
+                    "run proved the one-winner property but NOTHING about "
+                    f"concurrency: {intervals}"
+                )
+
+    asyncio.run(go())
+
+
+# --- AC6: the real verifier refuses four forgeries ---------------------------
+
+
+def _resolve_with_principal(*, base_url: str, token: str, approval_id: str) -> httpx.Response:
+    """POST one forged principal at the real resolve route, header PRESENT.
+
+    The header being present is the whole point. ``approval_auth.py:80-81``
+    raises the SAME 401 body for a request that carries no credential at all, so
+    a test asserting only "401" could be landing on the missing-credential
+    branch and never reaching ``verify_claims``.
+
+    The asserts below are a construction check on this helper, not the
+    discriminator: a request built with the header will always have it. The real
+    discriminator lives inside each forgery test, which re-sends the identical
+    envelope through THIS helper with a genuine token and shows it is accepted
+    (200). That is what makes the 401 attributable to the forgery and to nothing
+    else.
+    """
+
+    headers = {"X-Curie-Approval-Principal": token}
+    with httpx.Client(timeout=10.0) as client:
+        request = client.build_request(
+            "POST",
+            f"{base_url}/approvals/{approval_id}/resolve",
+            json={"decision": "approved"},
+            headers=headers,
+        )
+        assert "X-Curie-Approval-Principal" in request.headers, (
+            "the principal header must actually be on the wire, or this 401 is "
+            "the missing-credential branch and the verifier never ran"
+        )
+        assert request.headers["X-Curie-Approval-Principal"] == token
+        return client.send(request)
+
+
+def test_ac6_control_a_valid_principal_on_the_same_route_resolves(
+    api: Any, approval_api_server: Any, approval_api_env: Any
+) -> None:
+    """The positive control the four forgery cases lean on.
+
+    Same route, same header name, same request shape: only the token differs. If
+    this did not return 200, every "refused" assertion below would be consistent
+    with the route simply being unreachable or the header being ignored.
+    """
+
+    created = api.create_approval()
+    approval_id = created["id"]
+    token = mint_chat_principal(
+        approval_api_env.attester_secret,
+        subject=_APPROVER,
+        actor_channel=_APPROVERS_CHANNEL,
+        approval_id=approval_id,
+    )
+
+    response = _resolve_with_principal(
+        base_url=approval_api_server.base_url, token=token, approval_id=approval_id
+    )
+
+    assert response.status_code == 200, response.text
+    assert api.approval(approval_id)["status"] == "approved"
+
+
+@pytest.mark.parametrize("forgery", ["tampered", "expired", "mismatched_approval", "wrong_secret"])
+def test_ac6_the_real_verifier_refuses_a_forged_principal(
+    make_harness: Any,
+    api: Any,
+    approval_api_server: Any,
+    approval_api_env: Any,
+    forgery: str,
+) -> None:
+    """Four forgeries, each refused by ``verify_claims`` rather than by absence.
+
+    * tampered -- one byte of a validly minted token flipped
+      (approval_principal.py:133, ``hmac.compare_digest``);
+    * expired -- minted at ``now - 61``. ``mint_chat_principal`` sets
+      ``exp = issued_at + 60``, so ``now - 1`` would still be VALID and the test
+      would pass for no reason (approval_principal.py:165);
+    * mismatched_approval -- a token minted for approval A submitted against
+      approval B, with BOTH rows present so the refusal cannot be a 404
+      (approval_principal.py:172);
+    * wrong_secret -- signed with the platform ``api_key`` instead of the
+      attester secret, claiming an authorized actor.
+    """
+
+    async def go() -> None:
+        target = api.create_approval()
+        approval_id = target["id"]
+        other = api.create_approval()
+
+        attester = approval_api_env.attester_secret
+        if forgery == "tampered":
+            valid = mint_chat_principal(
+                attester,
+                subject=_APPROVER,
+                actor_channel=_APPROVERS_CHANNEL,
+                approval_id=approval_id,
+            )
+            head, _, signature = valid.rpartition(".")
+            flipped = ("A" if signature[0] != "A" else "B") + signature[1:]
+            token = f"{head}.{flipped}"
+        elif forgery == "expired":
+            token = mint_chat_principal(
+                attester,
+                subject=_APPROVER,
+                actor_channel=_APPROVERS_CHANNEL,
+                approval_id=approval_id,
+                now=int(time.time()) - 61,
+            )
+        elif forgery == "mismatched_approval":
+            token = mint_chat_principal(
+                attester,
+                subject=_APPROVER,
+                actor_channel=_APPROVERS_CHANNEL,
+                approval_id=other["id"],
+            )
+        else:
+            token = mint_chat_principal(
+                approval_api_env.api_key,
+                subject=_APPROVER,
+                actor_channel=_APPROVERS_CHANNEL,
+                approval_id=approval_id,
+            )
+
+        response = _resolve_with_principal(
+            base_url=approval_api_server.base_url, token=token, approval_id=approval_id
+        )
+
+        assert response.status_code == 401, response.text
+        assert api.approval(approval_id)["status"] == "pending"
+        assert api.approval(other["id"])["status"] == "pending"
+        # A forged identity must never reach the authorization stage, so there
+        # is no audit row naming the actor it claimed to be.
+        assert [e for e in api.audit(approval_id) if e["actor"] == _APPROVER] == []
+
+        async with make_harness() as h:
+            assert await h.async_redis.xlen(h.config.stream) == 0
+
+            # THE DISCRIMINATOR, local to this case. ``verify_claims`` and the
+            # missing-credential branch raise the SAME 401 body ("missing or
+            # invalid approval principal", approval_auth.py:31-36, 80-81,
+            # 112-113), so "401" alone is also consistent with the header being
+            # dropped or ignored outright. Send the IDENTICAL envelope -- same
+            # route, same approval, same header name, same helper -- differing
+            # only in that the token is correctly signed, unexpired and bound to
+            # THIS approval, and show it is accepted. That pins the refusal above
+            # on the forgery rather than on absence, within this test rather than
+            # by leaning on a sibling one.
+            genuine = _resolve_with_principal(
+                base_url=approval_api_server.base_url,
+                token=mint_chat_principal(
+                    attester,
+                    subject=_APPROVER,
+                    actor_channel=_APPROVERS_CHANNEL,
+                    approval_id=approval_id,
+                ),
+                approval_id=approval_id,
+            )
+            assert genuine.status_code == 200, genuine.text
+            assert api.approval(approval_id)["status"] == "approved"
+            # And the accepted resolve is what puts an entry on the stream the
+            # forged ones left empty, so the ``xlen == 0`` above is a real
+            # observation of this stream rather than of a stream nothing ever
+            # writes to.
+            assert await h.async_redis.xlen(h.config.stream) == 1
+
+    asyncio.run(go())
+
+
+# --- AC-SEC3: the composed seam leaves no listening surface ------------------
+
+
+def test_ac_sec3_the_composed_port_refuses_connections_after_teardown(
+    approval_api_db: str, approval_api_env: Any
+) -> None:
+    """The loopback server exists only inside the fixture's lifetime.
+
+    It uses ``composed_api_server`` directly rather than the fixture because the
+    observation has to happen AFTER teardown, which a test still inside the
+    fixture cannot make. A closed-client assertion would prove nothing -- it is
+    true of any closed client; a refused TCP connection to the port the server
+    was really bound to is the structural claim.
+    """
+
+    with composed_api_server() as api:
+        port = api.port
+        with httpx.Client(timeout=10.0) as client:
+            assert client.get(f"{api.base_url}/config").status_code == 200
+
+    with httpx.Client(timeout=5.0) as client, pytest.raises(httpx.ConnectError):
+        # ``/health`` (main.py:328), not ``/healthz``: an unrouted path would
+        # make this step vacuous, since a 404 proves the server is alive just as
+        # well as a 200 does, and only the ConnectError is the claim.
+        client.get(f"http://127.0.0.1:{port}/health")

--- a/charts/curie/ci/approval-principal-wiring-assertions.sh
+++ b/charts/curie/ci/approval-principal-wiring-assertions.sh
@@ -76,6 +76,131 @@ for deployment in ("curie-worker", "curie-ui"):
     if env_name in refs(deployment):
         raise SystemExit(f"{deployment} must not receive {env_name}")
 
+# The shipped dev attester literal must never reach a DEFAULT (sealed) render.
+# values.yaml carries it only as the curie.managedSecret comparison default, so
+# a bare install generates a random secret instead; values-dev.yaml emits it on
+# purpose via allowDevDefaults and is deliberately not checked here.
+DEV_ATTESTER_LITERAL = "curie-dev-approval-chat-attester"
+sealed_secrets = [doc for doc in docs if doc.get("kind") == "Secret"]
+if not sealed_secrets:
+    raise SystemExit("sealed render produced no Secret; the dev-literal assertion is vacuous")
+for doc in sealed_secrets:
+    if DEV_ATTESTER_LITERAL in yaml.safe_dump(doc):
+        name = doc.get("metadata", {}).get("name")
+        raise SystemExit(f"sealed render Secret {name} ships the dev attester default")
+
+# --- Full-render sweep -------------------------------------------------
+# The checks above read only containers[0].env of four named Deployments and
+# only kind==Secret for the literal. Kubernetes injects secrets by several
+# other routes, so the claim "the sealed render never ships the attester to
+# anything but api/dispatcher, and never ships the dev literal" is only as
+# strong as a sweep over EVERY rendered document and EVERY pod spec.
+import base64
+
+ALLOWED_ATTESTER_WORKLOADS = {"curie-api", "curie-dispatcher"}
+LITERAL_B64 = base64.b64encode(DEV_ATTESTER_LITERAL.encode()).decode()
+
+# 1. The literal (or its base64 encoding) anywhere in the sealed render --
+#    ConfigMap, plain env value, annotation, Secret data -- is a leak.
+for doc in docs:
+    dumped = yaml.safe_dump(doc)
+    kind = doc.get("kind")
+    name = doc.get("metadata", {}).get("name")
+    if DEV_ATTESTER_LITERAL in dumped:
+        raise SystemExit(f"sealed render {kind}/{name} ships the dev attester literal")
+    if LITERAL_B64 in dumped:
+        raise SystemExit(f"sealed render {kind}/{name} ships the base64 dev attester literal")
+    # base64 `data:` would hide the plaintext from the scan above, so decode it.
+    if kind == "Secret":
+        for key, value in (doc.get("data") or {}).items():
+            try:
+                decoded = base64.b64decode(str(value), validate=True).decode("utf-8", "replace")
+            except Exception:
+                continue
+            if DEV_ATTESTER_LITERAL in decoded:
+                raise SystemExit(
+                    f"sealed render Secret {name} data.{key} decodes to the dev attester literal"
+                )
+
+# 2. Every pod spec in the render -- containers, initContainers and
+#    ephemeralContainers of any Deployment/StatefulSet/DaemonSet/Job/CronJob
+#    or bare Pod -- not just containers[0] of four names.
+def pod_specs(doc):
+    kind = doc.get("kind")
+    spec = doc.get("spec") or {}
+    if kind == "Pod":
+        yield spec
+    elif kind == "CronJob":
+        job = ((spec.get("jobTemplate") or {}).get("spec") or {})
+        yield ((job.get("template") or {}).get("spec") or {})
+    elif kind in ("Deployment", "StatefulSet", "DaemonSet", "Job", "ReplicaSet"):
+        yield ((spec.get("template") or {}).get("spec") or {})
+
+EXPECTED_SOURCE = {
+    "name": "curie-secrets",
+    "key": "approvalChatAttesterSecret",
+}
+for doc in docs:
+    name = doc.get("metadata", {}).get("name")
+    kind = doc.get("kind")
+    for pod in pod_specs(doc):
+        if not pod:
+            continue
+        containers = []
+        for field in ("containers", "initContainers", "ephemeralContainers"):
+            containers.extend(pod.get(field) or [])
+        for container in containers:
+            label = f"{kind}/{name} container {container.get('name')}"
+            for entry in container.get("env") or []:
+                if entry.get("name") != env_name:
+                    continue
+                if name not in ALLOWED_ATTESTER_WORKLOADS:
+                    raise SystemExit(f"{label} must not receive {env_name}")
+                source = ((entry.get("valueFrom") or {}).get("secretKeyRef") or {})
+                if entry.get("value") is not None or source != EXPECTED_SOURCE:
+                    raise SystemExit(
+                        f"{label} sources {env_name} from {entry!r}, not "
+                        f"secretKeyRef {EXPECTED_SOURCE}"
+                    )
+            # envFrom of curie-secrets hands the whole Secret, attester
+            # included, to a workload no named-env check would ever see.
+            for source in container.get("envFrom") or []:
+                ref = (source.get("secretRef") or {}).get("name")
+                if ref == "curie-secrets" and name not in ALLOWED_ATTESTER_WORKLOADS:
+                    raise SystemExit(
+                        f"{label} envFrom secretRef curie-secrets, which carries "
+                        f"{env_name}; only {sorted(ALLOWED_ATTESTER_WORKLOADS)} may"
+                    )
+
+# 3. The sealed curie-secrets object itself must carry a real, generated,
+#    independent attester -- present, non-empty, distinct from apiKey, and
+#    not the published dev literal.
+sealed_secret = next(
+    (
+        doc for doc in docs
+        if doc.get("kind") == "Secret" and doc.get("metadata", {}).get("name") == "curie-secrets"
+    ),
+    None,
+)
+if sealed_secret is None:
+    raise SystemExit("sealed render has no curie-secrets Secret; the sealed assertions are vacuous")
+sealed_values = dict(sealed_secret.get("stringData") or {})
+for key, value in (sealed_secret.get("data") or {}).items():
+    try:
+        sealed_values.setdefault(key, base64.b64decode(str(value), validate=True).decode())
+    except Exception:
+        sealed_values.setdefault(key, str(value))
+sealed_attester = sealed_values.get("approvalChatAttesterSecret")
+if not sealed_attester:
+    raise SystemExit("sealed curie-secrets has no non-empty approvalChatAttesterSecret")
+if sealed_attester == sealed_values.get("apiKey"):
+    raise SystemExit("sealed approvalChatAttesterSecret equals apiKey")
+# Backstop only: the whole-render literal sweep above already covers this
+# object, so this line is redundant by construction rather than independently
+# reachable. It is kept so the sealed Secret states its own invariant.
+if sealed_attester == DEV_ATTESTER_LITERAL:
+    raise SystemExit("sealed approvalChatAttesterSecret is the published dev literal")
+
 sandboxes = [doc for doc in docs if doc.get("kind") == "SandboxTemplate"]
 if not sandboxes:
     raise SystemExit("sealed render produced no SandboxTemplate; runner isolation assertion is vacuous")

--- a/compose/tests/test_generate_release_compose.py
+++ b/compose/tests/test_generate_release_compose.py
@@ -520,6 +520,72 @@ def test_approval_chat_attester_secret_is_independent_and_minimally_distributed(
             )
 
 
+def test_no_dev_approval_surface_ships_and_the_attester_key_set_is_closed():
+    """Neither compose form ships a dev approval surface, on either axis.
+
+    The test above pins the worker and the UI by name. This one pins the
+    COMPLEMENT: any service that is not the attestation producer (dispatcher)
+    or its verifier (API) must not receive the key, so a service added later
+    cannot silently inherit it by being absent from a named list. The second
+    axis is the KEY's own reach: no service outside that pair may carry the
+    attester value under any env name at all, so renaming the variable is not
+    an escape hatch either.
+
+    The name/image token scan below is deliberately NOT part of this claim. A
+    name denylist is the same control this PR rejected for API routes: it does
+    not see `curie-dev-signer`, `curie-fake-slack`, or any second process that
+    forges clicks without advertising itself in its own name. It is kept only
+    as a cheap extra tripwire; the two env-based pins above and below are what
+    the test actually guarantees.
+
+    Known gap, tracked separately: this pins the attester's REACH, not its
+    VALUE. compose.dev.yaml:414 writes
+    `${CURIE_APPROVAL_CHAT_ATTESTER_SECRET:-curie-dev-approval-chat-attester}`
+    and the generator copies that line verbatim, so the generated release
+    compose still resolves to the published dev default when the variable is
+    unset. Removing that default from compose.dev.yaml is the fix; asserting it
+    here today would simply fail.
+    """
+    env_name = "CURIE_APPROVAL_CHAT_ATTESTER_SECRET"
+    allowed = {"curie-api", "curie-dispatcher"}
+    # Cheap extra tripwire only -- see docstring. Nothing in this test's claim
+    # depends on it.
+    forbidden = ("approval", "attest", "mock", "stub", "synthetic")
+    for label, doc in compose_docs():
+        services = doc["services"]
+        assert allowed <= set(services), (
+            f"{label}: {sorted(allowed - set(services))} missing; the allowed-set "
+            f"assertion below would be vacuous"
+        )
+        for service_name, spec in services.items():
+            image = str(spec.get("image", ""))
+            for token in forbidden:
+                assert token not in service_name.lower(), (
+                    f"{label}: service {service_name!r} looks like a dev/mock "
+                    f"approval surface (matched {token!r})"
+                )
+                assert token not in image.lower(), (
+                    f"{label}: service {service_name!r} runs image {image!r}, "
+                    f"which looks like a dev/mock approval surface (matched {token!r})"
+                )
+            if service_name in allowed:
+                continue
+            env = env_map(spec)
+            assert env_name not in env, (
+                f"{label}: {service_name} is outside {sorted(allowed)} and still "
+                f"receives {env_name}; only the attestation producer and verifier may"
+            )
+            # The value, not just the name: a forger service handed the same
+            # secret under `SIGNING_KEY` would pass the name check above.
+            attester_value = env_map(services["curie-api"])[env_name]
+            leaked = sorted(key for key, value in env.items() if value == attester_value)
+            assert not leaked, (
+                f"{label}: {service_name} is outside {sorted(allowed)} and still "
+                f"carries the chat attestation value under {leaked}; renaming the "
+                f"variable is not an escape hatch"
+            )
+
+
 def test_dispatcher_depends_on_api_healthy():
     """The dispatcher waits for the API to be healthy before it starts.
 


### PR DESCRIPTION
Stage 2 of the three-PR interface pilot stack. **Stacked on `task/interface-pilot-1-measure` (PR #2616), not on `next`.** Draft, and **not independently merge-ready** — Brian reviews and decides on the assembled stack as a whole at stage 3.

## What this adds

One approval driven end to end across three apps, with no scripted stand-in anywhere between them:

real `approval_card(allow_free_text=True)` render → real Bolt `SocketModeHandler` → real ownership probe → real `views_open` note modal → real `view_submission` → real `ApprovalResolveClient` over loopback HTTP → the real `curie_api` app **with its lifespan entered** → real principal verifier + real authorizer → real Postgres → real `ResumeQueue.enqueue` → a real Valkey stream → the real worker `Consumer` and `Kernel`.

No test in this repo previously drove a Slack interactivity payload through the dispatcher handlers into the API's resume enqueue and on into a live worker kernel. The existing lifecycle test fakes the approval API at the `ApprovalCreator` seam and hand-builds resume turns.

**Ships zero production code.** `git diff --name-only` against the base matches nothing under any `src/`.

## Three findings from review worth calling out

- **Production posts *note* cards.** `kernel.py:3816` passes `allow_free_text=True` unconditionally, so the immediate `APPROVE_ACTION_ID` buttons are the older migration path. Testing only those would have made "the real approval journey" a false claim, so the note path is the journey under test and the immediate render is kept as an explicitly labelled variant.
- **A route-name denylist was the wrong control.** It collided with the real production route `POST /approvals/principals/operator`, and it only defends against surfaces named the way we would name them. The exclusion test instead freezes an inventory off the live app — exactly one mint handler and one resolve handler, asserted by object — so a new `POST /approvals/principals/chat` fails it by construction.
- **The first version of the sweeper/reconciler guard did not bind.** It set `CURIE_`-prefixed names that `Settings` (no env prefix, `extra="ignore"`) silently drops. Fixed to the real names, plus an assertion on the *resolved* settings so a future rename cannot quietly re-break it.

## Why the assertions can actually fail

Four mutations of real production code, each run by the driver and each caught:

| Mutation | Tests failing |
|---|---|
| `kernel.py:3816` note flag flipped | 1 |
| Authorizer always allows | 16 |
| `ResumeQueue.enqueue` never xadds | 3 |
| Verifier ignores signature tampering | 3 |

Chart assertions were mutation-tested separately (13 injected violations, each failing).

Every refusal pins *why* it failed: an authorizer refusal asserts the audit row and its authorizer name and that it is **not** `UnboundRouteBinding`; each forged principal re-sends the identical envelope correctly signed to prove it would otherwise succeed; the replay loser asserts the 409 body names the winner.

## Honest labelling

The runner is the existing in-process `FakeRunner` and Slack is the existing socket/`WebClient` fakes, so this proves **API, worker and dispatcher behavior only** — not real-runner or real-Slack behavior. The module docstring says so and also notes that "the card settled" is a `chat_update` call on a mock, and that ledger entries are fake-runner frames. Stage 3 connects the real runner.

## Verification

Run against real isolated Postgres, Valkey and RustFS in a private compose project. `CI_REQUIRE_VALKEY_TESTS=1` is required: without it 13 of 27 dispatcher approval tests silently skip, which is how a green run can mean nothing here.

- 33 new tests pass (17 journey + 16 exclusion); 36 compose tests; chart assertions OK
- Regression baselines green with no skips: dispatcher approval 27, API approval principals 13, action ledger, prod-gate
- Full kernel suite 480 passed / 2 skipped (both pre-existing opt-in long-run harnesses) in random order
- `ruff check` clean, `mypy` clean on 253 source files, docs gate OK

Reviews: adversarial plan review (13 blocking findings, all addressed), then code, scope and security reviews via `agent-router` on an independent engine. Scope review returned no unjustified creep. Security review found no harness reachability into production.

## Deferred to stage 3

Reject/expiry terminal outcomes, resume-enqueue failure and reconciliation, the note-modal *failure* half (validation, cancellation), the real runner, `SlackUserGroupMembers`, operator/console as journeys, and **the full assembled repository baseline and union of required tiers** — owed against the assembled three-PR candidate.

Known limits, stated rather than papered over: the concurrent-resolve overlap check skips (rather than fails) if the scheduler serialises it, so it never claims concurrency it did not observe; the live-app issuance inventory is static and package-scoped, so a mint reached by dynamic dispatch would evade it; and bearer replay inside the 60s TTL and `dependency_overrides` remain undefended.

## Observation, not a finding

The generated release compose inherits `${CURIE_APPROVAL_CHAT_ATTESTER_SECRET:-curie-dev-approval-chat-attester}` from `compose.dev.yaml`. This is the established dev-compose posture — it sits alongside `curie-dev-key` and `curie-dev-worker-token`, and is in fact stricter than both since it is overridable. Production is gated by `_refuse_dev_defaults_in_prod` under `ENVIRONMENT=prod` and by the chart's generated managed secret, and the sealed chart render is asserted clean. Flagging for awareness only; no change made here.
