### PR TITLE
Carry the channel event id on request-path spans

### DIFF
--- a/apps/worker/src/curie_worker/consumer.py
+++ b/apps/worker/src/curie_worker/consumer.py
@@ -44,6 +44,7 @@ from datetime import UTC, datetime
 from curie_dispatcher.queue import from_stream_fields
 from curie_telemetry import (
     TRACEPARENT_STREAM_FIELD,
+    channel_event_id_scope,
     extract_trace_context,
     operation_span,
     record_metric,
@@ -365,6 +366,12 @@ class Consumer(StreamConsumer):
                         )
                         return
 
+                    # The ``curie.queue.process`` span opened before the parse,
+                    # so the id is attached post-hoc. This mutates only THIS
+                    # turn's own span, so it is safe ahead of the drain below.
+                    if qevent.event_id:
+                        span.set_attribute("event_id", qevent.event_id)
+
                     age = self._message_age_seconds(qevent.received_at)
                     for name in (
                         "curie.queue.wait.duration",
@@ -397,110 +404,121 @@ class Consumer(StreamConsumer):
                             "thread-reset drain before turn %s failed; continuing",
                             entry_id,
                         )
-                    try:
-                        if self._leases is None:
-                            # No fence configured: call the kernel EXACTLY as it
-                            # was called before ADR-0131. The base yields a
-                            # permissive sentinel so this handler body stays
-                            # uniform, but forwarding that sentinel would claim
-                            # an authority nobody holds -- and ``process_event``
-                            # keeps its lease optional for precisely this caller.
-                            await self._kernel.process_event(qevent)
-                        else:
-                            await self._kernel.process_event(qevent, lease=lease)
-                    except Exception as exc:
-                        # Leave the entry pending: the lease-expiry reclaim pass
-                        # picks it up one lease TTL after this handler released
-                        # its lease, with XAUTOCLAIM still the 15 minute backstop
-                        # behind that (#2433).
-                        if hasattr(span, "set_status"):
-                            span.set_status(StatusCode.ERROR)
-                        span.add_event(
-                            "queue.processing.failed",
-                            {"outcome": "failure", "error.class": type(exc).__name__},
-                        )
-                        record_metric(
-                            "curie.queue.process",
-                            attributes={**metric_attributes, "outcome": "failure"},
-                        )
-                        record_metric(
-                            "curie.queue.settle",
-                            attributes={**metric_attributes, "outcome": "pending"},
-                        )
-                        logger.exception("processing failed for entry %s; left pending", entry_id)
-                        # Best-effort, and belt and braces: the kernel method
-                        # already swallows its own failures, but an exception
-                        # escaping THIS branch is the #673 shape exactly, and a
-                        # notice may never change the settlement outcome of a
-                        # delivery. The return below stays unconditional.
+                    # Opened AFTER the thread-reset drain on purpose: the
+                    # drain tears down OTHER threads (release_thread opens
+                    # curie.runner.rpc, curie.thread.lock and
+                    # curie.sandbox.release, the last via asyncio.to_thread,
+                    # which COPIES this context). Opening the scope earlier
+                    # would stamp another thread's teardown with this turn's
+                    # event id -- silent wrong correlation. Do not move it up.
+                    # Likewise, do not add teardown or maintenance work for a
+                    # DIFFERENT thread inside this scope: it would be stamped
+                    # with this turn's event id and land in this request's trace.
+                    with channel_event_id_scope(qevent.event_id):
                         try:
-                            # This branch can run AFTER lease loss and sits ahead
-                            # of the pre-ACK guard below, so terminality alone is
-                            # not permission to edit. A replacement that holds the
-                            # fence now owns this thread and will speak for it;
-                            # talking over it is worse than saying nothing. On the
-                            # leaseless sentinel this never raises, so a base-only
-                            # consumer still notifies.
-                            lease.raise_if_lost()
-                            await self._kernel.notify_turn_not_started(
-                                qevent, lease=lease
+                            if self._leases is None:
+                                # No fence configured: call the kernel EXACTLY as it
+                                # was called before ADR-0131. The base yields a
+                                # permissive sentinel so this handler body stays
+                                # uniform, but forwarding that sentinel would claim
+                                # an authority nobody holds -- and ``process_event``
+                                # keeps its lease optional for precisely this caller.
+                                await self._kernel.process_event(qevent)
+                            else:
+                                await self._kernel.process_event(qevent, lease=lease)
+                        except Exception as exc:
+                            # Leave the entry pending: the lease-expiry reclaim pass
+                            # picks it up one lease TTL after this handler released
+                            # its lease, with XAUTOCLAIM still the 15 minute backstop
+                            # behind that (#2433).
+                            if hasattr(span, "set_status"):
+                                span.set_status(StatusCode.ERROR)
+                            span.add_event(
+                                "queue.processing.failed",
+                                {"outcome": "failure", "error.class": type(exc).__name__},
                             )
+                            record_metric(
+                                "curie.queue.process",
+                                attributes={**metric_attributes, "outcome": "failure"},
+                            )
+                            record_metric(
+                                "curie.queue.settle",
+                                attributes={**metric_attributes, "outcome": "pending"},
+                            )
+                            logger.exception(
+                                "processing failed for entry %s; left pending", entry_id
+                            )
+                            # Best-effort, and belt and braces: the kernel method
+                            # already swallows its own failures, but an exception
+                            # escaping THIS branch is the #673 shape exactly, and a
+                            # notice may never change the settlement outcome of a
+                            # delivery. The return below stays unconditional.
+                            try:
+                                # This branch can run AFTER lease loss and sits ahead
+                                # of the pre-ACK guard below, so terminality alone is
+                                # not permission to edit. A replacement that holds the
+                                # fence now owns this thread and will speak for it;
+                                # talking over it is worse than saying nothing. On the
+                                # leaseless sentinel this never raises, so a base-only
+                                # consumer still notifies.
+                                lease.raise_if_lost()
+                                await self._kernel.notify_turn_not_started(qevent, lease=lease)
+                            except LeaseLostError:
+                                logger.warning(
+                                    "skipping the not-started notice for entry %s: this "
+                                    "owner lost the delivery lease, and the current owner "
+                                    "speaks for the thread",
+                                    entry_id,
+                                )
+                            except Exception:
+                                logger.warning(
+                                    "not-started notice failed for entry %s",
+                                    entry_id,
+                                    exc_info=True,
+                                )
+                            return
+                        try:
+                            # A stale owner may not ACK. Checked immediately before
+                            # the ack, because the fence can move at any point during
+                            # a long turn and the ack is the irreversible one: it
+                            # takes the entry off the group, out from under the
+                            # replacement that now owns it.
+                            lease.raise_if_lost()
                         except LeaseLostError:
                             logger.warning(
-                                "skipping the not-started notice for entry %s: this "
-                                "owner lost the delivery lease, and the current owner "
-                                "speaks for the thread",
+                                "refusing to ack entry %s: this owner lost the delivery "
+                                "lease mid-turn; leaving it pending for the current owner",
                                 entry_id,
                             )
-                        except Exception:
-                            logger.warning(
-                                "not-started notice failed for entry %s",
-                                entry_id,
-                                exc_info=True,
+                            record_metric(
+                                "curie.queue.process",
+                                attributes={**metric_attributes, "outcome": "failure"},
                             )
-                        return
-                    try:
-                        # A stale owner may not ACK. Checked immediately before
-                        # the ack, because the fence can move at any point during
-                        # a long turn and the ack is the irreversible one: it
-                        # takes the entry off the group, out from under the
-                        # replacement that now owns it.
-                        lease.raise_if_lost()
-                    except LeaseLostError:
-                        logger.warning(
-                            "refusing to ack entry %s: this owner lost the delivery "
-                            "lease mid-turn; leaving it pending for the current owner",
-                            entry_id,
-                        )
+                            record_metric(
+                                "curie.queue.settle",
+                                attributes={**metric_attributes, "outcome": "pending"},
+                            )
+                            return
+                        await self._ack(entry_id)
+                        # Terminal acknowledgement: remove the delivery state as well
+                        # as the lease (the base's release drops only the lease). The
+                        # state's one-day retention is the backstop for a crash
+                        # between the ack and here, not the normal way it goes away --
+                        # without this a dead-lettered-and-redelivered event id
+                        # accumulates state keys until that TTL. Best-effort: the ack
+                        # above already happened.
+                        await self._settle_delivery_best_effort(entry_id)
+                        process_outcome = "success"
+                        span.add_event("queue.message.acked", {"outcome": "ack"})
                         record_metric(
                             "curie.queue.process",
-                            attributes={**metric_attributes, "outcome": "failure"},
+                            attributes={**metric_attributes, "outcome": "success"},
                         )
                         record_metric(
                             "curie.queue.settle",
-                            attributes={**metric_attributes, "outcome": "pending"},
+                            attributes={**metric_attributes, "outcome": "ack"},
                         )
                         return
-                    await self._ack(entry_id)
-                    # Terminal acknowledgement: remove the delivery state as well
-                    # as the lease (the base's release drops only the lease). The
-                    # state's one-day retention is the backstop for a crash
-                    # between the ack and here, not the normal way it goes away --
-                    # without this a dead-lettered-and-redelivered event id
-                    # accumulates state keys until that TTL. Best-effort: the ack
-                    # above already happened.
-                    await self._settle_delivery_best_effort(entry_id)
-                    process_outcome = "success"
-                    span.add_event("queue.message.acked", {"outcome": "ack"})
-                    record_metric(
-                        "curie.queue.process",
-                        attributes={**metric_attributes, "outcome": "success"},
-                    )
-                    record_metric(
-                        "curie.queue.settle",
-                        attributes={**metric_attributes, "outcome": "ack"},
-                    )
-                    return
         finally:
             record_metric(
                 "curie.queue.process.duration",

--- a/apps/worker/tests/kernel/test_otel_runtime.py
+++ b/apps/worker/tests/kernel/test_otel_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 import uuid
 from collections.abc import Iterator, Mapping
@@ -28,6 +29,7 @@ from curie_telemetry import (
     inject_trace_context,
     operation_span,
     record_metric,
+    stamp_event_id,
 )
 from curie_worker import consumer as consumer_module
 from curie_worker import kernel as kernel_module
@@ -43,6 +45,7 @@ from opentelemetry import trace
 from opentelemetry.trace import (
     NonRecordingSpan,
     SpanContext,
+    SpanKind,
     StatusCode,
     TraceFlags,
     TraceState,
@@ -106,6 +109,11 @@ class _Probe:
         self.spans: list[_SpanCall] = []
         self.metrics: list[_Metric] = []
         self._next_span_id = 0x4000000000000000
+        # operation_span is called from asyncio.to_thread worker threads (the
+        # sandbox claim/release hops in kernel.py), not just the event loop.
+        # Without a lock, two threads can read the same _next_span_id and mint
+        # duplicate span ids, which collapses T6's {span_id: call} root-join map.
+        self._lock = threading.Lock()
 
     @contextmanager
     def operation_span(
@@ -120,17 +128,21 @@ class _Probe:
         if parent is None:
             parent_span = trace.get_current_span().get_span_context()
         trace_id = parent_span.trace_id if parent_span.is_valid else _REMOTE_TRACE_ID + 1
-        span_id = self._next_span_id
-        self._next_span_id += 1
-        call = _SpanCall(
-            name=name,
-            kind=kind,
-            parent_trace_id=parent_span.trace_id,
-            parent_span_id=parent_span.span_id,
-            span_id=span_id,
-            attributes=dict(attributes or {}),
-        )
-        self.spans.append(call)
+        with self._lock:
+            span_id = self._next_span_id
+            self._next_span_id += 1
+            call = _SpanCall(
+                name=name,
+                kind=kind,
+                parent_trace_id=parent_span.trace_id,
+                parent_span_id=parent_span.span_id,
+                span_id=span_id,
+                # The REAL stamping helper, not a reimplementation: this probe
+                # replaces ``operation_span`` wholesale, so anything reimplemented
+                # here would be tested instead of the production code path.
+                attributes=dict(stamp_event_id(attributes)),
+            )
+            self.spans.append(call)
         child = SpanContext(
             trace_id=trace_id,
             span_id=span_id,
@@ -151,7 +163,8 @@ class _Probe:
         *,
         attributes: Mapping[str, str] | None = None,
     ) -> None:
-        self.metrics.append(_Metric(name, float(value), dict(attributes or {})))
+        with self._lock:
+            self.metrics.append(_Metric(name, float(value), dict(attributes or {})))
 
 
 def _install(monkeypatch: pytest.MonkeyPatch) -> _Probe:
@@ -869,3 +882,442 @@ def test_stream_timeout_emits_a_timeout_rpc_result_and_a_failed_span(
                 await client.close()
 
     asyncio.run(go())
+
+
+# --- #2622: the channel event id on request-path spans ------------------------
+#
+# R3: the probe stores CALLER keys (``stamp_event_id`` returns caller
+# spellings, and ``_ProbeSpan.set_attribute`` writes ``name`` raw), so every
+# assertion below names ``event_id``. The EXPORTED name
+# (``curie.channel.event_id``) is pinned exactly once, in
+# ``packages/telemetry/tests/test_event_id_scope.py``; a rename must fail there.
+
+_REQUEST_PATH_SPANS = (
+    "curie.queue.process",
+    "curie.sandbox.claim",
+    "curie.runner.rpc",
+    "curie.reply.update",
+)
+
+
+def _event_ids(probe: _Probe, name: str) -> list[str | None]:
+    return [span.attributes.get("event_id") for span in _spans(probe, name)]
+
+
+def test_every_named_request_path_span_carries_the_delivered_event_id(
+    make_harness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T4 (AC 1, AC 2): one turn stamps all four named spans with one id."""
+
+    async def go() -> None:
+        probe = _install(monkeypatch)
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="stamped", status=DONE)]
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            event = _qevent("stamp me", event_id="Ev0EXAMPLEKNOWN1")
+
+            await _deliver(consumer, h, {"payload": event.model_dump_json()})
+
+            for name in _REQUEST_PATH_SPANS:
+                observed = _event_ids(probe, name)
+                assert observed, f"{name} was never opened; the turn did not run"
+                assert set(observed) == {"Ev0EXAMPLEKNOWN1"}, (
+                    f"{name} spans carried {observed!r}, not the delivered event id"
+                )
+            # The consequence sites (§2 #6-#9) are inside the scope too.
+            assert set(_event_ids(probe, "curie.turn.process")) == {"Ev0EXAMPLEKNOWN1"}
+            for point in probe.metrics:
+                assert set(point.attributes) <= _BOUNDED_KEYS
+                assert "Ev0EXAMPLEKNOWN1" not in point.attributes.values()
+
+    asyncio.run(go())
+
+
+def test_failed_processing_keeps_the_event_id_on_the_span_and_off_the_metrics(
+    make_harness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T5a (AC 1): the ``queue.processing.failed`` branch is inside the span."""
+
+    async def go() -> None:
+        probe = _install(monkeypatch)
+        async with make_harness() as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            async def fail(_turn: QueuedTurn) -> None:
+                raise RuntimeError("injected processing failure")
+
+            h.kernel.process_event = fail  # type: ignore[method-assign]
+            event = _qevent("failing", event_id="Ev0EXAMPLEFAILED1")
+
+            await _deliver(consumer, h, {"payload": event.model_dump_json()})
+
+            process = _spans(probe, "curie.queue.process")
+            assert len(process) == 1
+            assert process[0].attributes.get("event_id") == "Ev0EXAMPLEFAILED1"
+            assert any(
+                name == "queue.processing.failed" for name, _a in process[0].events
+            ), "the failure branch did not run; this test proved nothing"
+            assert {
+                point.attributes["outcome"]
+                for point in _metrics(probe, "curie.queue.settle")
+            } == {"pending"}
+            for point in probe.metrics:
+                assert set(point.attributes) <= _BOUNDED_KEYS
+                assert "Ev0EXAMPLEFAILED1" not in point.attributes.values()
+
+    asyncio.run(go())
+
+
+def test_lease_loss_pending_path_keeps_the_event_id_on_the_span(
+    make_harness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T5b (AC 1): the pre-ack lease-loss branch shares the same span object."""
+
+    async def go() -> None:
+        from curie_worker.delivery_lease import LeaseLostError
+
+        probe = _install(monkeypatch)
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="pending", status=DONE)]
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            class _LostLease:
+                def raise_if_lost(self) -> None:
+                    raise LeaseLostError("the delivery lease moved to a replacement")
+
+            class _LostLeaseCM:
+                def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+                    pass
+
+                async def __aenter__(self) -> _LostLease:
+                    return _LostLease()
+
+                async def __aexit__(self, *_exc: Any) -> bool:
+                    return False
+
+            monkeypatch.setattr(consumer, "_delivery_lease", _LostLeaseCM)
+            event = _qevent("lease loss", event_id="Ev0EXAMPLEPENDING1")
+
+            await _deliver(consumer, h, {"payload": event.model_dump_json()})
+
+            process = _spans(probe, "curie.queue.process")
+            assert len(process) == 1
+            assert process[0].attributes.get("event_id") == "Ev0EXAMPLEPENDING1"
+            assert not any(
+                name == "queue.message.acked" for name, _a in process[0].events
+            ), "the entry was acked; the lease-loss pending branch did not run"
+            assert "pending" in {
+                point.attributes["outcome"]
+                for point in _metrics(probe, "curie.queue.settle")
+            }
+            for point in probe.metrics:
+                assert "Ev0EXAMPLEPENDING1" not in point.attributes.values()
+
+    asyncio.run(go())
+
+
+class _Rendezvous:
+    """A barrier shaped like ``FakeRunner.hold`` (it is awaited as ``.wait()``).
+
+    The fake runner parks on it AFTER writing its prefix frame and BEFORE its
+    terminal frame -- i.e. mid-turn, inside the event-id scope -- so every turn
+    that reaches it is provably still in flight. ``admitted`` is what the test
+    asserts on: without that assertion a harness change that serialized the
+    deliveries would silently reduce T6 to N sequential turns, which cannot
+    distinguish a contextvar from a process global.
+    """
+
+    def __init__(self, parties: int, timeout: float = 20.0) -> None:
+        self._barrier = asyncio.Barrier(parties)
+        self._timeout = timeout
+        self.arrived = 0
+        self.admitted = 0
+
+    async def wait(self) -> None:
+        self.arrived += 1
+        try:
+            await asyncio.wait_for(self._barrier.wait(), self._timeout)
+        except (TimeoutError, asyncio.BrokenBarrierError):
+            # Return rather than raise: the turn then completes normally and the
+            # test fails on ``admitted``, naming the real problem (no overlap),
+            # instead of on a runner error that looks like something else.
+            return
+        self.admitted += 1
+
+
+def _root_of(probe: _Probe, span: _SpanCall) -> _SpanCall | None:
+    """The ``curie.queue.process`` ancestor of ``span``, by span-id linkage."""
+
+    by_id = {call.span_id: call for call in probe.spans}
+    seen: set[int] = set()
+    current: _SpanCall | None = span
+    while current is not None and current.name != "curie.queue.process":
+        if current.span_id in seen:
+            return None
+        seen.add(current.span_id)
+        current = by_id.get(current.parent_span_id)
+    return current
+
+
+def test_twelve_overlapping_turns_keep_their_event_ids_on_their_own_subtrees(
+    make_harness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T6 (AC 5), the centrepiece.
+
+    NOT written with ``_deliver``: that helper gathers all of
+    ``consumer._inflight`` before returning, so N concurrent ``_deliver`` calls
+    run strictly sequentially and the test would pass against a process-global
+    id. Here all N entries are XADDed, read in ONE ``xreadgroup``, dispatched,
+    and only then awaited.
+
+    > Why disjointness alone is TAUTOLOGICAL -- do not "simplify" this back.
+    > Grouping spans by their own event id and asserting the groups are
+    > pairwise disjoint is true by construction of the grouping. It cannot fail
+    > even under a process-global id, because the post-hoc
+    > ``span.set_attribute`` gives each ``curie.queue.process`` root the correct
+    > id regardless of the stamping mechanism, and every other check is
+    > satisfied by any labelling at all. MEMBERSHIP is what breaks under a
+    > global: with N overlapping turns a turn's nested spans collapse onto the
+    > last writer's id. So the primary assertion below joins each child span to
+    > its root by span-id linkage and compares the two ids. Coverage and the
+    > negative checks are secondary.
+    """
+
+    turns = 12
+
+    async def go() -> None:
+        probe = _install(monkeypatch)
+        async with make_harness(per_sandbox_runners=turns) as h:
+            rendezvous = _Rendezvous(turns)
+            for runner in (h.runner, *h.runners.values()):
+                runner.default_script = [TextDelta(text="working")]
+                runner.tail = [Final(text="done", status=DONE)]
+                runner.hold = rendezvous
+
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            assert consumer._max_concurrency >= turns, (
+                "the consumer semaphore must admit every turn at once, or the "
+                "deliveries cannot overlap and T6 tests nothing"
+            )
+
+            events = [
+                _qevent(
+                    f"concurrent {index}",
+                    thread=f"thread-concurrent-{index}",
+                    event_id=f"Ev0EXAMPLECONCURRENT{index:02d}",
+                )
+                for index in range(turns)
+            ]
+            delivered_ids = {event.event_id for event in events}
+            assert len(delivered_ids) == turns
+
+            for event in events:
+                await h.async_redis.xadd(
+                    h.config.stream, {"payload": event.model_dump_json()}
+                )
+            rows = await h.async_redis.xreadgroup(
+                h.config.consumer_group,
+                h.config.consumer_name,
+                {h.config.stream: ">"},
+                count=turns,
+            )
+            entries = rows[0][1]
+            assert len(entries) == turns, f"expected {turns} entries, got {len(entries)}"
+            for entry_id, fields in entries:
+                await consumer._dispatch(entry_id, fields)
+            await asyncio.wait_for(
+                asyncio.gather(*list(consumer._inflight)), timeout=120
+            )
+
+            # PRECONDITION, not decoration: all N were parked mid-turn, inside
+            # their own scope, at the same instant.
+            assert rendezvous.admitted == turns, (
+                f"only {rendezvous.admitted} of {turns} turns were simultaneously "
+                f"in flight ({rendezvous.arrived} reached the barrier); the "
+                "deliveries serialized and this test cannot distinguish a "
+                "contextvar from a process-global id"
+            )
+
+            roots = _spans(probe, "curie.queue.process")
+            assert len(roots) == turns
+            by_event_id: dict[str, _SpanCall] = {}
+            for root in roots:
+                event_id = root.attributes.get("event_id")
+                assert event_id is not None, "a queue.process root was not stamped"
+                assert event_id not in by_event_id, f"two roots claim {event_id!r}"
+                by_event_id[event_id] = root
+            assert set(by_event_id) == delivered_ids
+
+            # 1. MEMBERSHIP (primary). Every stamped span belongs to the subtree
+            #    of the root carrying the same id. This is the assertion that
+            #    fails under a process-global.
+            stamped = [
+                span for span in probe.spans if span.attributes.get("event_id") is not None
+            ]
+            assert stamped
+            for span in stamped:
+                root = _root_of(probe, span)
+                assert root is not None, (
+                    f"{span.name} carries an event id but descends from no "
+                    "curie.queue.process root"
+                )
+                assert span.attributes["event_id"] == root.attributes.get("event_id"), (
+                    f"{span.name} carries {span.attributes['event_id']!r} but "
+                    f"descends from the turn for {root.attributes.get('event_id')!r}"
+                )
+
+            # Each id's group holds that turn's OWN four named spans.
+            for event_id, root in by_event_id.items():
+                group = {
+                    span.name
+                    for span in stamped
+                    if span.attributes["event_id"] == event_id
+                    and _root_of(probe, span) is root
+                }
+                assert set(_REQUEST_PATH_SPANS) <= group, (
+                    f"turn {event_id} is missing {set(_REQUEST_PATH_SPANS) - group}"
+                )
+
+            # 2. COVERAGE (secondary). Includes the post-hoc-stamped roots.
+            assert {span.attributes["event_id"] for span in stamped} == delivered_ids
+
+            # 3. NEGATIVE (secondary).
+            for span in probe.spans:
+                value = span.attributes.get("event_id")
+                assert value is None or value in delivered_ids, (
+                    f"{span.name} carries an undelivered event id {value!r}"
+                )
+            for point in probe.metrics:
+                assert delivered_ids.isdisjoint(point.attributes.values())
+
+    asyncio.run(go())
+
+
+def test_no_event_id_survives_a_turn_or_crosses_into_the_next_one(
+    make_harness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T8 (E4b, AC 5): the scope is entered by token and always reset."""
+
+    async def go() -> None:
+        probe = _install(monkeypatch)
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="a", status=DONE)]
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            first = _qevent("first", thread="thread-leak-a", event_id="Ev0EXAMPLELEAKA1")
+            await _deliver(consumer, h, {"payload": first.model_dump_json()})
+
+            # Between turns, on the very task that just ran one.
+            with probe.operation_span("curie.queue.process", kind=SpanKind.CONSUMER):
+                pass
+            between = probe.spans[-1]
+            assert "event_id" not in between.attributes, (
+                f"a context-free span inherited {between.attributes.get('event_id')!r}; "
+                "the scope leaked past the turn"
+            )
+
+            probe.spans.clear()
+            second = _qevent("second", thread="thread-leak-b", event_id="Ev0EXAMPLELEAKB1")
+            await _deliver(consumer, h, {"payload": second.model_dump_json()})
+
+            observed = {
+                span.attributes["event_id"]
+                for span in probe.spans
+                if "event_id" in span.attributes
+            }
+            assert observed == {"Ev0EXAMPLELEAKB1"}, (
+                f"the second turn's spans carried {observed!r}; a stale id crossed "
+                "from the first turn"
+            )
+
+    asyncio.run(go())
+
+
+def test_thread_reset_drain_spans_are_not_stamped_with_the_turns_event_id(
+    make_harness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T9 (R1, AC 3/AC 5): the wrong-correlation pin for the scope placement.
+
+    Keyed on ``curie.sandbox.release`` ONLY. ``release_thread`` always opens it
+    (kernel.py:1966) and the turn path does not open it on this route.
+    ``curie.thread.lock`` and ``curie.runner.rpc`` are unusable as drain
+    identifiers: the turn path opens both names, and AC 2 REQUIRES the rpc one
+    stamped, so keying on either would false-fail a correct implementation.
+    (``_rpc("interrupt")`` is also not emitted at all unless the reset thread
+    already has a live sandbox, which is the second reason.)
+    """
+
+    async def go() -> None:
+        probe = _install(monkeypatch)
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="drained", status=DONE)]
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            # A DIFFERENT thread than the turn's: the drain tears down thread B
+            # while turn A is in flight on the same handler task.
+            await h.async_redis.sadd(
+                consumer_module.THREAD_RESET_SET, "thread-reset-victim"
+            )
+            try:
+                event = _qevent(
+                    "turn under a drain",
+                    thread="thread-drain-turn",
+                    event_id="Ev0EXAMPLEDRAIN1",
+                )
+                await _deliver(consumer, h, {"payload": event.model_dump_json()})
+
+                releases = _spans(probe, "curie.sandbox.release")
+                # (a) Fail loudly rather than pass vacuously: no release span
+                #     means the drain never ran and (b) below proves nothing.
+                assert releases, (
+                    "the thread-reset drain did not run, so this test could not "
+                    "observe whether its spans were wrongly stamped"
+                )
+                # (b) The drain describes ANOTHER thread; a Tempo query for this
+                #     turn must not return it.
+                assert [span.attributes.get("event_id") for span in releases] == [
+                    None
+                ] * len(releases), (
+                    "a thread-reset teardown span was stamped with the in-flight "
+                    "turn's event id: the scope opens before the drain"
+                )
+                # The turn's own spans are stamped, so this is not passing
+                # because stamping is broken everywhere.
+                for name in _REQUEST_PATH_SPANS:
+                    assert set(_event_ids(probe, name)) == {"Ev0EXAMPLEDRAIN1"}, (
+                        f"{name} lost the event id"
+                    )
+            finally:
+                await h.async_redis.delete(consumer_module.THREAD_RESET_SET)
+                await h.async_redis.delete(consumer_module.THREAD_RESET_INFLIGHT_SET)
+
+    asyncio.run(go())
+
+
+def test_claim_latency_log_line_is_unchanged(request: pytest.FixtureRequest) -> None:
+    """T7 (AC 6): a no-change pin on the kernel's claim-latency log line.
+
+    The other half of D8 -- an EMPTY ``git diff origin/main`` for ``kernel.py``
+    -- belongs to the done-check, not to a unit test that would shell out.
+    """
+
+    from pathlib import Path
+
+    kernel_source = (
+        Path(__file__).resolve().parents[2] / "src" / "curie_worker" / "kernel.py"
+    ).read_text()
+    line = 'logger.info("claim latency for %s: %d ms", thread_key, claim_ms)'
+    assert kernel_source.count(line) == 1, (
+        "AC 6 is a no-change assertion: the claim-latency log line must stay "
+        "exactly as it is, and kernel.py must not be edited by this ticket"
+    )

--- a/docs/interfaces/telemetry-otel/INTERFACE.md
+++ b/docs/interfaces/telemetry-otel/INTERFACE.md
@@ -57,10 +57,25 @@ than an open bag of `gen_ai.*` names.
 - `operation_span`
   (`packages/telemetry/src/curie_telemetry/tracing.py::operation_span`) provides explicit
   parentage and honest status for platform operations. Its caller vocabulary is closed
-  to `service.name`, `operation`, `role`, `source`, `outcome`, and `retry_class`; custom
-  keys export only as `curie.operation`, `curie.role`, `curie.source`, `curie.outcome`,
-  and `curie.retry_class`. Event mutations are separately closed to `curie.outcome` and
-  the standard `error.type`; adding an arbitrary identifier at construction or later
+  to `service.name`, `operation`, `role`, `source`, `outcome`, `retry_class`, and
+  `event_id`; custom keys export only as `curie.operation`, `curie.role`, `curie.source`,
+  `curie.outcome`, `curie.retry_class`, and `curie.channel.event_id`. `event_id` is the
+  one correlation identifier the vocabulary admits, and it is admitted on spans only:
+  the metric catalog stays closed to it, because `record_metric` enumerates a value
+  domain per attribute and an identifier has none. Spans describing the turn's own
+  request-path work carry `curie.channel.event_id`, so a query on that attribute never
+  returns another request's spans -- it may simply not return every span of its own
+  request. Two cases are deliberately not stamped. Maintenance work interleaved on the
+  same handler task is not stamped -- specifically the thread-reset drain
+  (`_drain_thread_reset_requests`), which tears down *other* threads and whose spans would
+  otherwise be falsely attributed to this request. Work driven by a task created before
+  the event-id scope opens also does not inherit it: the delivery-lease heartbeat task
+  (created at `apps/worker/src/curie_worker/stream_consumer.py::StreamConsumer._delivery_lease`, before the scope
+  opens in `consumer.py`) can lose its lease and issue an `interrupt` RPC for this same
+  turn, and that `curie.runner.rpc` span carries no event id. The value propagates by contextvar, is
+  per-asyncio-task, is stamped verbatim, is omitted entirely when no turn is in scope, and
+  is never emitted on any metric. Event mutations are separately closed to `curie.outcome`
+  and the standard `error.type`; adding an arbitrary identifier at construction or later
   fails before export. Producers inject
   and consumers extract only W3C `traceparent` through the separate Stream field or
   runner HTTP header using `inject_trace_context` and `extract_trace_context`

--- a/packages/telemetry/src/curie_telemetry/__init__.py
+++ b/packages/telemetry/src/curie_telemetry/__init__.py
@@ -15,7 +15,11 @@ from .context import (
 from .logging import configure_service_logging
 from .metrics import configure_meter_provider, record_metric
 from .resource import build_resource, deployment_environment, service_instance_id
-from .tracing import operation_span
+from .tracing import (
+    channel_event_id_scope,
+    operation_span,
+    stamp_event_id,
+)
 
 __all__ = [
     "TRACEPARENT_STREAM_FIELD",
@@ -24,6 +28,7 @@ __all__ = [
     "build_otlp_span_exporter",
     "build_resource",
     "canonicalize_traceparent",
+    "channel_event_id_scope",
     "configure_meter_provider",
     "configure_service_logging",
     "deployment_environment",
@@ -34,4 +39,5 @@ __all__ = [
     "resolve_otlp_endpoint",
     "resolve_otlp_protocol",
     "service_instance_id",
+    "stamp_event_id",
 ]

--- a/packages/telemetry/src/curie_telemetry/tracing.py
+++ b/packages/telemetry/src/curie_telemetry/tracing.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import Any, cast
 
 from opentelemetry import trace
@@ -22,11 +23,66 @@ from .redact import redact_span_attribute
 
 _tracer: Tracer = trace.NoOpTracerProvider().get_tracer("curie-telemetry")
 
+# The channel event id for the turn currently being handled on this asyncio task.
+# ``asyncio`` copies the context per task and ``asyncio.to_thread`` copies it per
+# hop, so two concurrent turns physically cannot read each other's value.
+_CHANNEL_EVENT_ID: ContextVar[str | None] = ContextVar("curie_channel_event_id", default=None)
+
+
+@contextmanager
+def channel_event_id_scope(event_id: str | None) -> Iterator[None]:
+    """Bind ``event_id`` for the duration of the block, always resetting it.
+
+    The reset is by token in a ``finally``: a bare ``set()`` would leak a stale id
+    onto the next entry handled by a reused worker task, attributing one request's
+    spans to another. That is silent wrong correlation, which is worse than a
+    missing attribute.
+    """
+
+    token = _CHANNEL_EVENT_ID.set(event_id)
+    try:
+        yield
+    finally:
+        _CHANNEL_EVENT_ID.reset(token)
+
+
+def current_channel_event_id() -> str | None:
+    """Return the channel event id bound to the current context, if any."""
+
+    return _CHANNEL_EVENT_ID.get()
+
+
+def stamp_event_id(
+    attributes: Mapping[str, AttributeValue] | None,
+) -> Mapping[str, AttributeValue]:
+    """Return ``attributes`` carrying the ambient channel event id.
+
+    The key is omitted entirely when no id is bound -- never ``""`` and never
+    ``"None"``, either of which would make a correlation query match every
+    context-free span. A caller-supplied ``event_id`` always wins. The caller's
+    mapping is never mutated: the worker reuses one dict for its span and its
+    metrics, and the metric surface must stay closed to the id. When there is
+    nothing to stamp -- no id bound, or the caller already supplied one -- the
+    caller's mapping is returned unchanged rather than copied, since this runs
+    on every ``operation_span`` call across the platform.
+    """
+
+    event_id = _CHANNEL_EVENT_ID.get()
+    if not event_id or (attributes is not None and "event_id" in attributes):
+        return attributes if attributes is not None else {}
+    stamped: dict[str, AttributeValue] = dict(attributes or {})
+    stamped["event_id"] = event_id
+    return stamped
+
+
 # Platform lifecycle spans deliberately use a small closed vocabulary. Callers
 # use the metric-catalog spelling while the exported custom keys are namespaced.
-# Per-run identifiers belong in correlated runner spans/logs, never in these
-# shared orchestration attributes. New custom attributes must be added here and
-# to the telemetry interface before they can reach the exporter.
+# The vocabulary admits exactly one correlation identifier, ``event_id``, and it
+# is admitted on spans only. The metric catalog stays closed to it: ``record_metric``
+# enumerates a value domain per attribute and an identifier has no domain to
+# enumerate, so an id reaching a metric fails loudly rather than exploding
+# cardinality. New custom attributes must be added here and to the telemetry
+# interface before they can reach the exporter.
 PLATFORM_SPAN_ATTRIBUTE_KEYS = {
     "service.name": "service.name",
     "operation": "curie.operation",
@@ -34,6 +90,7 @@ PLATFORM_SPAN_ATTRIBUTE_KEYS = {
     "source": "curie.source",
     "outcome": "curie.outcome",
     "retry_class": "curie.retry_class",
+    "event_id": "curie.channel.event_id",
 }
 PLATFORM_EVENT_ATTRIBUTE_KEYS = {
     "outcome": "curie.outcome",
@@ -106,8 +163,10 @@ def operation_span(
 ) -> Iterator[OperationSpan]:
     """Open one operation span and convert escaped failures to ERROR."""
 
+    # Stamp before the closed-vocabulary check so an undeclared caller key still
+    # raises. ``record_metric`` is deliberately not stamped.
     safe_attributes = _closed_attributes(
-        attributes, PLATFORM_SPAN_ATTRIBUTE_KEYS, surface="span"
+        stamp_event_id(attributes), PLATFORM_SPAN_ATTRIBUTE_KEYS, surface="span"
     )
     with _tracer.start_as_current_span(
         name,

--- a/packages/telemetry/tests/test_event_id_scope.py
+++ b/packages/telemetry/tests/test_event_id_scope.py
@@ -1,0 +1,279 @@
+"""The channel event id is a span-only correlation attribute (#2622).
+
+T1-T3 of the plan. These are the authoritative pins for the *exported* name and
+for the contextvar lifecycle: the worker suite (``test_otel_runtime.py``)
+monkeypatches ``operation_span`` wholesale, so it asserts CALLER spellings only
+and can never see the export name or the ``operation_span`` wiring.
+"""
+
+from __future__ import annotations
+
+import pytest
+from curie_telemetry import (
+    build_resource,
+    channel_event_id_scope,
+    configure_meter_provider,
+    operation_span,
+    record_metric,
+    stamp_event_id,
+)
+from curie_telemetry.tracing import (
+    PLATFORM_SPAN_ATTRIBUTE_KEYS,
+    configure_tracer_provider,
+    current_channel_event_id,
+)
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind
+
+# The two production shapes an event id actually arrives in: a Slack ``Ev...``
+# id, and the neutral channel-agnostic form the non-Slack adapters mint.
+_SLACK_EVENT_ID = "Ev0EXAMPLE2622A"
+_NEUTRAL_EVENT_ID = "chn-0example-2622-b"
+
+# The Tempo-visible name. AC 3 is a query on this exact string, so it is spelled
+# out here as a literal rather than read from the vocabulary: a rename must fail
+# this file, not silently follow along.
+_EXPORT_KEY = "curie.channel.event_id"
+
+
+def _provider() -> tuple[TracerProvider, InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_tracer_provider(provider)
+    return provider, exporter
+
+
+def _attributes(exporter: InMemorySpanExporter) -> dict[str, object]:
+    (finished,) = exporter.get_finished_spans()
+    return dict(finished.attributes or {})
+
+
+# --- T1: the vocabulary and the exported name --------------------------------
+
+
+def test_event_id_is_declared_in_the_closed_span_vocabulary() -> None:
+    assert PLATFORM_SPAN_ATTRIBUTE_KEYS["event_id"] == _EXPORT_KEY
+
+
+@pytest.mark.parametrize(
+    "event_id",
+    [_SLACK_EVENT_ID, _NEUTRAL_EVENT_ID],
+    ids=["slack", "neutral"],
+)
+def test_caller_event_id_exports_under_the_channel_namespace_unmangled(
+    event_id: str,
+) -> None:
+    """THE pin for the Tempo attribute name and for redaction survival.
+
+    ``_closed_attributes`` runs ``redact_span_attribute`` over every value, so a
+    redactor that treated id-shaped strings as secrets would scrub the very
+    value AC 3 queries on -- fail-closed, but silently unqueryable. Assert the
+    id arrives byte-for-byte (no truncation, no case folding: the channel logged
+    the raw string and the Tempo query must match it).
+    """
+
+    provider, exporter = _provider()
+    try:
+        with operation_span(
+            "curie.queue.process",
+            kind=SpanKind.CONSUMER,
+            attributes={"service.name": "curie-worker", "event_id": event_id},
+        ):
+            pass
+
+        attributes = _attributes(exporter)
+        assert attributes.get(_EXPORT_KEY) == event_id, attributes
+        assert "event_id" not in attributes, "the caller spelling must not reach the wire"
+    finally:
+        configure_tracer_provider(None)
+        provider.shutdown()
+
+
+def test_event_id_can_be_stamped_post_hoc_on_an_open_span() -> None:
+    """``curie.queue.process`` opens before the parse, so AC 1 needs this."""
+
+    provider, exporter = _provider()
+    try:
+        with operation_span("curie.queue.process", kind=SpanKind.CONSUMER) as span:
+            span.set_attribute("event_id", _SLACK_EVENT_ID)
+
+        assert _attributes(exporter).get(_EXPORT_KEY) == _SLACK_EVENT_ID
+    finally:
+        configure_tracer_provider(None)
+        provider.shutdown()
+
+
+def test_widening_the_vocabulary_by_one_key_leaves_it_closed() -> None:
+    with pytest.raises(ValueError, match="undeclared platform span attribute"):
+        with operation_span(
+            "curie.queue.process",
+            kind=SpanKind.CONSUMER,
+            attributes={"thread_key": "thread-example"},
+        ):
+            pass
+
+    with operation_span("curie.queue.process", kind=SpanKind.CONSUMER) as span:
+        with pytest.raises(ValueError, match="undeclared platform span attribute"):
+            span.set_attribute("thread_key", "thread-example")
+
+
+# --- T2: contextvar semantics ------------------------------------------------
+
+
+def test_operation_span_stamps_the_ambient_event_id() -> None:
+    """The pin that ``operation_span`` itself calls ``stamp_event_id``.
+
+    Without this the worker suite's T6 would pass even if the wiring inside
+    ``operation_span`` were never added, because its probe calls the stamping
+    helper directly.
+    """
+
+    provider, exporter = _provider()
+    try:
+        with channel_event_id_scope(_SLACK_EVENT_ID):
+            with operation_span("curie.runner.rpc", kind=SpanKind.CLIENT):
+                pass
+
+        assert _attributes(exporter).get(_EXPORT_KEY) == _SLACK_EVENT_ID
+    finally:
+        configure_tracer_provider(None)
+        provider.shutdown()
+
+
+def test_spans_outside_any_scope_omit_the_key_entirely() -> None:
+    """Omit, never ``""`` and never ``"None"`` (E4c).
+
+    An empty-string value would make the AC 3 Tempo query match every
+    context-free span in the fleet -- worse than no attribute at all.
+    """
+
+    provider, exporter = _provider()
+    try:
+        assert current_channel_event_id() is None
+        with operation_span("curie.runner.rpc", kind=SpanKind.CLIENT):
+            pass
+
+        attributes = _attributes(exporter)
+        assert _EXPORT_KEY not in attributes, attributes
+    finally:
+        configure_tracer_provider(None)
+        provider.shutdown()
+
+
+def test_scope_restores_the_outer_value_on_exit() -> None:
+    assert current_channel_event_id() is None
+    with channel_event_id_scope(_SLACK_EVENT_ID):
+        assert current_channel_event_id() == _SLACK_EVENT_ID
+        with channel_event_id_scope(_NEUTRAL_EVENT_ID):
+            assert current_channel_event_id() == _NEUTRAL_EVENT_ID
+        # Reset BY TOKEN, not by re-setting a remembered value: a bare ``.set()``
+        # leaks a stale id onto the next entry handled by a reused worker task,
+        # which is silent wrong correlation (E4b).
+        assert current_channel_event_id() == _SLACK_EVENT_ID
+    assert current_channel_event_id() is None
+
+
+def test_scope_resets_even_when_the_body_raises() -> None:
+    with pytest.raises(RuntimeError, match="boom"):
+        with channel_event_id_scope(_SLACK_EVENT_ID):
+            raise RuntimeError("boom")
+    assert current_channel_event_id() is None
+
+
+def test_caller_supplied_event_id_wins_over_the_ambient_one() -> None:
+    with channel_event_id_scope(_SLACK_EVENT_ID):
+        assert stamp_event_id({"event_id": _NEUTRAL_EVENT_ID}) == {
+            "event_id": _NEUTRAL_EVENT_ID
+        }
+        assert stamp_event_id({"service.name": "curie-worker"}) == {
+            "service.name": "curie-worker",
+            "event_id": _SLACK_EVENT_ID,
+        }
+        assert stamp_event_id(None) == {"event_id": _SLACK_EVENT_ID}
+
+
+def test_stamping_outside_a_scope_is_the_identity() -> None:
+    assert stamp_event_id(None) == {}
+    assert stamp_event_id({"service.name": "curie-worker"}) == {
+        "service.name": "curie-worker"
+    }
+
+
+def test_stamping_does_not_mutate_the_callers_dict() -> None:
+    """``consumer.py`` reuses ONE dict for its span and its metrics."""
+
+    supplied = {"service.name": "curie-worker", "source": "worker"}
+    with channel_event_id_scope(_SLACK_EVENT_ID):
+        stamped = stamp_event_id(supplied)
+    assert supplied == {"service.name": "curie-worker", "source": "worker"}
+    assert stamped["event_id"] == _SLACK_EVENT_ID
+
+
+# --- T3: the metric surface stays closed to it -------------------------------
+
+
+def test_metrics_never_carry_the_event_id_inside_a_scope() -> None:
+    """The regression pin for the shared-dict trap in ``consumer.py``.
+
+    The same attribute dict feeds ``operation_span`` and ``record_metric`` there
+    (and again in ``reply_sink.py``). Stamping lives only in the span path, so
+    the metric point must be byte-identical to what the caller supplied.
+    """
+
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(
+        metric_readers=[reader],
+        resource=build_resource(
+            "curie-worker",
+            service_version="0.0.0",
+            service_instance_id="event-id-scope",
+            deployment_environment="test",
+        ),
+    )
+    configure_meter_provider(provider)
+    try:
+        supplied = {
+            "service.name": "curie-worker",
+            "source": "worker",
+            "outcome": "success",
+        }
+        with channel_event_id_scope(_SLACK_EVENT_ID):
+            record_metric("curie.queue.process", attributes=supplied)
+
+        data = reader.get_metrics_data()
+        assert data is not None
+        points = [
+            dict(point.attributes or {})
+            for resource_metrics in data.resource_metrics
+            for scope_metrics in resource_metrics.scope_metrics
+            for metric in scope_metrics.metrics
+            if metric.name == "curie.queue.process"
+            for point in getattr(metric.data, "data_points", ())
+        ]
+        assert points, "the metric under test did not record"
+        for point in points:
+            assert point == supplied, point
+            assert _EXPORT_KEY not in point
+            assert _SLACK_EVENT_ID not in {str(value) for value in point.values()}
+    finally:
+        provider.shutdown()
+
+
+def test_record_metric_rejects_the_event_id_as_an_undeclared_attribute() -> None:
+    """Belt and braces: even a deliberate future attempt fails loudly."""
+
+    with pytest.raises(ValueError, match="undeclared attribute"):
+        record_metric(
+            "curie.queue.process",
+            attributes={
+                "service.name": "curie-worker",
+                "source": "worker",
+                "outcome": "success",
+                "event_id": _SLACK_EVENT_ID,
+            },
+        )


### PR DESCRIPTION
Ref #2622. Deployed verification of AC3 is #2624 — see "What this does not do".

A trace could not be resolved back to the channel event that caused it, so correlating a request meant scraping the claim-latency log line and joining on a time window. That join is only sound at concurrency 1, which is exactly what the soak burst staircase is not.

## Approach

The span vocabulary now admits one correlation identifier, `event_id`, exported as `curie.channel.event_id`. A turn-scoped contextvar set in the consumer carries it, and `operation_span` stamps every span the turn opens — so `curie.sandbox.claim`, `curie.runner.rpc` and `curie.reply.update` are covered with no edits at those call sites and no new parameters threaded through three layers. `ReplyUpdate` carries no `event_id` on the wire (only `TurnCompleted` does), so threading it there would have meant a channel-protocol contract change.

Contextvars are per-asyncio-task, so two concurrent turns cannot read each other's value. Disjointness is a property of the mechanism rather than something each call site has to get right.

Two decisions worth a reviewer's attention:

**The scope opens after the thread-reset drain, not at the parse.** That drain calls `release_thread` for *other* threads, and `asyncio.to_thread` copies the context, so an earlier scope would stamp another thread's teardown with this turn's id. A query would then return the wrong request's spans, which is worse than returning none. There is a test keyed on `curie.sandbox.release` that fails if the scope moves up.

**`record_metric` is untouched.** The metric catalog enumerates a value domain per attribute and an identifier has none, so the metric surface stays closed structurally and a leak fails loudly rather than widening cardinality. The consumer's shared `metric_attributes` dict is deliberately not modified.

## Acceptance criteria

| AC | State | Evidence |
|---|---|---|
| 1 — on `curie.queue.process` incl. failure and pending | met | Post-hoc `set_attribute` on the root after the parse; all outcome branches share that span object. Tests cover both branches. |
| 2 — same name on claim / rpc / reply.update | met | Stamped inside `operation_span`; zero edits at those sites. |
| 3 — single Tempo query at concurrency 10 | **partial** | In-process partition proven; deployed proof is #2624. See below. |
| 4 — documented | met | `docs/interfaces/telemetry-otel/INTERFACE.md`. |
| 5 — concurrent disjoint span sets | met | 12 overlapping turns behind a rendezvous barrier, asserting child-to-root membership. |
| 6 — `claim latency` log line unchanged | met | `kernel.py` is absent from the diff. |

## What this does not do

**It does not by itself unblock the soak ramp's phase two.** AC3 asks for a Tempo query; this change is in-process only. The default trace exporter is Langfuse, not Tempo, and `BatchSpanProcessor` has a 1000 ms delay with a flush only on graceful exit — so a worker pod killed mid-burst, which is the burst experiment's whole design, may lose its spans. #2624 carries the deployed proof and the pod-deletion characterisation.

Two paths carry no id by design: the thread-reset drain (it tears down other threads) and work on tasks created before the scope opens, such as the delivery lease's heartbeat interrupt RPC. Those spans are *missing* the attribute, never carrying another request's — a query never returns the wrong request's spans, it may just not return every span of its own. Both are documented in the interface file.

Entries whose payload fails to parse are unstamped because no id exists to emit.

## Testing

The concurrency test asserts that every stamped child span carries the same id as the `curie.queue.process` root it descends from. Grouping spans by their own id and asserting the groups are disjoint is true by construction; membership is what actually fails when the id is not per-task — there is a comment on the test saying so, because the tautological version is the tempting simplification.

Three mutations were run against the finished code and each was caught:

- `operation_span` not calling `stamp_event_id` → the telemetry-package test fails (the worker tests do not, because the probe replaces `operation_span`; that is why the pin lives in both places).
- the scope moved above the drain → the drain test fails.
- the contextvar replaced by a process-global → the membership, leak and drain tests fail.

`577 passed, 2 skipped` across `apps/worker/tests/kernel` and `packages/telemetry/tests`; ruff and mypy clean.

One caveat on the suite: `apps/worker/tests/kernel` shows cross-run state sensitivity against a shared Valkey — a run following a polluted one failed a different unrelated test each time (`test_workspace_reaper_holds_the_route_lock_during_exact_ledger_recheck`, then `test_kill_interrupts_a_live_turn`), while a clean database passes 413/413 consistently. `origin/main` behaved the same way under seeded state, and the tests added here clean up after themselves. Pre-existing, not introduced by this branch, and not something this PR tries to fix.