### PR TITLE
Make the approval journey drivable and prove the harness cannot ship

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -39,6 +39,19 @@ on:
       # (#2190) both read compose.dev.yaml to check third-party image tags,
       # so a compose-only edit that unpins one must run this workflow too.
       - "compose.dev.yaml"
+      # The dev-harness exclusion gate EXECUTES every production image recipe
+      # and the runner pin exporter. A PR that adds the harness to one of them
+      # touches no charts/ path, so without these the gate that exists to catch
+      # exactly that is skipped. `adapters/discord/Dockerfile` is a production
+      # recipe of the same shape (COPY . . then a --package uv sync) and was
+      # missing here, so a Dockerfile-only path-install there ran no gate.
+      - "runner/Dockerfile"
+      - "runner/export_dependency_pins.py"
+      - "apps/api/Dockerfile"
+      - "apps/dispatcher/Dockerfile"
+      - "apps/worker/Dockerfile"
+      - "apps/mail-adapter/Dockerfile"
+      - "adapters/discord/Dockerfile"
 
 permissions:
   contents: read
@@ -520,6 +533,27 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/approval-principal-wiring-assertions.sh
 
+      # `uv` must exist BEFORE the dev-harness exclusion gate below: that gate's
+      # PRIMARY control is `uv export --frozen --no-dev`, so a setup-uv step
+      # placed after it (as it was) makes the step fail on a hosted runner
+      # before it reaches the chart sweep or its own seeded self-checks. The
+      # later `uv sync` for the web-identity gate stays where it is; only the
+      # toolchain install is hoisted.
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: "3.13"
+
+      # The dev interaction harness (packages/test-support) must reach no
+      # shipped artifact: neither the resolved --no-dev dependency closure of
+      # the five production images nor any document of the sealed chart render
+      # may name it. The script seeds violations against both controls and must
+      # reject them, so a typo'd needle cannot pass for a clean result.
+      - name: helm render assertions (dev harness exclusion)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/dev-harness-exclusion-assertions.sh
+
       # Prove the mail adapter's chart wiring (issue #1515): it does not render
       # at all by default, it is told where the platform API is, it receives its
       # channel token, egress secret and AgentMail key by reference only, and it
@@ -600,11 +634,9 @@ jobs:
       # the real API and worker BundleStore objects under each rendered
       # workload's env and asks the constructed boto3 client which credential
       # provider won. Reading the manifests alone cannot tell an omitted
-      # credential apart from one the SDK signs as an empty identity.
-      - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-        with:
-          python-version: "3.13"
+      # credential apart from one the SDK signs as an empty identity. `uv`
+      # itself is installed much earlier, above the dev-harness exclusion gate,
+      # because that gate's primary control shells out to `uv export`.
       - name: Sync workspace
         run: uv sync
 

--- a/apps/api/tests/test_approval_dev_surface_exclusion.py
+++ b/apps/api/tests/test_approval_dev_surface_exclusion.py
@@ -36,15 +36,23 @@ Bypasses this set does NOT test, stated plainly rather than claimed complete:
 
 from __future__ import annotations
 
+import ast
 import contextlib
 import inspect
 import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
 import threading
 import time
+import tomllib
 import types
 import uuid
 from collections.abc import Iterator
 from datetime import UTC, datetime
+from pathlib import Path, PurePath
 from typing import Any
 
 import httpx
@@ -732,3 +740,953 @@ def test_the_composed_loopback_api_seam_does_not_outlive_its_fixture(
 
     with httpx.Client() as after, pytest.raises(httpx.ConnectError):
         after.get(f"http://127.0.0.1:{port}/health")
+
+
+# --- Stage 3: the dev interaction harness never reaches production ----------
+#
+# Stage 3 adds a dev-only interaction harness at
+# ``packages/test-support/src/curie_test_support/interaction/`` with a
+# ``python -m curie_test_support.interaction`` entry point. It registers no
+# route, adds no service and adds no toggle -- so the assertions below defend
+# the CAPABILITY ("nothing that can drive an approval without a genuine chat
+# click ships"), not the name. The primary control is the resolved
+# ``--no-dev`` dependency closure: a distribution that is not installed cannot
+# be imported however it is spelled, where a module-name grep only ever finds
+# the name we happened to think of.
+
+HARNESS_DISTRIBUTION = "curie-test-support"
+HARNESS_MODULE = "curie_test_support"
+HARNESS_SUBMODULE = f"{HARNESS_MODULE}.interaction"
+HARNESS_PACKAGE_PATH = "packages/test-support"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+# Every first-party image whose build context is the WORKSPACE, keyed by the
+# distribution its Dockerfile installs and valued by the workspace member that
+# ships in it. Those are the only images the harness could reach, because they
+# are the only ones that copy `packages/test-support` into a build stage at all.
+#
+# `adapters/discord` was missing from this list while being exactly that shape
+# (`COPY . .` then `uv sync --frozen --no-dev --no-editable --package
+# curie-discord-adapter`), so "every production image" excluded an image. The
+# list is re-derived and cross-checked against the tree below rather than
+# hand-maintained, so the next one cannot go missing silently.
+APP_PACKAGES = (
+    "curie-api",
+    "curie-dispatcher",
+    "curie-worker",
+    "curie-mail-adapter",
+    "curie-discord-adapter",
+)
+APP_MEMBERS = {
+    "curie-api": "apps/api",
+    "curie-dispatcher": "apps/dispatcher",
+    "curie-worker": "apps/worker",
+    "curie-mail-adapter": "apps/mail-adapter",
+    "curie-discord-adapter": "adapters/discord",
+}
+APP_NAMES = ("api", "dispatcher", "worker", "mail-adapter")
+APP_DOCKERFILES = tuple(f"{member}/Dockerfile" for member in APP_MEMBERS.values())
+PROD_DOCKERFILES = (*APP_DOCKERFILES, "runner/Dockerfile")
+# Images whose build context is their own directory (the sre-bot connectors) or
+# which install no Python from the workspace (apps/ui, node) cannot reach a
+# workspace member at all; `prototypes/` and `cli/scripts/fixtures/` are not
+# shipped. `test_the_production_image_list_covers_every_workspace_context_image`
+# below re-derives this from the tree so the exclusion is checked, not asserted.
+NON_WORKSPACE_DOCKERFILES = frozenset(
+    {
+        "apps/ui/Dockerfile",
+        "examples/sre-bot/connectors/tempo/Dockerfile",
+        "examples/sre-bot/connectors/self-upgrade/Dockerfile",
+        "prototypes/runner/Dockerfile",
+        "cli/scripts/fixtures/mcp-receipt/Dockerfile",
+        "charts/curie/ci/postgres-readiness-delay.Dockerfile",
+        "compose/worker-local.Dockerfile",
+    }
+)
+
+
+def _normalize_distribution(name: str) -> str:
+    """PEP 503 normalization, so ``curie_test_support`` and ``Curie-Test-Support`` match."""
+
+    return re.sub(r"[-_.]+", "-", name).strip().lower()
+
+
+def _editable_distribution(relative: str) -> str:
+    """The distribution a ``-e <path>`` entry actually installs.
+
+    Reality check, corrected after this parser first shipped: ``uv export``
+    writes workspace members as PATHS (``-e ./packages/test-support``), and the
+    directory basename is NOT the distribution name -- that path installs
+    ``curie-test-support``. Deriving the name from the basename made every
+    editable member unrecognisable, so both the harness assertion and its own
+    sanity guard were looking for names that can never appear. The name is read
+    from the member's ``[project] name`` instead, with the basename kept only as
+    a fallback for a path that carries no pyproject.
+    """
+
+    pyproject = REPO_ROOT / relative / "pyproject.toml"
+    if pyproject.is_file():
+        declared = (tomllib.loads(pyproject.read_text()).get("project") or {}).get("name")
+        if isinstance(declared, str) and declared:
+            return _normalize_distribution(declared)
+    return _normalize_distribution(Path(relative).name)
+
+
+def _closure_distributions(exported: str) -> set[str]:
+    """Distribution names in a ``uv export`` / pip-requirements document.
+
+    Parses both shapes the production images install: pinned registry
+    requirements (``name==1.2.3``) and workspace members exported as editable
+    paths (``-e ./packages/foo``). The editable form is the one that matters
+    here -- the harness would arrive that way, and a scan that only understood
+    ``==`` lines would be blind to exactly the case under test.
+    """
+
+    found: set[str] = set()
+    for raw in exported.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line or line.startswith("-"):
+            if line.startswith("-e "):
+                found.add(_editable_distribution(line[3:].strip()))
+            continue
+        found.add(_normalize_distribution(re.split(r"[<>=!~\[; ]", line, maxsplit=1)[0]))
+    return {name for name in found if name}
+
+
+def _export_closure(package: str) -> str:
+    """The exact closure the image installs: ``uv export --frozen --no-dev --package <p>``."""
+
+    completed = subprocess.run(
+        ["uv", "export", "--frozen", "--no-dev", "--package", package],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "NO_COLOR": "1"},
+        timeout=600,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return completed.stdout
+
+
+def _runner_pins() -> str:
+    """The runner image's own pinned requirements, produced by its real exporter.
+
+    ``runner/Dockerfile`` does not use ``uv sync`` at all: it pipes ``uv.lock``
+    through ``runner/export_dependency_pins.py`` and installs the result with
+    ``--no-deps``. Asserting on that exporter's actual output is the only way
+    this covers the fifth image rather than assuming it resembles the other four.
+    """
+
+    completed = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "runner" / "export_dependency_pins.py")],
+        cwd=REPO_ROOT,
+        input=(REPO_ROOT / "uv.lock").read_text(),
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return completed.stdout
+
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv is not installed")
+def test_no_production_dependency_closure_installs_the_harness_distribution() -> None:
+    """PRIMARY control: the harness distribution is in no production closure.
+
+    Decision 3 of the plan: assert on the resolved ``--no-dev`` closure rather
+    than building five images. The four app Dockerfiles install with
+    ``uv sync --frozen --no-dev --no-editable --package curie-<app>`` and the
+    runner installs ``export_dependency_pins.py``'s output, so these are the
+    same sets those images end up with -- not a proxy for them.
+
+    This is deliberately an assertion about the DISTRIBUTION, not about a module
+    name: it is complete against any harness surface however it is renamed,
+    where the name sweep below is only complete against today's spelling.
+    """
+
+    closures = {
+        package: _closure_distributions(_export_closure(package)) for package in APP_PACKAGES
+    }
+    closures["curie-runner"] = _closure_distributions(_runner_pins())
+
+    for package, distributions in closures.items():
+        # Guard the guard: an export that silently produced nothing would make
+        # the absence assertion below pass for the wrong reason.
+        assert len(distributions) > 20, (package, sorted(distributions))
+        assert _normalize_distribution(package) in distributions or package == "curie-runner", (
+            f"{package}'s own closure does not contain {package}; the parse is wrong, "
+            "so its absence assertion proves nothing"
+        )
+        assert _normalize_distribution(HARNESS_DISTRIBUTION) not in distributions, (
+            f"{package}'s --no-dev closure installs {HARNESS_DISTRIBUTION}; the dev "
+            "interaction harness would be importable inside the production image"
+        )
+
+    # Seeded violation: the same parser, handed a closure that DOES carry the
+    # harness, must report it. Without this the assertion above could be passing
+    # because the parser never recognises the distribution at all.
+    seeded = _closure_distributions(
+        "\n".join(["-e ./apps/api", "-e ./packages/test-support", "httpx==0.27.0"])
+    )
+    assert _normalize_distribution(HARNESS_DISTRIBUTION) in seeded, seeded
+
+
+def _harness_declaration_sites(pyproject: dict[str, Any]) -> dict[str, list[str]]:
+    """Where ``curie-test-support`` is declared in a parsed pyproject document.
+
+    Returns a map of site -> the declaring list, so a failure names the exact
+    table a future author added it to rather than only saying "somewhere".
+    """
+
+    target = _normalize_distribution(HARNESS_DISTRIBUTION)
+
+    def declares(entries: Any) -> bool:
+        return isinstance(entries, list) and any(
+            isinstance(entry, str)
+            and _normalize_distribution(re.split(r"[<>=!~\[; ]", entry, maxsplit=1)[0]) == target
+            for entry in entries
+        )
+
+    sites: dict[str, list[str]] = {}
+    project = pyproject.get("project") or {}
+    if declares(project.get("dependencies")):
+        sites["project.dependencies"] = list(project["dependencies"])
+    for extra, entries in (project.get("optional-dependencies") or {}).items():
+        if declares(entries):
+            sites[f"project.optional-dependencies.{extra}"] = list(entries)
+    for group, entries in (pyproject.get("dependency-groups") or {}).items():
+        if declares(entries):
+            sites[f"dependency-groups.{group}"] = list(entries)
+    return sites
+
+
+def test_the_harness_distribution_is_declared_only_in_the_dev_dependency_group() -> None:
+    """``--no-dev`` is sufficient ONLY while ``dev`` is the single declaration.
+
+    The image assertion above is downstream of this one: the moment
+    ``curie-test-support`` also appears in an app's ``[project] dependencies``,
+    ``--no-dev`` stops excluding it and every production image gains the
+    harness. A future author who adds it there fails here, at the declaration,
+    with the reason attached -- rather than shipping it.
+
+    ``[tool.uv.sources]`` and ``[tool.uv.workspace] members`` are NOT
+    declarations of a dependency; they only say where the workspace member
+    lives, so they are expected and are not counted as sites.
+    """
+
+    root = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    assert _harness_declaration_sites(root) == {
+        "dependency-groups.dev": root["dependency-groups"]["dev"]
+    }, "curie-test-support must be declared only in [dependency-groups] dev"
+
+    # Every workspace member that ships in an image must not declare it either:
+    # a per-app dependency would reach the image through --package resolution.
+    for relative in (*APP_MEMBERS.values(), "runner"):
+        member = tomllib.loads((REPO_ROOT / relative / "pyproject.toml").read_text())
+        assert _harness_declaration_sites(member) == {}, (
+            f"{relative}/pyproject.toml declares {HARNESS_DISTRIBUTION}; it would then be "
+            "installed by --package resolution regardless of --no-dev"
+        )
+
+    # Seeded violation: a second declaration in a runtime dependency list must
+    # be reported by the very helper the assertions above trust.
+    seeded = dict(root)
+    seeded["project"] = {
+        **root["project"],
+        "dependencies": [*root["project"]["dependencies"], HARNESS_DISTRIBUTION],
+    }
+    assert "project.dependencies" in _harness_declaration_sites(seeded)
+
+
+def _dev_only_workspace_members() -> dict[str, str]:
+    """Workspace members that ONLY the dev dependency group installs.
+
+    Derived from the root pyproject rather than listed here: a member is
+    dev-only when the root declares its distribution in a
+    ``[dependency-groups]`` table and never in the root's runtime
+    ``[project] dependencies``. Today that is the harness plus the two dev
+    tools; a future dev-only member is covered without an edit.
+    """
+
+    root = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+
+    def names(entries: Any) -> set[str]:
+        return {
+            _normalize_distribution(re.split(r"[<>=!~\[; ]", entry, maxsplit=1)[0])
+            for entry in entries or []
+            if isinstance(entry, str)
+        }
+
+    runtime = names((root.get("project") or {}).get("dependencies"))
+    grouped: set[str] = set()
+    for entries in (root.get("dependency-groups") or {}).values():
+        grouped |= names(entries)
+
+    members: dict[str, str] = {}
+    workspace = ((root.get("tool") or {}).get("uv") or {}).get("workspace") or {}
+    for relative in workspace.get("members") or []:
+        pyproject = REPO_ROOT / relative / "pyproject.toml"
+        if not pyproject.is_file():
+            continue
+        declared = (tomllib.loads(pyproject.read_text()).get("project") or {}).get("name")
+        name = _normalize_distribution(declared) if isinstance(declared, str) else ""
+        if name and name in grouped and name not in runtime:
+            members[name] = relative
+    return members
+
+
+# ``uv sync --package <member>`` IS an install: it resolves that member into the
+# builder venv the runtime stage ships. Leaving it out of this tuple was how a
+# ``uv sync --frozen --no-dev --package curie-api --package curie-test-support``
+# passed every control (round-2 review finding A).
+_INSTALL_VERBS = (
+    ("pip", "install"),
+    ("pip3", "install"),
+    ("uv", "pip", "install"),
+    ("uv", "add"),
+    ("poetry", "add"),
+    ("uv", "sync"),
+)
+_SYNC_VERB = ("uv", "sync")
+_SHELL_OPERATORS = frozenset({"&&", "||", ";", "|", "&", "(", ")", "{", "}"})
+# Flags that put a non-runtime dependency group back into a ``--no-dev`` sync.
+_DEV_GROUP_FLAGS = ("--dev", "--all-groups", "--group", "--only-group", "--only-dev")
+_WORKSPACE_COPY = re.compile(r"COPY\s+\.\s+\./?$", re.IGNORECASE)
+
+
+def _dockerfile_commands(text: str) -> list[str]:
+    """One string per Dockerfile instruction, continuations joined, comments dropped.
+
+    A per-LINE reading is what let finding 1 through: a shell continuation
+    splits ``uv sync`` from its flags, and a line-oriented check then judges a
+    fragment. Joining first is what makes "the flags of THIS instruction" a
+    question the checker can actually answer.
+    """
+
+    commands: list[str] = []
+    buffer = ""
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if line.lstrip().startswith("#") or (not buffer and not line.strip()):
+            continue
+        if line.endswith("\\"):
+            buffer += line[:-1] + " "
+            continue
+        commands.append(" ".join(f"{buffer}{line}".split()))
+        buffer = ""
+    if buffer.strip():
+        commands.append(" ".join(buffer.split()))
+    return commands
+
+
+def _tokenize(command: str) -> list[str]:
+    """Shell tokens of one instruction, with end-of-line comments removed.
+
+    Round-2 finding B: ``"--no-dev" in command`` is satisfied by text uv never
+    receives -- ``uv sync ... # --no-dev``. ``shlex`` with ``comments=True``
+    drops what the shell drops, so flags are judged as ARGUMENTS.
+    """
+
+    try:
+        return shlex.split(command, comments=True)
+    except ValueError:
+        return [token for token in command.split() if not token.startswith("#")]
+
+
+def _segments(command: str) -> list[list[str]]:
+    """The shell commands inside one ``RUN``, each as its own token list.
+
+    Round-2 finding B again, second shape: ``uv sync ... || echo --no-dev``.
+    Splitting on the shell operators is what keeps a flag belonging to `echo`
+    from being read as a flag of the sync. The argv head is reduced to its
+    basename (``/app/.venv/bin/pip`` -> ``pip``) and leading ``VAR=value``
+    assignments and ``python -m`` are stripped, so the verb match is on the
+    program actually run.
+    """
+
+    tokens = _tokenize(command)
+    if not tokens or tokens[0] != "RUN":
+        return []
+    tokens = tokens[1:]
+    while tokens and tokens[0].startswith("--mount"):
+        tokens = tokens[1:]
+    split: list[list[str]] = []
+    current: list[str] = []
+    for token in tokens:
+        if token in _SHELL_OPERATORS:
+            split.append(current)
+            current = []
+        else:
+            current.append(token)
+    split.append(current)
+    found: list[list[str]] = []
+    for segment in split:
+        while segment and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", segment[0]):
+            segment = segment[1:]
+        if (
+            len(segment) > 2
+            and PurePath(segment[0]).name in ("python", "python3")
+            and segment[1] == "-m"
+        ):
+            segment = segment[2:]
+        if segment:
+            found.append([PurePath(segment[0]).name, *segment[1:]])
+    return found
+
+
+def _starts_with(segment: list[str], verb: tuple[str, ...]) -> bool:
+    return tuple(segment[: len(verb)]) == verb
+
+
+def _has_flag(segment: list[str], flag: str) -> bool:
+    return any(token == flag or token.startswith(f"{flag}=") for token in segment)
+
+
+def _flag_value(token: str) -> str:
+    """The value half of ``--flag=value``; the token itself otherwise."""
+
+    if token.startswith("-") and "=" in token:
+        return token.split("=", 1)[1]
+    return token
+
+
+def _names_path(token: str, target: str) -> bool:
+    cleaned = _flag_value(token).strip("'\"")
+    cleaned = cleaned[2:] if cleaned.startswith("./") else cleaned
+    cleaned = cleaned.rstrip("/")
+    target = target[2:] if target.startswith("./") else target
+    target = target.rstrip("/")
+    return bool(target) and (cleaned == target or cleaned.startswith(f"{target}/"))
+
+
+def _names_distribution(token: str, distribution: str) -> bool:
+    head = re.split(r"[<>=!~\[;]", _flag_value(token).strip("'\""), maxsplit=1)[0]
+    return _normalize_distribution(head) == distribution
+
+
+def _copy_aliases(commands: list[str], member: str) -> set[str]:
+    """Destinations a ``COPY`` gave the dev-only member's tree.
+
+    Round-2 finding C: ``COPY packages/test-support /opt/x`` then
+    ``RUN uv pip install /opt/x`` names neither the member path nor the
+    distribution, so a name match alone cannot see it. Following the COPY is
+    what keeps the renamed path recognisable as the harness.
+    """
+
+    aliases: set[str] = set()
+    for command in commands:
+        tokens = _tokenize(command)
+        if not tokens or tokens[0] != "COPY":
+            continue
+        operands = [token for token in tokens[1:] if not token.startswith("--")]
+        if len(operands) < 2:
+            continue
+        for source in operands[:-1]:
+            if _names_path(source, member):
+                aliases.add(operands[-1])
+    return aliases
+
+
+def _dockerfile_posture(path: str, text: str) -> list[str]:
+    """Violations of the no-dev / no-dev-member posture in one Dockerfile.
+
+    A list rather than an assertion so the seeded-violation cases below can run
+    the SAME check against mutated text; a checker that is only ever called on
+    the real files cannot be shown to be capable of failing.
+
+    Four independent controls, because ``uv export`` sees none of them. The
+    app images ``COPY . .`` into the builder and ship that stage's
+    ``/app/.venv``, so a single builder line can install a dev-only member into
+    the shipped venv while every export-based control still reads clean:
+
+    1. no install verb (``pip install`` / ``uv pip install`` / ``uv add`` /
+       ``uv sync``) may name a dev-only workspace member -- by distribution, by
+       path, or by a path a ``COPY`` renamed it to;
+    2. every ``uv sync`` carries ``--no-dev`` as a real argument, and none
+       re-admits a group with ``--group`` / ``--all-groups`` / ``--dev``;
+    3. the FINAL sync -- the one after ``COPY . .``, the only one whose result
+       is what ships -- carries ``--no-dev`` and ``--package``. "Some line has
+       the flag" is not this property: the pre-copy dependency-layer sync
+       already carries it, so dropping it from the post-copy sync passes any
+       any-line check.
+    """
+
+    problems: list[str] = []
+    commands = _dockerfile_commands(text)
+    parsed = [(command, _segments(command)) for command in commands]
+
+    for distribution, member in _dev_only_workspace_members().items():
+        targets = {member, *_copy_aliases(commands, member)}
+        for command, command_segments in parsed:
+            for segment in command_segments:
+                if not any(_starts_with(segment, verb) for verb in _INSTALL_VERBS):
+                    continue
+                if any(
+                    any(_names_path(token, target) for target in targets)
+                    or _names_distribution(token, distribution)
+                    for token in segment[1:]
+                ):
+                    problems.append(
+                        f"{path} installs the dev-only workspace member {member} "
+                        f"({distribution}) into the image venv: {command}"
+                    )
+
+    if path == "runner/Dockerfile":
+        if HARNESS_PACKAGE_PATH in text:
+            problems.append(f"{path} references {HARNESS_PACKAGE_PATH}")
+        return problems
+
+    installs = [
+        (command, segment)
+        for command, command_segments in parsed
+        for segment in command_segments
+        if _starts_with(segment, _SYNC_VERB)
+    ]
+    if not installs:
+        problems.append(f"{path} has no uv sync line; the posture assertion would be vacuous")
+    for command, segment in installs:
+        if not _has_flag(segment, "--no-dev"):
+            problems.append(f"{path} installs without --no-dev: {command}")
+        for flag in _DEV_GROUP_FLAGS:
+            if _has_flag(segment, flag):
+                problems.append(
+                    f"{path} re-admits a non-runtime dependency group with {flag}: {command}"
+                )
+
+    copies = [index for index, command in enumerate(commands) if _WORKSPACE_COPY.match(command)]
+    if not copies:
+        problems.append(
+            f"{path} has no `COPY . .`; this checker assumes the workspace-copy image shape "
+            "and cannot judge the final install layer of a different one"
+        )
+        return problems
+    final = [
+        (command, segment)
+        for command, command_segments in parsed[copies[-1] :]
+        for segment in command_segments
+        if _starts_with(segment, _SYNC_VERB)
+    ]
+    if not final:
+        problems.append(
+            f"{path} runs no uv sync after `COPY . .`; the shipped venv is then whatever "
+            "an earlier layer left, which this checker cannot bound"
+        )
+    for command, segment in final:
+        if not _has_flag(segment, "--no-dev"):
+            problems.append(f"{path} post-`COPY . .` sync omits --no-dev: {command}")
+        if not _has_flag(segment, "--package"):
+            problems.append(
+                f"{path} post-`COPY . .` sync omits --package, so it resolves the whole "
+                f"workspace rather than one member: {command}"
+            )
+    return problems
+
+
+def test_the_production_image_list_covers_every_workspace_context_image() -> None:
+    """Nothing in the tree builds from the workspace without being on the list.
+
+    ``adapters/discord/Dockerfile`` was a production recipe of exactly the app
+    shape and was on no list in this module -- so "every production image" was
+    an unchecked claim about a hand-maintained tuple. This re-derives the
+    Dockerfile set from the tree and forces every one of them to be either a
+    production workspace image (checked above) or an explicitly named
+    non-workspace one.
+    """
+
+    ignored = {".git", ".venv", "node_modules", "target", ".worktrees", "dist", ".mypy_cache"}
+    # Filter on the path RELATIVE to the repo root: this checkout is itself
+    # under a `.worktrees/` directory, so filtering absolute parts discards
+    # every file in the tree and the sweep passes vacuously.
+    found = {
+        str(path.relative_to(REPO_ROOT))
+        for path in REPO_ROOT.rglob("*Dockerfile")
+        if not ignored & set(path.relative_to(REPO_ROOT).parts)
+    }
+    assert set(PROD_DOCKERFILES) <= found, sorted(set(PROD_DOCKERFILES) - found)
+    unaccounted = found - set(PROD_DOCKERFILES) - NON_WORKSPACE_DOCKERFILES
+    assert unaccounted == set(), (
+        f"{sorted(unaccounted)} is neither on the production workspace-image list nor "
+        "declared as building outside the workspace; if it copies the workspace it can "
+        "install the dev harness and must be added to APP_MEMBERS/PROD_DOCKERFILES"
+    )
+
+
+def test_every_production_image_installs_without_the_dev_dependency_group() -> None:
+    """The Dockerfile posture that makes the closure assertion true in the image.
+
+    The closure test proves ``--no-dev`` EXCLUDES the harness; this proves the
+    images actually pass ``--no-dev`` -- and, since ``uv export`` cannot see a
+    Dockerfile-level install at all, that no builder line puts a dev-only
+    workspace member into the venv that ships.
+    """
+
+    for relative in PROD_DOCKERFILES:
+        text = (REPO_ROOT / relative).read_text()
+        assert _dockerfile_posture(relative, text) == [], (
+            relative,
+            _dockerfile_posture(relative, text),
+        )
+
+    # Seeded violation: --no-dev stripped everywhere.
+    for relative in APP_DOCKERFILES:
+        mutated = (REPO_ROOT / relative).read_text().replace("--no-dev", "")
+        assert _dockerfile_posture(relative, mutated) != [], relative
+
+    # Seeded violation (finding 1): --no-dev dropped from the FINAL, post-
+    # `COPY . .` sync ONLY. Every earlier line keeps the flag, so an any-line
+    # check reads the file as clean while the shipped venv gains the dev group.
+    for relative in APP_DOCKERFILES:
+        text = (REPO_ROOT / relative).read_text()
+        head, sep, tail = text.rpartition("uv sync")
+        assert sep, relative
+        mutated = f"{head}{sep}{tail.replace(' --no-dev', '', 1)}"
+        # Where the image has a pre-copy dependency-layer sync (four of the
+        # five), the flag survives on that earlier line -- which is the whole
+        # point: an any-line check still sees "--no-dev" here.
+        if text.count("uv sync") > 1:
+            assert "--no-dev" in mutated, relative
+        problems = _dockerfile_posture(relative, mutated)
+        assert any("post-`COPY . .` sync omits --no-dev" in problem for problem in problems), (
+            relative,
+            problems,
+        )
+
+    # Seeded violation (finding 1): a path- or name-install of the dev-only
+    # harness in the builder. `uv export` is byte-identical under this edit and
+    # every sync keeps --no-dev, so this is exactly the shape that no
+    # closure-based control -- here or in the chart script -- could ever see.
+    for relative in PROD_DOCKERFILES:
+        for line in (
+            f"RUN uv pip install ./{HARNESS_PACKAGE_PATH}",
+            f"RUN pip install {HARNESS_PACKAGE_PATH}",
+            f"RUN uv add {HARNESS_DISTRIBUTION}",
+            f"RUN uv pip install \\\n    ./{HARNESS_PACKAGE_PATH}",
+        ):
+            mutated = f"{(REPO_ROOT / relative).read_text()}\n{line}\n"
+            problems = _dockerfile_posture(relative, mutated)
+            assert any("dev-only workspace member" in problem for problem in problems), (
+                relative,
+                line,
+                problems,
+            )
+
+    # Seeded violation A (round-2 review): `uv sync --package <dev-only member>`.
+    # `--no-dev` and `--package` are both present and `uv export --frozen
+    # --no-dev --package curie-api` is byte-identical, so every other control
+    # here reads clean while the member lands in the builder venv that ships.
+    for relative in APP_DOCKERFILES:
+        mutated = (REPO_ROOT / relative).read_text() + (
+            f"\nRUN uv sync --frozen --no-dev --no-editable --package curie-api "
+            f"--package {HARNESS_DISTRIBUTION}\n"
+        )
+        problems = _dockerfile_posture(relative, mutated)
+        assert any("dev-only workspace member" in problem for problem in problems), (
+            relative,
+            problems,
+        )
+
+    # Seeded violation B (round-2 review): a `--no-dev` uv never receives. Both
+    # shapes -- an end-of-line comment and an `|| echo` the shell only reaches
+    # on failure -- satisfy a substring match on the joined instruction.
+    for relative in APP_DOCKERFILES:
+        text = (REPO_ROOT / relative).read_text()
+        head, sep, tail = text.rpartition("uv sync")
+        assert sep, relative
+        # Only the REST OF THAT LINE is rewritten: appending at EOF would leave
+        # the real final sync untouched and the seed would prove nothing.
+        line, newline, rest = tail.partition("\n")
+        for suffix in ("# --no-dev", "|| echo --no-dev"):
+            mutated = f"{head}{sep}{line.replace(' --no-dev', '', 1)} {suffix}{newline}{rest}"
+            # The decoy text IS on the sync line: a substring check still sees it.
+            assert "--no-dev" in mutated.rpartition("uv sync")[2].partition("\n")[0], relative
+            problems = _dockerfile_posture(relative, mutated)
+            assert any("post-`COPY . .` sync omits --no-dev" in problem for problem in problems), (
+                relative,
+                suffix,
+                problems,
+            )
+
+    # Seeded violation C (round-2 review): the harness copied to a renamed path
+    # and installed from there. The RUN names neither `packages/test-support`
+    # nor `curie-test-support`, so only following the COPY can see it.
+    for relative in APP_DOCKERFILES:
+        mutated = (REPO_ROOT / relative).read_text() + (
+            f"\nCOPY {HARNESS_PACKAGE_PATH} /opt/vendored\nRUN uv pip install /opt/vendored\n"
+        )
+        assert HARNESS_DISTRIBUTION not in "RUN uv pip install /opt/vendored"
+        problems = _dockerfile_posture(relative, mutated)
+        assert any("dev-only workspace member" in problem for problem in problems), (
+            relative,
+            problems,
+        )
+
+    # Seeded violation D (found while closing A-C): `--no-dev` is present and
+    # honest, and a later `--group dev` puts the dev group straight back.
+    for relative in APP_DOCKERFILES:
+        mutated = (REPO_ROOT / relative).read_text() + (
+            "\nRUN uv sync --frozen --no-dev --group dev --no-editable --package curie-api\n"
+        )
+        problems = _dockerfile_posture(relative, mutated)
+        assert any("re-admits a non-runtime dependency group" in problem for problem in problems), (
+            relative,
+            problems,
+        )
+
+    runner_mutated = (
+        REPO_ROOT / "runner" / "Dockerfile"
+    ).read_text() + f"\nCOPY {HARNESS_PACKAGE_PATH} ./{HARNESS_PACKAGE_PATH}\n"
+    assert _dockerfile_posture("runner/Dockerfile", runner_mutated) != []
+
+
+def _python_sources(*relatives: str) -> Iterator[Path]:
+    for relative in relatives:
+        yield from sorted((REPO_ROOT / relative).rglob("*.py"))
+
+
+def _imports_harness(source: str) -> bool:
+    """Does this module import ``curie_test_support`` (either import form)?
+
+    SECONDARY to the distribution assertion above, by design: a renamed harness
+    module would evade this and not the closure probe. It is kept because it
+    fails at edit time, in the file that introduced the coupling, where the
+    closure probe fails later and further away.
+    """
+
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            if any(alias.name.split(".")[0] == HARNESS_MODULE for alias in node.names):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            if (node.module or "").split(".")[0] == HARNESS_MODULE:
+                return True
+    return False
+
+
+def test_no_production_module_imports_the_harness() -> None:
+    """No shipped source tree reaches the harness, by AST rather than by grep.
+
+    A substring scan would hit this test file, every docstring mentioning the
+    module, and nothing that matters; the AST answers the real question, which
+    is whether a production module would fail to import inside an image that
+    (correctly) does not install the distribution.
+    """
+
+    trees = (*(f"{member}/src" for member in APP_MEMBERS.values()), "runner/src")
+    scanned = 0
+    for path in _python_sources(*trees):
+        scanned += 1
+        assert not _imports_harness(path.read_text()), (
+            f"{path.relative_to(REPO_ROOT)} imports {HARNESS_MODULE}, which no production "
+            "image installs; the module would ImportError at boot"
+        )
+    assert scanned > 50, scanned
+
+    # Seeded violations: both import spellings must be detected.
+    assert _imports_harness(f"import {HARNESS_SUBMODULE}\n")
+    assert _imports_harness(f"from {HARNESS_SUBMODULE} import harness\n")
+
+
+def _harness_toggle_fields(source: str) -> list[str]:
+    """Settings fields whose name or default could switch a harness on.
+
+    The threat is not "a field named after the harness" -- it is "a field whose
+    VALUE can enable it". So this looks at both: any assignment whose target
+    name or whose literal default text mentions the harness, interaction
+    harness, or a synthetic-principal switch.
+    """
+
+    needles = (HARNESS_MODULE, HARNESS_DISTRIBUTION, "interaction_harness", "synthetic_principal")
+    found: list[str] = []
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        targets: list[str] = []
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            targets = [node.target.id]
+        elif isinstance(node, ast.Assign):
+            targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if not targets:
+            continue
+        rendered = f"{' '.join(targets)} {ast.unparse(node)}".lower()
+        if any(needle in rendered for needle in needles):
+            found.extend(targets)
+    return found
+
+
+def test_no_production_config_carries_a_toggle_that_could_enable_the_harness() -> None:
+    """There is no production switch, so there is nothing an operator can flip.
+
+    Decision 2 of the plan says the harness adds no production toggle. That is
+    a claim about config surface, so it is asserted over the real config
+    modules -- and the seeded violation proves the scan can see such a field,
+    which a scan over four clean files otherwise could not demonstrate.
+    """
+
+    configs = sorted(
+        {
+            *REPO_ROOT.glob("apps/*/src/**/config.py"),
+            *REPO_ROOT.glob("adapters/*/src/**/config.py"),
+        }
+    )
+    assert len(configs) >= 5, [str(path) for path in configs]
+    for path in configs:
+        assert _harness_toggle_fields(path.read_text()) == [], path.relative_to(REPO_ROOT)
+
+    seeded = "class Settings:\n    enable_interaction_harness: bool = False\n"
+    assert _harness_toggle_fields(seeded) == ["enable_interaction_harness"]
+    seeded_by_value = f'class Settings:\n    extra_module: str = "{HARNESS_SUBMODULE}"\n'
+    assert _harness_toggle_fields(seeded_by_value) == ["extra_module"]
+
+
+def _mint_resolve_inventory(app: Any) -> dict[str, set[str]]:
+    """The live-router inventory PR2 pins, extracted so a seeded app can use it.
+
+    PR2 asserted this inline, which made the walk itself unfalsifiable: an
+    inventory that resolved nothing reads identically to "no surfaces exist".
+    Sharing the function with a deliberately-violating app is what proves it
+    would notice a new surface named after the harness.
+    """
+
+    targets = {
+        id(approval_principal.mint): "mint",
+        id(crud.claim_approval_resolution): "resolve",
+    }
+    inventory: dict[str, set[str]] = {}
+    for route in _api_routes(app):
+        reached = _reaches(route.endpoint, targets)
+        if reached:
+            inventory[route.endpoint.__qualname__] = reached
+    return inventory
+
+
+def test_a_harness_shaped_synthetic_surface_would_fail_the_live_app_inventory() -> None:
+    """The inventory catches a NEW mint/resolve surface, harness-named or not.
+
+    The production assertion (exactly one mint, one resolve) already exists
+    above. What it could not show is that it would fail -- so here the same
+    walk runs against an app carrying a synthetic route named after the
+    harness, and must report it. If a future harness ever grew an HTTP surface
+    to drive approvals, this is the assertion that stops it.
+    """
+
+    app = create_app()
+    assert _mint_resolve_inventory(app) == {
+        "mint_operator_principal": {"mint"},
+        "resolve_approval": {"resolve"},
+    }
+
+    seeded = create_app()
+
+    async def mint_interaction_harness_principal() -> dict[str, str]:
+        """A synthetic-principal surface of exactly the shape being excluded."""
+        return {
+            "token": approval_principal.mint(
+                "k",
+                subject=SUBJECT,
+                kind="chat",
+                actor_channel=CARD_CHANNEL,
+                approval_id="a",
+                scope=approval_principal.APPROVE_SCOPE,
+                exp=0,
+            )
+        }
+
+    seeded.post("/curie-test-support/principals")(mint_interaction_harness_principal)
+    # Reality check: the inventory is keyed by ``__qualname__``, so a handler
+    # defined inside a test function is keyed ``<test>.<locals>.<name>``, never
+    # by its bare name. Match the final segment -- asserting the bare name made
+    # this fail even though the seeded surface WAS detected.
+    reached = _mint_resolve_inventory(seeded)
+    seeded_keys = [
+        key for key in reached if key.split(".")[-1] == "mint_interaction_harness_principal"
+    ]
+    assert seeded_keys, reached
+    assert reached[seeded_keys[0]] == {"mint"}, reached
+
+
+def test_synthetic_action_and_identity_probes_in_prod_are_refused_and_change_nothing(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """The harness's two verbs, aimed at a genuinely prod-booted app, move nothing.
+
+    A refusal alone is not the property worth pinning -- a 403 returned AFTER
+    the approval was resolved, or after an audit row was written, is the exact
+    failure this test exists to catch. So the status and the full audit trail
+    are captured before and compared after, and the comparison happens outside
+    the prod block so it is made with the ordinary platform credential rather
+    than depending on the prod key the probes ran under.
+
+    Corrected after review: this used to reuse ``approvals_client``, whose
+    ``create_app()`` had already run under the TEST environment, and merely
+    clear the settings cache under ``ENVIRONMENT=prod``. Routers were never
+    rebuilt, so an ``environment == "prod"`` branch in ``create_app()`` that
+    mounted a synthetic mint/resolve router was invisible to this test AND to
+    the dev-time live-app inventory -- which is exactly the surface AC8 claims
+    does not exist. A SECOND app is now built inside the prod block, from the
+    real factory under real prod settings, the mint/resolve inventory is taken
+    against THAT app, and the probes are driven against it.
+
+    What this now proves: the prod-configured router table contains exactly one
+    mint surface and one resolve surface, both the production ones, and neither
+    harness verb moves the row or the audit trail.
+    What it still does NOT prove: anything about a surface introduced by
+    something other than ``create_app()`` under these settings -- a reverse
+    proxy, a sidecar, or in-process ``dependency_overrides`` (see the module
+    docstring's stated bypasses). The inventory walk's own blind spot
+    (indirection outside ``curie_api``, a ``getattr``-resolved target) is
+    unchanged by this and is stated there too.
+    """
+
+    approval = _create_approval(approvals_client, auth_headers)
+    before_status = _status(approvals_client, approval["id"], auth_headers)
+    before_audit = _audit(approvals_client, approval["id"], auth_headers)
+    assert before_status == "pending"
+    assert before_audit == []
+
+    with _settings_env(
+        ENVIRONMENT="prod",
+        API_KEY=_PLATFORM_CREDENTIAL_VALUE,
+        GITHUB_WEBHOOK_SECRET=_WEBHOOK_VALUE,
+        CURIE_INTERNAL_WORKER_TOKEN=_WORKER_TOKEN_VALUE,
+        **{ATTESTER_ENV: _ATTESTER_VALUE},
+    ):
+        # The real factory, under real prod settings. `create_app()` reads
+        # `get_settings()` at build time, and the cache was just cleared, so
+        # every router this app mounts is the set a prod process mounts.
+        prod_app = create_app()
+        # Guard the guard: if the settings cache had not actually retargeted,
+        # this would be a second dev app wearing a prod label.
+        assert get_settings().environment == "prod"
+
+        # Take the inventory against the PROD app, not the dev one: a
+        # `if settings.environment == "prod"` router is precisely the shape the
+        # dev-time inventory cannot see.
+        prod_routes = list(_api_routes(prod_app))
+        assert len(prod_routes) > 50, len(prod_routes)
+        assert _mint_resolve_inventory(prod_app) == {
+            "mint_operator_principal": {"mint"},
+            "resolve_approval": {"resolve"},
+        }, _mint_resolve_inventory(prod_app)
+
+        with TestClient(prod_app) as prod_client:
+            # Probe 1 -- synthetic ACTION: "approve this" with no chat principal
+            # at all, the shape a harness verb would take if it ever leaked.
+            action_probe = prod_client.post(
+                f"/approvals/{approval['id']}/resolve",
+                json={"decision": "approved", "actor": SUBJECT, "principal": HARNESS_SUBMODULE},
+            )
+            # Probe 2 -- synthetic IDENTITY: a principal header that is a harness
+            # string rather than a minted, signed chat principal.
+            identity_probe = prod_client.post(
+                f"/approvals/{approval['id']}/resolve",
+                json={"decision": "approved"},
+                headers=_principal_headers(f"{HARNESS_DISTRIBUTION}-synthetic-principal"),
+            )
+
+    for label, response in (("action", action_probe), ("identity", identity_probe)):
+        assert response.status_code in (401, 403, 422), (
+            f"{label} probe: {response.status_code} {response.text}"
+        )
+
+    assert _status(approvals_client, approval["id"], auth_headers) == before_status
+    assert _audit(approvals_client, approval["id"], auth_headers) == before_audit

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -16,7 +16,6 @@ import contextlib
 import os
 import socket
 import threading
-import time
 from collections.abc import AsyncIterator, Callable, Iterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -38,6 +37,23 @@ from channel_protocol.reply import (
     SettledOutcome,
     TurnCompleted,
     TurnStatus,
+)
+from curie_test_support.interaction.harness import (
+    JOURNEY_ATTESTER_VALUE,
+    JOURNEY_ENV_KEYS,
+    JOURNEY_PLATFORM_CREDENTIAL,
+    ComposedApi,
+    JourneyEnv,
+    JourneyRecorder,
+    composed_api_server,
+    disposable_migrated_database,
+    journey_env,
+    resolve_client_factory,
+)
+from curie_test_support.interaction.harness import (
+    # Re-exported, not used here: the journey module reads it off this conftest
+    # by path. The redundant alias is what marks it as a deliberate re-export.
+    gated_call as gated_call,
 )
 from curie_test_support.valkey import (
     VALKEY_HOST as _VALKEY_HOST,
@@ -153,9 +169,7 @@ class FakeSink:
         # so this double records the intent, not blocks. The endpoint is the
         # transport the post is delivered through (#451): None means the worker's
         # default Slack transport.
-        self.posts: list[
-            tuple[str, OutboundMessage, str, str | None, str | None]
-        ] = []
+        self.posts: list[tuple[str, OutboundMessage, str, str | None, str | None]] = []
         # In-place edits of an already-posted message (settling the approval
         # card: expired in #419, resolved in #1084):
         # (channel, ts, message, endpoint, settled) per update_message. Like
@@ -829,12 +843,32 @@ async def kernel_harness(
                 await extra_server.close()
 
 
-# --- Composed approval-journey fixtures (interface pilot stage 2) -------------
+# --- Composed approval-journey fixtures (stage 2, delegating since stage 3) ---
 #
 # Everything below is ADDITIVE and explicitly requested: nothing here is
-# autouse. Only ``test_approval_journey_dev.py`` asks for these, because they
-# mutate process environment (``RUNS_STREAM``, ``DATABASE_URL``, the API's
-# Valkey parts) that every other kernel test in the session must not inherit.
+# autouse. Only the approval-journey modules ask for these, because they mutate
+# process environment (``RUNS_STREAM``, ``DATABASE_URL``, the API's Valkey
+# parts) that every other kernel test in the session must not inherit.
+#
+# The composition itself now lives in
+# ``curie_test_support.interaction.harness``: the disposable migrated database,
+# the journey environment (with the four traps its docstring records), the
+# composed loopback API, the real resolve-client factory, the action-ledger
+# recorder and the gated-call script all moved there WITH their explanatory
+# docstrings. What remains here are thin wrappers that yield from them, so the
+# journey module and the agent-facing harness drive ONE implementation. Mutate
+# the COMPOSITION in the harness -- the journey environment, the disposable
+# database, the composed loopback API, the resolve-client factory, the recorder
+# -- and these fixtures, and therefore every journey test, change with it; that
+# is the property the delegation exists to have, and a copy here would silently
+# lose it.
+#
+# What does NOT delegate, stated so the claim above is not read wider than it
+# is: the stage-2 click/submit DRIVERS are still local to the journey modules
+# (their own ``_card``/``_click``/``FakeSocketClient`` helpers). Mutating
+# ``InteractionHarness.act`` moves the harness's own contract tests and the D3
+# cases that call it, not those. The action path is shared only where a case
+# calls ``harness.act`` directly.
 #
 # The seam they build: the real ``curie_api`` app under a real uvicorn server on
 # a loopback ephemeral port, so the dispatcher's real ``ApprovalResolveClient``
@@ -845,50 +879,14 @@ async def kernel_harness(
 # real authorizer and the real enqueue) are composed
 # (apps/api/src/curie_api/main.py:78-95).
 
-
-# Test placeholders hoisted to constants (not inline literals) so the repo's
-# secret-shaped-literal gate does not trip on these quoted values.
-_JOURNEY_PLATFORM_CREDENTIAL = "journey-platform-api-key"
-# Deliberately DISTINCT from the platform key: sharing them is what
-# ``approval_auth.py:92-97`` refuses outright, and what ADR-0106 (#1531) exists
-# to prevent. ``config.py:430-431`` also refuses equal values at boot.
-_JOURNEY_ATTESTER_VALUE = "journey-chat-attester-secret"
-
-# Env vars the journey fixtures own. Snapshotted and restored as a unit so a
-# failed test cannot leak API settings into the rest of the session.
-_JOURNEY_ENV_KEYS = (
-    "RUNS_STREAM",
-    "CURIE_STREAM",
-    "VALKEY_URL",
-    "VALKEY_HOST",
-    "VALKEY_PORT",
-    "VALKEY_PASSWORD",
-    "API_KEY",
-    "CURIE_APPROVAL_CHAT_ATTESTER_SECRET",
-    # NOT ``CURIE_``-prefixed: ``Settings`` has no ``env_prefix`` and these two
-    # fields carry no ``validation_alias`` (config.py:237, :270), so pydantic-
-    # settings reads the bare field names. With ``extra="ignore"`` (config.py:35)
-    # a ``CURIE_``-prefixed key is silently dropped and the guard never binds.
-    "APPROVAL_SWEEP_INTERVAL_S",
-    "RESUME_RECONCILER_ENABLED",
-    # Owned per-test rather than left to the session fixture below, so this
-    # module can neither be broken by nor break ``apps/api/tests`` (which owns
-    # the same key, apps/api/tests/conftest.py:117-142) in one session.
-    "DATABASE_URL",
-    "S3_ENDPOINT_URL",
-    "S3_ACCESS_KEY",
-    "S3_SECRET_KEY",
-    "ENVIRONMENT",
-)
-
-
-@dataclass(frozen=True)
-class JourneyEnv:
-    """The credentials and stream the composed API booted with."""
-
-    api_key: str
-    attester_secret: str
-    runs_stream: str
+# Re-exported under their historical names because the journey module reads them
+# off THIS module by path (``--import-mode=importlib`` with no ``__init__.py``
+# means it cannot import the package helpers by name from a test module without
+# the same dance). The names are the import surface of this conftest; the bodies
+# are the harness's.
+_JOURNEY_PLATFORM_CREDENTIAL = JOURNEY_PLATFORM_CREDENTIAL
+_JOURNEY_ATTESTER_VALUE = JOURNEY_ATTESTER_VALUE
+_JOURNEY_ENV_KEYS = JOURNEY_ENV_KEYS
 
 
 @pytest.fixture
@@ -897,265 +895,31 @@ def approval_api_env(names: dict[str, str], approval_api_db: str) -> Iterator[Jo
 
     Not autouse, on purpose: ``RUNS_STREAM`` and the Valkey parts are process
     globals, and leaking them would retarget any later test that builds API
-    settings.
-
-    Two apps, two different names for one Valkey. The worker harness reads
-    ``curie_test_support.valkey``'s ``TEST_VALKEY_*`` constants, FROZEN at import
-    (valkey.py:19-21); the API reads its own ``valkey_host``/``valkey_port``/
-    ``valkey_password`` settings, which default to ``localhost:26379``
-    (config.py:197-199). On the isolated pilot stack (36379) that divergence
-    would leave the API writing the resume onto a DIFFERENT store -- or, worse,
-    onto a shared one where a pre-existing entry makes an assertion pass for the
-    wrong reason. So the parts are copied across from the frozen constants.
-
-    ``VALKEY_URL`` is DELETED rather than set: it wins outright over the parts
-    (config.py:404-406, #2315), so setting the parts underneath an inherited URL
-    is a silent no-op that re-opens exactly that trap.
-
-    ``DATABASE_URL`` is set HERE, per test, rather than being left to the
-    session-scoped ``approval_api_db``: that key is also owned by
-    ``apps/api/tests/conftest.py:117-142``, so a session that interleaves the two
-    suites would otherwise be order-dependent in both directions.
-
-    Both background loops the app would otherwise start are disabled. The expiry
-    sweeper (config.py:237, 30s) can flip a pending row mid-test and the resume
-    reconciler (config.py:270, enabled by default) can enqueue a SECOND resume,
-    either of which breaks "exactly one stream entry" for a reason that has
-    nothing to do with the code under test. Both are stage 3's to drive.
-
-    That disable is ASSERTED against the resolved ``Settings`` below, not merely
-    written into ``os.environ``: the keys are unprefixed field names and a future
-    rename (or a re-added ``CURIE_`` prefix) would otherwise drop them silently
-    under ``extra="ignore"`` and leave both loops running on every composed
-    server (main.py:146-167).
+    settings. Every trap this guards against -- the ``VALKEY_URL`` precedence
+    trap, the ``DATABASE_URL`` ownership collision with
+    ``apps/api/tests/conftest.py:117-142``, and the two disabled background loops
+    with their resolved-``Settings`` assertion -- is documented on
+    ``curie_test_support.interaction.harness.journey_env``, which this yields
+    from.
     """
 
-    previous = {key: os.environ.get(key) for key in _JOURNEY_ENV_KEYS}
-
-    os.environ["DATABASE_URL"] = approval_api_db
-    os.environ["RUNS_STREAM"] = names["stream"]
-    os.environ.pop("VALKEY_URL", None)
-    os.environ["VALKEY_HOST"] = _VALKEY_HOST
-    os.environ["VALKEY_PORT"] = str(_VALKEY_PORT)
-    os.environ["VALKEY_PASSWORD"] = _VALKEY_PW or ""
-    os.environ["API_KEY"] = _JOURNEY_PLATFORM_CREDENTIAL
-    os.environ["CURIE_APPROVAL_CHAT_ATTESTER_SECRET"] = _JOURNEY_ATTESTER_VALUE
-    os.environ["APPROVAL_SWEEP_INTERVAL_S"] = "0"
-    os.environ["RESUME_RECONCILER_ENABLED"] = "false"
-    # The lifespan calls ``BundleStore.ensure_bucket()``; the pilot stack serves
-    # RustFS on 39000. ``setdefault`` so an exported value wins, mirroring
-    # apps/api/tests/conftest.py:41-42.
-    os.environ.setdefault("S3_ENDPOINT_URL", "http://localhost:39000")
-    os.environ.setdefault("S3_ACCESS_KEY", "rustfs")
-    os.environ.setdefault("S3_SECRET_KEY", "rustfssecret")
-    # ``dev``: the prod boot gate (config.py:422) is Stream C's subject, not this
-    # module's, and an inherited ENVIRONMENT=prod would refuse boot here.
-    os.environ["ENVIRONMENT"] = "dev"
-
-    # Every mutation above precedes the cache clear, which precedes any
-    # ``create_app()``: ``get_settings`` is ``lru_cache``d, so building the app
-    # first and mutating after is a silent no-op.
-    from curie_api.config import get_settings
-
-    get_settings.cache_clear()
-    try:
-        # The guards above are only real if they BIND. Resolve the settings the
-        # app is about to be built from and check the values, so a rename, a
-        # re-added prefix or an inherited ``.env`` fails here with a clear
-        # message instead of silently re-arming a background loop or pointing
-        # the API at a second Valkey.
-        settings = get_settings()
-        assert settings.approval_sweep_interval_s <= 0, (
-            "the expiry sweeper is NOT disabled: APPROVAL_SWEEP_INTERVAL_S did "
-            f"not bind (resolved {settings.approval_sweep_interval_s!r}). "
-            "main.py:146-167 starts the loop on every composed server."
-        )
-        assert settings.resume_reconciler_enabled is False, (
-            "the resume reconciler is NOT disabled: RESUME_RECONCILER_ENABLED "
-            f"did not bind (resolved {settings.resume_reconciler_enabled!r})."
-        )
-        # ``VALKEY_URL`` popped from ``os.environ`` is not enough: ``Settings``
-        # also reads ``env_file=".env"`` (config.py:35) and a URL from there wins
-        # outright over the parts (config.py:404-406, #2315). Assert the RESOLVED
-        # dsn, which is the only thing that closes the two-Valkey trap.
-        assert not settings.valkey_url, (
-            "VALKEY_URL is set (most likely from a .env file) and wins over the "
-            "host/port parts, so the API would write the resume to a different "
-            f"store than the worker reads: {settings.valkey_url!r}"
-        )
-        assert settings.valkey_host == _VALKEY_HOST and settings.valkey_port == _VALKEY_PORT, (
-            "the API is pointed at a different Valkey than the worker harness: "
-            f"{settings.valkey_dsn()!r} vs {_VALKEY_HOST}:{_VALKEY_PORT}"
-        )
-        yield JourneyEnv(
-            api_key=_JOURNEY_PLATFORM_CREDENTIAL,
-            attester_secret=_JOURNEY_ATTESTER_VALUE,
-            runs_stream=names["stream"],
-        )
-    finally:
-        for key, value in previous.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
-        get_settings.cache_clear()
+    with journey_env(runs_stream=names["stream"], database_url=approval_api_db) as env:
+        yield env
 
 
 @pytest.fixture(scope="session")
 def approval_api_db() -> Iterator[str]:
     """A disposable, migrated database, and the URL every reader must use.
 
-    Recipe from apps/api/tests/conftest.py:127-143 (create / ``alembic upgrade
-    head`` / drop). Migrating is not optional: the app lifespan calls
-    ``assert_servable()``, which refuses to boot against an unmigrated schema
-    with "database schema None is below application min ...".
-
-    Not autouse, and it hands back the URL rather than leaving ``DATABASE_URL``
-    set, so the API app, the direct row assertions and the AC3 seeding provably
-    read ONE database rather than three that merely look alike. ``DATABASE_URL``
-    is set only for the duration of the migration and then RESTORED: the
-    function-scoped ``approval_api_env`` re-sets it per test. Holding it for the
-    whole session would make an interleaved run with ``apps/api/tests`` (which
-    owns the same key, apps/api/tests/conftest.py:117-142) order-dependent.
+    Session-scoped so one migration serves the whole run; the per-test
+    ``DATABASE_URL`` is set by ``approval_api_env`` above, which is what keeps an
+    interleaved run with ``apps/api/tests`` order-independent. See
+    ``disposable_migrated_database`` for the recipe and why migrating is not
+    optional.
     """
 
-    import asyncio as _asyncio
-    import secrets
-    from datetime import UTC as _UTC
-    from datetime import datetime as _datetime
-    from pathlib import Path
-
-    import asyncpg
-    from alembic import command
-    from alembic.config import Config
-    from curie_api.config import get_settings
-    from sqlalchemy import make_url
-
-    base_url = os.environ.get(
-        "TEST_DATABASE_URL",
-        "postgresql+asyncpg://postgres:postgres@localhost:25432/postgres",
-    )
-    base = make_url(base_url)
-    run_db = f"curie_journey_{_datetime.now(_UTC).strftime('%Y%m%d%H%M%S')}_{secrets.token_hex(3)}"
-
-    async def _admin(sql: str) -> None:
-        conn = await asyncpg.connect(
-            user=base.username,
-            password=base.password,
-            host=base.host,
-            port=base.port,
-            database="postgres",
-        )
-        try:
-            await conn.execute(sql)
-        finally:
-            await conn.close()
-
-    _asyncio.run(_admin(f'CREATE DATABASE "{run_db}"'))
-    url = base.set(database=run_db).render_as_string(hide_password=False)
-    previous = os.environ.get("DATABASE_URL")
-    os.environ["DATABASE_URL"] = url
-    get_settings.cache_clear()
-    try:
-        # Inside the try so a failed migration still drops the database.
-        alembic_dir = Path(__file__).resolve().parents[3] / "api" / "alembic"
-        cfg = Config()
-        cfg.set_main_option("script_location", str(alembic_dir))
-        command.upgrade(cfg, "head")
-        # Hand the key back the moment the migration no longer needs it.
-        _restore_database_url(previous)
-        get_settings.cache_clear()
+    with disposable_migrated_database() as url:
         yield url
-    finally:
-        _asyncio.run(_admin(f'DROP DATABASE IF EXISTS "{run_db}" WITH (FORCE)'))
-        _restore_database_url(previous)
-        get_settings.cache_clear()
-
-
-def _restore_database_url(previous: str | None) -> None:
-    if previous is None:
-        os.environ.pop("DATABASE_URL", None)
-    else:
-        os.environ["DATABASE_URL"] = previous
-
-
-@dataclass(frozen=True)
-class ComposedApi:
-    """A live loopback API: its base URL and the port it is bound to."""
-
-    base_url: str
-    port: int
-
-
-@contextlib.contextmanager
-def composed_api_server(*, startup_timeout_s: float = 30.0) -> Iterator[ComposedApi]:
-    """Run the REAL ``curie_api`` app on a loopback ephemeral port.
-
-    Exposed as a context manager as well as the ``approval_api_server`` fixture
-    because AC-SEC3 has to observe the port AFTER teardown, which a fixture the
-    test is still inside cannot do.
-
-    The port is picked by binding 0 and closing the probe socket rather than by
-    reading it back off ``server.servers[0].sockets[0]``: the client and the
-    AC-SEC3 assertion both need the number, and a pre-picked port is available
-    before the server thread exists. The narrow race (something else grabbing
-    the port in between) fails loudly as a bind error, never silently.
-
-    A lifespan failure (unmigrated schema, unreachable RustFS) means the server
-    never reports ``started``; the captured exception is re-raised here so the
-    test says what actually broke instead of timing out into a confusing
-    connection-refused.
-    """
-
-    import uvicorn
-    from curie_api.config import get_settings
-    from curie_api.main import create_app
-
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
-        probe.bind(("127.0.0.1", 0))
-        port = int(probe.getsockname()[1])
-
-    get_settings.cache_clear()
-    server = uvicorn.Server(
-        uvicorn.Config(
-            create_app(),
-            host="127.0.0.1",
-            port=port,
-            log_level="warning",
-            lifespan="on",
-        )
-    )
-    failure: list[BaseException] = []
-
-    def _serve() -> None:
-        try:
-            server.run()
-        except BaseException as exc:  # noqa: BLE001 - surfaced below, not swallowed
-            failure.append(exc)
-
-    thread = threading.Thread(target=_serve, name=f"journey-api-{port}", daemon=True)
-    thread.start()
-    try:
-        deadline = time.monotonic() + startup_timeout_s
-        while not server.started:
-            if failure:
-                raise AssertionError(
-                    f"the composed API failed to start on port {port}: {failure[0]!r}"
-                ) from failure[0]
-            if not thread.is_alive():
-                raise AssertionError(
-                    f"the composed API server thread exited before starting on port {port}"
-                )
-            if time.monotonic() > deadline:
-                raise AssertionError(
-                    f"the composed API did not start within {startup_timeout_s}s on port {port}"
-                )
-            time.sleep(0.02)
-        yield ComposedApi(base_url=f"http://127.0.0.1:{port}", port=port)
-    finally:
-        server.should_exit = True
-        thread.join(timeout=startup_timeout_s)
-        assert not thread.is_alive(), f"the composed API on port {port} did not shut down"
 
 
 @pytest.fixture
@@ -1183,111 +947,10 @@ def composed_resolver_factory(
     what this module exists NOT to use.
     """
 
-    from curie_dispatcher.approval_actions import ApprovalResolveClient
-
-    built: list[Any] = []
-
-    def factory(**overrides: Any) -> Any:
-        kwargs: dict[str, Any] = {
-            "api_base_url": approval_api_server.base_url,
-            "api_key": approval_api_env.api_key,
-            "approval_chat_attester_secret": approval_api_env.attester_secret,
-        }
-        kwargs.update(overrides)
-        client = ApprovalResolveClient(**kwargs)
-        built.append(client)
-        return client
-
-    yield factory
-
-    # The class owns its default ``httpx.Client`` and exposes no ``close()``
-    # (approval_actions.py:262), so nothing else would ever release the
-    # connection pool. AC5 builds two of these per run.
-    for client in built:
-        with contextlib.suppress(Exception):
-            client._client.close()
-
-
-# --- The action ledger recorder and its gated-tool script --------------------
-#
-# Redeclared from apps/worker/tests/kernel/test_action_ledger.py:37 (FakeRecorder)
-# and :76 (_call), NOT moved: that module is not in this PR's file list and
-# hoisting its helpers here would silently change its import surface. It stays
-# byte-identical and green, which is what keeps the duplication from drifting
-# unnoticed.
-#
-# Why a recorder at all: ``kernel_harness`` defaults ``actions=None`` and
-# ``FakeRunner.default_script`` is a bare ``Final`` (conftest.py:464), so with
-# neither a recorder nor a gated tool call, BOTH "zero side effects" and
-# "exactly one side effect" are assertions that cannot fail.
-
-
-@dataclass
-class JourneyRecorder:
-    """Records the calls the kernel makes to the action ledger (ADR-0117)."""
-
-    recorded: list[dict[str, Any]] = field(default_factory=list)
-    completed: list[tuple[str, Any]] = field(default_factory=list)
-
-    async def record(
-        self,
-        frame: Any,
-        *,
-        event_id: str,
-        conversation_id: str,
-        agent_id: str | None,
-        gate_approval_id: str | None = None,
-    ) -> Any:
-        from curie_worker.actions import RecordedAction
-
-        self.recorded.append(
-            {
-                "frame": frame,
-                "event_id": event_id,
-                "conversation_id": conversation_id,
-                "agent_id": agent_id,
-                "gate_approval_id": gate_approval_id,
-            }
-        )
-        return RecordedAction(id=f"a{len(self.recorded)}", status="pending")
-
-    async def complete(self, action_id: str, frame: Any) -> dict[str, Any]:
-        self.completed.append((action_id, frame))
-        return {
-            "tool": frame.tool,
-            "result": frame.result,
-            "detail": frame.detail,
-            "status": "failed" if frame.failed else "succeeded",
-            "undoable": bool(frame.result and frame.result.get("prior")),
-        }
+    with resolve_client_factory(approval_api_server, approval_api_env) as factory:
+        yield factory
 
 
 @pytest.fixture
 def journey_recorder() -> JourneyRecorder:
     return JourneyRecorder()
-
-
-def gated_call(call_id: str, tool: str = "scale_deployment") -> list[OutboundEvent]:
-    """The two frames one side-effecting tool call produces.
-
-    Mirrors test_action_ledger.py:76-95. A runner script containing one of these
-    is what makes ``len(recorder.recorded) == 1`` mutation-sensitive.
-    """
-
-    from aci_protocol import SideEffectFlag
-
-    return [
-        SideEffectFlag(
-            tool=tool,
-            call_id=call_id,
-            arguments={"replicas": 10},
-            detail="non-idempotent tool executed",
-        ),
-        SideEffectFlag(
-            tool=tool,
-            call_id=call_id,
-            failed=False,
-            result={"ok": True, "prior": {"spec": {"replicas": 3}}},
-            detail="non-idempotent tool completed",
-        ),
-    ]

--- a/apps/worker/tests/kernel/test_approval_journey_dev.py
+++ b/apps/worker/tests/kernel/test_approval_journey_dev.py
@@ -15,11 +15,17 @@ stream -> the real worker ``Consumer`` and ``Kernel``.
 
 HONEST LABELLING -- what this module does NOT prove:
 
-    This module proves API/worker/dispatcher behavior only. The runner is the
-    existing in-process ``FakeRunner`` fake (apps/worker/tests/kernel/conftest.py)
-    and Slack is the existing ``FakeSocketClient`` + mocked ``WebClient``. It does
-    not prove real-runner or real-Slack behavior. Stage 3 connects the real
-    runner. Three smaller stand-ins sit beside them, all on the Slack/kernel
+    This module proves API/worker/dispatcher behavior only, with ONE stated
+    exception. Every journey below EXCEPT
+    ``test_d2_the_completed_journey_runs_against_the_real_runner`` drives the
+    existing in-process ``FakeRunner`` fake (apps/worker/tests/kernel/conftest.py);
+    that one test builds the REAL ``curie_runner`` through the real boot path
+    (``build_runner(config, fake_model=True)`` -> ``create_app``) and serves it
+    through ``kernel_harness(runner_app=...)``, so the frames the ledger records
+    there are production ACI frames rather than a scripted fake's. Only the MODEL
+    is faked on that path. Slack remains the existing ``FakeSocketClient`` +
+    mocked ``WebClient`` everywhere, so no test here proves real-Slack behavior.
+    Three smaller stand-ins sit beside them, all on the Slack/kernel
     edges rather than in the journey itself: ``_authorize`` (Bolt's workspace
     authorization lookup), ``JourneyRecorder`` (the action-ledger recorder) and
     ``_RecordingApprovals`` (the kernel's ``ApprovalCreator``, used only where a
@@ -53,7 +59,7 @@ import sys
 import threading
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -178,24 +184,126 @@ def test_the_imported_dispatcher_fakes_are_the_real_ones() -> None:
 # wrong reason.
 
 
-def test_the_isolated_pilot_stack_is_what_we_are_running_against() -> None:
-    assert os.environ.get("CI_REQUIRE_VALKEY_TESTS"), (
+def _assert_the_stack_is_deliberately_chosen_and_empty(
+    *,
+    env: Mapping[str, str],
+    frozen_valkey_port: int,
+    stream: str,
+    sync_redis: redis.Redis,
+) -> None:
+    """The module's precondition, as ONE callable so it can be proven fallible.
+
+    D4: this replaces a pair of literals (``TEST_VALKEY_PORT == "36379"`` and
+    ``VALKEY_PORT == 36379``) that pinned the module to stage 2's private compose
+    stack. Those literals made the module fail on CI (Valkey 26379) and on every
+    other developer's machine, while proving nothing the properties below do not.
+    NOTHING is weakened: each of the four original guarantees is still asserted,
+    and the "isolated" property the port number was standing in for is now
+    asserted DIRECTLY -- as an empty, per-run namespace -- rather than inferred
+    from which compose stack happens to be up.
+
+    It takes ``env`` and the frozen port as parameters rather than reading
+    globals so the two negative tests below can drive it into failure. A guard
+    that cannot be made to fail is exactly the defect being fixed here.
+    """
+
+    assert env.get("CI_REQUIRE_VALKEY_TESTS"), (
         "CI_REQUIRE_VALKEY_TESTS must be set: without it an unreachable Valkey "
-        "SKIPS instead of failing, and this module's whole claim is that the "
-        "journey actually ran."
+        "SKIPS instead of failing (#1755), and this module's whole claim is "
+        "that the journey actually ran."
     )
-    assert os.environ.get("TEST_VALKEY_PORT") == "36379", (
-        "this module must run against the isolated pilot stack's Valkey on "
-        f"36379, not {os.environ.get('TEST_VALKEY_PORT')!r}; the constants are "
-        "frozen at import (curie_test_support/valkey.py:19-21), so no fixture "
-        "can retarget the worker afterwards."
+    chosen = env.get("TEST_VALKEY_PORT")
+    assert chosen, (
+        "TEST_VALKEY_PORT is unset, so nobody CHOSE a store and the worker fell "
+        "back to the localhost:26379 default. Bring up a Curie dev stack and "
+        "export the Valkey port it publishes (the repo's compose stack, or the "
+        "isolated pilot stack) before running this module."
     )
-    assert "VALKEY_URL" not in os.environ, (
+    assert frozen_valkey_port == int(chosen), (
+        "the worker's Valkey constants are FROZEN at import "
+        "(curie_test_support/valkey.py:19-21), so a fixture that retargets "
+        "TEST_VALKEY_PORT afterwards is a silent no-op and the two halves of "
+        f"the journey would use two different stores: frozen {frozen_valkey_port!r} "
+        f"vs TEST_VALKEY_PORT {chosen!r}. This agreement -- not any particular "
+        "port number -- is the property."
+    )
+    assert "VALKEY_URL" not in env, (
         "VALKEY_URL wins outright over the host/port parts (config.py:404-406), "
         "so with it set the API would write the resume to a different store "
         "than the worker reads."
     )
-    assert VALKEY_PORT == 36379
+    # What "isolated pilot stack" actually bought, asserted rather than implied.
+    # The per-test ``names`` fixture mints a fresh uuid4 hex per test, so this is
+    # unique to THIS run even when two of these tests share a process; and the
+    # namespace being EMPTY is what stops a pre-existing entry on a shared stack
+    # from making a later assertion pass for the wrong reason.
+    prefix, _, token = stream.rpartition(":")
+    assert prefix == "test:curie:runs", (
+        f"the run's stream {stream!r} is not in this suite's per-test namespace "
+        "(apps/worker/tests/conftest.py:40-46); without that namespace two runs "
+        "on one store would read each other's entries."
+    )
+    uuid.UUID(hex=token)  # raises if the token is not a per-run uuid4 hex
+    assert sync_redis.exists(stream) == 0, (
+        f"the run's stream {stream!r} already has entries before the test wrote "
+        "anything, so every 'exactly one entry' assertion in this module could "
+        "be satisfied by somebody else's data."
+    )
+
+
+def test_the_stack_we_are_running_against_was_deliberately_chosen_and_is_empty(
+    names: dict[str, str], sync_redis: redis.Redis
+) -> None:
+    """The positive control: the real environment satisfies the guard."""
+
+    _assert_the_stack_is_deliberately_chosen_and_empty(
+        env=os.environ,
+        frozen_valkey_port=VALKEY_PORT,
+        stream=names["stream"],
+        sync_redis=sync_redis,
+    )
+
+
+def test_the_stack_guard_fails_when_the_env_disagrees_with_the_frozen_port(
+    names: dict[str, str], sync_redis: redis.Redis
+) -> None:
+    """Negative control 1: the agreement check is real.
+
+    The frozen constant is read at IMPORT of ``curie_test_support.valkey``; an
+    environment that says a different port describes a store the worker will
+    never talk to. This is the exact shape the old literal could not catch on a
+    machine whose stack simply ran elsewhere.
+    """
+
+    disagreeing = {**os.environ, "TEST_VALKEY_PORT": str(VALKEY_PORT + 1)}
+
+    with pytest.raises(AssertionError, match="FROZEN at import"):
+        _assert_the_stack_is_deliberately_chosen_and_empty(
+            env=disagreeing,
+            frozen_valkey_port=VALKEY_PORT,
+            stream=names["stream"],
+            sync_redis=sync_redis,
+        )
+
+
+def test_the_stack_guard_fails_when_the_run_namespace_is_not_empty(
+    names: dict[str, str], sync_redis: redis.Redis
+) -> None:
+    """Negative control 2: the emptiness check is real.
+
+    Seeded on the run's OWN stream, which the ``names`` fixture deletes on
+    teardown, so this test leaves nothing behind for the next one.
+    """
+
+    sync_redis.xadd(names["stream"], {"payload": "somebody else's entry"})
+
+    with pytest.raises(AssertionError, match="already has entries"):
+        _assert_the_stack_is_deliberately_chosen_and_empty(
+            env=os.environ,
+            frozen_valkey_port=VALKEY_PORT,
+            stream=names["stream"],
+            sync_redis=sync_redis,
+        )
 
 
 # --- Shared journey scaffolding ----------------------------------------------
@@ -1598,3 +1706,190 @@ def test_ac_sec3_the_composed_port_refuses_connections_after_teardown(
         # make this step vacuous, since a 404 proves the server is alive just as
         # well as a 200 does, and only the ConnectError is the claim.
         client.get(f"http://127.0.0.1:{port}/health")
+
+
+# --- D2: the completed journey, against the REAL runner ----------------------
+#
+# Everything above dials the tiny in-process ``FakeRunner`` (conftest.py:~432),
+# whose "frames" are whatever the test scripted. This block builds the REAL
+# ``curie_runner`` through its real boot path with only the MODEL faked
+# (``build_runner(config, fake_model=True)`` -> ``create_app``, the pattern
+# test_runner_client.py:23-26 and runner/tests/test_server.py:62-95 already use)
+# and serves it through the ``runner_app=`` parameter ``kernel_harness`` already
+# has (conftest.py:721, added by f57c9232 for exactly this reason). No new seam.
+
+
+def _real_runner_bundle(tmp_path: Path) -> Any:
+    """A minimal real bundle, so ``build_runner`` takes its production path.
+
+    ``RunnerConfig.from_env`` + a ``.claude-plugin/plugin.json`` manifest is the
+    real boot input; the runner compiles the bundle, wires the side-effect
+    classifier and the session loop from it. Copied in shape from
+    runner/tests/test_server.py:62-95 rather than invented here.
+    """
+
+    from curie_runner.config import RunnerConfig
+
+    plugin_dir = tmp_path / "bundle"
+    (plugin_dir / ".claude-plugin").mkdir(parents=True)
+    (plugin_dir / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "journey-bot"}), encoding="utf-8"
+    )
+    return RunnerConfig.from_env(
+        {
+            "CURIE_PLUGIN_DIR": str(plugin_dir),
+            "CURIE_SESSION_ID": f"journey-{uuid.uuid4().hex[:8]}",
+            "CURIE_SANDBOX_ID": f"journey-sandbox-{uuid.uuid4().hex[:8]}",
+            "CURIE_BUDGET": '{"max_output_tokens_per_run": 10000, "max_usd_per_day": 1.0}',
+        }
+    )
+
+
+def test_d2_the_completed_journey_runs_against_the_real_runner(
+    make_harness: Any,
+    api: Any,
+    composed_resolver_factory: Any,
+    journey_recorder: Any,
+    sync_redis: redis.Redis,
+    tmp_path: Path,
+) -> None:
+    """The AC2 happy path again, with the REAL runner behind the kernel.
+
+    Substituting ``FakeRunner`` back breaks this test in three independent
+    places, which is what makes it a real-runner proof rather than a second copy
+    of AC2:
+
+    * the ledger frame's ``tool``/``call_id`` are ``Bash``/``t1``, produced by
+      the real ``SideEffectClassifier`` over the fake MODEL's scripted tool use
+      (runner/src/curie_runner/fake.py:69-82). ``FakeRunner`` emits only the
+      frames a test scripts into ``default_script``, and this test scripts NONE;
+    * the delivered text is the real session loop's final (``all done``), again
+      unscripted here;
+    * the real ``SessionRunner`` is asserted to have run the resume turn through
+      its state machine and to have settled on the status the turn's own final
+      carried, with the turn closed. ``FakeRunner`` has no ``SessionRunner`` at
+      all, so the reference the assertions below read does not exist on that
+      path.
+
+    Every bound here is taken from ``h.config.runner_total_timeout_s`` -- the
+    same value that drives the worker's ``RunnerClient`` budget (conftest.py's
+    ``kernel_harness``) -- rather than from a fresh magic number, because the
+    real state machine is slower than the fake and #2011 makes these bounds
+    load-bearing evidence rather than padding.
+    """
+
+    from curie_runner import create_app
+    from curie_runner.__main__ import build_runner
+
+    runner = build_runner(_real_runner_bundle(tmp_path), fake_model=True)
+
+    async def go() -> None:
+        await runner.start()
+        # The fake MODEL session is the only fake in the runner. Its recorded
+        # queries are how this test proves the real turn loop ran twice.
+        session = runner._session  # noqa: SLF001 - the model seam is the assertion
+        assert session.queries == []
+
+        created = api.create_approval()
+        approval_id = created["id"]
+        card = _card(approval_id, allow_free_text=True)
+        approve = _buttons(card)[0]
+
+        async with make_harness(actions=journey_recorder, runner_app=create_app(runner)) as h:
+            bound = h.config.runner_total_timeout_s
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            app, web_client = _build_dispatcher(
+                _dispatcher_config(h.config.stream),
+                sync_redis,
+                composed_resolver_factory(),
+            )
+            web_client.conversations_replies = MagicMock(  # type: ignore[method-assign]
+                return_value={"messages": [card]}
+            )
+            handler = SocketModeHandler(app, app_token="xapp-test")
+
+            handler.handle(
+                FakeSocketClient(),
+                _click(
+                    "env-real-runner-click",
+                    card=card,
+                    button=approve,
+                    user=_APPROVER,
+                    channel=_APPROVERS_CHANNEL,
+                ),
+            )
+            _wait_for(
+                lambda: bool(web_client.views_open.call_args),
+                what="the note modal to be opened after the click",
+                timeout=bound,
+            )
+            metadata = web_client.views_open.call_args.kwargs["view"]["private_metadata"]
+
+            submit = FakeSocketClient()
+            handler.handle(
+                submit,
+                _view_submission(
+                    "env-real-runner-submit",
+                    private_metadata=metadata,
+                    user=_APPROVER,
+                    note=_NOTE_TEXT,
+                ),
+            )
+            _wait_for(
+                lambda: bool(web_client.chat_update.call_args),
+                what="the resolved card to be stamped after the submission",
+                timeout=bound,
+            )
+            _drain(app, timeout=bound)
+            assert submit.ack_payload_for("env-real-runner-submit") is None
+            assert api.approval(approval_id)["status"] == "approved"
+
+            turns = await _stream_entries(h)
+            assert len(turns) == 1, turns
+            assert turns[0].event_id == resume_event_id(approval_id)
+
+            # ``all done`` is the REAL session loop's final text for the fake
+            # model's default turn; nothing in this test scripted it.
+            await _consume_the_resume(
+                h,
+                consumer=consumer,
+                event_id=turns[0].event_id,
+                expect_text="all done",
+            )
+
+            # The ledger frame came out of the real runner's own side-effect
+            # classification, not out of ``gated_call``.
+            assert len(journey_recorder.recorded) == 1, journey_recorder.recorded
+            frame = journey_recorder.recorded[0]["frame"]
+            assert frame.tool == "Bash", (
+                "the recorded frame did not come from the real runner's "
+                f"SideEffectClassifier over the fake model's scripted turn: {frame!r}"
+            )
+            assert frame.call_id == "t1"
+            assert journey_recorder.recorded[0]["event_id"] == turns[0].event_id
+
+        # The real turn state machine, after the harness has released the
+        # server: two turns went through ``SessionRunner.run_turn`` (the original
+        # mention is not part of this journey, so the queries are the resume turn
+        # and nothing else), and it came back to rest rather than being left
+        # mid-turn.
+        assert len(session.queries) == 1, session.queries
+        assert _NOTE_TEXT in session.queries[0], (
+            "the resume turn the real runner ran did not carry the approver's "
+            f"note, so the journey did not reach the model seam: {session.queries!r}"
+        )
+        # CORRECTED to the runner's real terminal state. ``IDLE_AWAITING_INPUT``
+        # was wrong about the product: ``SessionRunner`` adopts the turn's own
+        # final status (session.py:1033, ``self._status = final.status``), and
+        # the fake model's default turn ends in a ``ResultMessage`` whose final
+        # is ``DONE`` (runner/src/curie_runner/fake.py:68-84) -- the same "all
+        # done" text this test already pins above. ``IDLE_AWAITING_INPUT`` is
+        # what an INTERRUPTED or non-terminal turn settles on (session.py:1015),
+        # which this journey is not.
+        assert runner.status is SessionStatus.DONE
+        assert runner.ready is True
+        assert runner._turn_open is False  # noqa: SLF001 - the state machine is the assertion
+
+    asyncio.run(go())

--- a/apps/worker/tests/kernel/test_approval_journey_failures_dev.py
+++ b/apps/worker/tests/kernel/test_approval_journey_failures_dev.py
@@ -1,0 +1,931 @@
+"""The failure half of the approval journey (D3) -- the seven cases stage 2 deferred.
+
+Stage 2 (``test_approval_journey_dev.py``) proved the journey's SUCCESS paths and
+five refusals (duplicate click, concurrent click, tampered / expired / mismatched
+principal, wrong channel, unauthorized actor). None of those are re-implemented
+here. This module adds SIX of the seven cases it deferred, each driven through
+the same real API / worker / dispatcher / Postgres / Valkey composition, and each
+carrying a POSITIVE control plus a comment naming the exact mutation that must
+break it. The seventh -- note-modal validation failure -- is not provable in this
+stage and is NOT claimed as covered; see the UNMET PROOF note below, and case 4,
+which characterises the shipped behavior instead.
+
+Every case is driven honestly, which for the two background loops means
+something specific. ``approval_api_env`` DISABLES the expiry sweeper and the
+resume reconciler (conftest.py, ``APPROVAL_SWEEP_INTERVAL_S=0`` /
+``RESUME_RECONCILER_ENABLED=false``) because a live loop can flip a row or
+enqueue a second resume mid-test. So the two cases about those loops invoke the
+PRODUCTION code exactly once, directly, using the LIVE ``app.state`` objects the
+running server's lifespan composed (its sessionmaker, its ``ResumeQueue``, and
+for case 3 the ``ResumeReconciler`` instance itself), driven on the server's own
+event loop. What those cases do NOT do is assert ``x is module.x`` for a name
+they imported themselves: that check cannot fail and proves nothing. The pins
+they carry instead walk the chain the app walks at runtime -- ``lifespan``'s own
+bytecode still naming the scheduled callable, ``curie_api.main`` resolving that
+global to the production module's object, and the loop's bytecode still naming
+the function under test -- so a rename or a wrapper anywhere on that chain
+breaks one of them rather than leaving a stale local copy passing.
+
+UNMET PROOF: note-modal *validation* failure cannot be proven, because no
+server-side note validation exists. ``build_note_modal`` declares the note input
+``optional`` with ``max_length=_NOTE_MAX_LENGTH`` (approval_actions.py:522-565),
+but that bound is a Block Kit CLIENT-side constraint: the submit handler
+(``resolve_note_submission``, approval_actions.py:647-717) reads the note, strips
+it and posts it, and ``ApprovalResolve.note`` on the API side is an unconstrained
+``str | None`` (schemas.py:1559-1566). Adding such validation is a production
+``src/`` change and is out of this stage's authority, so case 4 is NOT covered
+here and is not claimed as covered anywhere. It is tracked as a gap in the
+stage-3 handoff. What case 4 carries instead is a CHARACTERISATION test of the
+behavior that actually ships today, named so it cannot be mistaken for a
+validation proof.
+
+Placement and the import dance mirror ``test_approval_journey_dev.py``: under
+``--import-mode=importlib`` with no ``__init__.py`` a test module cannot import a
+sibling's helpers by name, so the stage-2 module is loaded BY PATH and its
+helpers are reused rather than forked. Forking ``_card`` / ``_click`` /
+``_view_submission`` / ``_refusal_assertions`` would let this module drift away
+from the renders and envelopes stage 2 pins.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import redis
+from curie_api.resumequeue import resume_event_id
+from curie_dispatcher.approval_actions import NOTE_MODAL_CALLBACK_ID
+from fastapi import Request
+from slack_bolt.adapter.socket_mode import SocketModeHandler
+from slack_sdk.socket_mode.request import SocketModeRequest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+
+def _module_from_path(path: Path, name: str) -> Any:
+    """Import one file as a module, by path, reusing an already-imported one.
+
+    Deliberately a local copy of ``test_approval_journey_dev.py``'s helper: that
+    module is the thing being loaded, so it cannot also be the source of the
+    loader. Everything else below comes from it rather than being redeclared.
+    """
+
+    for module in list(sys.modules.values()):
+        file = getattr(module, "__file__", None)
+        if file and Path(file).resolve() == path:
+            return module
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_JOURNEY = _module_from_path(
+    Path(__file__).resolve().parent / "test_approval_journey_dev.py",
+    "_journey_stage_two",
+)
+
+_card = _JOURNEY._card
+_buttons = _JOURNEY._buttons
+_click = _JOURNEY._click
+_view_submission = _JOURNEY._view_submission
+_drain = _JOURNEY._drain
+_wait_for = _JOURNEY._wait_for
+_stream_entries = _JOURNEY._stream_entries
+_build_dispatcher = _JOURNEY._build_dispatcher
+_dispatcher_config = _JOURNEY._dispatcher_config
+FakeSocketClient = _JOURNEY.FakeSocketClient
+_APPROVERS_CHANNEL = _JOURNEY._APPROVERS_CHANNEL
+_APPROVER = _JOURNEY._APPROVER
+_NOTE_TEXT = _JOURNEY._NOTE_TEXT
+_DB_SCHEMA = _JOURNEY._DB_SCHEMA
+
+# The agent-facing harness Stream A is building. Imported at module scope on
+# purpose: if it is missing, every test in this module errors loudly rather than
+# silently falling back to the stage-2 composition it exists to replace.
+from curie_test_support.interaction import (  # noqa: E402 - see the comment above
+    InteractionHarness,
+    UncapturedAction,
+)
+
+
+@pytest.fixture
+def api(approval_api_server: Any, approval_api_env: Any) -> Any:
+    """The composed API's read/write helper, reused from stage 2 by path.
+
+    Stage 2 declares this fixture in its own module body, and a fixture declared
+    in a test module is visible only to that module -- which is why every case
+    here that asked for ``api`` errored with "fixture 'api' not found". Declared
+    here over the SAME ``_Api`` class rather than forked, for the reason the
+    module docstring gives: a copy would drift from the routes stage 2 pins.
+    """
+
+    helper = _JOURNEY._Api(approval_api_server.base_url, approval_api_env.api_key)
+    try:
+        yield helper
+    finally:
+        helper.close()
+
+
+# Bounds. Every blocking call in this module carries one: the threaded uvicorn
+# server, the Bolt listener executor and the real consumer are all hang
+# surfaces, and a hang reports nothing at all in the run report.
+_DEADLINE_S = 20.0
+
+
+def _server_loop(composed: Any, api_key: str) -> asyncio.AbstractEventLoop:
+    """The event loop the uvicorn thread is actually serving this app on.
+
+    Every object the lifespan composed -- ``app.state.sessionmaker`` and its
+    asyncpg pool, ``app.state.resume_queue``'s async redis client,
+    ``app.state.resume_reconciler`` -- belongs to THAT loop; awaiting one from a
+    loop of this test's own dies with "got Future attached to a different loop".
+    The loop is not reachable off the app object, so it is captured through the
+    seam FastAPI provides for exactly this: ``dependency_overrides`` wraps the
+    production ``get_session`` for the duration of ONE ordinary request (a GET
+    of an approval id that does not exist -- the dependency runs before the
+    handler, so a 404 is a fine carrier), the wrapper reads
+    ``asyncio.get_running_loop()`` and then delegates to the real dependency,
+    and the override is removed again in a ``finally``. No route is added, no
+    production module is patched, and the only thing the wrapper does beyond
+    delegating is read the loop.
+
+    Cached on ``app.state`` so a second caller does not re-run the probe.
+    """
+
+    from curie_api.deps import get_session
+
+    cached = getattr(composed.app.state, "journey_server_loop", None)
+    if cached is not None:
+        return cached  # type: ignore[no-any-return]
+
+    captured: dict[str, asyncio.AbstractEventLoop] = {}
+
+    async def _capturing_session(request: Request) -> Any:
+        captured["loop"] = asyncio.get_running_loop()
+        async for session in get_session(request):
+            yield session
+
+    composed.app.dependency_overrides[get_session] = _capturing_session
+    try:
+        response = httpx.get(
+            f"{composed.base_url}/approvals/{uuid.uuid4()}",
+            headers={"X-API-Key": api_key},
+            timeout=_DEADLINE_S,
+        )
+        assert response.status_code == 404, response.text
+    finally:
+        composed.app.dependency_overrides.pop(get_session, None)
+
+    loop = captured["loop"]
+    assert loop.is_running(), "the captured server loop is not running"
+    composed.app.state.journey_server_loop = loop
+    return loop
+
+
+async def _on_server_loop(loop: asyncio.AbstractEventLoop, coro: Any) -> Any:
+    """Await ``coro`` on the API server's loop from this test's loop, bounded."""
+
+    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    return await asyncio.wait_for(asyncio.wrap_future(future), timeout=_DEADLINE_S)
+
+
+async def _resolve_note_through_the_dispatcher(
+    *,
+    h: Any,
+    api: Any,
+    approval_id: str,
+    resolver: Any,
+    sync_redis: redis.Redis,
+    envelope: str,
+    note: str | None = None,
+    mutate_metadata: Callable[[str], str] | None = None,
+) -> tuple[Any, Any, Any]:
+    """Click, capture the modal metadata, then submit -- the stage-2 note path.
+
+    Returns ``(submit_socket, web_client, card)``. ``mutate_metadata`` is the
+    only addition over stage 2's inline sequence and exists for case 6: it
+    receives the CAPTURED ``private_metadata`` and returns the string the
+    submission carries, so the tamper is applied to real captured bytes rather
+    than to a hand-built blob that might not resemble what production emits.
+    """
+
+    card = _card(approval_id, allow_free_text=True)
+    approve = _buttons(card)[0]
+    app, web_client = _build_dispatcher(_dispatcher_config(h.config.stream), sync_redis, resolver)
+    web_client.conversations_replies = MagicMock(return_value={"messages": [card]})
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(
+        FakeSocketClient(),
+        _click(
+            f"{envelope}-click",
+            card=card,
+            button=approve,
+            user=_APPROVER,
+            channel=_APPROVERS_CHANNEL,
+        ),
+    )
+    _wait_for(
+        lambda: bool(web_client.views_open.call_args),
+        what="the note modal to be opened after the click",
+        timeout=_DEADLINE_S,
+    )
+    metadata = web_client.views_open.call_args.kwargs["view"]["private_metadata"]
+    if mutate_metadata is not None:
+        metadata = mutate_metadata(metadata)
+
+    submit = FakeSocketClient()
+    handler.handle(
+        submit,
+        _view_submission(
+            f"{envelope}-submit",
+            private_metadata=metadata,
+            user=_APPROVER,
+            note=note,
+        ),
+    )
+    _drain(app, timeout=_DEADLINE_S)
+    return submit, web_client, card
+
+
+# --- Case 1: a rejection is a terminal outcome, and the worker resumes with it
+
+
+def test_case1_a_rejected_approval_resumes_the_session_with_the_rejection() -> None:
+    """A real reject card action reaches ``rejected`` and wakes the session.
+
+    Driven entirely through the harness verbs -- ``send`` / ``messages`` /
+    ``act`` / ``await_outcome`` -- because this case is the one with a fully
+    known answer, which makes it the honest place to prove the harness is
+    usable rather than merely present. ``act`` is given the action OBJECT
+    captured from ``messages()``; handing it the literal action id raises
+    ``UncapturedAction``, and that anti-shortcut is asserted here too so this
+    module cannot quietly degrade into driving literals.
+
+    FALSIFIABLE NEGATIVE: flip the kernel's reject branch to take the approve
+    path (``kernel.py`` approval-resume routing) and the resumed turn no longer
+    carries the rejection -- ``outcome.status`` stops being ``rejected`` and the
+    delivered text stops naming the refusal.
+    """
+
+    with InteractionHarness() as harness:
+        sent = harness.send("please approve scaling payments to 10 replicas")
+        assert sent.to_dict(), "every harness result must be JSON-serialisable"
+
+        captured = harness.messages()
+        card = captured.cards[-1]
+        reject = [a for a in card.actions if "reject" in a.action_id][0]
+
+        # Anti-shortcut: a bare string is not a captured action.
+        with pytest.raises(UncapturedAction):
+            harness.act(message=card.message, action=reject.action_id, actor=_APPROVER)
+
+        acted = harness.act(
+            message=card.message, action=reject, actor=_APPROVER, deadline_s=_DEADLINE_S
+        )
+        assert acted.accepted is True, acted.to_dict()
+
+        outcome = harness.await_outcome(
+            predicate=lambda state: state.approval_status == "rejected",
+            deadline_s=_DEADLINE_S,
+        )
+        assert outcome.approval_status == "rejected"
+        assert outcome.resolved_by == _APPROVER
+        # Terminal for the APPROVAL and a wake for the SESSION: exactly one
+        # resume, and the resumed turn carries the rejection rather than
+        # silently resuming as though it had been approved.
+        assert len(outcome.resume_turns) == 1, outcome.to_dict()
+        assert outcome.resume_turns[0].event_id == resume_event_id(outcome.approval_id)
+        assert "reject" in outcome.resume_turns[0].text.casefold(), outcome.to_dict()
+        assert json.dumps(outcome.to_dict())
+
+
+# --- Case 2: expiry, driven by the PRODUCTION sweeper, invoked once ----------
+
+
+async def _age_the_approval(approval_id: str, *, age: timedelta) -> None:
+    """Move the row's ``expires_at`` into the past, in the real database.
+
+    Ageing the ROW rather than passing a future ``now`` to the sweeper is what
+    keeps the case honest: the sweeper then selects the record through its own
+    real ``list_expired_pending_approvals`` query against a real clock, instead
+    of being told what time it is.
+    """
+
+    engine = create_async_engine(os.environ["DATABASE_URL"])
+    try:
+        async with engine.begin() as conn:
+            result = await conn.execute(
+                text(
+                    f"UPDATE {_DB_SCHEMA}.approvals SET expires_at = :expires "
+                    "WHERE id = CAST(:id AS uuid) AND status = 'pending'"
+                ),
+                {
+                    "expires": datetime.now(UTC).replace(tzinfo=None) - age,
+                    "id": approval_id,
+                },
+            )
+            assert result.rowcount == 1, (
+                f"approval {approval_id} was not pending when it was aged, so the "
+                "sweep below would have nothing to select and would pass vacuously"
+            )
+    finally:
+        await engine.dispose()
+
+
+def test_case2_the_production_expiry_sweeper_expires_and_wakes_the_session(
+    make_harness: Any,
+    api: Any,
+    approval_api_server: Any,
+    approval_api_env: Any,
+    journey_recorder: Any,
+) -> None:
+    """One direct call to the REAL ``sweep_expired_approvals``, after ageing a row.
+
+    The sweeper loop is disabled by ``approval_api_env`` (its 30 s interval can
+    flip a pending row out from under any other test in the module), so it is
+    invoked exactly ONCE here, by hand -- but against the LIVE
+    ``app.state.sessionmaker`` and ``app.state.resume_queue`` the running
+    server's lifespan composed, driven on that server's own loop, not against a
+    look-alike engine and queue built here. Those objects are what make the pins
+    below mean something: an ``is`` check against a name this test imported
+    itself cannot fail, so the honest pins are (a) ``lifespan``'s own bytecode
+    still naming ``run_expiry_sweeper``, (b) the name ``curie_api.main`` resolves
+    that global to being the sweeper module's function, and (c) the loop's
+    bytecode still naming ``sweep_expired_approvals``. Together those are the
+    chain lifespan actually walks at runtime; a rename or a wrapper anywhere on
+    it breaks one of the three.
+
+    FALSIFIABLE NEGATIVE: remove the expiry check (make
+    ``crud.expire_approval``'s CAS unconditional, or drop the ``expires_at``
+    filter from ``list_expired_pending_approvals``) and either the flip count or
+    the "still pending before the sweep" assertion fails.
+    """
+
+    import inspect
+
+    from curie_api import main as api_main
+    from curie_api import sweeper as api_sweeper
+
+    # The chain the running app walks, pinned link by link. `lifespan` is an
+    # @asynccontextmanager, so unwrap to the function whose bytecode schedules
+    # the loop.
+    lifespan_fn = inspect.unwrap(api_main.lifespan)
+    assert "run_expiry_sweeper" in lifespan_fn.__code__.co_names, (
+        "the API lifespan no longer schedules run_expiry_sweeper by that global "
+        "name, so this test is invoking a sweeper the app does not run"
+    )
+    scheduled = api_main.__dict__["run_expiry_sweeper"]
+    assert scheduled is api_sweeper.run_expiry_sweeper, (
+        "curie_api.main resolves run_expiry_sweeper to something other than the "
+        "sweeper module's function"
+    )
+    sweep_expired_approvals = api_sweeper.sweep_expired_approvals
+    assert "sweep_expired_approvals" in scheduled.__code__.co_names, (
+        "the production sweeper loop no longer calls sweep_expired_approvals by "
+        "that global name, so invoking it here proves nothing about the loop"
+    )
+
+    state = approval_api_server.app.state
+    loop = _server_loop(approval_api_server, approval_api_env.api_key)
+
+    async def go() -> None:
+        created = api.create_approval()
+        approval_id = created["id"]
+        await _age_the_approval(approval_id, age=timedelta(minutes=5))
+        assert api.approval(approval_id)["status"] == "pending"
+
+        async with make_harness(actions=journey_recorder) as h:
+            # The live queue must be writing to the stream this test reads, or
+            # the "exactly one wake" assertion below would be vacuous.
+            assert state.resume_queue._stream == h.config.stream
+
+            async def sweep() -> int:
+                async with state.sessionmaker() as session:
+                    swept = await sweep_expired_approvals(session, state.resume_queue)
+                    await session.commit()
+                    return swept
+
+            flipped = await _on_server_loop(loop, sweep())
+
+            assert flipped == 1, "the aged approval was not swept"
+            row = api.approval(approval_id)
+            assert row["status"] == "expired"
+            assert row["resolved_by"] is None
+
+            audit = api.audit(approval_id)
+            expired = [e for e in audit if e["action"] == "expired"]
+            assert len(expired) == 1, audit
+            assert expired[0]["authorizer"] == "ExpirySweeper"
+
+            # The wake reached the stream exactly once, and it is the expiry
+            # resume rather than a resolve resume.
+            turns = await _stream_entries(h)
+            assert len(turns) == 1, turns
+            assert turns[0].event_id == resume_event_id(approval_id)
+
+    asyncio.run(go())
+
+
+# --- Case 3: a lost resume enqueue, recovered by the PRODUCTION reconciler ---
+
+
+def test_case3_the_production_reconciler_enqueues_exactly_one_lost_resume() -> None:
+    """The enqueue is dropped by an armed fault; the reconciler re-enqueues once.
+
+    Driven entirely inside the harness -- one composition, one database, one
+    stream namespace. Mixing the harness with stage 2's fixtures here would put
+    two API servers on one row and make "exactly one resume" ambiguous about
+    which server wrote it.
+
+    ``inject_fault("resume_enqueue_lost")`` is a context manager and auto-reverts;
+    a leaked fault would poison every later test in the process, which is why the
+    recovery pass below is asserted rather than assumed.
+
+    FALSIFIABLE NEGATIVE: never call the reconciler (or disable it) and the
+    stream stays empty; drop the ``resumed_at`` mark / the row claim and the
+    second pass enqueues again, which double-wakes the session.
+    """
+
+    import inspect
+
+    from curie_api import main as api_main
+    from curie_api import resumereconciler as api_reconciler
+
+    ResumeReconciler = api_reconciler.ResumeReconciler
+    # The chain the running app walks: lifespan's own bytecode still names the
+    # class, and main resolves that global to the reconciler module's class. An
+    # ``is`` check against a name imported here could not fail and proves
+    # nothing; these two can.
+    lifespan_fn = inspect.unwrap(api_main.lifespan)
+    assert "ResumeReconciler" in lifespan_fn.__code__.co_names, (
+        "the API lifespan no longer constructs ResumeReconciler by that global "
+        "name, so this test drives a reconciler the app does not run"
+    )
+    assert api_main.__dict__["ResumeReconciler"] is ResumeReconciler
+
+    async def go() -> None:
+        with InteractionHarness() as harness:
+            approval_id = harness.create_approval().approval_id
+
+            with harness.inject_fault("resume_enqueue_lost"):
+                acted = harness.resolve(
+                    approval_id=approval_id,
+                    decision="approved",
+                    actor=_APPROVER,
+                    deadline_s=_DEADLINE_S,
+                )
+                assert acted.accepted is True, acted.to_dict()
+
+            # The resolve committed; the wake did not reach the stream. That is
+            # precisely the stranded shape the reconciler exists for.
+            assert harness.approval(approval_id).status == "approved"
+            assert harness.resume_turns().turns == ()
+
+            # The LIVE objects, not look-alikes: the reconciler instance the
+            # app's lifespan composed, holding app.state.sessionmaker and
+            # app.state.resume_queue. Those belong to the uvicorn server's loop
+            # (an asyncpg connection and an asyncio redis client are bound to
+            # the loop they were created on), so the pass is driven there with
+            # ``_on_server_loop`` rather than on a loop of this test's own.
+            composed = harness.api
+            state = composed.app.state
+            loop = _server_loop(composed, harness.env.api_key)
+
+            reconciler = state.resume_reconciler
+            assert type(reconciler) is ResumeReconciler, (
+                "the lifespan composed something other than the production ResumeReconciler"
+            )
+            # The method invoked is the production one, not a subclass override.
+            assert type(reconciler).reconcile_once is ResumeReconciler.reconcile_once
+            # And it is wired to the app's own state, so the row it claims and
+            # the stream it enqueues on are the ones this harness is reading.
+            assert reconciler._sessionmaker is state.sessionmaker
+            assert reconciler._resume_queue is state.resume_queue
+            assert state.resume_queue._stream == harness.stream
+
+            # The single divergence from the running configuration, and the only
+            # one: a zero grace. The grace exists so a live inline-delivered
+            # turn is not double-woken, and the fault above guarantees no turn
+            # was ever delivered. It is set on the production instance (and
+            # restored below) rather than escaped by building a second
+            # reconciler, so everything else about the object under test is what
+            # the app runs.
+            grace = reconciler._grace_seconds
+            reconciler._grace_seconds = 0
+            try:
+                enqueued = await _on_server_loop(loop, reconciler.reconcile_once())
+                assert enqueued == 1, "the reconciler did not recover the lost wake"
+
+                turns = harness.resume_turns().turns
+                assert len(turns) == 1, turns
+                assert turns[0].event_id == resume_event_id(approval_id)
+
+                # A second pass is a no-op: ``resumed_at`` is now set, so the
+                # NULL-gated finder no longer selects the row. Without this,
+                # "exactly one" above would only mean "one so far".
+                assert await _on_server_loop(loop, reconciler.reconcile_once()) == 0
+                assert len(harness.resume_turns().turns) == 1
+            finally:
+                reconciler._grace_seconds = grace
+
+    asyncio.run(go())
+
+
+# --- Case 4: what the product actually does with a note today ---------------
+#
+# NOT a validation proof. See the module docstring's UNMET PROOF note: there is
+# no server-side note validation to exercise, so this records the shipped
+# behavior instead of asserting behavior nobody implemented.
+
+
+def test_case4_the_product_does_not_validate_the_note_server_side_today(
+    make_harness: Any, api: Any, composed_resolver_factory: Any, sync_redis: redis.Redis
+) -> None:
+    """CHARACTERISATION: a note of any length and content is accepted and stored.
+
+    This test documents a gap; it does not endorse it. The modal declares
+    ``max_length=_NOTE_MAX_LENGTH`` on its input element, which Slack enforces in
+    the CLIENT. Nothing downstream re-checks it: ``resolve_note_submission``
+    strips the note and posts it, and ``ApprovalResolve.note`` is an
+    unconstrained ``str | None``. So a submission carrying a note longer than the
+    modal's own declared bound -- which is exactly what an envelope replayed or
+    synthesised outside the Slack client looks like -- resolves normally.
+
+    If a note validator is ever added, THIS test is the one that must be changed,
+    deliberately, to the refusal shape. That is the point of characterising it:
+    the change becomes visible in review instead of silently widening.
+
+    The genuine modal error path is NOT re-implemented here. The one production
+    source of a ``response_action: errors`` body is a non-200 resolve outcome
+    (``resolve_note_submission``, approval_actions.py:700-706), and stage 2
+    already covers it end to end in
+    ``test_approval_journey_dev.py::test_ac3_an_unlisted_actor_is_refused_by_the_explicit_user_list``
+    (a 403 rendered into the view ack) and
+    ``::test_ac5_a_replayed_submission_loses_and_is_told_who_won`` (a 409). Its
+    single-fact coupling to this module is asserted below, against the same
+    captured ack, rather than duplicated.
+    """
+
+    from curie_api.resumequeue import _RESUME_NOTE_MAX
+    from curie_dispatcher.approval_actions import _NOTE_MAX_LENGTH, _VERDICT_LINE_MAX
+
+    async def go() -> None:
+        created = api.create_approval()
+        approval_id = created["id"]
+        over_long = "x" * (_NOTE_MAX_LENGTH + 1)
+
+        async with make_harness() as h:
+            submit, web_client, card = await _resolve_note_through_the_dispatcher(
+                h=h,
+                api=api,
+                approval_id=approval_id,
+                resolver=composed_resolver_factory(),
+                sync_redis=sync_redis,
+                envelope="env-note-unvalidated",
+                note=over_long,
+            )
+
+            # An EMPTY ack body is the accepted submission; an errors body is the
+            # refusal. Today the over-length note takes the first branch.
+            assert submit.acked_envelope_ids == ["env-note-unvalidated-submit"]
+            assert submit.ack_payload_for("env-note-unvalidated-submit") is None, (
+                "a note longer than the modal's declared max_length was REFUSED, "
+                "which means server-side note validation now exists; the gap this "
+                "test characterises has been closed, so rewrite it to the refusal "
+                "shape rather than relaxing this assertion"
+            )
+
+            # And it really did resolve and persist, unvalidated and untruncated.
+            row = api.approval(approval_id)
+            assert row["status"] == "approved"
+            assert row["resolved_by"] == _APPROVER
+            resolved = [e for e in api.audit(approval_id) if e["action"] == "resolved"]
+            assert len(resolved) == 1, api.audit(approval_id)
+            # The DURABLE record is the unvalidated one, and that is the gap
+            # being characterised: nothing between the modal and the database
+            # checked the note's length, so the row holds all 2001 characters.
+            assert row["resolution_note"] == over_long, (
+                "the stored note was not the submitted note, so something "
+                "between the modal and the database is now validating or "
+                "transforming it and this characterisation is out of date"
+            )
+
+            turns = await _stream_entries(h)
+            assert len(turns) == 1, turns
+            # CORRECTED to the product's real behavior. The resume turn does NOT
+            # carry the note verbatim: ``_framed_note`` cuts it to
+            # ``_RESUME_NOTE_MAX`` and marks the cut with an ellipsis
+            # (resumequeue.py:144-167). That is a RENDER bound on what is handed
+            # to the model, the same class of bound as the card's verdict line
+            # below -- not validation, which is why this remains a
+            # characterisation of an unvalidated note rather than a proof of one.
+            assert _RESUME_NOTE_MAX < len(over_long), (
+                "the over-long note is no longer past the resume turn's own "
+                "bound, so the truncation asserted below is vacuous"
+            )
+            framed = over_long[: _RESUME_NOTE_MAX - 1] + "\u2026"
+            assert framed in turns[0].text, turns[0].text[-200:]
+            assert over_long not in turns[0].text
+
+            # The card settled carrying the WHOLE note. CORRECTED: the previous
+            # expectation (the verdict line truncated for Slack's own limit) was
+            # wrong about the product at this length -- the card's render bounds
+            # are ``_VERDICT_LINE_MAX`` (2900) on the context block and
+            # ``_FALLBACK_TEXT_MAX`` (39000) on the ``text`` fallback, and a note
+            # one character past the MODAL's 2000 is under both. That is the
+            # characterisation's point rather than a detail: the only bound the
+            # note ever meets is the resume turn's, and no surface refuses it.
+            web_client.chat_update.assert_called_once()
+            update = web_client.chat_update.call_args.kwargs
+            assert update["ts"] == card["ts"]
+            assert len(over_long) < _VERDICT_LINE_MAX, (
+                "the over-long note now exceeds the card's own render bound, so "
+                "the whole-note assertion below is asserting truncation instead"
+            )
+            assert over_long in update["text"]
+
+    asyncio.run(go())
+
+
+# --- Case 5: the approver cancels the modal ----------------------------------
+
+
+def _view_closed(envelope_id: str, *, private_metadata: str, user: str) -> SocketModeRequest:
+    """A ``view_closed`` envelope for the note modal, from CAPTURED metadata.
+
+    Same envelope shape Slack sends when the approver presses Cancel: the view,
+    its callback id and its ``private_metadata``, with no ``state`` values at
+    all, because nothing was submitted.
+    """
+
+    return SocketModeRequest(
+        type="interactive",
+        envelope_id=envelope_id,
+        payload={
+            "type": "view_closed",
+            "team": {"id": "T1"},
+            "user": {"id": user},
+            "api_app_id": "A1",
+            "token": "verif",
+            "is_cleared": False,
+            "view": {
+                "id": f"V-{envelope_id}",
+                "type": "modal",
+                "callback_id": NOTE_MODAL_CALLBACK_ID,
+                "private_metadata": private_metadata,
+                "state": {"values": {}},
+                "hash": "1",
+                "title": {"type": "plain_text", "text": "Approve request"},
+                "blocks": [],
+            },
+        },
+    )
+
+
+def test_case5_cancelling_the_modal_changes_nothing_at_all(
+    make_harness: Any,
+    api: Any,
+    composed_resolver_factory: Any,
+    journey_recorder: Any,
+    sync_redis: redis.Redis,
+) -> None:
+    """Cancel is a no-op on every surface: record, card and stream.
+
+    The click already happened, so the approval is mid-journey with a modal open;
+    the cancel must leave it exactly where the click left it. All three surfaces
+    are asserted because "still pending" alone is also true of a dispatcher that
+    stamped the card or wrote a stream entry and then failed to persist.
+
+    FALSIFIABLE NEGATIVE: treat cancel as an approve (register a ``view_closed``
+    listener that resolves) and the status, the card and the stream assertions
+    all fail together.
+    """
+
+    async def go() -> None:
+        created = api.create_approval()
+        approval_id = created["id"]
+        card = _card(approval_id, allow_free_text=True)
+        approve = _buttons(card)[0]
+
+        async with make_harness(actions=journey_recorder) as h:
+            app, web_client = _build_dispatcher(
+                _dispatcher_config(h.config.stream), sync_redis, composed_resolver_factory()
+            )
+            handler = SocketModeHandler(app, app_token="xapp-test")
+
+            handler.handle(
+                FakeSocketClient(),
+                _click(
+                    "env-cancel-click",
+                    card=card,
+                    button=approve,
+                    user=_APPROVER,
+                    channel=_APPROVERS_CHANNEL,
+                ),
+            )
+            _wait_for(
+                lambda: bool(web_client.views_open.call_args),
+                what="the note modal to be opened after the click",
+                timeout=_DEADLINE_S,
+            )
+            metadata = web_client.views_open.call_args.kwargs["view"]["private_metadata"]
+            # Nothing is resolved by the click itself; this is the BEFORE half of
+            # the comparison the cancel must not move.
+            assert api.approval(approval_id)["status"] == "pending"
+
+            sock = FakeSocketClient()
+            handler.handle(
+                sock,
+                _view_closed("env-cancel-closed", private_metadata=metadata, user=_APPROVER),
+            )
+            _drain(app, timeout=_DEADLINE_S)
+
+            row = api.approval(approval_id)
+            assert row["status"] == "pending"
+            assert row["resolved_by"] is None
+            # No audit row at all: a cancel is not a decision, and recording one
+            # would put a phantom actor in the trail an operator reads.
+            assert api.audit(approval_id) == []
+            # The card is untouched -- no settle stamp, no ephemeral.
+            web_client.chat_update.assert_not_called()
+            web_client.chat_postEphemeral.assert_not_called()
+            assert await h.async_redis.xlen(h.config.stream) == 0
+            assert journey_recorder.recorded == []
+
+    asyncio.run(go())
+
+
+# --- Case 6: unusable / tampered private_metadata ----------------------------
+
+
+@pytest.mark.parametrize(
+    ("tamper", "why"),
+    [
+        ("drop_approval_id", "no approval id at all"),
+        ("unparseable", "not JSON"),
+        ("foreign_decision", "a decision the handler does not accept"),
+    ],
+)
+def test_case6_a_tampered_private_metadata_is_refused_not_declined(
+    make_harness: Any,
+    api: Any,
+    composed_resolver_factory: Any,
+    journey_recorder: Any,
+    sync_redis: redis.Redis,
+    tamper: str,
+    why: str,
+) -> None:
+    """The submission is refused, and the refusal is NOT an ownership decline.
+
+    The distinction is the whole point and it is structural, not cosmetic. An
+    ownership DECLINE leaves the Socket Mode envelope UNACKED so Slack retries it
+    on another connection of the same app (``decline_unowned_envelope``,
+    approval_actions.py:140-156) -- that is how two releases sharing one Slack app
+    hand work to each other. An unusable ``private_metadata`` is this release's
+    own problem: there is nothing to hand over, so the envelope IS acked and the
+    journey simply stops. Asserting only "still pending" would be satisfied by
+    both, and by a crash.
+
+    The metadata is mutated from the bytes ``views_open`` really carried, never
+    hand-built, so a change to what production puts in there moves this test
+    with it.
+
+    FALSIFIABLE NEGATIVE: an ignore-metadata mutation (default the decision to
+    ``approved``, or read the approval id off the view id) resolves the approval,
+    and the pending/stream/card assertions fail.
+    """
+
+    def _mutate(raw: str) -> str:
+        if tamper == "unparseable":
+            return raw[: len(raw) // 2]
+        meta = json.loads(raw)
+        assert meta["approval_id"], "the captured metadata carried no approval id to tamper with"
+        if tamper == "drop_approval_id":
+            meta.pop("approval_id")
+        else:
+            meta["decision"] = "maybe"
+        return json.dumps(meta)
+
+    async def go() -> None:
+        created = api.create_approval()
+        approval_id = created["id"]
+
+        async with make_harness(actions=journey_recorder) as h:
+            submit, web_client, _card_message = await _resolve_note_through_the_dispatcher(
+                h=h,
+                api=api,
+                approval_id=approval_id,
+                resolver=composed_resolver_factory(),
+                sync_redis=sync_redis,
+                envelope=f"env-tamper-{tamper}",
+                note=_NOTE_TEXT,
+                mutate_metadata=_mutate,
+            )
+
+            # REFUSED, not declined: the envelope was acked, so Slack will not
+            # retry it against another release.
+            assert submit.acked_envelope_ids == [f"env-tamper-{tamper}-submit"], (
+                f"an unusable private_metadata ({why}) must be acked and dropped, "
+                "not left unacked for another release to retry -- there is "
+                "nothing for another release to pick up"
+            )
+            # Nothing moved, which is what separates this from an ACCEPTED
+            # submission (also acked, also empty-bodied).
+            assert api.approval(approval_id)["status"] == "pending"
+            assert api.audit(approval_id) == []
+            web_client.chat_update.assert_not_called()
+            assert await h.async_redis.xlen(h.config.stream) == 0
+            assert journey_recorder.recorded == []
+
+    asyncio.run(go())
+
+
+# --- Case 7: the resolve call itself fails -----------------------------------
+
+
+def test_case7_a_failed_resolve_transport_is_surfaced_and_wakes_nobody() -> None:
+    """The resolve POST never lands; the approver is told, and nothing resumes.
+
+    The dangerous shape this pins is the phantom resume: a dispatcher that
+    optimistically settled the card or enqueued a wake on a resolve it never got
+    an answer to would resume a session for a decision the database does not
+    have. ``ResolveOutcome(status_code=0)`` is explicitly an UNKNOWN outcome
+    (approval_actions.py:239-244), and the only safe rendering of unknown is to
+    tell the approver it failed and change nothing.
+
+    FALSIFIABLE NEGATIVE: swallow the ``httpx.HTTPError`` in
+    ``ApprovalResolveClient.resolve`` and return a 200-shaped outcome, and both
+    the ``status_code == 0`` assertion and the empty-stream assertion fail.
+    """
+
+    with InteractionHarness() as harness:
+        approval_id = harness.create_approval().approval_id
+
+        with harness.inject_fault("resolve_transport_error"):
+            acted = harness.resolve(
+                approval_id=approval_id,
+                decision="approved",
+                actor=_APPROVER,
+                deadline_s=_DEADLINE_S,
+            )
+
+        assert acted.accepted is False, acted.to_dict()
+        # CORRECTED to the product's real behavior at this seam. The original
+        # expectation (``response_action == "errors"`` plus a rendered "try
+        # again") describes the MODAL surface, and ``resolve`` deliberately has
+        # no card and no view: ``response_action`` is built by
+        # ``resolve_note_submission`` out of a ``view_submission`` body
+        # (approval_actions.py:700-706) and the text is stamped by
+        # ``render_note_submission``. Neither runs on the bare resolve hop, so a
+        # harness that reported them here would be inventing a Slack surface the
+        # product never rendered. What the product really does is below, and it
+        # is the stronger claim: the client turns the transport error into the
+        # explicit UNKNOWN outcome and hands it back untouched.
+        assert acted.status_code == 0, acted.to_dict()
+        assert acted.detail == "injected resolve transport failure", acted.to_dict()
+        assert acted.approval_id == approval_id, acted.to_dict()
+        # And the words the approver gets for that outcome are the dispatcher's
+        # own, from the one shared wording function both surfaces render through.
+        # Asserted against the SAME ``ResolveOutcome`` shape the hop produced, so
+        # a change to either half moves this with it; the rendering of it INTO a
+        # view is covered end to end by stage 2's 403 and 409 cases.
+        from curie_dispatcher.approval_actions import ResolveOutcome, _refusal_text
+
+        assert (
+            "try again"
+            in _refusal_text(
+                ResolveOutcome(status_code=acted.status_code, detail=acted.detail)
+            ).casefold()
+        )
+
+        # Nothing was committed and nothing was woken.
+        assert harness.approval(approval_id).status == "pending"
+        assert harness.audit(approval_id).entries == ()
+        assert harness.resume_turns().turns == ()
+
+        # And the fault auto-reverted: the same act now succeeds, which is what
+        # proves the empty stream above was caused by the fault rather than by a
+        # harness that never drove anything at all.
+        recovered = harness.resolve(
+            approval_id=approval_id,
+            decision="approved",
+            actor=_APPROVER,
+            deadline_s=_DEADLINE_S,
+        )
+        assert recovered.accepted is True, recovered.to_dict()
+        assert harness.approval(approval_id).status == "approved"
+        assert len(harness.resume_turns().turns) == 1

--- a/charts/curie/ci/dev-harness-exclusion-assertions.sh
+++ b/charts/curie/ci/dev-harness-exclusion-assertions.sh
@@ -1,0 +1,614 @@
+#!/usr/bin/env bash
+# The dev interaction harness (packages/test-support/src/curie_test_support/
+# interaction/) reaches no shipped artifact.
+#
+# Two independent controls, in the order of their strength:
+#
+#   1. The resolved --no-dev dependency closure of every production image. This
+#      is the PRIMARY control and it is about the DISTRIBUTION, not a name: a
+#      distribution that is not installed cannot be imported however the harness
+#      is spelled, where a module-name sweep only ever finds today's spelling.
+#      The five workspace-context app Dockerfiles (api, dispatcher, worker,
+#      mail-adapter and adapters/discord) install `uv sync --frozen --no-dev
+#      --no-editable --package curie-<app>`, so `uv export --frozen --no-dev
+#      --package <p>` is the same set; runner/Dockerfile installs
+#      export_dependency_pins.py's output with --no-deps, so that exporter is
+#      run for the sixth image. Building the images is deliberately NOT made a
+#      CI job (plan decision 3); where an image is already present locally it is
+#      additionally probed.
+#   1b. The Dockerfile POSTURE, per instruction. The export is not the image:
+#      the app images `COPY . .` and ship the builder's /app/.venv, so a builder
+#      line that installs a dev-only workspace member by path, or a post-copy
+#      `uv sync` with --no-dev dropped, changes nothing control 1 can see. Both
+#      shapes are seeded against the checker at the end of this script.
+#   2. A sealed-chart-render sweep for the module name, the distribution name and
+#      their base64 encodings, over EVERY rendered document and EVERY pod-spec
+#      container kind (containers, initContainers, ephemeralContainers) plus
+#      decoded Secret `data` -- the sibling
+#      ci/approval-principal-wiring-assertions.sh's method, for the same reason:
+#      a check that reads containers[0] of four named Deployments is not a claim
+#      about the render.
+#
+# A typo'd path in an assertion script exits 0 and proves nothing, so both
+# controls are exercised against a SEEDED VIOLATION at the end of this script
+# and must reject it. Removing that self-check removes the only evidence that
+# this script is capable of failing.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$CHART/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "ASSERTION FAILED: $1" >&2; exit 1; }
+
+HARNESS_MODULE="curie_test_support"
+HARNESS_DISTRIBUTION="curie-test-support"
+HARNESS_PATH="packages/test-support"
+APP_PACKAGES=(curie-api curie-dispatcher curie-worker curie-mail-adapter curie-discord-adapter)
+# Every Dockerfile whose build context is the WORKSPACE. adapters/discord was a
+# production recipe of exactly the app shape (COPY . . then a --package uv sync)
+# and was on none of these lists, so "every production image" excluded an image.
+PROD_DOCKERFILES=(
+  apps/api/Dockerfile
+  apps/dispatcher/Dockerfile
+  apps/worker/Dockerfile
+  apps/mail-adapter/Dockerfile
+  adapters/discord/Dockerfile
+  runner/Dockerfile
+)
+
+# --- Assertion 1: the resolved --no-dev closures -----------------------------
+# Written to files first so the closure checker below runs over the same shape
+# for the real closures and for the seeded one.
+assert_closure_excludes_harness() {
+  local label="$1" file="$2"
+  local lines
+  lines="$(grep -cve '^[[:space:]]*$' "$file" || true)"
+  # Guard the guard: an empty export would make the absence check vacuous.
+  [ "$lines" -gt 20 ] || fail "$label closure has only $lines lines; the exclusion check is vacuous"
+  if grep -qiE "(^|[/[:space:]])(${HARNESS_DISTRIBUTION}|${HARNESS_MODULE})([[:space:]=<>!~]|$)|${HARNESS_PATH}" "$file"; then
+    fail "$label installs the dev interaction harness: $(grep -inE "${HARNESS_DISTRIBUTION}|${HARNESS_MODULE}|${HARNESS_PATH}" "$file" | head -3)"
+  fi
+}
+
+for package in "${APP_PACKAGES[@]}"; do
+  NO_COLOR=1 uv export --frozen --no-dev --package "$package" \
+    --directory "$REPO_ROOT" >"$TMP/$package.txt" \
+    || fail "uv export failed for $package"
+  assert_closure_excludes_harness "$package" "$TMP/$package.txt"
+done
+
+python3 "$REPO_ROOT/runner/export_dependency_pins.py" <"$REPO_ROOT/uv.lock" >"$TMP/curie-runner.txt" \
+  || fail "runner/export_dependency_pins.py failed"
+assert_closure_excludes_harness "curie-runner" "$TMP/curie-runner.txt"
+
+# runner/Dockerfile installs by explicit path, so its exclusion is also a
+# negative assertion on the Dockerfile itself: an added COPY of the package
+# would not show up in the pins above.
+if grep -q "$HARNESS_PATH" "$REPO_ROOT/runner/Dockerfile"; then
+  fail "runner/Dockerfile references $HARNESS_PATH"
+fi
+# The `uv export` closure above is NOT the image. App images `COPY . .` into the
+# builder and ship that stage's /app/.venv, so a single builder line -- `uv pip
+# install ./packages/test-support`, or a post-copy `uv sync` with --no-dev
+# dropped -- lands the harness in the shipped venv while the export is
+# byte-identical. `grep -q -- "--no-dev" <file>`, which is what this used to be,
+# passes on that file: the pre-copy dependency-layer sync still carries the flag.
+#
+# So posture is judged per INSTRUCTION (continuations joined), with three
+# properties: no install verb names a dev-only workspace member; every
+# `uv sync` carries --no-dev; and the FINAL sync, the one after `COPY . .`
+# whose result is what ships, carries --no-dev and --package.
+cat >"$TMP/dockerfile_posture.py" <<'PY'
+"""Report dev-harness posture violations in one Dockerfile.
+
+In a file, not inline, so the real Dockerfiles and the seeded violations at the
+bottom of this script are judged by exactly the same code.
+"""
+
+import pathlib
+import re
+import shlex
+import sys
+import tomllib
+
+REPO_ROOT = pathlib.Path(sys.argv[1])
+# `uv sync --package <member>` IS an install: it resolves that member into the
+# builder venv the runtime stage ships (round-2 review finding A).
+INSTALL_VERBS = (
+    ("pip", "install"),
+    ("pip3", "install"),
+    ("uv", "pip", "install"),
+    ("uv", "add"),
+    ("poetry", "add"),
+    ("uv", "sync"),
+)
+SYNC_VERB = ("uv", "sync")
+SHELL_OPERATORS = frozenset({"&&", "||", ";", "|", "&", "(", ")", "{", "}"})
+# Flags that put a non-runtime dependency group back into a `--no-dev` sync.
+DEV_GROUP_FLAGS = ("--dev", "--all-groups", "--group", "--only-group", "--only-dev")
+WORKSPACE_COPY = re.compile(r"COPY\s+\.\s+\./?$", re.IGNORECASE)
+HARNESS_PATH = "packages/test-support"
+
+
+def normalize(name):
+    return re.sub(r"[-_.]+", "-", name).strip().lower()
+
+
+def dev_only_members():
+    """Workspace members only the dev dependency group installs -- derived, not listed."""
+    root = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+
+    def names(entries):
+        return {
+            normalize(re.split(r"[<>=!~\[; ]", entry, maxsplit=1)[0])
+            for entry in entries or []
+            if isinstance(entry, str)
+        }
+
+    runtime = names((root.get("project") or {}).get("dependencies"))
+    grouped = set()
+    for entries in (root.get("dependency-groups") or {}).values():
+        grouped |= names(entries)
+    members = {}
+    workspace = ((root.get("tool") or {}).get("uv") or {}).get("workspace") or {}
+    for relative in workspace.get("members") or []:
+        pyproject = REPO_ROOT / relative / "pyproject.toml"
+        if not pyproject.is_file():
+            continue
+        declared = (tomllib.loads(pyproject.read_text()).get("project") or {}).get("name")
+        name = normalize(declared) if isinstance(declared, str) else ""
+        if name and name in grouped and name not in runtime:
+            members[name] = relative
+    if not members:
+        raise SystemExit("no dev-only workspace member resolved; this checker is vacuous")
+    return members
+
+
+def commands(text):
+    """One string per instruction, shell continuations joined, comments dropped."""
+    out = []
+    buffer = ""
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if line.lstrip().startswith("#") or (not buffer and not line.strip()):
+            continue
+        if line.endswith("\\"):
+            buffer += line[:-1] + " "
+            continue
+        out.append(" ".join(f"{buffer}{line}".split()))
+        buffer = ""
+    if buffer.strip():
+        out.append(" ".join(buffer.split()))
+    return out
+
+
+def tokenize(command):
+    """Shell tokens of one instruction, end-of-line comments removed (finding B)."""
+    try:
+        return shlex.split(command, comments=True)
+    except ValueError:
+        return [token for token in command.split() if not token.startswith("#")]
+
+
+def segments(command):
+    """The shell commands inside one RUN, each as its own token list.
+
+    Splitting on the shell operators is what keeps `|| echo --no-dev` from
+    reading as a flag of the sync (finding B, second shape).
+    """
+    tokens = tokenize(command)
+    if not tokens or tokens[0] != "RUN":
+        return []
+    tokens = tokens[1:]
+    while tokens and tokens[0].startswith("--mount"):
+        tokens = tokens[1:]
+    split = []
+    current = []
+    for token in tokens:
+        if token in SHELL_OPERATORS:
+            split.append(current)
+            current = []
+        else:
+            current.append(token)
+    split.append(current)
+    found = []
+    for segment in split:
+        while segment and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", segment[0]):
+            segment = segment[1:]
+        if (
+            len(segment) > 2
+            and pathlib.PurePath(segment[0]).name in ("python", "python3")
+            and segment[1] == "-m"
+        ):
+            segment = segment[2:]
+        if segment:
+            found.append([pathlib.PurePath(segment[0]).name, *segment[1:]])
+    return found
+
+
+def starts_with(segment, verb):
+    return tuple(segment[: len(verb)]) == verb
+
+
+def has_flag(segment, flag):
+    return any(token == flag or token.startswith(f"{flag}=") for token in segment)
+
+
+def flag_value(token):
+    """The value half of `--flag=value`; the token itself otherwise."""
+    if token.startswith("-") and "=" in token:
+        return token.split("=", 1)[1]
+    return token
+
+
+def names_path(token, target):
+    cleaned = flag_value(token).strip("'\"")
+    cleaned = cleaned[2:] if cleaned.startswith("./") else cleaned
+    cleaned = cleaned.rstrip("/")
+    target = target[2:] if target.startswith("./") else target
+    target = target.rstrip("/")
+    return bool(target) and (cleaned == target or cleaned.startswith(f"{target}/"))
+
+
+def names_distribution(token, distribution):
+    head = re.split(r"[<>=!~\[;]", flag_value(token).strip("'\""), maxsplit=1)[0]
+    return normalize(head) == distribution
+
+
+def copy_aliases(instructions, member):
+    """Destinations a COPY gave the dev-only member's tree (finding C)."""
+    aliases = set()
+    for command in instructions:
+        tokens = tokenize(command)
+        if not tokens or tokens[0] != "COPY":
+            continue
+        operands = [token for token in tokens[1:] if not token.startswith("--")]
+        if len(operands) < 2:
+            continue
+        for source in operands[:-1]:
+            if names_path(source, member):
+                aliases.add(operands[-1])
+    return aliases
+
+
+def posture(path, text):
+    problems = []
+    instructions = commands(text)
+    parsed = [(command, segments(command)) for command in instructions]
+    for distribution, member in dev_only_members().items():
+        targets = {member, *copy_aliases(instructions, member)}
+        for command, command_segments in parsed:
+            for segment in command_segments:
+                if not any(starts_with(segment, verb) for verb in INSTALL_VERBS):
+                    continue
+                if any(
+                    any(names_path(token, target) for target in targets)
+                    or names_distribution(token, distribution)
+                    for token in segment[1:]
+                ):
+                    problems.append(
+                        f"{path} installs the dev-only workspace member {member} "
+                        f"({distribution}) into the image venv: {command}"
+                    )
+    if path == "runner/Dockerfile":
+        if HARNESS_PATH in text:
+            problems.append(f"{path} references {HARNESS_PATH}")
+        return problems
+    syncs = [
+        (command, segment)
+        for command, command_segments in parsed
+        for segment in command_segments
+        if starts_with(segment, SYNC_VERB)
+    ]
+    if not syncs:
+        problems.append(f"{path} has no uv sync line; the posture assertion would be vacuous")
+    for command, segment in syncs:
+        if not has_flag(segment, "--no-dev"):
+            problems.append(f"{path} installs without --no-dev: {command}")
+        for flag in DEV_GROUP_FLAGS:
+            if has_flag(segment, flag):
+                problems.append(
+                    f"{path} re-admits a non-runtime dependency group with {flag}: {command}"
+                )
+    copies = [i for i, command in enumerate(instructions) if WORKSPACE_COPY.match(command)]
+    if not copies:
+        problems.append(f"{path} has no `COPY . .`; this checker cannot judge its final layer")
+        return problems
+    final = [
+        (command, segment)
+        for command, command_segments in parsed[copies[-1] :]
+        for segment in command_segments
+        if starts_with(segment, SYNC_VERB)
+    ]
+    if not final:
+        problems.append(f"{path} runs no uv sync after `COPY . .`")
+    for command, segment in final:
+        if not has_flag(segment, "--no-dev"):
+            problems.append(f"{path} post-`COPY . .` sync omits --no-dev: {command}")
+        if not has_flag(segment, "--package"):
+            problems.append(f"{path} post-`COPY . .` sync omits --package: {command}")
+    return problems
+
+
+found = posture(sys.argv[2], pathlib.Path(sys.argv[3]).read_text())
+for problem in found:
+    print(problem)
+raise SystemExit(1 if found else 0)
+PY
+
+for dockerfile in "${PROD_DOCKERFILES[@]}"; do
+  python3 "$TMP/dockerfile_posture.py" "$REPO_ROOT" "$dockerfile" "$REPO_ROOT/$dockerfile" \
+    || fail "$dockerfile fails the dev-harness posture check (see above)"
+done
+
+# Opportunistic image probe: only where the image already exists locally, so
+# this script stays runnable without a five-image build.
+if command -v docker >/dev/null 2>&1; then
+  for app in api dispatcher worker mail-adapter discord-adapter runner; do
+    image="ghcr.io/curie-eng/curie-$app:dev"
+    docker image inspect "$image" >/dev/null 2>&1 || continue
+    if docker run --rm --entrypoint /app/.venv/bin/python "$image" \
+      -c "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('$HARNESS_MODULE') is None else 1)"; then
+      echo "  probed $image: $HARNESS_MODULE absent"
+    else
+      fail "$image has $HARNESS_MODULE importable inside the production venv"
+    fi
+  done
+fi
+
+# --- Assertion 2: the sealed chart render ------------------------------------
+cat >"$TMP/sweep.py" <<'PY'
+"""Sweep a rendered chart directory for any dev-harness reference.
+
+Kept in a file rather than inline so the real render and the seeded-violation
+render below are judged by exactly the same code.
+"""
+
+import base64
+import pathlib
+import sys
+
+import yaml
+
+MODULE = "curie_test_support"
+DISTRIBUTION = "curie-test-support"
+PACKAGE_PATH = "packages/test-support"
+NEEDLES = [MODULE, DISTRIBUTION, PACKAGE_PATH]
+ENCODED = {base64.b64encode(needle.encode()).decode(): needle for needle in NEEDLES}
+
+
+def load(root):
+    docs = []
+    for path in pathlib.Path(root).rglob("*.yaml"):
+        with path.open() as stream:
+            docs.extend(doc for doc in yaml.safe_load_all(stream) if doc)
+    return docs
+
+
+def pod_specs(doc):
+    kind = doc.get("kind")
+    spec = doc.get("spec") or {}
+    if kind == "Pod":
+        yield spec
+    elif kind == "CronJob":
+        job = (spec.get("jobTemplate") or {}).get("spec") or {}
+        yield (job.get("template") or {}).get("spec") or {}
+    elif kind in ("Deployment", "StatefulSet", "DaemonSet", "Job", "ReplicaSet"):
+        yield (spec.get("template") or {}).get("spec") or {}
+
+
+docs = load(sys.argv[1])
+if not docs:
+    raise SystemExit("render produced no documents; the harness sweep is vacuous")
+
+for doc in docs:
+    kind = doc.get("kind")
+    name = doc.get("metadata", {}).get("name")
+    dumped = yaml.safe_dump(doc)
+    for needle in NEEDLES:
+        if needle in dumped:
+            raise SystemExit(f"render {kind}/{name} references the dev harness ({needle})")
+    for encoded, needle in ENCODED.items():
+        if encoded in dumped:
+            raise SystemExit(f"render {kind}/{name} carries base64 {needle}")
+    # A base64 `data:` payload hides its plaintext from the sweep above.
+    if kind == "Secret":
+        for key, value in (doc.get("data") or {}).items():
+            try:
+                decoded = base64.b64decode(str(value), validate=True).decode("utf-8", "replace")
+            except Exception:
+                continue
+            for needle in NEEDLES:
+                if needle in decoded:
+                    raise SystemExit(f"Secret {name} data.{key} decodes to {needle}")
+    # Every container kind, not containers[0] of a few named workloads: a dev
+    # signer or harness sidecar would most plausibly arrive as an initContainer.
+    for pod in pod_specs(doc):
+        if not pod:
+            continue
+        containers = []
+        for field in ("containers", "initContainers", "ephemeralContainers"):
+            containers.extend(pod.get(field) or [])
+        for container in containers:
+            label = f"{kind}/{name} container {container.get('name')}"
+            rendered = yaml.safe_dump(container)
+            for needle in NEEDLES:
+                if needle in rendered:
+                    raise SystemExit(f"{label} references the dev harness ({needle})")
+            for entry in container.get("env") or []:
+                blob = yaml.safe_dump(entry)
+                for needle in NEEDLES:
+                    if needle in blob:
+                        raise SystemExit(f"{label} env {entry.get('name')} names the dev harness")
+PY
+
+sealed_render="$TMP/sealed-render"
+mkdir -p "$sealed_render"
+helm template curie "$CHART" --output-dir "$sealed_render" \
+  --set dispatcher.slack.appToken=xapp-assert \
+  --set dispatcher.slack.botToken=xoxb-assert >/dev/null \
+  || fail "sealed chart render failed"
+python3 "$TMP/sweep.py" "$sealed_render" || fail "sealed render references the dev interaction harness"
+
+# --- Self-check: both controls must reject a seeded violation ----------------
+# Without this, a typo'd path or a needle that never matches leaves every
+# assertion above passing for the wrong reason.
+printf -- '-e ./apps/api\n-e ./%s\n' "$HARNESS_PATH" >"$TMP/seeded-closure.txt"
+for i in $(seq 1 40); do echo "filler-package-$i==1.0.0" >>"$TMP/seeded-closure.txt"; done
+if (assert_closure_excludes_harness "seeded" "$TMP/seeded-closure.txt") >/dev/null 2>&1; then
+  fail "the closure check accepted a closure that installs $HARNESS_DISTRIBUTION"
+fi
+
+# The seed above is an editable PATH install, so on its own it only ever proves
+# the HARNESS_PATH alternative of the grep fires: a broken DISTRIBUTION/MODULE
+# branch would still look green while a real `uv export` line
+# `curie-test-support==...` slipped through. Seed that exact shape too, with no
+# path anywhere in the file, so the named-requirement branch is proven
+# independently.
+printf '%s==0.0.0\n' "$HARNESS_DISTRIBUTION" >"$TMP/seeded-named.txt"
+for i in $(seq 1 40); do echo "filler-package-$i==1.0.0" >>"$TMP/seeded-named.txt"; done
+if grep -q "$HARNESS_PATH" "$TMP/seeded-named.txt"; then
+  fail "the named-requirement seed contains $HARNESS_PATH; it cannot prove the distribution branch"
+fi
+if (assert_closure_excludes_harness "seeded-named" "$TMP/seeded-named.txt") >/dev/null 2>&1; then
+  fail "the closure check accepted a closure pinning $HARNESS_DISTRIBUTION==0.0.0"
+fi
+
+seeded_render="$TMP/seeded-render"
+cp -r "$sealed_render" "$seeded_render"
+cat >"$seeded_render/seeded-violation.yaml" <<YAML
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: curie-seeded-violation
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: dev-signer
+          image: curie-seeded
+          command: ["python", "-m", "${HARNESS_MODULE}.interaction"]
+      containers:
+        - name: app
+          image: curie-seeded
+YAML
+if python3 "$TMP/sweep.py" "$seeded_render" >/dev/null 2>&1; then
+  fail "the render sweep accepted a pod spec running the dev harness"
+fi
+
+seeded_sealed_dir="$TMP/seeded-secret"
+cp -r "$sealed_render" "$seeded_sealed_dir"
+{
+  echo "apiVersion: v1"
+  echo "kind: Secret"
+  echo "metadata:"
+  echo "  name: curie-seeded-secret"
+  echo "data:"
+  echo "  harness: $(printf '%s' "$HARNESS_MODULE" | base64 | tr -d '\n')"
+} >"$seeded_sealed_dir/seeded-secret.yaml"
+if python3 "$TMP/sweep.py" "$seeded_sealed_dir" >/dev/null 2>&1; then
+  fail "the render sweep accepted a Secret whose data decodes to the dev harness"
+fi
+
+# The Dockerfile posture checker must reject the two shapes finding 1 named --
+# proven by running it, not by reading it. Both seeds leave `uv export` output
+# byte-identical, so nothing above this line could ever see them.
+for dockerfile in "${PROD_DOCKERFILES[@]}"; do
+  # Seed A: a path-install of the dev-only harness in the builder.
+  cp "$REPO_ROOT/$dockerfile" "$TMP/seeded-dockerfile"
+  printf 'RUN uv pip install ./%s\n' "$HARNESS_PATH" >>"$TMP/seeded-dockerfile"
+  if python3 "$TMP/dockerfile_posture.py" "$REPO_ROOT" "$dockerfile" "$TMP/seeded-dockerfile" \
+    >/dev/null 2>&1; then
+    fail "the posture checker accepted $dockerfile with a path-install of $HARNESS_PATH"
+  fi
+
+  # Seed B: --no-dev dropped from the FINAL, post-`COPY . .` sync only. On the
+  # four images with a pre-copy dependency-layer sync the flag is still present
+  # in the file, which is exactly what the old `grep -q -- "--no-dev"` read.
+  python3 - "$REPO_ROOT/$dockerfile" "$TMP/seeded-final-sync" <<'PY'
+import pathlib
+import sys
+
+source, destination = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+head, separator, tail = source.read_text().rpartition("uv sync")
+if not separator:
+    raise SystemExit(0)
+destination.write_text(f"{head}{separator}{tail.replace(' --no-dev', '', 1)}")
+PY
+  if [ -f "$TMP/seeded-final-sync" ]; then
+    if python3 "$TMP/dockerfile_posture.py" "$REPO_ROOT" "$dockerfile" "$TMP/seeded-final-sync" \
+      >/dev/null 2>&1; then
+      fail "the posture checker accepted $dockerfile with --no-dev dropped from its final sync"
+    fi
+    rm -f "$TMP/seeded-final-sync"
+  fi
+
+  # Seed A (round-2 review): `uv sync --package <dev-only member>`. --no-dev and
+  # --package are both present and `uv export` is byte-identical, so assertion 1
+  # and the old flag checks all read clean while the member lands in the venv.
+  cp "$REPO_ROOT/$dockerfile" "$TMP/seeded-dockerfile"
+  printf 'RUN uv sync --frozen --no-dev --no-editable --package curie-api --package %s\n' \
+    "$HARNESS_DISTRIBUTION" >>"$TMP/seeded-dockerfile"
+  if python3 "$TMP/dockerfile_posture.py" "$REPO_ROOT" "$dockerfile" "$TMP/seeded-dockerfile" \
+    >/dev/null 2>&1; then
+    fail "the posture checker accepted $dockerfile with a uv sync --package $HARNESS_DISTRIBUTION"
+  fi
+
+  # Seed C (round-2 review): the harness COPYed to a renamed path and installed
+  # from there. The RUN names neither the member path nor the distribution.
+  cp "$REPO_ROOT/$dockerfile" "$TMP/seeded-dockerfile"
+  printf 'COPY %s /opt/vendored\nRUN uv pip install /opt/vendored\n' \
+    "$HARNESS_PATH" >>"$TMP/seeded-dockerfile"
+  if python3 "$TMP/dockerfile_posture.py" "$REPO_ROOT" "$dockerfile" "$TMP/seeded-dockerfile" \
+    >/dev/null 2>&1; then
+    fail "the posture checker accepted $dockerfile installing the harness from a renamed path"
+  fi
+
+  # runner/Dockerfile runs no uv sync, so the sync-flag seeds below do not apply.
+  if [ "$dockerfile" = "runner/Dockerfile" ]; then
+    continue
+  fi
+
+  # Seed B (round-2 review): a --no-dev uv never receives. Both shapes satisfy a
+  # substring match on the joined instruction; neither reaches uv.
+  for decoy in '# --no-dev' '|| echo --no-dev'; do
+    python3 - "$REPO_ROOT/$dockerfile" "$TMP/seeded-decoy" "$decoy" <<'SEED_B'
+import pathlib
+import sys
+
+source, destination, decoy = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2]), sys.argv[3]
+head, separator, tail = source.read_text().rpartition("uv sync")
+if not separator:
+    raise SystemExit(0)
+# Only the REST OF THAT LINE is rewritten: appending at EOF would leave the
+# real sync untouched and the seed would prove nothing.
+line, newline, rest = tail.partition("\n")
+mutated = f"{head}{separator}{line.replace(' --no-dev', '', 1)} {decoy}{newline}{rest}"
+if "--no-dev" not in mutated.rpartition("uv sync")[2].partition("\n")[0]:
+    raise SystemExit("the decoy seed lost its --no-dev text; it proves nothing")
+destination.write_text(mutated)
+SEED_B
+    if [ -f "$TMP/seeded-decoy" ]; then
+      if python3 "$TMP/dockerfile_posture.py" "$REPO_ROOT" "$dockerfile" "$TMP/seeded-decoy" \
+        >/dev/null 2>&1; then
+        fail "the posture checker accepted $dockerfile whose final sync only says '$decoy'"
+      fi
+      rm -f "$TMP/seeded-decoy"
+    fi
+  done
+
+  # Seed D (found while closing A-C): --no-dev is present and honest, and a
+  # later --group dev puts the dev group straight back.
+  cp "$REPO_ROOT/$dockerfile" "$TMP/seeded-dockerfile"
+  printf 'RUN uv sync --frozen --no-dev --group dev --no-editable --package curie-api\n' \
+    >>"$TMP/seeded-dockerfile"
+  if python3 "$TMP/dockerfile_posture.py" "$REPO_ROOT" "$dockerfile" "$TMP/seeded-dockerfile" \
+    >/dev/null 2>&1; then
+    fail "the posture checker accepted $dockerfile re-admitting the dev group with --group dev"
+  fi
+done
+
+echo "OK: dev interaction harness exclusion assertions passed"

--- a/compose/tests/test_generate_release_compose.py
+++ b/compose/tests/test_generate_release_compose.py
@@ -34,12 +34,7 @@ READINESS_DOCKERFILE_PATH = (
     REPO_ROOT / "charts" / "curie" / "ci" / "postgres-readiness-delay.Dockerfile"
 )
 READINESS_RUNTIME_SCRIPT_PATH = (
-    REPO_ROOT
-    / "charts"
-    / "curie"
-    / "ci"
-    / "runtime"
-    / "langfuse-postgres-readiness-runtime.sh"
+    REPO_ROOT / "charts" / "curie" / "ci" / "runtime" / "langfuse-postgres-readiness-runtime.sh"
 )
 
 DEV_TEXT = DEV_PATH.read_text()
@@ -183,8 +178,7 @@ def test_data_tier_pins_agree_across_artifacts():
     chart_postgres = values["postgres"]["image"]
     for label, doc in compose_docs():
         assert doc["services"]["postgres"]["image"] == chart_postgres, (
-            f"{label} postgres image must match the chart's postgres.image "
-            f"{chart_postgres!r}"
+            f"{label} postgres image must match the chart's postgres.image {chart_postgres!r}"
         )
 
     dockerfile_args = re.findall(
@@ -264,8 +258,7 @@ def test_rustfs_and_aws_bucket_bootstrap_preserve_the_s3_consumer_contract():
         assert bootstrap is not None, f"{label} must bootstrap the Langfuse bucket through RustFS"
         assert bootstrap.get("image") == "amazon/aws-cli:2.32.6"
         assert (
-            bootstrap.get("depends_on", {}).get("rustfs", {}).get("condition")
-            == "service_healthy"
+            bootstrap.get("depends_on", {}).get("rustfs", {}).get("condition") == "service_healthy"
         )
         bootstrap_command = str(bootstrap.get("entrypoint", ""))
         assert "aws " in bootstrap_command and "s3" in bootstrap_command
@@ -669,9 +662,7 @@ def test_worker_traces_to_shipped_collector_by_default():
             f"{otel_endpoint!r}, expected {expected_worker!r}; the host-network "
             "worker cannot resolve a Compose service name"
         )
-        runner_endpoint = resolve_shell_default(
-            env.get("CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT")
-        )
+        runner_endpoint = resolve_shell_default(env.get("CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT"))
         assert runner_endpoint == expected_runner, (
             f"{label}: runner OTLP endpoint resolves to {runner_endpoint!r}, "
             f"expected {expected_runner!r} on the isolated runner network"
@@ -718,21 +709,24 @@ def test_platform_services_export_to_shipped_collector_by_default(service_name):
         ({"OTEL_EXPORTER_OTLP_ENDPOINT": ""}, "", ""),
         (
             {"OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector.example.com:4318"},
-            "http://collector.example.com:4318", "http://collector.example.com:4318",
+            "http://collector.example.com:4318",
+            "http://collector.example.com:4318",
         ),
         (
             {
                 "OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector.example.com:4318",
                 "CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT": "",
             },
-            "", "http://collector.example.com:4318",
+            "",
+            "http://collector.example.com:4318",
         ),
         (
             {
                 "OTEL_EXPORTER_OTLP_ENDPOINT": "http://otel-collector:4318",
                 "CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT": "http://127.0.0.1:24318",
             },
-            "http://127.0.0.1:24318", "http://otel-collector:4318",
+            "http://127.0.0.1:24318",
+            "http://otel-collector:4318",
         ),
     ],
 )
@@ -747,16 +741,33 @@ def test_worker_endpoint_split_executes_compose_interpolation(
             for key in ("OTEL_EXPORTER_OTLP_ENDPOINT", "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT")
         }
         config = tmp_path / label
-        config.write_text(yaml.safe_dump({
-            "services": {"worker": {"image": "example-worker", "environment": selected}}
-        }))
-        clean_env = {key: value for key, value in os.environ.items() if key not in (
-            "OTEL_EXPORTER_OTLP_ENDPOINT", "CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT"
-        )}
+        config.write_text(
+            yaml.safe_dump(
+                {"services": {"worker": {"image": "example-worker", "environment": selected}}}
+            )
+        )
+        clean_env = {
+            key: value
+            for key, value in os.environ.items()
+            if key
+            not in ("OTEL_EXPORTER_OTLP_ENDPOINT", "CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT")
+        }
         result = subprocess.run(
-            ["docker", "compose", "--env-file", "/dev/null", "-f", str(config),
-             "config", "--format", "json"],
-            env={**clean_env, **overrides}, capture_output=True, text=True, check=True,
+            [
+                "docker",
+                "compose",
+                "--env-file",
+                "/dev/null",
+                "-f",
+                str(config),
+                "config",
+                "--format",
+                "json",
+            ],
+            env={**clean_env, **overrides},
+            capture_output=True,
+            text=True,
+            check=True,
         )
         rendered = json.loads(result.stdout)["services"]["worker"]["environment"]
         assert rendered["OTEL_EXPORTER_OTLP_ENDPOINT"] == worker_endpoint
@@ -825,12 +836,10 @@ def _assert_component_references_resolve(config, label):
 
         processors = pipeline.get("processors", [])
         assert "memory_limiter" in processors and "batch" in processors, (
-            f"{label}: {signal} pipeline must contain memory_limiter and batch; "
-            f"got {processors!r}"
+            f"{label}: {signal} pipeline must contain memory_limiter and batch; got {processors!r}"
         )
         assert processors.index("memory_limiter") < processors.index("batch"), (
-            f"{label}: {signal} pipeline must limit memory before batching; "
-            f"got {processors!r}"
+            f"{label}: {signal} pipeline must limit memory before batching; got {processors!r}"
         )
 
     extensions = config.get("extensions", {})
@@ -905,9 +914,7 @@ def test_dev_collector_receives_every_signal_with_durable_bounded_delivery():
 
     doc = yaml.safe_load(DEV_TEXT)
     collector = doc["services"]["otel-collector"]
-    volume_name = _collector_storage_mount(
-        collector, storage_directory, "compose.dev.yaml"
-    )
+    volume_name = _collector_storage_mount(collector, storage_directory, "compose.dev.yaml")
     assert volume_name in (doc.get("volumes") or {}), (
         f"compose.dev.yaml: Collector storage volume {volume_name!r} is not declared"
     )
@@ -1098,11 +1105,109 @@ def test_threaded_bot_allowlist_reaches_dev_and_generated_release_compose(raw, t
         path.write_text(content)
         result = subprocess.run(
             [
-                "docker", "compose", "--env-file", "/dev/null",
-                "--project-directory", str(REPO_ROOT), "-f", str(path),
-                "--profile", "slack", "--profile", "full", "config", "--format", "json",
+                "docker",
+                "compose",
+                "--env-file",
+                "/dev/null",
+                "--project-directory",
+                str(REPO_ROOT),
+                "-f",
+                str(path),
+                "--profile",
+                "slack",
+                "--profile",
+                "full",
+                "config",
+                "--format",
+                "json",
             ],
-            env=env, capture_output=True, text=True, check=True, timeout=30,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
         )
         dispatcher = json.loads(result.stdout)["services"]["curie-dispatcher"]
         assert dispatcher["environment"]["CURIE_SLACK_THREADED_BOT_ALLOWLIST"] == (raw or "[]")
+
+
+# --- The dev interaction harness reaches no compose service (stage 3) -------
+# `packages/test-support/src/curie_test_support/interaction/` is a dev/test-only
+# harness with a `python -m curie_test_support.interaction` entry point. It adds
+# no service, so the assertion is a complement-set one in this module's existing
+# style: NO service in either document mounts the package, carries its name in
+# env, or has its command/entrypoint redirected at the module. A service-name
+# allowlist would say nothing about a harness bolted onto an existing service.
+HARNESS_MODULE = "curie_test_support"
+HARNESS_DISTRIBUTION = "curie-test-support"
+HARNESS_PACKAGE_PATH = "packages/test-support"
+HARNESS_NEEDLES = (HARNESS_MODULE, HARNESS_DISTRIBUTION, HARNESS_PACKAGE_PATH)
+
+
+def harness_violations(doc, label):
+    """Every place a compose document would carry the dev harness into a service.
+
+    Returns a list rather than asserting, so the seeded-violation test below can
+    run this exact function against a deliberately poisoned document. A checker
+    only ever called on clean input cannot be shown to be able to fail.
+    """
+    violations = []
+
+    def hits(value):
+        text = str(value)
+        return [needle for needle in HARNESS_NEEDLES if needle in text]
+
+    for name, spec in (doc.get("services") or {}).items():
+        if not isinstance(spec, dict):
+            continue
+        for mount in spec.get("volumes") or []:
+            if hits(mount):
+                violations.append(f"{label}: service {name} mounts the harness: {mount!r}")
+        for key, value in env_map(spec).items():
+            if hits(key) or hits(value):
+                violations.append(f"{label}: service {name} env {key}={value!r} names the harness")
+        for field in ("command", "entrypoint"):
+            value = spec.get(field)
+            if value is not None and hits(value):
+                violations.append(f"{label}: service {name} {field} runs the harness: {value!r}")
+        build = spec.get("build")
+        if isinstance(build, dict) and hits(build):
+            violations.append(f"{label}: service {name} build stage references the harness")
+    return violations
+
+
+def test_no_compose_service_carries_the_dev_interaction_harness():
+    """Neither the dev document nor the generated release document ships it.
+
+    Both are checked for the reason the OTEL and connector-scope pins above give:
+    the generator copies most of a service through untouched, so a guard on only
+    one document leaves the other free to drift.
+    """
+    for label, doc in compose_docs():
+        # Guard the guard: an empty service map would make this vacuous.
+        assert len(doc.get("services") or {}) > 5, label
+        assert harness_violations(doc, label) == []
+
+
+@pytest.mark.parametrize(
+    "shape, mutation",
+    [
+        ("volume mount", {"volumes": ["./packages/test-support:/app/packages/test-support"]}),
+        (
+            "env var",
+            {"environment": {"CURIE_HARNESS": "curie_test_support.interaction"}},
+        ),
+        ("command override", {"command": ["python", "-m", "curie_test_support.interaction"]}),
+    ],
+)
+def test_a_seeded_harness_reference_fails_the_compose_sweep(shape, mutation):
+    """Each shape the harness could arrive in is one the sweep actually catches.
+
+    Three separate injections rather than one, because a sweep that happened to
+    check only `volumes` would pass the single-shape version of this test while
+    a command override walked straight through it.
+    """
+    doc = yaml.safe_load(DEV_TEXT)
+    service = next(iter(doc["services"]))
+    doc["services"][service] = {**doc["services"][service], **mutation}
+    assert harness_violations(doc, "seeded") != [], shape

--- a/packages/test-support/src/curie_test_support/interaction/__init__.py
+++ b/packages/test-support/src/curie_test_support/interaction/__init__.py
@@ -1,0 +1,89 @@
+"""The agent-facing interaction harness (dev/test only).
+
+``curie_test_support`` is declared ONLY in the workspace root's
+``[dependency-groups] dev``, and every production image installs with
+``uv sync --no-dev``, so nothing in this subpackage reaches a shipped artifact.
+That posture is asserted by the exclusion suite rather than left as a reading of
+the Dockerfiles -- if a future change installs the dev group into an image, a
+test fails instead of the harness shipping.
+
+Everything the public contract names is re-exported here so a caller imports
+from one place:
+
+    from curie_test_support.interaction import InteractionHarness
+
+    with InteractionHarness() as harness:
+        harness.send("scale the payments deployment to 10 replicas")
+        card = next(m for m in harness.messages().messages if m.actions)
+        harness.act(message=card.message_id, action=card.actions[0], actor="U0EXAMPLE1")
+
+The same surface is scriptable over a pipe with
+``python -m curie_test_support.interaction`` (NDJSON in, NDJSON out). Faults are
+armed there with the ``arm_fault`` / ``disarm_fault`` verbs, which are the pipe's
+form of the in-process ``inject_fault`` context manager -- a ``with`` block
+cannot span two NDJSON lines, and without them an agent on the pipe could drive
+only the happy path.
+"""
+
+from __future__ import annotations
+
+from .faults import SUPPORTED_FAULTS, ArmedFault
+from .harness import (
+    ComposedApi,
+    HarnessTimeout,
+    InteractionHarness,
+    JourneyEnv,
+    JourneyRecorder,
+    UncapturedAction,
+    composed_api_server,
+    disposable_migrated_database,
+    gated_call,
+    journey_env,
+    resolve_client_factory,
+)
+from .results import (
+    ActResult,
+    ApprovalRecord,
+    AuditEntry,
+    AuditResult,
+    CapturedAction,
+    CapturedCard,
+    CapturedMessage,
+    MessagesResult,
+    OutcomeResult,
+    ResetResult,
+    ResumeTurn,
+    ResumeTurnsResult,
+    SendResult,
+    Snapshot,
+)
+
+__all__ = [
+    "SUPPORTED_FAULTS",
+    "ActResult",
+    "ApprovalRecord",
+    "ArmedFault",
+    "AuditEntry",
+    "AuditResult",
+    "CapturedAction",
+    "CapturedCard",
+    "CapturedMessage",
+    "ComposedApi",
+    "HarnessTimeout",
+    "InteractionHarness",
+    "JourneyEnv",
+    "JourneyRecorder",
+    "MessagesResult",
+    "OutcomeResult",
+    "ResetResult",
+    "ResumeTurn",
+    "ResumeTurnsResult",
+    "SendResult",
+    "Snapshot",
+    "UncapturedAction",
+    "composed_api_server",
+    "disposable_migrated_database",
+    "gated_call",
+    "journey_env",
+    "resolve_client_factory",
+]

--- a/packages/test-support/src/curie_test_support/interaction/__main__.py
+++ b/packages/test-support/src/curie_test_support/interaction/__main__.py
@@ -1,0 +1,232 @@
+"""``python -m curie_test_support.interaction``: the harness over a pipe.
+
+NDJSON in, NDJSON out, one object per verb, in order, flushed as it goes. Line
+per verb rather than one document at the end because an agent streaming the
+harness needs the result of step 1 before it writes step 2, and a buffered
+single document is unusable for that.
+
+Why a ``python -m`` entry point and not a ``curie`` subcommand: a ``curie`` verb
+would make this change CLI-surface-bearing and pull the ``local`` and
+``local-release`` E2E tiers into a stage that alters no runtime behavior. The
+module entry point gives an agent the same scriptable surface with no
+released-binary identity, and is reachable only from a source checkout with the
+dev dependency group installed.
+
+Failure framing is the load-bearing part. An unknown verb exits non-zero, names
+itself on stderr, and emits NO object claiming success -- an agent that reads a
+partial success and believes an approval was sent when it was not is exactly the
+class of false proof this stage exists to prevent. A ``HarnessTimeout`` is
+reported as a structured object naming the verb and the bound, not as a killed
+process with a traceback the caller has to regex.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Callable
+from typing import Any
+
+from .faults import SUPPORTED_FAULTS
+from .harness import HarnessTimeout, InteractionHarness, UncapturedAction
+from .results import FaultResult, Snapshot
+
+# Named predicates: a scripted ``await_outcome`` cannot send a Python callable
+# over a pipe, and accepting a source string to ``eval`` would make the entry
+# point an arbitrary-code surface for the sake of a test helper. The vocabulary
+# is closed for the same reason the fault set is -- a typo must fail loudly
+# rather than wait for a predicate that can never be true.
+_PREDICATES: dict[str, Callable[[Snapshot], bool]] = {
+    "never": lambda snapshot: False,
+    "always": lambda snapshot: True,
+    "any_message": lambda snapshot: bool(snapshot.messages),
+    "any_action": lambda snapshot: any(message.actions for message in snapshot.messages),
+    "any_stream_entry": lambda snapshot: snapshot.stream_entries > 0,
+    "approval_settled": lambda snapshot: snapshot.approval_status not in (None, "pending"),
+}
+
+_VERBS = (
+    "send",
+    "messages",
+    "act",
+    "await_outcome",
+    "reset",
+    "create_approval",
+    "approval",
+    "audit",
+    "resume_turns",
+    "arm_fault",
+    "disarm_fault",
+)
+
+_EXIT_UNKNOWN_VERB = 2
+_EXIT_VERB_FAILED = 1
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def _dispatch(harness: InteractionHarness, verb: str, request: dict[str, Any]) -> Any:
+    if verb == "send":
+        return harness.send(
+            str(request.get("text", "")),
+            thread=request.get("thread"),
+            deadline_s=float(request.get("deadline_s", 60.0)),
+        )
+    if verb == "arm_fault":
+        # The pipe's form of ``inject_fault``. A context manager cannot cross a
+        # line-per-verb boundary, so without this pair an agent scripting the
+        # harness could arm no fault at all and every failure case the harness
+        # can express was in-process-only. ``disarm_fault`` is the other half,
+        # and ``__exit__`` still reverts anything a script leaves armed.
+        name = str(request["fault"])
+        harness.arm_fault(name, **dict(request.get("options") or {}))
+        return FaultResult(fault=name, armed=True, armed_faults=harness.armed_faults)
+    if verb == "disarm_fault":
+        return harness.disarm_fault(str(request["fault"]))
+    if verb == "messages":
+        return harness.messages()
+    if verb == "reset":
+        return harness.reset(deadline_s=float(request.get("deadline_s", 30.0)))
+    if verb == "resume_turns":
+        return harness.resume_turns()
+    if verb == "create_approval":
+        return harness.create_approval(**dict(request.get("body") or {}))
+    if verb == "approval":
+        return harness.approval(str(request["approval_id"]))
+    if verb == "audit":
+        return harness.audit(str(request["approval_id"]))
+    if verb == "await_outcome":
+        name = str(request.get("predicate", "always"))
+        predicate = _PREDICATES.get(name)
+        if predicate is None:
+            raise ValueError(
+                f"unknown predicate {name!r}; supported predicates are: "
+                f"{', '.join(sorted(_PREDICATES))}"
+            )
+        return harness.await_outcome(
+            predicate=predicate, deadline_s=float(request.get("deadline_s", 30.0))
+        )
+    if verb == "act":
+        # The captured action is looked up by its HANDLE -- the unguessable
+        # token the harness minted for that one action when it captured it off
+        # the real render, and which only a prior ``messages`` call can have
+        # told the caller.
+        #
+        # This is the identity rule expressed over a pipe. In process, ``act``
+        # matches on object identity, so a caller who hand-builds a
+        # field-identical ``CapturedAction`` is refused. Looking the stored
+        # object up from the request's OTHER fields reopened exactly that hole
+        # at the process boundary: the identity check was then handed the real
+        # stored object and could not fail, while every field it was found by
+        # is reconstructible without a card ever rendering -- the action id is
+        # an importable renderer constant, the message id follows the harness's
+        # ``1700.%04d`` scheme, and ``value`` was optional. A caller who never
+        # called ``messages`` could click. The handle is the one field that
+        # cannot be reconstructed, so it is the only one the lookup trusts.
+        #
+        # ``message`` is still required and still checked, against the handle's
+        # own message: a request that names the wrong card is a scripting bug
+        # worth reporting, not something to silently correct.
+        handle = request.get("handle")
+        if not isinstance(handle, str) or not handle:
+            raise UncapturedAction(
+                "act() refuses a request with no 'handle': an action is "
+                "identified over the pipe by the unguessable handle that "
+                "messages() emitted for it, never by its action id, message id "
+                "or value -- all three are reconstructible without the card "
+                "ever rendering, which is the shortcut act() exists to refuse. "
+                "Call the 'messages' verb and pass the action's 'handle'."
+            )
+        message_id = str(request["message"])
+        captured = next(
+            (
+                action
+                for message in harness.messages().messages
+                for action in message.actions
+                if action.handle == handle
+            ),
+            None,
+        )
+        if captured is None:
+            raise UncapturedAction(
+                f"act() refuses the handle {handle!r} on message {message_id!r}: "
+                "no action captured on this harness carries it. A handle is "
+                "minted per captured action, so one that was fabricated, or "
+                "taken from a different harness process, has nothing to name."
+            )
+        return harness.act(
+            message=message_id,
+            action=captured,
+            actor=str(request["actor"]),
+            note=request.get("note"),
+            deadline_s=float(request.get("deadline_s", 30.0)),
+        )
+    raise AssertionError(f"verb {verb!r} passed validation but has no handler")
+
+
+def _error_payload(exc: BaseException) -> dict[str, Any]:
+    payload: dict[str, Any] = {"type": type(exc).__name__, "message": str(exc)}
+    if isinstance(exc, HarnessTimeout):
+        payload["verb"] = exc.verb
+        payload["what"] = exc.what
+        payload["deadline_s"] = exc.deadline_s
+        payload["elapsed_s"] = exc.elapsed_s
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Read, execute and answer ONE line at a time, never the whole script first.
+
+    Line-at-a-time is load bearing, not a micro-optimisation. ``act`` now takes
+    the unguessable handle ``messages`` minted, and a handle is minted per
+    captured action inside THIS process -- so a caller has to read the
+    ``messages`` answer before it can write the ``act`` line. Reading all of
+    stdin up front made that impossible and would have left the pipe's only
+    honest ``act`` route unreachable, which is the pressure that pushes a
+    provenance rule back into a guessable one. The answer to each verb is
+    flushed as it goes, so a caller holding the other end of the pipe has it
+    before it writes the next line.
+    """
+
+    harness: InteractionHarness | None = None
+    try:
+        for number, line in enumerate(sys.stdin, start=1):
+            if not line.strip():
+                continue
+            try:
+                parsed = json.loads(line)
+            except ValueError as exc:
+                sys.stderr.write(f"line {number} is not valid JSON: {exc}\n")
+                return _EXIT_UNKNOWN_VERB
+            if not isinstance(parsed, dict) or "verb" not in parsed:
+                sys.stderr.write(f"line {number} has no 'verb' key: {line}")
+                return _EXIT_UNKNOWN_VERB
+            verb = str(parsed["verb"])
+            if verb not in _VERBS:
+                # Reported BEFORE anything is emitted for this line: no object
+                # may claim success for a verb that was rejected.
+                sys.stderr.write(
+                    f"unknown verb {verb!r}; supported verbs are: {', '.join(_VERBS)}\n"
+                    f"(supported faults are: {', '.join(SUPPORTED_FAULTS)})\n"
+                )
+                return _EXIT_UNKNOWN_VERB
+            if harness is None:
+                harness = InteractionHarness()
+                harness.__enter__()
+            try:
+                result = _dispatch(harness, verb, parsed)
+            except Exception as exc:  # noqa: BLE001 - reported, not swallowed
+                _emit({"verb": verb, "ok": False, "error": _error_payload(exc)})
+                return _EXIT_VERB_FAILED
+            _emit({"verb": verb, "ok": True, "result": result.to_dict()})
+    finally:
+        if harness is not None:
+            harness.__exit__(None, None, None)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/test-support/src/curie_test_support/interaction/faults.py
+++ b/packages/test-support/src/curie_test_support/interaction/faults.py
@@ -1,0 +1,231 @@
+"""The closed fault vocabulary, and how each one is armed and reverted.
+
+Two rules govern everything in this module, and both exist because of a failure
+mode that is invisible at the point it is caused:
+
+* **The set is CLOSED.** An unknown name raises, naming :data:`SUPPORTED_FAULTS`.
+  The alternative -- a silent no-op for a typo'd name -- lets a test arm nothing,
+  drive the happy path, and report that it covered the failure case. That is a
+  falsely claimed proof, so the typo has to be fatal.
+* **Every fault reverts in a ``finally``.** A leaked fault does not fail the test
+  that leaked it; it fails some later, unrelated test in the same process, with
+  nothing in the report pointing back here.
+
+Faults come in two shapes. Some are *patches* over a production callable
+(``unittest.mock.patch`` objects, started on arm and stopped on revert); the rest
+are *options* the harness consults at the moment it builds or drives something,
+because the object they bend does not exist until the verb runs. Both live behind
+one :class:`ArmedFault` so a caller cannot tell them apart -- and so neither can
+leak by a different route than the other.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import patch
+
+__all__ = ["SUPPORTED_FAULTS", "ArmedFault", "arm_fault", "wrap_resolve_client"]
+
+# The vocabulary, pinned here and asserted as an exact set by the contract
+# tests. A name added without a case behind it is a capability nobody is
+# watching; a name removed silently turns its case into a no-op.
+SUPPORTED_FAULTS: tuple[str, ...] = (
+    "resume_enqueue_lost",
+    "resolve_transport_error",
+    "private_metadata_unusable",
+)
+
+# How long a hung transport stays hung. Bounded on purpose: the point of
+# ``hang=True`` is to outlive the VERB's deadline, not to outlive the suite. An
+# unbounded sleep would leave a Bolt listener thread parked for the rest of the
+# session, and the drain that follows the timed-out verb would then be the thing
+# that hangs.
+_HANG_SECONDS = 5.0
+
+# Distinguishes "this attribute was absent" from "it was present and None". A
+# plain ``None`` default would make an absent attribute indistinguishable from a
+# real one, and restore would then invent one that was never there.
+_MISSING: Any = object()
+
+
+def _injected_transport_error() -> Exception:
+    """The exception the broken transport raises.
+
+    An ``httpx`` transport error specifically, not a bare ``Exception``: the
+    dispatcher's resolve client catches ``httpx.HTTPError`` and turns it into
+    ``ResolveOutcome(status_code=0)`` (approval_actions.py), which is the
+    behavior the "resolve call itself fails" case is about. A foreign exception
+    type would escape that handler and prove something else entirely -- that an
+    unhandled error kills the Bolt listener.
+    """
+
+    import httpx
+
+    return httpx.ConnectError("injected resolve transport failure")
+
+
+@dataclass
+class ArmedFault:
+    """One armed fault: its patches, and the options verbs must consult."""
+
+    name: str
+    options: dict[str, Any] = field(default_factory=dict)
+    _patches: list[Any] = field(default_factory=list)
+
+    def revert(self) -> None:
+        """Stop every patch, in reverse order, tolerating an already-stopped one.
+
+        Reverse order because two patches over the same attribute must unwind as
+        a stack; tolerant because ``revert`` runs from a ``finally`` that may be
+        reached after an exception mid-arm, where some patches never started.
+        """
+
+        while self._patches:
+            patcher = self._patches.pop()
+            try:
+                patcher.stop()
+            except RuntimeError:  # pragma: no cover - already stopped
+                pass
+
+
+def arm_fault(name: str, **kwargs: Any) -> ArmedFault:
+    """Arm one fault by name, returning the handle that reverts it.
+
+    Raises ``ValueError`` naming :data:`SUPPORTED_FAULTS` for an unknown name.
+    """
+
+    if name not in SUPPORTED_FAULTS:
+        raise ValueError(
+            f"unknown fault {name!r}; supported faults are: {', '.join(SUPPORTED_FAULTS)}"
+        )
+    armed = ArmedFault(name=name, options=dict(kwargs))
+    try:
+        if name == "resume_enqueue_lost":
+            _arm_resume_enqueue_lost(armed)
+        # ``resolve_transport_error`` and ``private_metadata_unusable`` are
+        # option-only: the transport belongs to a resolve client the harness
+        # builds per ``act``, and the metadata is a value read off a modal that
+        # has not opened yet, so there is nothing to patch until the verb runs.
+    except Exception:
+        armed.revert()
+        raise
+    return armed
+
+
+class _OnRevert:
+    """A ``stop()``-shaped callback, so non-patch cleanup unwinds with the rest.
+
+    ``ArmedFault.revert`` knows only how to ``stop()`` things in reverse order.
+    Anything that has to be undone alongside a patch is wrapped in one of these
+    rather than being remembered somewhere else, because "somewhere else" is how
+    a fault leaks past the ``finally`` that was supposed to clear it.
+    """
+
+    def __init__(self, undo: Any) -> None:
+        self._undo = undo
+
+    def stop(self) -> None:
+        self._undo()
+
+
+def _arm_resume_enqueue_lost(armed: ArmedFault) -> None:
+    """Lose the API's resume enqueue while leaving the resolution itself real.
+
+    Patched at ``ResumeQueue.enqueue`` rather than at the Valkey client: the
+    reconciliation case under test is "the row is resolved but no turn was
+    queued", and cutting Valkey would also break the reconciler that is supposed
+    to heal it.
+
+    It RAISES rather than returning a stream id. A silent success was the wrong
+    shape and produced the wrong state: the resolve endpoint marks ``resumed_at``
+    as soon as ``enqueue`` returns (approvals.py:420-433), so a fault that
+    returned ``"0-0"`` left a fully-resumed row that the reconciler's NULL-gated
+    finder correctly never selects -- the stranded shape the case is about was
+    never created. A raise is also the real failure this backstop exists for (a
+    Valkey blip), and it leaves ``resolved_at`` set with ``resumed_at`` NULL.
+
+    ``RESUME_RECONCILER_ENABLED`` is forced on for the duration, for the same
+    reason and from the same code path: with it off the route deliberately
+    re-raises a failed enqueue as a 500 rather than stranding the session
+    (approvals.py:415-433), so the 200-and-defer contract under test only exists
+    when a backstop is declared. This flips the SETTING, which the route reads
+    per request, not the LOOP -- ``journey_env`` keeps the live reconciler task
+    out of the composition, so the only pass that ever runs is the one the case
+    invokes by hand.
+    """
+
+    from curie_api.config import get_settings
+    from curie_api.resumequeue import ResumeQueue
+
+    async def _dropped(self: Any, turn: Any, *, parent: Any = None) -> str:
+        import redis.exceptions
+
+        raise redis.exceptions.ConnectionError("injected resume enqueue failure")
+
+    # Appended FIRST so it unwinds LAST: the cache must be cleared after the
+    # environment has been put back, not before.
+    armed._patches.append(_OnRevert(get_settings.cache_clear))
+    env_patcher = patch.dict(os.environ, {"RESUME_RECONCILER_ENABLED": "true"})
+    env_patcher.start()
+    armed._patches.append(env_patcher)
+    get_settings.cache_clear()
+
+    patcher = patch.object(ResumeQueue, "enqueue", _dropped)
+    patcher.start()
+    armed._patches.append(patcher)
+
+
+def wrap_resolve_client(client: Any, faults: dict[str, ArmedFault]) -> None:
+    """Apply the option-shaped transport fault to one built resolve client.
+
+    Mutates the client's private ``httpx.Client`` in place rather than passing a
+    ``client=`` override, because the production default transport is precisely
+    what the composed journey exists to exercise: swapping the whole client for a
+    fake would take the real ``_RESOLVE_TIMEOUT`` out of the picture along with
+    the fault.
+    """
+
+    armed = faults.get("resolve_transport_error")
+    if armed is None:
+        return
+    hang = bool(armed.options.get("hang", False))
+    transport = client._client
+
+    def _broken(*_args: Any, **_kwargs: Any) -> Any:
+        if hang:
+            time.sleep(_HANG_SECONDS)
+        raise _injected_transport_error()
+
+    # Remembered BEFORE the overwrite, and restored on revert. Today ``act`` and
+    # ``resolve`` happen to build a fresh client per call, so an unrestored wrap
+    # leaks nothing -- but that is an incidental property of the caller, not a
+    # guarantee of this function, and the day a client is reused the leak is a
+    # permanently broken transport on a shared object with nothing pointing here.
+    # ``_MISSING`` distinguishes "had an instance attribute" from "inherited the
+    # bound method off the class"; the two restore differently.
+    # ``__dict__``, not ``getattr``: ``getattr`` resolves an inherited bound
+    # method and cannot tell "shadowed by an instance attribute" from "found on
+    # the class", so restoring what it returns would leave a shadowing instance
+    # attribute where there was none. Only the instance dict answers the
+    # question that restore actually has to undo.
+    previous = {name: vars(transport).get(name, _MISSING) for name in ("get", "post")}
+
+    def _restore() -> None:
+        for name, original in previous.items():
+            if original is _MISSING:
+                # Only delete what we put there; another wrap may have already
+                # restored it, and ``revert`` must tolerate running twice.
+                transport.__dict__.pop(name, None)
+            else:
+                setattr(transport, name, original)
+
+    armed._patches.append(_OnRevert(_restore))
+
+    # Both verbs: the ownership probe GETs and the resolution POSTs, and a fault
+    # that only broke one would let a click sail past the probe and then fail in
+    # a place the case is not about.
+    transport.get = _broken
+    transport.post = _broken

--- a/packages/test-support/src/curie_test_support/interaction/harness.py
+++ b/packages/test-support/src/curie_test_support/interaction/harness.py
@@ -1,0 +1,2372 @@
+"""The agent-facing interaction harness: one composed Curie stack, six verbs.
+
+What this is
+------------
+Stage 2 proved the approval journey runs across real API, worker, dispatcher,
+Postgres and Valkey, but did it as one pytest module with the composition
+inlined in ``apps/worker/tests/kernel/conftest.py``. This module is that
+composition, generalised: a sync context manager that owns a disposable migrated
+Postgres database, the REAL ``curie_api`` app under a real uvicorn server on a
+loopback port, the real kernel over real Valkey, and the real dispatcher with the
+real ``ApprovalResolveClient`` -- and exposes them as six bounded verbs whose
+results are frozen, JSON-serialisable dataclasses.
+
+The stand-ins are exactly the two stage 2 named, and no more: **the model**
+(behind the REAL ``curie_runner``, booted through ``build_runner(...,
+fake_model=True)`` -> ``create_app`` and served to the kernel as ``runner_app=``)
+and **the Slack edge** (a mocked ``WebClient`` plus a fake socket). Everything
+between them is production code, the runner included: a turn driven through
+``send`` compiles a real bundle, runs the real session loop, and emits
+production ACI frames. ``send`` steers that turn with the fake model's own
+approval MARKER rather than by scripting frames, so the approval the kernel
+creates came out of the production ``mcp__curie__request_approval`` path.
+
+Why the verbs look like this
+----------------------------
+* **``act`` takes a captured action object, never a literal action id.** The
+  harness exists to prove a REAL chat click drove the system. An ``act`` that
+  accepted a literal id would let every future test skip the card entirely -- the
+  render, the ownership probe, the block structure -- and still report a green
+  approval journey. The refusal (``UncapturedAction``) is what keeps "the harness
+  drove it" from degrading into "the harness POSTed something".
+* **Every blocking verb takes an explicit ``deadline_s`` and raises
+  ``HarnessTimeout``.** An unbounded wait in a test harness is the worst failure
+  mode available: the suite reports nothing, the CI job dies on its outer
+  timeout, and the report names no test.
+* **Faults revert in a ``finally``.** A leaked fault fails a LATER, unrelated
+  test, with nothing pointing back to the cause.
+
+The composition helpers below the harness class (``journey_env``,
+``disposable_migrated_database``, ``composed_api_server``,
+``resolve_client_factory``, ``JourneyRecorder``, ``gated_call``) are the stage 2
+fixtures, moved here WITH their explanatory docstrings. Those docstrings are the
+record of four separate traps -- the ``VALKEY_URL`` precedence trap, the
+``DATABASE_URL`` ownership collision, the disabled sweeper and the disabled
+reconciler -- and deleting them re-opens all four. ``apps/worker/tests/kernel/
+conftest.py`` now holds thin wrappers that yield from these, so the journey
+module and the harness share ONE implementation rather than two that can drift.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import importlib.util
+import json
+import os
+import secrets
+import socket
+import sys
+import threading
+import time
+import uuid
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import ModuleType, TracebackType
+from typing import Any
+
+import redis
+
+from curie_test_support.valkey import (
+    VALKEY_HOST as _VALKEY_HOST,
+)
+from curie_test_support.valkey import (
+    VALKEY_PORT as _VALKEY_PORT,
+)
+from curie_test_support.valkey import (
+    VALKEY_PW as _VALKEY_PW,
+)
+from curie_test_support.valkey import connect_or_skip
+
+from .faults import ArmedFault, arm_fault, wrap_resolve_client
+from .results import (
+    ActResult,
+    ApprovalRecord,
+    AuditEntry,
+    AuditResult,
+    CapturedAction,
+    CapturedCard,
+    CapturedMessage,
+    FaultResult,
+    MessagesResult,
+    OutcomeResult,
+    ResetResult,
+    ResumeTurn,
+    ResumeTurnsResult,
+    SendResult,
+    Snapshot,
+)
+
+__all__ = [
+    "ComposedApi",
+    "HarnessTimeout",
+    "InteractionHarness",
+    "JourneyEnv",
+    "JourneyRecorder",
+    "UncapturedAction",
+    "composed_api_server",
+    "disposable_migrated_database",
+    "gated_call",
+    "journey_env",
+    "resolve_client_factory",
+]
+
+
+# Test placeholders hoisted to constants (not inline literals) so the repo's
+# secret-shaped-literal gate does not trip on these quoted values.
+JOURNEY_PLATFORM_CREDENTIAL = "journey-platform-api-key"
+# Deliberately DISTINCT from the platform key: sharing them is what
+# ``approval_auth.py:92-97`` refuses outright, and what ADR-0106 (#1531) exists
+# to prevent. ``config.py:430-431`` also refuses equal values at boot.
+JOURNEY_ATTESTER_VALUE = "journey-chat-attester-secret"
+
+# Env vars the journey composition owns. Snapshotted and restored as a unit so a
+# failed run cannot leak API settings into the rest of the process.
+JOURNEY_ENV_KEYS = (
+    "RUNS_STREAM",
+    "CURIE_STREAM",
+    "VALKEY_URL",
+    "VALKEY_HOST",
+    "VALKEY_PORT",
+    "VALKEY_PASSWORD",
+    "API_KEY",
+    "CURIE_APPROVAL_CHAT_ATTESTER_SECRET",
+    # NOT ``CURIE_``-prefixed: ``Settings`` has no ``env_prefix`` and these two
+    # fields carry no ``validation_alias`` (config.py:237, :270), so pydantic-
+    # settings reads the bare field names. With ``extra="ignore"`` (config.py:35)
+    # a ``CURIE_``-prefixed key is silently dropped and the guard never binds.
+    "APPROVAL_SWEEP_INTERVAL_S",
+    "RESUME_RECONCILER_ENABLED",
+    # Owned per-run rather than session-wide, so this composition can neither be
+    # broken by nor break ``apps/api/tests`` (which owns the same key,
+    # apps/api/tests/conftest.py:117-142) in one session.
+    "DATABASE_URL",
+    "S3_ENDPOINT_URL",
+    "S3_ACCESS_KEY",
+    "S3_SECRET_KEY",
+    "ENVIRONMENT",
+)
+
+# The channel the harness's synthetic person speaks in, and the person itself.
+# ``C0EXAMPLE1`` shaped rather than a realistic id: the gitleaks Slack-id rule
+# treats a realistic-looking channel id as a finding.
+HARNESS_CHANNEL = "C0EXAMPLE1"
+HARNESS_AUTHOR = "U0EXAMPLE4"
+_DEFAULT_NOTE = "approved through the interaction harness"
+
+# How often a bounded wait re-checks. Short enough that a 1s deadline is not
+# quantised into something visibly longer (the contract tests assert the verb
+# returns inside 2x its deadline), long enough not to spin a core.
+_POLL_INTERVAL_S = 0.02
+
+# The ceiling one HTTP call to the composed API may take when no verb deadline
+# is narrower. A ceiling, never the bound: inside a verb the call is clipped to
+# what is LEFT of that verb's deadline (``InteractionHarness._budget``).
+_HTTP_TIMEOUT_S = 10.0
+
+# The floor on what is handed to ``_call``: a coroutine scheduled with a zero or
+# negative timeout reports a timeout it never had a chance to beat.
+_MIN_CALL_S = 0.05
+
+# The ceiling one Valkey command may take when no verb deadline is narrower.
+# ``connect_or_skip`` sets ``socket_connect_timeout`` but deliberately no
+# ``socket_timeout`` -- correct for a fixture whose whole job is one ping, and a
+# hole for a bounded verb: a Valkey that ACCEPTS and never answers blocks the
+# command inside the socket read, where ``_Deadline.wait`` (which only polls a
+# predicate) can never interrupt it. Every Valkey command a verb issues goes
+# through ``_redis_call`` instead, clipped to what is left of the verb.
+_VALKEY_TIMEOUT_S = 10.0
+
+# How long the real consumer is given to finish ONE entry inside ``send``. A
+# ceiling under the verb's own deadline, which is what actually bounds the verb.
+_CONSUME_TIMEOUT_S = 120.0
+
+
+class HarnessTimeout(AssertionError):
+    """A bounded verb gave up, naming the verb, the wait and the bound.
+
+    An ``AssertionError`` subclass so an unhandled one reads as a test failure
+    rather than an infrastructure error, and so a caller that only catches
+    ``AssertionError`` still sees it. The four attributes are part of the
+    contract: a bare ``TimeoutError`` from twenty frames down tells an agent
+    nothing about which of its scripted steps wedged.
+    """
+
+    def __init__(self, *, verb: str, what: str, deadline_s: float, elapsed_s: float) -> None:
+        self.verb = verb
+        self.what = what
+        self.deadline_s = deadline_s
+        self.elapsed_s = elapsed_s
+        super().__init__(
+            f"{verb} timed out after {elapsed_s:.2f}s (deadline {deadline_s:.2f}s) "
+            f"waiting for: {what}"
+        )
+
+
+class UncapturedAction(AssertionError):
+    """``act`` was handed something that did not come out of ``messages()``.
+
+    Raised for a bare string even when the string is the CORRECT action id. The
+    contract is provenance, not validity: the right id in the wrong FORM is still
+    a test that never looked at the card.
+    """
+
+
+# --- The disposable database -------------------------------------------------
+
+
+def _off_loop(work: Callable[[], None], *, what: str, timeout: float = 300.0) -> None:
+    """Run blocking, loop-owning work from sync code, loop or no loop.
+
+    ``asyncio.run`` is wrong here, and so is anything that calls it underneath:
+    this composition is entered from BOTH shapes -- a plain sync test, and a test
+    whose body is already inside ``asyncio.run`` (the repo's convention for async
+    kernel tests). Under the second shape ``asyncio.run`` raises "cannot be
+    called from a running event loop", and that reaches further than this
+    module's own two admin statements: Alembic's ``apps/api/alembic/env.py:96``
+    calls ``asyncio.run`` at import time, so even ``command.upgrade`` has to run
+    off the caller's loop. A private thread with no loop of its own is correct on
+    both shapes, and it is bounded like every other blocking call here.
+    """
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        work()
+        return
+
+    box: list[BaseException] = []
+
+    def _run() -> None:
+        try:
+            work()
+        except BaseException as exc:  # noqa: BLE001 - re-raised on the caller
+            box.append(exc)
+
+    thread = threading.Thread(target=_run, name="interaction-off-loop", daemon=True)
+    thread.start()
+    thread.join(timeout=timeout)
+    assert not thread.is_alive(), f"{what} did not finish within {timeout}s"
+    if box:
+        raise box[0]
+
+
+@contextlib.contextmanager
+def disposable_migrated_database() -> Iterator[str]:
+    """A disposable, migrated database, and the URL every reader must use.
+
+    Recipe from apps/api/tests/conftest.py:127-143 (create / ``alembic upgrade
+    head`` / drop). Migrating is not optional: the app lifespan calls
+    ``assert_servable()``, which refuses to boot against an unmigrated schema
+    with "database schema None is below application min ...".
+
+    It hands back the URL rather than leaving ``DATABASE_URL`` set, so the API
+    app, the direct row assertions and any seeding provably read ONE database
+    rather than three that merely look alike. ``DATABASE_URL`` is set only for
+    the duration of the migration and then RESTORED: :func:`journey_env` re-sets
+    it per run. Holding it open would make an interleaved run with
+    ``apps/api/tests`` (which owns the same key, apps/api/tests/conftest.py:117-142)
+    order-dependent in both directions.
+    """
+
+    import secrets
+    from datetime import UTC, datetime
+
+    import asyncpg  # type: ignore[import-untyped]
+    from alembic import command
+    from alembic.config import Config
+    from curie_api.config import get_settings
+    from sqlalchemy import make_url
+
+    base_url = os.environ.get(
+        "TEST_DATABASE_URL",
+        "postgresql+asyncpg://postgres:postgres@localhost:25432/postgres",
+    )
+    base = make_url(base_url)
+    run_db = f"curie_journey_{datetime.now(UTC).strftime('%Y%m%d%H%M%S')}_{secrets.token_hex(3)}"
+
+    async def _admin(sql: str) -> None:
+        conn = await asyncpg.connect(
+            user=base.username,
+            password=base.password,
+            host=base.host,
+            port=base.port,
+            database="postgres",
+        )
+        try:
+            await conn.execute(sql)
+        finally:
+            await conn.close()
+
+    _off_loop(lambda: asyncio.run(_admin(f'CREATE DATABASE "{run_db}"')), what="CREATE DATABASE")
+    url = str(base.set(database=run_db).render_as_string(hide_password=False))
+    previous = os.environ.get("DATABASE_URL")
+    os.environ["DATABASE_URL"] = url
+    get_settings.cache_clear()
+    try:
+        # Inside the try so a failed migration still drops the database.
+        cfg = Config()
+        cfg.set_main_option("script_location", str(repo_root() / "apps" / "api" / "alembic"))
+        # Off the caller's loop: alembic's env.py calls ``asyncio.run`` itself.
+        _off_loop(lambda: command.upgrade(cfg, "head"), what="the alembic migration")
+        # Hand the key back the moment the migration no longer needs it.
+        _restore_database_url(previous)
+        get_settings.cache_clear()
+        yield url
+    finally:
+        _off_loop(
+            lambda: asyncio.run(_admin(f'DROP DATABASE IF EXISTS "{run_db}" WITH (FORCE)')),
+            what="DROP DATABASE",
+        )
+        _restore_database_url(previous)
+        get_settings.cache_clear()
+
+
+def _restore_database_url(previous: str | None) -> None:
+    if previous is None:
+        os.environ.pop("DATABASE_URL", None)
+    else:
+        os.environ["DATABASE_URL"] = previous
+
+
+# --- The composed API's environment ------------------------------------------
+
+
+@dataclass(frozen=True)
+class JourneyEnv:
+    """The credentials and stream the composed API booted with."""
+
+    api_key: str
+    attester_secret: str
+    runs_stream: str
+
+
+@contextlib.contextmanager
+def journey_env(*, runs_stream: str, database_url: str) -> Iterator[JourneyEnv]:
+    """Point the API's settings at THIS run's Valkey namespace and stack.
+
+    Two apps, two different names for one Valkey. The worker harness reads
+    ``curie_test_support.valkey``'s ``TEST_VALKEY_*`` constants, FROZEN at import
+    (valkey.py:19-21); the API reads its own ``valkey_host``/``valkey_port``/
+    ``valkey_password`` settings, which default to ``localhost:26379``
+    (config.py:197-199). On an isolated stack that divergence would leave the API
+    writing the resume onto a DIFFERENT store -- or, worse, onto a shared one
+    where a pre-existing entry makes an assertion pass for the wrong reason. So
+    the parts are copied across from the frozen constants.
+
+    ``VALKEY_URL`` is DELETED rather than set: it wins outright over the parts
+    (config.py:404-406, #2315), so setting the parts underneath an inherited URL
+    is a silent no-op that re-opens exactly that trap.
+
+    ``DATABASE_URL`` is set HERE, per run, rather than being held for a whole
+    session: that key is also owned by ``apps/api/tests/conftest.py:117-142``, so
+    a session that interleaves the two suites would otherwise be order-dependent
+    in both directions.
+
+    Both background loops the app would otherwise start are disabled. The expiry
+    sweeper (config.py:237, 30s) can flip a pending row mid-run and the resume
+    reconciler (config.py:270, enabled by default) can enqueue a SECOND resume,
+    either of which breaks "exactly one stream entry" for a reason that has
+    nothing to do with the code under test. Both are driven deliberately, by
+    direct invocation, where a case needs them.
+
+    That disable is ASSERTED against the resolved ``Settings`` below, not merely
+    written into ``os.environ``: the keys are unprefixed field names and a future
+    rename (or a re-added ``CURIE_`` prefix) would otherwise drop them silently
+    under ``extra="ignore"`` and leave both loops running on every composed
+    server (main.py:146-167).
+    """
+
+    previous = {key: os.environ.get(key) for key in JOURNEY_ENV_KEYS}
+
+    os.environ["DATABASE_URL"] = database_url
+    os.environ["RUNS_STREAM"] = runs_stream
+    os.environ.pop("VALKEY_URL", None)
+    os.environ["VALKEY_HOST"] = _VALKEY_HOST
+    os.environ["VALKEY_PORT"] = str(_VALKEY_PORT)
+    os.environ["VALKEY_PASSWORD"] = _VALKEY_PW or ""
+    os.environ["API_KEY"] = JOURNEY_PLATFORM_CREDENTIAL
+    os.environ["CURIE_APPROVAL_CHAT_ATTESTER_SECRET"] = JOURNEY_ATTESTER_VALUE
+    os.environ["APPROVAL_SWEEP_INTERVAL_S"] = "0"
+    os.environ["RESUME_RECONCILER_ENABLED"] = "false"
+    # The lifespan calls ``BundleStore.ensure_bucket()``; the pilot stack serves
+    # RustFS on 39000. ``setdefault`` so an exported value wins, mirroring
+    # apps/api/tests/conftest.py:41-42.
+    os.environ.setdefault("S3_ENDPOINT_URL", "http://localhost:39000")
+    os.environ.setdefault("S3_ACCESS_KEY", "rustfs")
+    os.environ.setdefault("S3_SECRET_KEY", "rustfssecret")
+    # ``dev``: the prod boot gate (config.py:422) is the exclusion suite's
+    # subject, not this composition's, and an inherited ENVIRONMENT=prod would
+    # refuse boot here.
+    os.environ["ENVIRONMENT"] = "dev"
+
+    # Every mutation above precedes the cache clear, which precedes any
+    # ``create_app()``: ``get_settings`` is ``lru_cache``d, so building the app
+    # first and mutating after is a silent no-op.
+    from curie_api.config import get_settings
+
+    get_settings.cache_clear()
+    try:
+        # The guards above are only real if they BIND. Resolve the settings the
+        # app is about to be built from and check the values, so a rename, a
+        # re-added prefix or an inherited ``.env`` fails here with a clear
+        # message instead of silently re-arming a background loop or pointing
+        # the API at a second Valkey.
+        settings = get_settings()
+        assert settings.approval_sweep_interval_s <= 0, (
+            "the expiry sweeper is NOT disabled: APPROVAL_SWEEP_INTERVAL_S did "
+            f"not bind (resolved {settings.approval_sweep_interval_s!r}). "
+            "main.py:146-167 starts the loop on every composed server."
+        )
+        assert settings.resume_reconciler_enabled is False, (
+            "the resume reconciler is NOT disabled: RESUME_RECONCILER_ENABLED "
+            f"did not bind (resolved {settings.resume_reconciler_enabled!r})."
+        )
+        # ``VALKEY_URL`` popped from ``os.environ`` is not enough: ``Settings``
+        # also reads ``env_file=".env"`` (config.py:35) and a URL from there wins
+        # outright over the parts (config.py:404-406, #2315). Assert the RESOLVED
+        # dsn, which is the only thing that closes the two-Valkey trap.
+        assert not settings.valkey_url, (
+            "VALKEY_URL is set (most likely from a .env file) and wins over the "
+            "host/port parts, so the API would write the resume to a different "
+            f"store than the worker reads: {settings.valkey_url!r}"
+        )
+        assert settings.valkey_host == _VALKEY_HOST and settings.valkey_port == _VALKEY_PORT, (
+            "the API is pointed at a different Valkey than the worker harness: "
+            f"{settings.valkey_dsn()!r} vs {_VALKEY_HOST}:{_VALKEY_PORT}"
+        )
+        yield JourneyEnv(
+            api_key=JOURNEY_PLATFORM_CREDENTIAL,
+            attester_secret=JOURNEY_ATTESTER_VALUE,
+            runs_stream=runs_stream,
+        )
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        get_settings.cache_clear()
+
+
+# --- The composed API server -------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ComposedApi:
+    """A live loopback API: its base URL, its port, and the app object itself.
+
+    The app is carried so a caller can reach ``app.state.sessionmaker`` and
+    ``app.state.resume_queue`` -- the REAL objects the lifespan composed
+    (main.py:78-95). A case that invokes the production sweeper or reconciler
+    directly needs exactly those, and rebuilding a sessionmaker from
+    ``DATABASE_URL`` would hand it a second, look-alike connection pool that is
+    not the one the server is writing through.
+    """
+
+    base_url: str
+    port: int
+    app: Any = None
+
+
+@contextlib.contextmanager
+def composed_api_server(*, startup_timeout_s: float = 30.0) -> Iterator[ComposedApi]:
+    """Run the REAL ``curie_api`` app on a loopback ephemeral port.
+
+    A real server rather than an ``httpx.ASGITransport``: the transport is an
+    ``AsyncBaseTransport`` a sync ``httpx.Client`` will not accept, and it skips
+    the app lifespan, which is where ``app.state.sessionmaker`` / ``resume_queue``
+    / ``approver_sets`` (the real authorizer and the real enqueue) are composed
+    (apps/api/src/curie_api/main.py:78-95).
+
+    Exposed as a context manager (and not only as the harness's own server)
+    because the teardown-unreachability assertion has to observe the port AFTER
+    teardown, which a caller still inside the scope cannot do.
+
+    The port is picked by binding 0 and closing the probe socket rather than by
+    reading it back off ``server.servers[0].sockets[0]``: the client and the
+    teardown assertion both need the number, and a pre-picked port is available
+    before the server thread exists. The narrow race (something else grabbing the
+    port in between) fails loudly as a bind error, never silently.
+
+    A lifespan failure (unmigrated schema, unreachable RustFS) means the server
+    never reports ``started``; the captured exception is re-raised here so the
+    caller says what actually broke instead of timing out into a confusing
+    connection-refused.
+    """
+
+    import uvicorn
+    from curie_api.config import get_settings
+    from curie_api.main import create_app
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = int(probe.getsockname()[1])
+
+    get_settings.cache_clear()
+    app = create_app()
+    server = uvicorn.Server(
+        uvicorn.Config(
+            app,
+            host="127.0.0.1",
+            port=port,
+            log_level="warning",
+            lifespan="on",
+        )
+    )
+    failure: list[BaseException] = []
+
+    def _serve() -> None:
+        try:
+            server.run()
+        except BaseException as exc:  # noqa: BLE001 - surfaced below, not swallowed
+            failure.append(exc)
+
+    thread = threading.Thread(target=_serve, name=f"journey-api-{port}", daemon=True)
+    thread.start()
+    try:
+        deadline = time.monotonic() + startup_timeout_s
+        while not server.started:
+            if failure:
+                raise AssertionError(
+                    f"the composed API failed to start on port {port}: {failure[0]!r}"
+                ) from failure[0]
+            if not thread.is_alive():
+                raise AssertionError(
+                    f"the composed API server thread exited before starting on port {port}"
+                )
+            if time.monotonic() > deadline:
+                raise AssertionError(
+                    f"the composed API did not start within {startup_timeout_s}s on port {port}"
+                )
+            time.sleep(0.02)
+        yield ComposedApi(base_url=f"http://127.0.0.1:{port}", port=port, app=app)
+    finally:
+        server.should_exit = True
+        thread.join(timeout=startup_timeout_s)
+        assert not thread.is_alive(), f"the composed API on port {port} did not shut down"
+
+
+@contextlib.contextmanager
+def resolve_client_factory(api: ComposedApi, env: JourneyEnv) -> Iterator[Callable[..., Any]]:
+    """Build REAL ``ApprovalResolveClient``s against the loopback API.
+
+    ``client=`` is deliberately omitted so the production default
+    ``httpx.Client(timeout=_RESOLVE_TIMEOUT)`` is the transport
+    (approval_actions.py:251-262). The injectable seam every other test uses is
+    what this composition exists NOT to use.
+    """
+
+    from curie_dispatcher.approval_actions import ApprovalResolveClient
+
+    built: list[Any] = []
+
+    def factory(**overrides: Any) -> Any:
+        kwargs: dict[str, Any] = {
+            "api_base_url": api.base_url,
+            "api_key": env.api_key,
+            "approval_chat_attester_secret": env.attester_secret,
+        }
+        kwargs.update(overrides)
+        client = ApprovalResolveClient(**kwargs)
+        built.append(client)
+        return client
+
+    yield factory
+
+    # The class owns its default ``httpx.Client`` and exposes no ``close()``
+    # (approval_actions.py:262), so nothing else would ever release the
+    # connection pool.
+    for client in built:
+        with contextlib.suppress(Exception):
+            client._client.close()
+
+
+# --- The action ledger recorder and its gated-tool script --------------------
+
+
+@dataclass
+class JourneyRecorder:
+    """Records the calls the kernel makes to the action ledger (ADR-0117).
+
+    Why a recorder at all: the kernel harness defaults ``actions=None`` and the
+    fake runner's default script is a bare ``Final``, so with neither a recorder
+    nor a gated tool call, BOTH "zero side effects" and "exactly one side effect"
+    are assertions that cannot fail.
+    """
+
+    recorded: list[dict[str, Any]] = field(default_factory=list)
+    completed: list[tuple[str, Any]] = field(default_factory=list)
+
+    async def record(
+        self,
+        frame: Any,
+        *,
+        event_id: str,
+        conversation_id: str,
+        agent_id: str | None,
+        gate_approval_id: str | None = None,
+    ) -> Any:
+        from curie_worker.actions import RecordedAction
+
+        self.recorded.append(
+            {
+                "frame": frame,
+                "event_id": event_id,
+                "conversation_id": conversation_id,
+                "agent_id": agent_id,
+                "gate_approval_id": gate_approval_id,
+            }
+        )
+        return RecordedAction(id=f"a{len(self.recorded)}", status="pending")
+
+    async def complete(self, action_id: str, frame: Any) -> dict[str, Any]:
+        self.completed.append((action_id, frame))
+        return {
+            "tool": frame.tool,
+            "result": frame.result,
+            "detail": frame.detail,
+            "status": "failed" if frame.failed else "succeeded",
+            "undoable": bool(frame.result and frame.result.get("prior")),
+        }
+
+
+def gated_call(call_id: str, tool: str = "scale_deployment") -> list[Any]:
+    """The two frames one side-effecting tool call produces.
+
+    Mirrors test_action_ledger.py:76-95. A runner script containing one of these
+    is what makes ``len(recorder.recorded) == 1`` mutation-sensitive rather than
+    an assertion about an empty list that can never fail.
+    """
+
+    from aci_protocol import SideEffectFlag
+
+    return [
+        SideEffectFlag(
+            tool=tool,
+            call_id=call_id,
+            arguments={"replicas": 10},
+            detail="non-idempotent tool executed",
+        ),
+        SideEffectFlag(
+            tool=tool,
+            call_id=call_id,
+            failed=False,
+            result={"ok": True, "prior": {"spec": {"replicas": 3}}},
+            detail="non-idempotent tool completed",
+        ),
+    ]
+
+
+# --- Locating the kernel half -------------------------------------------------
+
+
+def repo_root() -> Path:
+    """The source checkout this dev-only package is installed from.
+
+    ``packages/test-support/src/curie_test_support/interaction/harness.py`` ->
+    five parents up. The package is a uv workspace member installed EDITABLE, so
+    this resolves to the checkout rather than to a site-packages copy; a
+    non-editable install has no kernel test tree to reach anyway, which is the
+    same statement as "this package never ships".
+    """
+
+    root = Path(__file__).resolve().parents[5]
+    assert (root / "pyproject.toml").is_file(), (
+        f"{root} does not look like the Curie checkout; the interaction harness "
+        "is dev/test-only and must be run from a source checkout"
+    )
+    return root
+
+
+def kernel_conftest() -> ModuleType:
+    """The worker kernel conftest, loaded BY PATH and reused if already imported.
+
+    Loaded rather than duplicated, and this is the deliberate direction of the
+    dependency: ``kernel_harness`` (the real ``Kernel``, the real
+    ``SandboxSubstrate`` over ``FakeK8s``, the real ``RunnerClient``, the fake
+    runner server) is ~150 lines of assembly that ~480 existing kernel tests
+    already depend on, and the plan's A1 block is explicit that the D2 real
+    runner enters through its EXISTING ``runner_app=`` parameter rather than
+    through a second seam. Copying it here would fork all of that.
+
+    ``--import-mode=importlib`` with no ``__init__.py`` means the conftest cannot
+    be imported by name, and pytest registers it under a mangled, unstable key.
+    An already-loaded module with the same resolved ``__file__`` is reused so the
+    conftest is never executed twice in one process -- which would give a test
+    session two ``FakeRunner`` classes and make ``isinstance`` lie.
+    """
+
+    path = repo_root() / "apps" / "worker" / "tests" / "kernel" / "conftest.py"
+    assert path.is_file(), f"kernel conftest not found at {path}"
+    for module in list(sys.modules.values()):
+        file = getattr(module, "__file__", None)
+        if file and Path(file).resolve() == path:
+            assert isinstance(module, ModuleType)
+            return module
+    name = "_curie_interaction_kernel_conftest"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Registered BEFORE it executes. ``@dataclass`` resolves its own module out
+    # of ``sys.modules`` while processing a class (CPython 3.14 dataclasses.py:
+    # ``_is_type``), so a module executed outside ``sys.modules`` dies on the
+    # first dataclass in the file with a bare ``NoneType has no __dict__``.
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop(name, None)
+        raise
+    return module
+
+
+def _authorize(**_kwargs: Any) -> Any:
+    """Bolt's workspace authorization, resolved to a fixed bot identity.
+
+    Mirrors apps/dispatcher/tests/conftest.py:30. Redeclared rather than loaded
+    by path: it is four literal fields with no behavior, and reaching into a
+    second app's conftest from a package would couple this module to that file's
+    layout for no gain, where the kernel conftest above is loaded precisely
+    because it has behavior worth not forking.
+    """
+
+    from slack_bolt.authorization import AuthorizeResult
+
+    return AuthorizeResult(
+        enterprise_id=None,
+        team_id="T1",
+        bot_token="xoxb-test",
+        bot_id="B1",
+        bot_user_id="U0BOT",
+    )
+
+
+class _CapturingSocket:
+    """Captures the envelope acks Bolt sends back over the socket.
+
+    The ack BODY, not just the id (#1053): a block_actions ack is empty, but a
+    view_submission ack is a channel in its own right -- it is where a refused
+    submission's reason is rendered, since the approver is standing in an open
+    modal. ``act`` reads its refusal verdict from here.
+    """
+
+    def __init__(self) -> None:
+        import logging
+
+        self.logger = logging.getLogger("interaction-harness-socket")
+        self.acked_envelope_ids: list[str] = []
+        self.ack_payloads: dict[str, Any] = {}
+
+    def send_socket_mode_response(self, response: Any) -> None:
+        self.acked_envelope_ids.append(response.envelope_id)
+        self.ack_payloads[response.envelope_id] = getattr(response, "payload", None)
+
+    def ack_payload_for(self, envelope_id: str) -> Any:
+        return self.ack_payloads.get(envelope_id)
+
+
+# --- The harness --------------------------------------------------------------
+
+
+class InteractionHarness:
+    """One composed Curie stack, driven through six bounded verbs.
+
+    Sync on purpose: an agent scripting this over a pipe has no event loop, and
+    every async collaborator (the kernel, the substrate, the Valkey client) is
+    driven on a private loop owned by this object and running on its own thread.
+    That loop is created in ``__enter__`` and stopped in ``__exit__``, so nothing
+    it owns can outlive the context -- which is the same property the teardown
+    port probe asserts for the API server.
+    """
+
+    def __init__(self) -> None:
+        self._run_id = uuid.uuid4().hex
+        self._entered = False
+        self._stack: contextlib.ExitStack | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._loop_thread: threading.Thread | None = None
+        self._redis: redis.Redis | None = None
+        self._names: dict[str, str] = {}
+        self._api: ComposedApi | None = None
+        self._env: JourneyEnv | None = None
+        self._kernel_harness: Any = None
+        self._recorder = JourneyRecorder()
+        self._resolver_factory: Callable[..., Any] | None = None
+        self._approval_http: Any = None
+        # Captured channel state. ``_cards`` keeps the FULL rendered card dict
+        # per message id, because a click envelope must carry the real message
+        # (blocks included) exactly as Slack would deliver it.
+        self._messages: list[CapturedMessage] = []
+        self._cards: dict[str, dict[str, Any]] = {}
+        self._threads_awaiting: set[str] = set()
+        self._faults: dict[str, ArmedFault] = {}
+        self._sends = 0
+        # The approval this run is currently about, and a short-lived cache of
+        # its status. ``await_outcome`` polls tens of times a second, so an
+        # uncached read per poll would make every wait a load test of the
+        # loopback server instead of a test of the behavior.
+        self._approval_id: str | None = None
+        self._status_cache: tuple[float, str | None] = (0.0, None)
+        self._consumer_obj: Any = None
+        self._runner: Any = None
+        # The deadline of the verb currently running, if any. Every blocking
+        # segment reached from inside a verb (an ``httpx`` request, a Valkey
+        # write) clips its own timeout to what is LEFT of this budget, which is
+        # what makes the verb's headline bound true of the whole verb rather
+        # than only of its local polling loops.
+        self._guard: _Deadline | None = None
+
+    # -- deadline plumbing ----------------------------------------------------
+
+    @contextlib.contextmanager
+    def _bounded(self, guard: _Deadline) -> Iterator[_Deadline]:
+        """Make ``guard`` the budget every nested blocking segment clips to."""
+
+        previous = self._guard
+        self._guard = guard
+        try:
+            yield guard
+        finally:
+            self._guard = previous
+
+    def _budget(self, default: float, *, what: str) -> float:
+        """The timeout one nested blocking call may take, under the active verb.
+
+        Raises rather than returning zero when the budget is already spent: a
+        call issued with a zero timeout either fails with a transport error that
+        names nothing, or (worse) is treated as "no timeout" by the library.
+        ``HarnessTimeout`` names the verb and the segment instead.
+        """
+
+        guard = self._guard
+        if guard is None:
+            return default
+        remaining = guard.remaining_s
+        if remaining <= 0.0:
+            raise guard.expired(what=what)
+        return min(default, remaining)
+
+    def _timed_out(
+        self, what: str, exc: BaseException, *, timeout: float, default: float
+    ) -> BaseException:
+        """Report a clipped call's timeout as the VERB's timeout, when it is one.
+
+        A clipped ``httpx`` read that expires because the verb's budget ran out
+        is the verb timing out, and must arrive as ``HarnessTimeout`` naming the
+        verb -- an agent that sees ``httpx.ReadTimeout`` cannot tell which
+        scripted step wedged. A read that expires with budget still left, on its
+        OWN full ceiling, is a genuinely slow API and keeps its own exception.
+
+        Which of the two it was is decided by the timeout the call actually
+        carried, not by re-reading the clock afterwards. ``remaining_s <= 0``
+        was the previous test and it is a race: ``httpx`` fires its own timer a
+        few milliseconds early, or the thread is descheduled the other way, and
+        the very same wedge surfaces as a bare ``httpx.TimeoutException`` on one
+        run and a ``HarnessTimeout`` on the next. If the segment was clipped
+        (``timeout < default``) it was the verb's budget that expired, full
+        stop.
+        """
+
+        guard = self._guard
+        if guard is None:
+            return exc
+        if timeout < default or guard.remaining_s <= 0.0:
+            return guard.expired(what=what)
+        return exc
+
+    def _redis_call(self, work: Callable[[], Any], *, what: str) -> Any:
+        """One Valkey command, bounded by the active verb's remaining budget.
+
+        Two mechanisms, because either alone leaves a hole. The socket timeout
+        is clipped so the command itself gives up (the client from
+        ``connect_or_skip`` has none, so a hung Valkey would otherwise block
+        forever in a C-level socket read). The call is then ALSO run through
+        ``_Deadline.run``, on a daemon thread joined under the budget, because a
+        socket timeout is per-recv rather than per-command and a trickling peer
+        can reset it indefinitely. ``_Deadline.run`` is what makes the verb's
+        headline bound true regardless of what the socket does.
+        """
+
+        guard = self._guard
+        if guard is None:
+            return work()
+        timeout = self._budget(_VALKEY_TIMEOUT_S, what=what)
+        self._clip_redis_socket(timeout)
+        return guard.run(work, what=what)
+
+    def _clip_redis_socket(self, timeout: float) -> None:
+        """Push ``timeout`` onto the Valkey client's pool AND its live sockets.
+
+        The pool kwargs alone govern only connections created from here on, and
+        the harness's client has a live one from ``__enter__``'s ping -- so the
+        one connection every verb actually uses would keep the library default
+        (none). Both are set.
+        """
+
+        pool = self.redis.connection_pool
+        pool.connection_kwargs["socket_timeout"] = timeout
+        for connection in (
+            *getattr(pool, "_available_connections", ()),
+            *getattr(pool, "_in_use_connections", ()),
+        ):
+            connection.socket_timeout = timeout
+            sock = getattr(connection, "_sock", None)
+            if sock is not None:
+                with contextlib.suppress(OSError):
+                    sock.settimeout(timeout)
+
+    # -- lifecycle ------------------------------------------------------------
+
+    def __enter__(self) -> InteractionHarness:
+        stack = contextlib.ExitStack()
+        self._stack = stack
+        try:
+            token = self._run_id
+            self._names = {
+                "stream": f"test:curie:runs:{token}",
+                "group": f"g-{token}",
+                "prefix": f"test:curie:worker:{token}",
+                "sandbox_prefix": f"test:curie:sandbox:{token}",
+            }
+            client = connect_or_skip(decode_responses=True)
+            stack.callback(client.close)
+            self._redis = client
+            stack.callback(self._purge_namespace)
+            # The run's namespace must be EMPTY at start. This is what "an
+            # isolated stack" actually bought, and unlike a port literal it is
+            # true on CI's Valkey and on any developer's.
+            assert client.exists(self._names["stream"]) == 0, (
+                f"the run's stream {self._names['stream']!r} already exists before "
+                "the harness sent anything; two runs are sharing a namespace"
+            )
+
+            database_url = stack.enter_context(disposable_migrated_database())
+            self._env = stack.enter_context(
+                journey_env(runs_stream=self._names["stream"], database_url=database_url)
+            )
+            self._api = stack.enter_context(composed_api_server())
+            self._resolver_factory = stack.enter_context(
+                resolve_client_factory(self._api, self._env)
+            )
+            self._start_loop(stack)
+            self._start_kernel(stack)
+            self._entered = True
+            return self
+        except BaseException:
+            stack.close()
+            self._stack = None
+            raise
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        # Faults first: a fault is a patch over production code, and leaving one
+        # armed past teardown poisons every later test in the process, which is
+        # the one failure this harness must never cause.
+        for armed in reversed(list(self._faults.values())):
+            armed.revert()
+        self._faults.clear()
+        port = self._api.port if self._api is not None else None
+        stack, self._stack = self._stack, None
+        self._entered = False
+        if stack is not None:
+            stack.close()
+        if port is not None:
+            self._assert_port_unreachable(port)
+
+    def _start_loop(self, stack: contextlib.ExitStack) -> None:
+        loop = asyncio.new_event_loop()
+        thread = threading.Thread(
+            target=loop.run_forever, name=f"interaction-loop-{self._run_id[:8]}", daemon=True
+        )
+        thread.start()
+        self._loop = loop
+        self._loop_thread = thread
+
+        def _stop() -> None:
+            loop.call_soon_threadsafe(loop.stop)
+            thread.join(timeout=30.0)
+            assert not thread.is_alive(), "the harness event loop did not stop"
+            loop.close()
+            self._loop = None
+
+        stack.callback(_stop)
+
+    def _start_kernel(self, stack: contextlib.ExitStack) -> None:
+        """Enter the shared ``kernel_harness`` on the private loop.
+
+        ``approvals=`` is the REAL ``ApprovalClient`` pointed at the composed
+        API, so an approval the kernel asks for is a real row in the disposable
+        database that the real dispatcher can later resolve. A recording fake
+        here would mint ids nothing else knows about, and every ``act`` would
+        then be driving an approval that does not exist.
+
+        ``runner_app=`` is the REAL ``curie_runner``, booted through its real
+        ``build_runner`` -> ``create_app`` path with only the MODEL faked, so the
+        verbs below drive production ACI frames rather than a test double's.
+        """
+
+        conftest = kernel_conftest()
+        assert self._api is not None and self._env is not None and self._redis is not None
+
+        runner, runner_app = self._build_real_runner(stack)
+
+        async def _enter() -> tuple[Any, Any, Any]:
+            import httpx
+            from curie_worker.approvals import ApprovalClient
+
+            await runner.start()
+            http = httpx.AsyncClient(timeout=30.0)
+            approvals = ApprovalClient(
+                api_base_url=self._api.base_url,  # type: ignore[union-attr]
+                api_key=self._env.api_key,  # type: ignore[union-attr]
+                client=http,
+                read_timeout_s=10.0,
+            )
+            cm = conftest.kernel_harness(
+                self._names,
+                self._redis,
+                approvals=approvals,
+                actions=self._recorder,
+                runner_app=runner_app,
+            )
+            harness = await cm.__aenter__()
+            return cm, harness, http
+
+        cm, harness, http = self._call(_enter(), timeout=120.0, verb="__enter__", what="the kernel")
+        self._kernel_harness = harness
+        self._approval_http = http
+
+        def _exit() -> None:
+            async def _close() -> None:
+                with contextlib.suppress(Exception):
+                    await cm.__aexit__(None, None, None)
+                with contextlib.suppress(Exception):
+                    await runner.stop()
+                with contextlib.suppress(Exception):
+                    await http.aclose()
+
+            with contextlib.suppress(Exception):
+                self._call(_close(), timeout=60.0, verb="__exit__", what="the kernel")
+
+        stack.callback(_exit)
+
+    def _build_real_runner(self, stack: contextlib.ExitStack) -> tuple[Any, Any]:
+        """The REAL runner, with the model seam faked, as an aiohttp app.
+
+        This is what makes "a real runner behind the verbs" a property of
+        ``send``/``act`` rather than of one bespoke test: the kernel dials this
+        app, so a turn driven through the harness compiles a real bundle, runs
+        the real session loop and emits production ACI frames. The MODEL is the
+        only stand-in, exactly as the two named ones allow.
+        """
+
+        import tempfile
+
+        from curie_runner import create_app
+        from curie_runner.__main__ import build_runner
+        from curie_runner.config import RunnerConfig
+
+        tmp = tempfile.TemporaryDirectory(prefix="interaction-runner-")
+        stack.callback(tmp.cleanup)
+        plugin_dir = Path(tmp.name) / "bundle"
+        (plugin_dir / ".claude-plugin").mkdir(parents=True)
+        (plugin_dir / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"name": "interaction-bot"}), encoding="utf-8"
+        )
+        config = RunnerConfig.from_env(
+            {
+                "CURIE_PLUGIN_DIR": str(plugin_dir),
+                "CURIE_SESSION_ID": f"interaction-{self._run_id[:8]}",
+                "CURIE_SANDBOX_ID": f"interaction-sandbox-{self._run_id[:8]}",
+                "CURIE_BUDGET": '{"max_output_tokens_per_run": 10000, "max_usd_per_day": 1.0}',
+            }
+        )
+        runner = build_runner(config, fake_model=True)
+        self._runner = runner
+        return runner, create_app(runner)
+
+    def _call(self, coro: Any, *, timeout: float, verb: str, what: str) -> Any:
+        """Run one coroutine on the private loop, bounded.
+
+        Bounded even for setup and teardown: a wedged kernel coroutine on a
+        daemon thread would otherwise hang the process with nothing in the report
+        naming it.
+        """
+
+        loop = self._loop
+        assert loop is not None, "the harness is not entered"
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+        started = time.monotonic()
+        try:
+            return future.result(timeout=timeout)
+        except TimeoutError:
+            future.cancel()
+            raise HarnessTimeout(
+                verb=verb,
+                what=what,
+                deadline_s=timeout,
+                elapsed_s=time.monotonic() - started,
+            ) from None
+
+    def _assert_port_unreachable(self, port: int) -> None:
+        """The composed API's port must refuse connections after teardown.
+
+        Asserted rather than assumed: a server thread that outlived its context
+        is a live, authenticated approval surface on a loopback port, and nothing
+        else in the process would ever notice.
+        """
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.settimeout(1.0)
+            try:
+                probe.connect(("127.0.0.1", port))
+            except OSError:
+                return
+        raise AssertionError(
+            f"the composed API on port {port} still accepts connections after teardown"
+        )
+
+    def _purge_namespace(self) -> None:
+        client = self._redis
+        if client is None:
+            return
+        for pattern in (
+            f"{self._names['prefix']}*",
+            f"{self._names['sandbox_prefix']}*",
+            self._names["stream"],
+        ):
+            with contextlib.suppress(Exception):
+                keys = list(client.scan_iter(match=pattern))
+                if keys:
+                    client.delete(*keys)
+
+    def _require_entered(self) -> None:
+        if not self._entered:
+            raise AssertionError(
+                "the InteractionHarness must be used as a context manager: "
+                "``with InteractionHarness() as harness:``"
+            )
+
+    # -- identity -------------------------------------------------------------
+
+    @property
+    def run_id(self) -> str:
+        return self._run_id
+
+    @property
+    def stream(self) -> str:
+        return self._names["stream"]
+
+    @property
+    def redis(self) -> redis.Redis:
+        assert self._redis is not None, "the harness is not entered"
+        return self._redis
+
+    @property
+    def api(self) -> ComposedApi:
+        assert self._api is not None, "the harness is not entered"
+        return self._api
+
+    @property
+    def env(self) -> JourneyEnv:
+        assert self._env is not None, "the harness is not entered"
+        return self._env
+
+    @property
+    def kernel(self) -> Any:
+        """The composed kernel harness, for assertions the verbs do not cover."""
+
+        assert self._kernel_harness is not None, "the harness is not entered"
+        return self._kernel_harness
+
+    @property
+    def runner(self) -> Any:
+        """The REAL ``curie_runner`` the kernel dials, with only its model faked.
+
+        Exposed so a test can assert against the runner's own state -- its fake
+        model session's recorded queries are the proof that a turn driven
+        through ``send`` really went through the production turn loop, and not
+        through a scripted double.
+        """
+
+        self._require_entered()
+        assert self._runner is not None, "the harness is not entered"
+        return self._runner
+
+    @property
+    def recorder(self) -> JourneyRecorder:
+        return self._recorder
+
+    @property
+    def sessionmaker(self) -> Any:
+        """The REAL sessionmaker the API's lifespan composed (main.py:78-95)."""
+
+        self._require_entered()
+        return self.api.app.state.sessionmaker
+
+    @property
+    def resume_queue(self) -> Any:
+        """The REAL ``ResumeQueue`` the API resolves through."""
+
+        self._require_entered()
+        return self.api.app.state.resume_queue
+
+    @property
+    def approval_id(self) -> str | None:
+        """The approval this run is currently about, if one has been created."""
+
+        return self._approval_id
+
+    @property
+    def armed_faults(self) -> tuple[str, ...]:
+        return tuple(self._faults)
+
+    # -- verbs ----------------------------------------------------------------
+
+    def send(self, text: str, *, thread: str | None = None, deadline_s: float = 60.0) -> SendResult:
+        """Drive one inbound turn through the REAL kernel.
+
+        PRODUCTION shape end to end, and one half of it only: the turn is xadded
+        to the run's stream with the dispatcher's own serialiser and then the
+        REAL worker ``Consumer`` reads it. Never both an xadd and a direct
+        ``process_event`` -- that pairing has no production counterpart and lets
+        two processors race one event id.
+
+        The first turn on a thread carries the fake model's approval MARKER, so
+        the REAL runner takes the production ``request_approval`` path: the
+        kernel creates a real record through the real ``ApprovalClient`` and
+        emits the real ``ConfirmIntent`` post. A SECOND turn on a thread that is
+        already suspended is a follow-up, not a second approval request, and is
+        sent unmarked -- a second card would queue a second pending decision for
+        one human and make ``messages()`` ambiguous about which card ``act``
+        should drive.
+        """
+
+        self._require_entered()
+        guard = _Deadline(verb="send", deadline_s=deadline_s)
+        with self._bounded(guard):
+            return self._send(text, thread=thread, guard=guard)
+
+    def _send(self, text: str, *, thread: str | None, guard: _Deadline) -> SendResult:
+        from aci_protocol import QueuedTurn as _QueuedTurn
+        from aci_protocol import ReplyHandle, TurnSource
+        from curie_runner.fake import APPROVAL_MARKER
+
+        self._sends += 1
+        thread_id = thread or f"th-{self._run_id[:8]}-{self._sends}"
+        event_id = uuid.uuid4().hex
+        first_turn = thread_id not in self._threads_awaiting
+        # The turn is steered through the REAL runner's fake-model marker, not
+        # by scripting a test double's frames: the fake model's default script
+        # branches on this marker and calls the production
+        # ``mcp__curie__request_approval`` tool, so the approval the kernel ends
+        # up creating came out of the real runner's real turn loop.
+        prompt = f"{APPROVAL_MARKER} {text}" if first_turn else text
+
+        qevent = _QueuedTurn(
+            event_id=event_id,
+            conversation_id=thread_id,
+            author=HARNESS_AUTHOR,
+            text=prompt,
+            reply_handle=ReplyHandle(
+                kind="slack", channel=HARNESS_CHANNEL, placeholder=f"p-{self._sends}"
+            ),
+            received_at=_now_iso(),
+            source=TurnSource.SLACK,
+        )
+        # PRODUCTION SHAPE, and exactly one of the two halves of it. The
+        # dispatcher xadds every inbound turn to the run's stream and the worker
+        # CONSUMES it; the API's ``ResumeQueue`` xadds resumes to that same
+        # stream (resumequeue.py:5,252-257). An earlier version did both -- xadd
+        # AND a direct ``kernel.process_event`` on the same ``QueuedTurn`` --
+        # which is a shape production never has: the entry is readable by a live
+        # ``Consumer`` while ``process_event`` is still in flight, so one event
+        # id gets two concurrent processors and the terminal-marker skip only
+        # helps the loser. So: xadd, then run the REAL consumer over THIS entry
+        # and stop it. The stream still carries the inbound turn (a run's
+        # namespace is not empty after a send, and a stream-entry predicate has
+        # a truthful thing to observe), and nothing ever processes it twice.
+        from curie_dispatcher.queue import to_stream_fields
+
+        fields: Any = to_stream_fields(qevent)
+        # The group offset must exist BEFORE the entry lands or the consumer
+        # never sees it.
+        self._call(
+            self._ensure_consumer_group(),
+            timeout=max(_MIN_CALL_S, guard.remaining_s),
+            verb="send",
+            what="the consumer group to exist",
+        )
+        self._redis_call(
+            lambda: self.redis.xadd(self.stream, fields),
+            what=f"the inbound turn {event_id} to be queued",
+        )
+        self._call(
+            self._consume_one(event_id),
+            timeout=max(_MIN_CALL_S, guard.remaining_s),
+            verb="send",
+            what=f"the worker to consume the turn {event_id}",
+        )
+        if first_turn:
+            self._threads_awaiting.add(thread_id)
+        self._capture()
+        return SendResult(
+            message_id=f"snd-{event_id[:12]}",
+            thread=thread_id,
+            run_id=self._run_id,
+            event_id=event_id,
+            text=text,
+        )
+
+    def messages(self) -> MessagesResult:
+        """Everything captured on the channel edge, with each card's actions."""
+
+        self._require_entered()
+        self._capture()
+        messages = tuple(self._messages)
+        cards = tuple(
+            CapturedCard(
+                message_id=message.message_id,
+                approval_id=message.approval_id,
+                actions=message.actions,
+                message=message,
+            )
+            for message in messages
+            if message.actions
+        )
+        return MessagesResult(messages=messages, cards=cards)
+
+    def act(
+        self,
+        *,
+        message: str | CapturedMessage | CapturedCard,
+        action: CapturedAction | Any,
+        actor: str,
+        note: str | None = None,
+        deadline_s: float = 30.0,
+    ) -> ActResult:
+        """Drive one CAPTURED action through the real dispatcher and API.
+
+        ``action`` must be a :class:`CapturedAction` that came out of
+        :meth:`messages`. A bare string raises :class:`UncapturedAction` even
+        when the string is the right action id -- see the class docstring for
+        why provenance rather than validity is the contract.
+        """
+
+        self._require_entered()
+        guard = _Deadline(verb="act", deadline_s=deadline_s)
+        # Bounded as a WHOLE, not just in its polling loops: the status
+        # read-back and every other HTTP call reached from inside this verb
+        # clips its own timeout to what is left of ``guard`` (``_budget``).
+        with self._bounded(guard):
+            return self._act(message=message, action=action, actor=actor, note=note, guard=guard)
+
+    def _act(
+        self,
+        *,
+        message: str | CapturedMessage | CapturedCard,
+        action: CapturedAction | Any,
+        actor: str,
+        note: str | None,
+        guard: _Deadline,
+    ) -> ActResult:
+        captured = self._require_captured_action(message, action)
+        card = self._cards[captured.message_id]
+        button = _button_for(card, captured)
+        from curie_dispatcher.approval_actions import (
+            APPROVE_NOTE_ACTION_ID,
+            NOTE_MODAL_CALLBACK_ID,
+            REJECT_NOTE_ACTION_ID,
+        )
+        from slack_bolt.adapter.socket_mode import SocketModeHandler
+
+        assert self._resolver_factory is not None
+
+        def _build() -> Any:
+            assert self._resolver_factory is not None
+            resolver = self._resolver_factory()
+            wrap_resolve_client(resolver, self._faults)
+            built_app, built_web_client = self._build_dispatcher(resolver, card)
+            return built_app, built_web_client, SocketModeHandler(built_app, app_token="xapp-test")
+
+        app, web_client, handler = guard.run(_build, what="the per-call dispatcher app to be built")
+        note_path = captured.action_id in {APPROVE_NOTE_ACTION_ID, REJECT_NOTE_ACTION_ID}
+        ack_body: Any = None
+        try:
+            click_socket = _CapturingSocket()
+            click_envelope = f"env-{uuid.uuid4().hex[:8]}"
+            click_request = _click_request(
+                click_envelope,
+                card=card,
+                button=button,
+                user=actor,
+                channel=HARNESS_CHANNEL,
+            )
+            guard.run(
+                lambda: handler.handle(click_socket, click_request),
+                what="the click to be dispatched",
+            )
+            if note_path:
+                guard.wait(
+                    lambda: bool(web_client.views_open.call_args),
+                    what="the note modal to open after the click",
+                )
+                view = web_client.views_open.call_args.kwargs["view"]
+                assert view["callback_id"] == NOTE_MODAL_CALLBACK_ID
+                metadata = str(view["private_metadata"])
+                if "private_metadata_unusable" in self._faults:
+                    # Tampered, not replaced: the refusal under test is the
+                    # dispatcher refusing metadata it cannot trust, and a wholly
+                    # invented string would also fail a shape check that is not
+                    # the thing being proven.
+                    metadata = metadata[:-1] + ("x" if not metadata.endswith("x") else "y")
+                submit_socket = _CapturingSocket()
+                submit_envelope = f"env-{uuid.uuid4().hex[:8]}"
+                submit_request = _view_submission_request(
+                    submit_envelope,
+                    private_metadata=metadata,
+                    user=actor,
+                    note=_DEFAULT_NOTE if note is None else note,
+                    callback_id=NOTE_MODAL_CALLBACK_ID,
+                )
+                guard.run(
+                    lambda: handler.handle(submit_socket, submit_request),
+                    what="the note submission to be dispatched",
+                )
+                guard.wait(
+                    lambda: submit_envelope in submit_socket.acked_envelope_ids,
+                    what="the note submission to be acked",
+                )
+                ack_body = submit_socket.ack_payload_for(submit_envelope)
+            else:
+                guard.wait(
+                    lambda: click_envelope in click_socket.acked_envelope_ids,
+                    what="the click to be acked",
+                )
+                ack_body = click_socket.ack_payload_for(click_envelope)
+            self._drain(app, guard)
+        finally:
+            # The Bolt listener executor is shut down exactly once, at the end,
+            # and never reused: ``shutdown(wait=True)`` is terminal, so a second
+            # envelope through the same app dies with "cannot schedule new
+            # futures after shutdown". One app per ``act`` is what makes that
+            # safe.
+            with contextlib.suppress(Exception):
+                app.listener_runner.listener_executor.shutdown(wait=False)
+
+        self._status_cache = (0.0, None)
+        rendered = web_client.chat_update.call_args
+        rendered_text = None if rendered is None else str(rendered.kwargs.get("text", ""))
+        outcome = guard.run(
+            lambda: self._approval_status(captured.value),
+            what="the approval status to be read back after the click",
+        )
+        # An empty ack body is the ACCEPTED submission: a refusal carries
+        # ``response_action: errors`` (handlers.py:637-645).
+        accepted = ack_body is None
+        self._capture()
+        return ActResult(
+            action_id=captured.action_id,
+            message_id=captured.message_id,
+            actor=actor,
+            accepted=accepted,
+            outcome=outcome,
+            note=None if note_path is False else (_DEFAULT_NOTE if note is None else note),
+            detail="" if ack_body is None else json.dumps(ack_body, default=str),
+            response_action=ack_body if isinstance(ack_body, dict) else None,
+            rendered_text=rendered_text,
+            approval_id=captured.value,
+        )
+
+    def create_approval(self, **overrides: Any) -> ApprovalRecord:
+        """Create a pending approval through the REAL ``POST /approvals``.
+
+        The same route an operator hits, with the platform key. Offered beside
+        :meth:`send` (which reaches the same route THROUGH the kernel) because a
+        failure case often needs a pending record without also needing a turn to
+        be suspended behind it -- and inventing a row with a direct SQL insert
+        would skip the API's own validation, which is part of what the journey
+        asserts.
+        """
+
+        self._require_entered()
+        body: dict[str, Any] = {
+            "conversation_id": f"th-{uuid.uuid4().hex[:8]}",
+            "author": HARNESS_AUTHOR,
+            "summary": "Scale the payments deployment to 10 replicas",
+            "reply_kind": "slack",
+            "reply_channel": HARNESS_CHANNEL,
+            "reply_placeholder": "p-1",
+            "dedupe_key": f"ev-{uuid.uuid4().hex}",
+            "card_channel": HARNESS_CHANNEL,
+        }
+        body.update(overrides)
+        payload = self._api_call("POST", "/approvals", json=body, expect=(200, 201))
+        self._approval_id = str(payload["id"])
+        self._status_cache = (0.0, None)
+        return _approval_record(payload)
+
+    def resolve(
+        self,
+        *,
+        approval_id: str,
+        decision: str,
+        actor: str,
+        channel: str = HARNESS_CHANNEL,
+        note: str | None = None,
+        deadline_s: float = 30.0,
+    ) -> ActResult:
+        """Resolve an approval through the real resolve client, WITHOUT a card.
+
+        INTERNAL, and deliberately NOT exposed as a CLI verb. It takes a literal
+        approval id and decision with no captured card, which is exactly the
+        shortcut :meth:`act`'s provenance rule exists to forbid; handing an agent
+        scripting the harness that shortcut would retire the rule in a release.
+        Its callers are the failure tests that have no card to click.
+
+        Deliberately a separate, explicitly named verb rather than a relaxation
+        of :meth:`act`. Some cases -- a resolution whose enqueue was dropped, a
+        resolve whose transport fails -- are about the resolve hop itself and
+        have no card to click; letting ``act`` take a bare id to serve them would
+        hand every future test the same shortcut, and the provenance rule would
+        be gone within a release. The name is the honesty: a case that calls
+        ``resolve`` is visibly NOT claiming a chat click drove it.
+        """
+
+        self._require_entered()
+        assert self._resolver_factory is not None
+        guard = _Deadline(verb="resolve", deadline_s=deadline_s)
+        with self._bounded(guard):
+            return self._resolve(
+                approval_id=approval_id,
+                decision=decision,
+                actor=actor,
+                channel=channel,
+                note=note,
+                guard=guard,
+            )
+
+    def _resolve(
+        self,
+        *,
+        approval_id: str,
+        decision: str,
+        actor: str,
+        channel: str,
+        note: str | None,
+        guard: _Deadline,
+    ) -> ActResult:
+        assert self._resolver_factory is not None
+        resolver = self._resolver_factory()
+        wrap_resolve_client(resolver, self._faults)
+        outcome_box: list[Any] = []
+        error_box: list[BaseException] = []
+
+        def _run() -> None:
+            try:
+                outcome_box.append(
+                    resolver.resolve(
+                        approval_id,
+                        decision=decision,
+                        attested_user=actor,
+                        attested_channel=channel,
+                        note=note,
+                    )
+                )
+            except BaseException as exc:  # noqa: BLE001 - surfaced through the box
+                error_box.append(exc)
+
+        # On a worker thread with a joined deadline, for the same reason every
+        # other wait here is bounded: an armed ``hang`` fault parks the call for
+        # longer than the verb's budget, and a direct call would block the
+        # caller with no way to report which verb wedged.
+        worker = threading.Thread(target=_run, name="interaction-resolve", daemon=True)
+        worker.start()
+        guard.wait(lambda: not worker.is_alive(), what=f"the resolve of {approval_id}")
+        if error_box:
+            raise error_box[0]
+        outcome = outcome_box[0]
+        self._status_cache = (0.0, None)
+        record = self.approval(approval_id)
+        return ActResult(
+            # Empty on purpose, and now informative rather than merely blank:
+            # this verb drove no card and no view, so there is no action id, no
+            # message id, no ack body and no ``chat_update`` -- inventing any of
+            # them would claim a chat surface the product never rendered here.
+            # The identity of what WAS driven rides in ``approval_id``, and the
+            # resolve hop's real answer in ``status_code``.
+            action_id="",
+            message_id="",
+            actor=actor,
+            accepted=200 <= int(outcome.status_code) < 300,
+            outcome=record.status,
+            note=note,
+            detail=str(outcome.detail or ""),
+            response_action=None,
+            rendered_text=None,
+            approval_id=approval_id,
+            status_code=int(outcome.status_code),
+        )
+
+    def approval(self, approval_id: str) -> ApprovalRecord:
+        """One approval row, over the REAL ``GET /approvals/{id}``."""
+
+        self._require_entered()
+        payload = self._api_call("GET", f"/approvals/{approval_id}", expect=(200,))
+        return _approval_record(payload)
+
+    def audit(self, approval_id: str) -> AuditResult:
+        """One approval's audit trail, over the REAL ``GET /approvals/{id}/audit``.
+
+        The audit trail is where the authorizer NAMES itself, which is what keeps
+        a refusal assertion honest: an unseeded route refuses everyone through
+        ``UnboundRouteBinding``, so a test asserting only "refused" would pass
+        without the authorizer under test ever running.
+        """
+
+        self._require_entered()
+        rows = self._api_call("GET", f"/approvals/{approval_id}/audit", expect=(200,))
+        assert isinstance(rows, list), f"audit did not return a list: {rows!r}"
+        return AuditResult(
+            approval_id=approval_id,
+            entries=tuple(_audit_entry(row) for row in rows),
+        )
+
+    def resume_turns(self) -> ResumeTurnsResult:
+        """Every resume turn currently on the run's stream, decoded.
+
+        Read off the stream the API's real ``ResumeQueue.enqueue`` xadded to, so
+        "a resume was queued" means an entry exists rather than meaning a mock
+        was called.
+        """
+
+        self._require_entered()
+        from aci_protocol import STREAM_PAYLOAD_FIELD
+        from aci_protocol.ndjson import parse_queued_turn
+        from curie_api.resumequeue import parse_resume_event_id
+
+        rows: Any = self._redis_call(
+            lambda: self.redis.xrange(self.stream, "-", "+"),
+            what=f"the stream {self.stream} to be read back",
+        )
+        turns = []
+        for entry_id, fields in rows or []:
+            payload = (fields or {}).get(STREAM_PAYLOAD_FIELD)
+            if payload is None:
+                continue
+            turn = parse_queued_turn(payload)
+            # RESUME turns only. The run's stream carries inbound turns too --
+            # ``send`` xadds one with the dispatcher's own serialiser, exactly as
+            # production does -- so an unfiltered read reported "two resumes" for
+            # one send plus one resolve, and every "exactly one resume" assertion
+            # in the failure suite was counting the wrong population. The filter
+            # is the PRODUCTION discriminator (``parse_resume_event_id``, the
+            # inverse of the key ``ResumeQueue`` enqueues under), not a local
+            # guess at what a resume looks like.
+            if parse_resume_event_id(turn.event_id) is None:
+                continue
+            turns.append(
+                ResumeTurn(
+                    entry_id=str(entry_id),
+                    event_id=turn.event_id,
+                    conversation_id=turn.conversation_id,
+                    text=turn.text,
+                )
+            )
+        return ResumeTurnsResult(stream=self.stream, turns=tuple(turns))
+
+    def await_outcome(
+        self, *, predicate: Callable[[Snapshot], bool], deadline_s: float
+    ) -> OutcomeResult:
+        """Poll until ``predicate`` accepts a snapshot, or raise ``HarnessTimeout``."""
+
+        self._require_entered()
+        guard = _Deadline(verb="await_outcome", deadline_s=deadline_s)
+        started = time.monotonic()
+        # Under the guard, not merely around it: the predicate reads
+        # ``snapshot()``, which reads the approval's status over HTTP, and that
+        # read carries its own 10s timeout. Outside the budget a single hung
+        # read holds a 1s verb for ten seconds -- the bound would be honoured by
+        # the polling loop and broken by the thing the loop calls.
+        with self._bounded(guard):
+            guard.wait(
+                lambda: predicate(self.snapshot()),
+                what="the await_outcome predicate to become true",
+            )
+            snapshot = self.snapshot()
+            record = self.approval(self._approval_id) if self._approval_id else None
+            resume_turns = self.resume_turns().turns
+        return OutcomeResult(
+            satisfied=True,
+            elapsed_s=time.monotonic() - started,
+            deadline_s=deadline_s,
+            stream_entries=snapshot.stream_entries,
+            message_count=len(snapshot.messages),
+            approval_id=self._approval_id,
+            approval_status=None if record is None else record.status,
+            resolved_by=None if record is None else record.resolved_by,
+            resume_turns=resume_turns,
+        )
+
+    def snapshot(self) -> Snapshot:
+        """The current observable state, as a value a predicate can read."""
+
+        self._capture()
+        return Snapshot(
+            run_id=self._run_id,
+            messages=tuple(self._messages),
+            stream_entries=int(
+                self._redis_call(
+                    lambda: self.redis.xlen(self.stream),
+                    what=f"the stream {self.stream} to report its length",
+                )
+            ),
+            approval_status=self._cached_status(),
+            approval_id=self._approval_id,
+        )
+
+    def reset(self, *, deadline_s: float = 30.0) -> ResetResult:
+        """Empty the run's stream namespace, leaving the harness usable.
+
+        Against the store, not against bookkeeping: a reset that zeroed a counter
+        and left the entries in Valkey would make the NEXT step's "exactly one
+        stream entry" read two. Idempotent because an agent resets defensively
+        between steps and has no cheap way to know whether anything happened.
+
+        Bounded like every other blocking verb. It was the one of the six that
+        took no ``deadline_s`` at all, on the reasoning that two Valkey commands
+        are fast -- true right up until Valkey is the thing that is wedged, at
+        which point the "defensive reset between steps" an agent is told to make
+        is an unbounded hang with no verb name on it.
+        """
+
+        self._require_entered()
+        guard = _Deadline(verb="reset", deadline_s=deadline_s)
+        with self._bounded(guard):
+            self._redis_call(
+                lambda: self.redis.delete(self.stream),
+                what=f"the stream {self.stream} to be deleted",
+            )
+            remaining = int(
+                self._redis_call(
+                    lambda: self.redis.exists(self.stream),
+                    what=f"the stream {self.stream} to report itself gone",
+                )
+            )
+        assert remaining == 0, f"the stream {self.stream!r} survived a reset"
+        return ResetResult(stream=self.stream, entries_remaining=0)
+
+    @contextlib.contextmanager
+    def inject_fault(self, name: str, **kwargs: Any) -> Iterator[ArmedFault]:
+        """Arm one fault for the body, and revert it in a ``finally``.
+
+        The revert is in a ``finally`` specifically because of the exceptional
+        path: an implementation without one passes every happy-path test and then
+        fails as an unrelated test, in a later module, with no trace back to the
+        fault that caused it.
+        """
+
+        armed = self.arm_fault(name, **kwargs)
+        try:
+            yield armed
+        finally:
+            self.disarm_fault(name)
+
+    def arm_fault(self, name: str, **kwargs: Any) -> ArmedFault:
+        """Arm one fault until it is disarmed, WITHOUT a scope to revert it.
+
+        The scoped :meth:`inject_fault` is the in-process form and the one to
+        prefer; this pair exists because the ``python -m`` entry point is a
+        sequence of independent NDJSON lines with no Python block to hang a
+        ``with`` on, so an agent on the pipe could otherwise arm no fault at all
+        and half the harness's failure surface was unreachable from it.
+        ``__exit__`` reverts whatever is still armed, so a script that forgets
+        to disarm still cannot leak a patch past the harness.
+        """
+
+        self._require_entered()
+        if name in self._faults:
+            raise ValueError(f"fault {name!r} is already armed: {self.armed_faults}")
+        armed = arm_fault(name, **kwargs)
+        self._faults[name] = armed
+        return armed
+
+    def disarm_fault(self, name: str) -> FaultResult:
+        """Revert one armed fault. Idempotent, so a defensive disarm is safe."""
+
+        self._require_entered()
+        armed = self._faults.pop(name, None)
+        if armed is not None:
+            armed.revert()
+        return FaultResult(fault=name, armed=False, armed_faults=self.armed_faults)
+
+    # -- internals ------------------------------------------------------------
+
+    @staticmethod
+    def _message_id_of(message: Any) -> str:
+        """The message id a caller named, however they named it.
+
+        ``messages()`` hands back three things that all identify one message -- a
+        ``CapturedMessage``, a ``CapturedCard`` and a bare id string -- and every
+        one of them is a reasonable thing to pass to ``act(message=...)``. Taking
+        only the string made the provenance check below compare a ``str`` against
+        a dataclass, which is never equal, so a legitimately captured action was
+        refused with a message that printed the whole object.
+        """
+
+        if isinstance(message, CapturedMessage | CapturedCard):
+            return message.message_id
+        return str(message)
+
+    def _require_captured_action(
+        self, message: str | CapturedMessage | CapturedCard, action: Any
+    ) -> CapturedAction:
+        if not isinstance(action, CapturedAction):
+            raise UncapturedAction(
+                f"act() refuses {action!r}: an action must be a CapturedAction "
+                "object taken from messages(), not a literal action id. The "
+                "harness proves a real click drove the system, and a literal "
+                "skips the card render, the ownership probe and the block "
+                "structure while still reporting a green journey."
+            )
+        message_id = self._message_id_of(message)
+        # Matched on OBJECT IDENTITY against the actions this harness itself
+        # captured, never on content. ``_capture`` appends each
+        # ``CapturedMessage`` exactly once and ``messages()`` hands back
+        # ``tuple(self._messages)``, so the very objects a caller holds ARE the
+        # stored ones -- identity costs a legitimate caller nothing, including
+        # one holding an action from an older ``messages()`` snapshot.
+        #
+        # Content matching is what this replaces, and it was a hole rather than
+        # a convenience: ``(message_id, action_id, value)`` is all reconstructible
+        # from an imported action-id constant, the harness's ``1700.%04d``
+        # message-id scheme and an approval id, so a caller could hand-build a
+        # ``CapturedAction`` and skip the card entirely -- the render, the
+        # ownership probe, the block structure -- which is the exact shortcut
+        # ``act`` exists to refuse.
+        seen_on: set[str] = set()
+        for candidate in self._messages:
+            for known in candidate.actions:
+                if known is not action:
+                    continue
+                seen_on.add(known.message_id)
+                if known.message_id == message_id:
+                    return known
+        if seen_on:
+            raise UncapturedAction(
+                f"act() refuses {action.action_id!r}: it was captured on "
+                f"message(s) {sorted(seen_on)!r}, not {message_id!r}"
+            )
+        looks_captured = any(
+            (known.message_id, known.action_id, known.value)
+            == (action.message_id, action.action_id, action.value)
+            for candidate in self._messages
+            for known in candidate.actions
+        )
+        if looks_captured:
+            raise UncapturedAction(
+                f"act() refuses {action.action_id!r}: its fields match a captured "
+                "action but the object itself did not come out of messages(). A "
+                "hand-built CapturedAction skips the card render, the ownership "
+                "probe and the block structure while still reporting a green "
+                "journey, so provenance is the object, not its contents -- pass "
+                "the action from messages() itself."
+            )
+        raise UncapturedAction(
+            f"act() refuses {action.action_id!r}: no such action was captured on "
+            "this harness; it did not come from messages()"
+        )
+
+    def _build_dispatcher(self, resolver: Any, card: dict[str, Any]) -> tuple[Any, Any]:
+        """The real dispatcher app, with only Slack's own surface faked."""
+
+        from unittest.mock import MagicMock
+
+        from curie_dispatcher.app import build_app
+        from curie_dispatcher.config import DispatcherConfig
+        from slack_sdk.web import WebClient
+
+        config = DispatcherConfig(
+            slack_app_token="xapp-test",
+            slack_bot_token="xoxb-test",
+            valkey_host=_VALKEY_HOST,
+            valkey_port=_VALKEY_PORT,
+            valkey_password=_VALKEY_PW,
+            stream=self.stream,
+            dedupe_prefix=f"test:curie:dedupe:{uuid.uuid4().hex}:",
+            dedupe_ttl_seconds=60,
+            placeholder_text="Working on it.",
+            approval_chat_attester_secret=self.env.attester_secret,
+        )
+        web_client = WebClient(token="xoxb-test")
+        web_client.chat_postMessage = MagicMock(return_value={"ts": "555.000"})  # type: ignore[method-assign]
+        web_client.chat_update = MagicMock(return_value={"ok": True})  # type: ignore[method-assign]
+        web_client.chat_postEphemeral = MagicMock(return_value={"ok": True})  # type: ignore[method-assign]
+        web_client.views_open = MagicMock(return_value={"ok": True})  # type: ignore[method-assign]
+        web_client.conversations_replies = MagicMock(  # type: ignore[method-assign]
+            return_value={"messages": [card]}
+        )
+        app = build_app(
+            config,
+            web_client=web_client,
+            redis_client=self.redis,
+            authorize=_authorize,
+            resolver=resolver,
+        )
+        return app, web_client
+
+    def _new_consumer(self) -> Any:
+        """A REAL worker ``Consumer`` over this run's stream.
+
+        One per ``send``, never reused: ``request_stop`` is terminal, so a second
+        ``run()`` on a stopped consumer returns immediately and the entry sits
+        unread until the verb's deadline.
+        """
+
+        from curie_worker.consumer import Consumer
+
+        return Consumer(
+            redis=self.kernel.async_redis,
+            kernel=self.kernel.kernel,
+            config=self.kernel.config,
+        )
+
+    async def _ensure_consumer_group(self) -> None:
+        self._consumer_obj = self._new_consumer()
+        await self._consumer_obj.ensure_group()
+
+    async def _consume_one(self, event_id: str) -> None:
+        """Run the real consumer until it has finished ONE entry, then stop it.
+
+        Run per send rather than left running for the harness's lifetime: a
+        background consumer would also pick up the resume entries the API
+        enqueues, so a verb that asserts "a resume is queued" would be racing a
+        consumer that drives a further turn and posts further messages. One
+        consumer, one entry, joined -- the production hop, without a second
+        processor anywhere in the picture.
+        """
+
+        consumer, self._consumer_obj = self._consumer_obj, None
+        assert consumer is not None, "the consumer group was not ensured before the xadd"
+        sink = self._kernel_harness.sink
+        before = len(sink.posts)
+        task = asyncio.create_task(consumer.run())
+        try:
+            deadline = time.monotonic() + _CONSUME_TIMEOUT_S
+            while True:
+                done = any(c.event_id == event_id for c in sink.completions)
+                if done or len(sink.posts) > before:
+                    return
+                if time.monotonic() >= deadline:
+                    raise HarnessTimeout(
+                        verb="send",
+                        what=f"the worker to finish the turn {event_id}",
+                        deadline_s=_CONSUME_TIMEOUT_S,
+                        elapsed_s=_CONSUME_TIMEOUT_S,
+                    )
+                await asyncio.sleep(0.01)
+        finally:
+            consumer.request_stop()
+            try:
+                await asyncio.wait_for(task, timeout=30.0)
+            except TimeoutError:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+                raise AssertionError(
+                    "the consumer did not stop within 30s of request_stop()"
+                ) from None
+
+    def _drain(self, app: Any, guard: _Deadline) -> None:
+        """Wait for every post-ack listener body to finish, bounded.
+
+        ``shutdown(wait=True)`` takes no deadline, so it runs on a helper thread
+        that IS joined with one: a listener body wedged on the loopback API would
+        otherwise hang the caller with nothing in the report to find it by.
+        """
+
+        executor = app.listener_runner.listener_executor
+        closer = threading.Thread(
+            target=lambda: executor.shutdown(wait=True), name="interaction-drain", daemon=True
+        )
+        closer.start()
+        guard.wait(lambda: not closer.is_alive(), what="the Bolt listener executor to drain")
+
+    def _api_call(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: Any = None,
+        expect: tuple[int, ...] = (200,),
+    ) -> Any:
+        """One authenticated call to the composed API, with the platform key."""
+
+        import httpx
+
+        what = f"{method} {path} to answer"
+        timeout = self._budget(_HTTP_TIMEOUT_S, what=what)
+        with httpx.Client(timeout=timeout) as client:
+            try:
+                response = client.request(
+                    method,
+                    f"{self.api.base_url}{path}",
+                    json=json,
+                    headers={"X-API-Key": self.env.api_key},
+                )
+            except httpx.TimeoutException as exc:
+                raise self._timed_out(what, exc, timeout=timeout, default=_HTTP_TIMEOUT_S) from exc
+        assert response.status_code in expect, (
+            f"{method} {path} answered HTTP {response.status_code} "
+            f"(expected one of {expect}): {response.text}"
+        )
+        return response.json()
+
+    def _cached_status(self) -> str | None:
+        """The current approval's status, re-read at most every 200ms.
+
+        Cached because ``await_outcome`` polls every 20ms and a predicate that
+        reads the status would otherwise issue fifty HTTP requests a second. The
+        window is short enough that no wait is meaningfully lengthened by it, and
+        every verb that CHANGES a status invalidates the cache rather than
+        waiting it out.
+        """
+
+        if self._approval_id is None:
+            return None
+        cached_at, value = self._status_cache
+        now = time.monotonic()
+        if value is not None and now - cached_at < 0.2:
+            return value
+        status = self._approval_status(self._approval_id)
+        self._status_cache = (now, status)
+        return status
+
+    def _approval_status(self, approval_id: str) -> str:
+        """The approval row's status, read over the REAL API with the platform key."""
+
+        import httpx
+
+        what = f"the approval {approval_id} to be read back"
+        timeout = self._budget(_HTTP_TIMEOUT_S, what=what)
+        with httpx.Client(timeout=timeout) as client:
+            try:
+                response = client.get(
+                    f"{self.api.base_url}/approvals/{approval_id}",
+                    headers={"X-API-Key": self.env.api_key},
+                )
+            except httpx.TimeoutException as exc:
+                raise self._timed_out(what, exc, timeout=timeout, default=_HTTP_TIMEOUT_S) from exc
+        if response.status_code != 200:
+            return f"unreadable:{response.status_code}"
+        return str(response.json()["status"])
+
+    def _capture(self) -> None:
+        """Project any new kernel posts onto the captured channel state.
+
+        The card is rendered HERE, from the ``ConfirmIntent`` the kernel emitted,
+        using the production ``approval_card`` renderer with the intent's own
+        ``allow_free_text``. That is the coupling that keeps ``act`` honest: the
+        action ids and values come out of the real render of the real intent, so
+        a change to either moves every captured action with it.
+        """
+
+        if self._kernel_harness is None:
+            return
+        from curie_worker.blocks import approval_card
+
+        posts = self._kernel_harness.sink.posts
+        while len(self._messages) < len(posts):
+            index = len(self._messages)
+            _channel, message, requested_by, thread_ts, _endpoint = posts[index]
+            message_id = f"1700.{index:04d}"
+            intent = getattr(message, "interaction", None)
+            actions: tuple[CapturedAction, ...] = ()
+            approval_id: str | None = None
+            text = getattr(message, "text", "") or ""
+            if intent is not None and getattr(intent, "kind", None) == "confirm":
+                approval_id = str(intent.id)
+                self._approval_id = approval_id
+                self._status_cache = (0.0, None)
+                fallback, blocks = approval_card(
+                    approval_id=approval_id,
+                    summary=intent.prompt,
+                    requested_by=requested_by,
+                    allow_free_text=intent.allow_free_text,
+                )
+                text = fallback
+                self._cards[message_id] = {
+                    "ts": message_id,
+                    "thread_ts": thread_ts or message_id,
+                    "text": fallback,
+                    "blocks": blocks,
+                }
+                elements = [b for b in blocks if b["type"] == "actions"]
+                assert len(elements) == 1, f"expected one actions block, got {len(elements)}"
+                actions = tuple(
+                    CapturedAction(
+                        action_id=str(element["action_id"]),
+                        message_id=message_id,
+                        value=str(element["value"]),
+                        text=str(element.get("text", {}).get("text", "")),
+                        # Minted HERE, once, as the action is captured off the
+                        # real render. ``secrets`` rather than a counter or a
+                        # hash of the fields: anything derived from the card is
+                        # reconstructible by a caller who never saw the card,
+                        # which is the whole hole this closes.
+                        handle=secrets.token_urlsafe(16),
+                    )
+                    for element in elements[0]["elements"]
+                )
+            self._messages.append(
+                CapturedMessage(
+                    message_id=message_id,
+                    thread=str(thread_ts or ""),
+                    text=text,
+                    approval_id=approval_id,
+                    actions=actions,
+                )
+            )
+
+
+class _Deadline:
+    """One verb's bound, shared across the several waits inside it.
+
+    Shared rather than per-wait: ``act`` waits three times (the modal, the ack,
+    the drain), and three independent ``deadline_s`` bounds would let the verb
+    take three times the bound its caller asked for -- which is exactly the
+    overrun the contract tests measure by wall clock.
+    """
+
+    def __init__(self, *, verb: str, deadline_s: float) -> None:
+        self.verb = verb
+        self.deadline_s = deadline_s
+        self.started = time.monotonic()
+
+    @property
+    def elapsed_s(self) -> float:
+        return time.monotonic() - self.started
+
+    @property
+    def remaining_s(self) -> float:
+        """What is LEFT of this verb's budget, never negative.
+
+        The number every blocking segment inside the verb has to be clipped to.
+        A segment that carries its own fixed timeout (an ``httpx`` read, a
+        Valkey socket) is bounded in its own right and still unbounded with
+        respect to the verb: a 10s HTTP read inside a 1s verb overruns by 10x
+        while every local wait looks correctly bounded.
+        """
+
+        return max(0.0, self.deadline_s - self.elapsed_s)
+
+    def expired(self, *, what: str) -> HarnessTimeout:
+        return HarnessTimeout(
+            verb=self.verb,
+            what=what,
+            deadline_s=self.deadline_s,
+            elapsed_s=self.elapsed_s,
+        )
+
+    def wait(self, predicate: Callable[[], bool], *, what: str) -> None:
+        while True:
+            if predicate():
+                return
+            if self.elapsed_s >= self.deadline_s:
+                raise HarnessTimeout(
+                    verb=self.verb,
+                    what=what,
+                    deadline_s=self.deadline_s,
+                    elapsed_s=self.elapsed_s,
+                )
+            time.sleep(_POLL_INTERVAL_S)
+
+    def run(self, work: Callable[[], Any], *, what: str) -> Any:
+        """Run one BLOCKING segment on a helper thread, bounded by this deadline.
+
+        The reason every blocking segment goes through here rather than being
+        called inline: a call that blocks in C (``ThreadPoolExecutor.shutdown``,
+        a socket read inside a Bolt listener that ran the click synchronously,
+        an ``httpx`` request) takes no deadline of its own, so an inline call
+        spends unbounded wall clock INSIDE a verb whose headline contract is
+        that it is bounded. Running it on a daemon thread and joining it with
+        ``wait`` puts every one of those segments under the same remaining
+        budget, and makes the overrun name the segment it was in instead of
+        surfacing as a mystery 8s verb.
+
+        The helper thread is deliberately NOT killed on timeout -- Python has no
+        safe way to -- so it is a daemon and the exception it may later raise is
+        dropped. Correctness comes from the caller abandoning the verb, not from
+        the segment stopping.
+        """
+
+        box: dict[str, Any] = {}
+
+        def _target() -> None:
+            try:
+                box["value"] = work()
+            except BaseException as exc:  # re-raised on the caller's thread below
+                box["error"] = exc
+
+        worker = threading.Thread(target=_target, name=f"interaction-{self.verb}", daemon=True)
+        worker.start()
+        self.wait(lambda: not worker.is_alive(), what=what)
+        error = box.get("error")
+        if error is not None:
+            raise error
+        return box.get("value")
+
+
+def _approval_record(payload: Any) -> ApprovalRecord:
+    body = dict(payload)
+    return ApprovalRecord(
+        approval_id=str(body.get("id", "")),
+        status=str(body.get("status", "")),
+        resolved_by=_optional_str(body.get("resolved_by")),
+        resolution_note=_optional_str(body.get("resolution_note")),
+        raw=_jsonable(body),
+    )
+
+
+def _audit_entry(payload: Any) -> AuditEntry:
+    body = dict(payload)
+    authorized = body.get("authorized")
+    return AuditEntry(
+        action=str(body.get("action", "")),
+        actor=_optional_str(body.get("actor")),
+        authorized=None if authorized is None else bool(authorized),
+        authorizer=_optional_str(body.get("authorizer")),
+        principal_kind=_optional_str(body.get("principal_kind")),
+        actor_channel=_optional_str(body.get("actor_channel")),
+        raw=_jsonable(body),
+    )
+
+
+def _optional_str(value: Any) -> str | None:
+    return None if value is None else str(value)
+
+
+def _jsonable(body: dict[str, Any]) -> dict[str, Any]:
+    """Force a response body through a JSON round trip.
+
+    The bodies here already came OUT of ``response.json()``, so this is cheap and
+    normally a no-op -- but it is the single place a non-primitive could enter a
+    result, and ``to_dict()``'s whole contract is that it cannot. Asserting it
+    here fails at the source rather than at the pipe.
+    """
+
+    return dict(json.loads(json.dumps(body)))
+
+
+def _now_iso() -> str:
+    from datetime import UTC, datetime
+
+    return datetime.now(UTC).isoformat()
+
+
+def _button_for(card: dict[str, Any], action: CapturedAction) -> dict[str, Any]:
+    """The rendered element the captured action came from, by id AND value."""
+
+    for block in card["blocks"]:
+        if block.get("type") != "actions":
+            continue
+        for element in block["elements"]:
+            if element["action_id"] == action.action_id and element["value"] == action.value:
+                return dict(element)
+    raise UncapturedAction(
+        f"act() cannot find {action.action_id!r} on the card it was captured from; "
+        "the card render changed underneath the capture"
+    )
+
+
+def _click_request(
+    envelope_id: str,
+    *,
+    card: dict[str, Any],
+    button: dict[str, Any],
+    user: str,
+    channel: str,
+) -> Any:
+    """A block_actions envelope whose action id and value are DERIVED.
+
+    ``button`` is an element read straight out of the rendered card, so nothing
+    here is a literal: a change to the action ids, or to the ``value`` the
+    buttons carry, moves this click with it.
+    """
+
+    from slack_sdk.socket_mode.request import SocketModeRequest
+
+    return SocketModeRequest(
+        type="interactive",
+        envelope_id=envelope_id,
+        payload={
+            "type": "block_actions",
+            "trigger_id": f"trig-{envelope_id}",
+            "team": {"id": "T1"},
+            "user": {"id": user},
+            "api_app_id": "A1",
+            "token": "verif",
+            "container": {"type": "message", "message_ts": card["ts"]},
+            "channel": {"id": channel},
+            "message": card,
+            "actions": [
+                {
+                    "type": "button",
+                    "action_id": button["action_id"],
+                    "action_ts": "2.0",
+                    "value": button["value"],
+                }
+            ],
+        },
+    )
+
+
+def _view_submission_request(
+    envelope_id: str,
+    *,
+    private_metadata: str,
+    user: str,
+    note: str | None,
+    callback_id: str,
+) -> Any:
+    """A view_submission envelope built from the CAPTURED modal metadata.
+
+    ``private_metadata`` is read back off the real ``views_open`` call arguments,
+    never hand-built: it is what carries the approval id, channel, card ts and
+    decision across a submission that has no channel or message of its own
+    (approval_actions.py:56-58).
+    """
+
+    from slack_sdk.socket_mode.request import SocketModeRequest
+
+    state: dict[str, Any] = {"values": {}}
+    if note is not None:
+        state["values"] = {"note": {"note-input": {"type": "plain_text_input", "value": note}}}
+    return SocketModeRequest(
+        type="interactive",
+        envelope_id=envelope_id,
+        payload={
+            "type": "view_submission",
+            "team": {"id": "T1"},
+            "user": {"id": user},
+            "api_app_id": "A1",
+            "token": "verif",
+            "trigger_id": f"trig-{envelope_id}",
+            "view": {
+                "id": f"V-{envelope_id}",
+                "type": "modal",
+                "callback_id": callback_id,
+                "private_metadata": private_metadata,
+                "state": state,
+                "hash": "1",
+                "title": {"type": "plain_text", "text": "Approve request"},
+                "blocks": [],
+            },
+        },
+    )

--- a/packages/test-support/src/curie_test_support/interaction/results.py
+++ b/packages/test-support/src/curie_test_support/interaction/results.py
@@ -1,0 +1,414 @@
+"""The verb results: frozen dataclasses that survive a JSON round trip.
+
+Every verb on :class:`~curie_test_support.interaction.harness.InteractionHarness`
+returns one of these. Two properties are load bearing and are the reason they are
+not plain dicts:
+
+* **Frozen.** An agent (or a test) holds a result across several steps and
+  compares it against a later one. A mutable result lets a later verb quietly
+  rewrite the evidence an earlier assertion was made from.
+* **``to_dict()`` yields ONLY JSON primitives.** The ``python -m`` entry point
+  writes these over a pipe, so a nested dataclass, a ``datetime``, a ``UUID`` or
+  a tuple-keyed dict survives every in-process assertion and dies at the process
+  boundary. The serialiser is written by hand, per class, rather than derived
+  with ``dataclasses.asdict``: ``asdict`` recurses into nested dataclasses but
+  leaves a ``UUID`` or a ``datetime`` exactly as it found it, which is the one
+  mistake this file exists to make impossible.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = [
+    "ActResult",
+    "ApprovalRecord",
+    "AuditEntry",
+    "AuditResult",
+    "CapturedCard",
+    "FaultResult",
+    "ResumeTurn",
+    "ResumeTurnsResult",
+    "CapturedAction",
+    "CapturedMessage",
+    "MessagesResult",
+    "OutcomeResult",
+    "ResetResult",
+    "SendResult",
+    "Snapshot",
+]
+
+
+@dataclass(frozen=True)
+class CapturedAction:
+    """One actionable element of a captured card, as the card rendered it.
+
+    ``action_id`` and ``value`` are read off the REAL rendered Block Kit
+    element, never composed here: ``act`` refuses anything that did not come
+    from a capture, and this object is the token of that provenance.
+    ``message_id`` rides along because two cards in one channel can carry
+    byte-identical buttons, and without it ``act`` cannot tell them apart.
+
+    ``handle`` is the pipe's form of that provenance. In process, ``act``
+    matches on object identity, which a caller cannot fabricate. Over the
+    ``python -m`` pipe there are no objects, so the CLI has to find the stored
+    action from what the request names -- and every OTHER field is
+    reconstructible without ever rendering a card (the action id is an
+    importable renderer constant, the message id follows the harness's
+    ``1700.%04d`` scheme, the value is the approval id). The handle is minted
+    with ``secrets`` when the action is captured and is the one field that is
+    not: a caller who never called ``messages()`` cannot produce one, so the
+    pipe refuses the same forgery the identity check refuses. It is unguessable,
+    not merely longer -- length is not the property, unpredictability is.
+    """
+
+    action_id: str
+    message_id: str
+    value: str
+    text: str
+    handle: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action_id": self.action_id,
+            "message_id": self.message_id,
+            "value": self.value,
+            "text": self.text,
+            "handle": self.handle,
+        }
+
+
+@dataclass(frozen=True)
+class CapturedMessage:
+    """One message the harness observed on the channel edge."""
+
+    message_id: str
+    thread: str
+    text: str
+    approval_id: str | None
+    actions: tuple[CapturedAction, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "message_id": self.message_id,
+            "thread": self.thread,
+            "text": self.text,
+            "approval_id": self.approval_id,
+            "actions": [action.to_dict() for action in self.actions],
+        }
+
+
+@dataclass(frozen=True)
+class SendResult:
+    """What one inbound turn created."""
+
+    message_id: str
+    thread: str
+    run_id: str
+    event_id: str
+    text: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "message_id": self.message_id,
+            "thread": self.thread,
+            "run_id": self.run_id,
+            "event_id": self.event_id,
+            "text": self.text,
+        }
+
+
+@dataclass(frozen=True)
+class CapturedCard:
+    """A captured message that carries actions, paired with those actions.
+
+    A projection of :class:`CapturedMessage`, not a second source of truth: the
+    same object appears under ``message``. It exists because "the cards" and
+    "the messages" are different questions -- a run posts plain replies too, and
+    a caller that wants the actionable ones should not have to filter and then
+    re-establish that what it filtered really did carry actions.
+    """
+
+    message_id: str
+    approval_id: str | None
+    actions: tuple[CapturedAction, ...]
+    message: CapturedMessage
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "message_id": self.message_id,
+            "approval_id": self.approval_id,
+            "actions": [action.to_dict() for action in self.actions],
+            "message": self.message.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class MessagesResult:
+    """Everything captured on the channel edge so far, newest last."""
+
+    messages: tuple[CapturedMessage, ...]
+    cards: tuple[CapturedCard, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "messages": [message.to_dict() for message in self.messages],
+            "cards": [card.to_dict() for card in self.cards],
+        }
+
+
+@dataclass(frozen=True)
+class ApprovalRecord:
+    """One approval row, as the REAL ``GET /approvals/{id}`` answered it.
+
+    ``raw`` keeps the whole body so a case can assert on a field this dataclass
+    does not name, without the dataclass having to mirror the API schema (and
+    silently drift from it). The named fields are the ones every case reads.
+    """
+
+    approval_id: str
+    status: str
+    resolved_by: str | None
+    resolution_note: str | None
+    raw: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "approval_id": self.approval_id,
+            "status": self.status,
+            "resolved_by": self.resolved_by,
+            "resolution_note": self.resolution_note,
+            "raw": self.raw,
+        }
+
+
+@dataclass(frozen=True)
+class AuditEntry:
+    """One audit row, as the REAL ``GET /approvals/{id}/audit`` answered it."""
+
+    action: str
+    actor: str | None
+    authorized: bool | None
+    authorizer: str | None
+    principal_kind: str | None
+    actor_channel: str | None
+    raw: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action": self.action,
+            "actor": self.actor,
+            "authorized": self.authorized,
+            "authorizer": self.authorizer,
+            "principal_kind": self.principal_kind,
+            "actor_channel": self.actor_channel,
+            "raw": self.raw,
+        }
+
+
+@dataclass(frozen=True)
+class AuditResult:
+    """One approval's audit trail, in the order the API returned it."""
+
+    approval_id: str
+    entries: tuple[AuditEntry, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "approval_id": self.approval_id,
+            "entries": [entry.to_dict() for entry in self.entries],
+        }
+
+
+@dataclass(frozen=True)
+class ResumeTurn:
+    """One resume turn read back off the REAL runs stream.
+
+    Decoded from the stream the API's real ``ResumeQueue.enqueue`` xadded to
+    (resumequeue.py:266). Hand-building one and feeding it to the kernel would
+    satisfy an event-id assertion while the API had xadded nothing at all, which
+    is why this type only ever comes from a read.
+    """
+
+    entry_id: str
+    event_id: str
+    conversation_id: str
+    text: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "entry_id": self.entry_id,
+            "event_id": self.event_id,
+            "conversation_id": self.conversation_id,
+            "text": self.text,
+        }
+
+
+@dataclass(frozen=True)
+class ResumeTurnsResult:
+    """Every resume turn currently on the run's stream."""
+
+    stream: str
+    turns: tuple[ResumeTurn, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"stream": self.stream, "turns": [turn.to_dict() for turn in self.turns]}
+
+
+@dataclass(frozen=True)
+class ActResult:
+    """The settled outcome of driving one captured action.
+
+    ``accepted`` is about the INTERACTION (the system took the click and
+    settled it), while ``outcome`` is the approval's resulting status. The two
+    are kept apart because a refused actor is an accepted interaction with an
+    unchanged outcome, and collapsing them would make a refusal indistinguishable
+    from a transport failure.
+    """
+
+    action_id: str
+    message_id: str
+    actor: str
+    accepted: bool
+    outcome: str
+    note: str | None
+    detail: str
+    # The body Bolt acked the view with: ``None`` closes the dialog and is the
+    # ACCEPTED submission, while ``{"response_action": "errors", ...}`` keeps it
+    # open with the reason attached to the note field (handlers.py:637-645).
+    # Kept whole, rather than collapsed into ``accepted``, because a case has to
+    # assert WHICH field the refusal was attached to.
+    response_action: dict[str, Any] | None = None
+    # What the dispatcher asked Slack to stamp onto the card. A ``chat_update``
+    # call on a mock, so it proves the dispatcher ASKED, not that Slack
+    # rendered -- the same honest labelling stage 2 carries.
+    rendered_text: str | None = None
+    # Which approval this result is about. ``action_id``/``message_id`` identify
+    # a CLICK, so the card-less ``resolve`` verb leaves them empty -- and left
+    # the whole result unidentifiable, which is the bug this field closes. Both
+    # verbs fill it.
+    approval_id: str | None = None
+    # The REAL ``ResolveOutcome.status_code`` when the verb owns the resolve hop
+    # directly (``resolve``); None on the click path, where the resolve happens
+    # inside the dispatcher and the outcome is observable as ``response_action``
+    # instead. ``0`` is the product's explicit UNKNOWN outcome -- the request may
+    # or may not have been delivered (approval_actions.py:239-244) -- and a case
+    # about a broken transport has to be able to say so rather than inferring it
+    # from a falsy ``accepted``.
+    status_code: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action_id": self.action_id,
+            "message_id": self.message_id,
+            "actor": self.actor,
+            "accepted": self.accepted,
+            "outcome": self.outcome,
+            "note": self.note,
+            "detail": self.detail,
+            "response_action": self.response_action,
+            "rendered_text": self.rendered_text,
+            "approval_id": self.approval_id,
+            "status_code": self.status_code,
+        }
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    """What a ``await_outcome`` predicate is handed on each poll.
+
+    Deliberately a VALUE, rebuilt per poll: a predicate closing over the live
+    harness could observe a half-applied state mid-capture, and the resulting
+    flake would be indistinguishable from a real ordering bug.
+    """
+
+    run_id: str
+    messages: tuple[CapturedMessage, ...]
+    stream_entries: int
+    # The status of the approval this run is currently about, or None before one
+    # exists. Read over the real API, briefly cached: a predicate polls tens of
+    # times a second and an uncached read would turn every wait into a load test
+    # of the loopback server rather than of the behavior.
+    approval_status: str | None = None
+    approval_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "messages": [message.to_dict() for message in self.messages],
+            "stream_entries": self.stream_entries,
+            "approval_status": self.approval_status,
+            "approval_id": self.approval_id,
+        }
+
+
+@dataclass(frozen=True)
+class OutcomeResult:
+    """A satisfied wait, and how long it actually took.
+
+    ``elapsed_s`` is REPORTED rather than merely measured: an agent scripting
+    the harness has no other way to tell "returned immediately" from "waited
+    29s", and that difference is the difference between a healthy run and a
+    flake that is one slow box away from failing.
+    """
+
+    satisfied: bool
+    elapsed_s: float
+    deadline_s: float
+    stream_entries: int
+    message_count: int
+    approval_id: str | None = None
+    approval_status: str | None = None
+    resolved_by: str | None = None
+    # The resume turns on the stream at the moment the predicate was satisfied.
+    # The COUNT is not enough for the reconciliation cases: "exactly one resume,
+    # and it is the one for THIS approval" is the property, and a count cannot
+    # distinguish a second resume for the same approval from the first.
+    resume_turns: tuple[ResumeTurn, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "satisfied": self.satisfied,
+            "elapsed_s": self.elapsed_s,
+            "deadline_s": self.deadline_s,
+            "stream_entries": self.stream_entries,
+            "message_count": self.message_count,
+            "approval_id": self.approval_id,
+            "approval_status": self.approval_status,
+            "resolved_by": self.resolved_by,
+            "resume_turns": [turn.to_dict() for turn in self.resume_turns],
+        }
+
+
+@dataclass(frozen=True)
+class ResetResult:
+    """The run's stream namespace after a reset."""
+
+    stream: str
+    entries_remaining: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"stream": self.stream, "entries_remaining": self.entries_remaining}
+
+
+@dataclass(frozen=True)
+class FaultResult:
+    """What is armed after one ``arm_fault`` / ``disarm_fault``.
+
+    Carries the WHOLE armed set, not just the name that changed: an agent on the
+    pipe has no other way to see what a previous line left armed, and a fault it
+    does not know about is exactly the thing that makes a later verb's result
+    unreadable.
+    """
+
+    fault: str
+    armed: bool
+    armed_faults: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "fault": self.fault,
+            "armed": self.armed,
+            "armed_faults": list(self.armed_faults),
+        }

--- a/packages/test-support/tests/test_interaction_harness.py
+++ b/packages/test-support/tests/test_interaction_harness.py
@@ -1,0 +1,1252 @@
+"""Contract tests for the agent-facing interaction harness (stage 3, D1).
+
+These tests are the *specification* of ``curie_test_support.interaction``. They
+are committed FAILING, before the module exists, and they deliberately assert
+the harness's public contract rather than its journey: what a verb returns, that
+the result survives ``json.dumps`` unchanged in shape, that every blocking verb
+is bounded, that ``act`` cannot be short-circuited with a literal action id, and
+that a fault is strictly scoped.
+
+Why the contract and not the journey: the journey is already proven by
+``apps/worker/tests/kernel/test_approval_journey_dev.py``. What stage 3 adds is a
+REUSABLE surface, and a reusable surface is only reusable if its shape is pinned
+somewhere that fails when the shape drifts. A test that drove a full approval
+here would duplicate stage 2 and would still pass after a result field was
+renamed, which is precisely the regression this module exists to catch.
+
+A skip is a FAILURE for this module. Stage 2 recorded the reason (#1755): an
+unreachable store that silently skips half a suite and exits 0 is a falsely
+claimed proof. So the preconditions are asserted, not skipped past -- and,
+unlike the stage-2 guard this stage is also fixing (D4), WITHOUT a
+machine-specific port literal. The property that matters is agreement between
+the frozen worker constant and the environment, plus an empty per-run namespace;
+36379 was only ever one machine's spelling of that.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from curie_test_support.interaction import (
+    SUPPORTED_FAULTS,
+    HarnessTimeout,
+    InteractionHarness,
+    UncapturedAction,
+)
+from curie_test_support.interaction.harness import ComposedApi
+from curie_test_support.interaction.results import (
+    ActResult,
+    CapturedAction,
+    MessagesResult,
+    OutcomeResult,
+    ResetResult,
+    SendResult,
+)
+
+# The frozen constants, imported as a MODULE attribute read at use time rather
+# than re-derived from ``os.environ``. ``curie_test_support.valkey`` binds
+# VALKEY_PORT at import (valkey.py:20), so anything that sets TEST_VALKEY_PORT
+# after that import is a silent no-op. Reading the frozen value is the only
+# honest way to check agreement.
+from curie_test_support.valkey import VALKEY_PORT
+
+# Deadlines used by the bounded-wait tests. Short, because the whole point is
+# that the verb RETURNS -- a bound long enough to be comfortable is a bound that
+# makes a hang look like a slow test.
+_NEVER_DEADLINE_S = 1.0
+
+# The upper bound each bounded-wait assertion allows. Twice the deadline, so a
+# loaded CI box does not turn a correct implementation red, while a verb that
+# ignores its deadline entirely (the mutation these tests defend against) still
+# fails: an unbounded wait blows through 2x immediately.
+_BOUND_SLACK = 2.0
+
+
+def _round_trips(result: Any) -> dict[str, Any]:
+    """Assert a verb result is JSON-serialisable and give back the parsed dict.
+
+    ``to_dict()`` must yield ONLY str/int/float/bool/None/list/dict -- the whole
+    reason the verbs return frozen dataclasses with an explicit serialiser is
+    that an agent reads them over a pipe. A nested dataclass, a ``datetime``, a
+    ``UUID`` or a tuple-keyed dict all survive an in-process assertion and die at
+    the CLI boundary, so the round-trip is asserted here, next to every verb,
+    rather than once in the CLI tests.
+    """
+
+    payload = result.to_dict()
+    assert isinstance(payload, dict), f"to_dict() must return a dict, got {type(payload)!r}"
+    encoded = json.dumps(payload)
+    reparsed: dict[str, Any] = json.loads(encoded)
+    assert reparsed == payload, (
+        "to_dict() did not survive a json round-trip unchanged; a non-JSON "
+        f"primitive leaked into the result: {payload!r}"
+    )
+    return reparsed
+
+
+# --- Module preconditions -----------------------------------------------------
+
+
+def test_the_harness_tests_run_against_a_real_chosen_valkey() -> None:
+    """The stack this module needs is up and is the one the worker constants name.
+
+    Deliberately portable. The property being protected is not "port 36379": it
+    is (a) somebody CHOSE a store rather than inheriting a default, (b) the
+    frozen worker constant agrees with that choice, and (c) no ``VALKEY_URL``
+    silently overrides the parts (config.py:404-406, #2315). All three are true
+    on CI's 26379 and on any developer's isolated stack; a literal is true on
+    exactly one machine and is the D4 defect being fixed in Stream B.
+    """
+
+    assert os.environ.get("CI_REQUIRE_VALKEY_TESTS"), (
+        "CI_REQUIRE_VALKEY_TESTS must be set: without it an unreachable Valkey "
+        "SKIPS instead of failing, and a skipped harness contract test proves "
+        "nothing while still exiting 0 (#1755)."
+    )
+    chosen = os.environ.get("TEST_VALKEY_PORT")
+    assert chosen, (
+        "TEST_VALKEY_PORT is unset, so this run inherited the compose default "
+        "rather than choosing a store. Bring up the pilot stack and export the "
+        "port it publishes."
+    )
+    assert VALKEY_PORT == int(chosen), (
+        "the frozen worker constant disagrees with the environment the harness "
+        f"will copy from: VALKEY_PORT={VALKEY_PORT!r} vs "
+        f"TEST_VALKEY_PORT={chosen!r}. The constants are frozen at import "
+        "(curie_test_support/valkey.py:20), so no fixture can retarget this "
+        "afterwards -- the disagreement is fatal, not recoverable."
+    )
+    assert "VALKEY_URL" not in os.environ, (
+        "VALKEY_URL wins outright over the host/port parts, so with it set the "
+        "harness's API half would write to a different store than its worker "
+        "half reads, and every assertion below would pass or fail for the "
+        "wrong reason."
+    )
+
+
+# --- Fixtures -----------------------------------------------------------------
+
+
+@pytest.fixture
+def harness() -> Any:
+    """One harness per test, entered and exited as a context manager.
+
+    Typed ``Any`` only because the module does not exist yet; the Implementer
+    narrows this to ``Iterator[InteractionHarness]``. The context manager is the
+    contract: the composed API server, the dispatcher, the kernel harness, the
+    disposable database and the per-run Valkey namespace are all owned by it, so
+    a test that forgets to tear down is impossible to write.
+    """
+
+    with InteractionHarness() as live:
+        yield live
+
+
+# --- One test per verb: result shape and JSON round-trip ----------------------
+
+
+def test_send_returns_a_structured_send_result(harness: InteractionHarness) -> None:
+    result = harness.send("scale the payments deployment to 10 replicas")
+
+    assert isinstance(result, SendResult)
+    payload = _round_trips(result)
+    # The identifiers an agent needs to address the next verb. ``message_id``
+    # and ``thread`` are what a follow-up ``send(thread=...)`` and every
+    # ``messages()`` lookup key on, so their absence is not cosmetic.
+    assert set(payload) >= {"message_id", "thread", "run_id"}
+    assert payload["message_id"], "send must name the message it created"
+    assert payload["run_id"] == harness.run_id, (
+        "the send must be attributed to THIS harness's run; a send that reports "
+        "another run's id would let a test assert against a neighbour's stream"
+    )
+
+
+def test_send_into_an_existing_thread_stays_in_that_thread(
+    harness: InteractionHarness,
+) -> None:
+    """``thread=`` is threading, not a second conversation.
+
+    Asserted because the obvious wrong implementation -- ignore the kwarg and
+    open a new thread -- produces a perfectly well-shaped SendResult, so the
+    shape test above cannot catch it.
+    """
+
+    first = harness.send("first turn")
+    second = harness.send("second turn", thread=first.thread)
+
+    assert second.thread == first.thread
+    assert second.message_id != first.message_id
+
+
+def test_messages_returns_captured_messages_and_their_cards(
+    harness: InteractionHarness,
+) -> None:
+    harness.send("scale the payments deployment to 10 replicas")
+    result = harness.await_outcome(
+        predicate=lambda snapshot: bool(snapshot.messages),
+        deadline_s=30.0,
+    )
+    assert result.satisfied
+
+    captured = harness.messages()
+    assert isinstance(captured, MessagesResult)
+    payload = _round_trips(captured)
+    assert isinstance(payload["messages"], list)
+    assert captured.messages, "the harness captured no channel message at all"
+
+    # Every captured action must carry the identity ``act`` needs. This is the
+    # other half of the anti-shortcut contract below: ``act`` may only be handed
+    # an object that came from here, so this is where that object's fields are
+    # pinned.
+    for message in captured.messages:
+        for action in message.actions:
+            assert action.action_id, "a captured action with no action_id is unusable"
+            assert action.message_id == message.message_id, (
+                "a captured action must know which message it belongs to, or "
+                "act() cannot tell two identical buttons apart"
+            )
+
+
+def test_act_returns_a_structured_act_result(harness: InteractionHarness) -> None:
+    harness.send("scale the payments deployment to 10 replicas")
+    harness.await_outcome(
+        predicate=lambda snapshot: any(m.actions for m in snapshot.messages),
+        deadline_s=30.0,
+    )
+    card = next(m for m in harness.messages().messages if m.actions)
+    action = card.actions[0]
+
+    result = harness.act(message=card.message_id, action=action, actor="U0EXAMPLE1")
+
+    assert isinstance(result, ActResult)
+    payload = _round_trips(result)
+    assert set(payload) >= {"action_id", "message_id", "actor", "accepted", "outcome"}
+    assert payload["action_id"] == action.action_id
+    assert payload["actor"] == "U0EXAMPLE1"
+
+
+def test_await_outcome_returns_a_structured_outcome_result(
+    harness: InteractionHarness,
+) -> None:
+    harness.send("scale the payments deployment to 10 replicas")
+
+    result = harness.await_outcome(
+        predicate=lambda snapshot: bool(snapshot.messages),
+        deadline_s=30.0,
+    )
+
+    assert isinstance(result, OutcomeResult)
+    payload = _round_trips(result)
+    assert set(payload) >= {"satisfied", "elapsed_s"}
+    assert payload["satisfied"] is True
+    # Elapsed is reported, not merely measured: an agent scripting the harness
+    # has no other way to tell "returned immediately" from "waited 29s", and
+    # that difference is the difference between a healthy run and a flake.
+    assert isinstance(payload["elapsed_s"], float)
+    assert payload["elapsed_s"] >= 0.0
+
+
+def test_reset_returns_a_structured_reset_result(harness: InteractionHarness) -> None:
+    harness.send("scale the payments deployment to 10 replicas")
+
+    result = harness.reset()
+
+    assert isinstance(result, ResetResult)
+    payload = _round_trips(result)
+    assert set(payload) >= {"stream", "entries_remaining"}
+    assert payload["stream"] == harness.stream
+
+
+def test_inject_fault_returns_a_context_manager(harness: InteractionHarness) -> None:
+    """``inject_fault`` is a context manager, not a verb that returns a result.
+
+    Stated as its own test because it is the one verb whose signature differs
+    from the other five, and an implementation that returned a result dataclass
+    here would be usable in a ``with`` statement only by accident.
+    """
+
+    with harness.inject_fault("resolve_transport_error") as armed:
+        assert armed is not None
+        assert harness.armed_faults == ("resolve_transport_error",)
+
+    assert harness.armed_faults == ()
+
+
+# --- The anti-shortcut test ---------------------------------------------------
+
+
+def test_act_refuses_a_literal_action_id_that_was_never_captured(
+    harness: InteractionHarness,
+) -> None:
+    """A bare string action id must raise, however plausible the string is.
+
+    This is the test the plan calls the anti-shortcut test, and it is the single
+    most load-bearing assertion in this module. ``act`` exists to prove a REAL
+    chat click drove the system. An ``act`` that accepts a literal ``action_id``
+    lets every future test skip the card entirely -- the card render, the
+    ownership probe, the block structure -- and still report a green approval
+    journey. The refusal is what keeps "the harness drove it" from degrading
+    into "the harness POSTed something".
+
+    Mutate ``act`` to accept a literal and this test fails. That is the whole
+    contract.
+    """
+
+    harness.send("scale the payments deployment to 10 replicas")
+    harness.await_outcome(
+        predicate=lambda snapshot: any(m.actions for m in snapshot.messages),
+        deadline_s=30.0,
+    )
+    card = next(m for m in harness.messages().messages if m.actions)
+    real_action_id = card.actions[0].action_id
+
+    # The string is the CORRECT action id, copied off a genuinely captured
+    # action. Using a nonsense string here would let an implementation pass by
+    # merely validating the id against a registry, which is not the contract:
+    # the contract is provenance, so even the right id in the wrong FORM is
+    # refused.
+    with pytest.raises(UncapturedAction) as raised:
+        harness.act(message=card.message_id, action=real_action_id, actor="U0EXAMPLE1")
+
+    assert "act" in str(raised.value)
+    assert real_action_id in str(raised.value), (
+        "the refusal must name the action it was handed, or a test author "
+        "cannot tell a provenance refusal from a typo"
+    )
+
+
+# --- Bounded waits: every blocking verb has a deadline it honours -------------
+
+
+def test_await_outcome_raises_harness_timeout_within_its_bound(
+    harness: InteractionHarness,
+) -> None:
+    """A predicate that can never become true must time out, not hang.
+
+    An unbounded wait in a test harness is the worst failure mode available: the
+    suite reports nothing at all, the CI job is killed by its outer timeout, and
+    the report names no test. So the bound is asserted by wall clock, and the
+    exception is asserted to NAME the verb and the predicate, because a bare
+    ``TimeoutError`` from 20 frames down tells an agent nothing about which of
+    its scripted steps wedged.
+    """
+
+    started = time.monotonic()
+    with pytest.raises(HarnessTimeout) as raised:
+        harness.await_outcome(predicate=lambda snapshot: False, deadline_s=_NEVER_DEADLINE_S)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < _NEVER_DEADLINE_S * _BOUND_SLACK, (
+        f"await_outcome overran its {_NEVER_DEADLINE_S}s deadline by more than "
+        f"{_BOUND_SLACK}x ({elapsed:.2f}s): the deadline is not being honoured"
+    )
+    assert raised.value.verb == "await_outcome"
+    assert raised.value.deadline_s == pytest.approx(_NEVER_DEADLINE_S)
+    assert raised.value.elapsed_s == pytest.approx(elapsed, abs=0.5)
+    assert raised.value.what, "the timeout must describe what it was waiting for"
+    assert "await_outcome" in str(raised.value)
+
+
+def test_act_raises_harness_timeout_within_its_bound(harness: InteractionHarness) -> None:
+    """``act`` is blocking too, and its wait is the one most likely to wedge.
+
+    Driven through an armed ``resolve_transport_error`` rather than a synthetic
+    predicate, because that is the real shape of the hang: the click is accepted,
+    the post-ack listener body wedges on the resolve transport, and the
+    settlement the verb is waiting for never arrives. A ``time.sleep`` stand-in
+    would prove the deadline plumbing and miss the wedge.
+    """
+
+    harness.send("scale the payments deployment to 10 replicas")
+    harness.await_outcome(
+        predicate=lambda snapshot: any(m.actions for m in snapshot.messages),
+        deadline_s=30.0,
+    )
+    card = next(m for m in harness.messages().messages if m.actions)
+
+    started = time.monotonic()
+    with harness.inject_fault("resolve_transport_error", hang=True):
+        with pytest.raises(HarnessTimeout) as raised:
+            harness.act(
+                message=card.message_id,
+                action=card.actions[0],
+                actor="U0EXAMPLE1",
+                deadline_s=_NEVER_DEADLINE_S,
+            )
+    elapsed = time.monotonic() - started
+
+    assert elapsed < _NEVER_DEADLINE_S * _BOUND_SLACK, (
+        f"act overran its {_NEVER_DEADLINE_S}s deadline by more than "
+        f"{_BOUND_SLACK}x ({elapsed:.2f}s)"
+    )
+    assert raised.value.verb == "act"
+    assert raised.value.deadline_s == pytest.approx(_NEVER_DEADLINE_S)
+    assert "act" in str(raised.value)
+
+
+# --- Fault injection: scoped, auto-reverting, and closed over a known set -----
+
+
+def test_inject_fault_reverts_even_when_the_body_raises(
+    harness: InteractionHarness,
+) -> None:
+    """A leaked fault silently poisons every later test in the process.
+
+    That is the failure this test exists for, and it is why the revert is
+    asserted on the EXCEPTIONAL path specifically: a ``try/finally``-less
+    implementation passes the happy-path test above and fails only here -- and
+    in production would fail as an unrelated test, in a later module, with no
+    trace back to the fault that caused it.
+    """
+
+    from curie_api.resumequeue import ResumeQueue
+
+    # The PRODUCTION objects this fault mutates, captured before it is armed.
+    # Asserting ``armed_faults == ()`` is not enough and was the hole this test
+    # used to have: a ``disarm_fault`` that popped its bookkeeping dict and
+    # never called ``ArmedFault.revert()`` passes that assertion while leaving
+    # ``ResumeQueue.enqueue`` patched for the rest of the process.
+    original_enqueue = ResumeQueue.__dict__["enqueue"]
+    reconciler_was_set = "RESUME_RECONCILER_ENABLED" in os.environ
+    original_reconciler = os.environ.get("RESUME_RECONCILER_ENABLED")
+
+    sentinel = RuntimeError("body blew up")
+    with pytest.raises(RuntimeError) as raised:
+        with harness.inject_fault("resume_enqueue_lost"):
+            assert harness.armed_faults == ("resume_enqueue_lost",)
+            assert ResumeQueue.__dict__["enqueue"] is not original_enqueue, (
+                "the fault armed nothing: the rest of this test would then prove "
+                "only that an unarmed fault reverts cleanly"
+            )
+            assert os.environ["RESUME_RECONCILER_ENABLED"] == "true"
+            raise sentinel
+
+    assert raised.value is sentinel
+    assert harness.armed_faults == (), (
+        "the fault survived an exception in the body: every later test in this "
+        "process now runs with a dropped resume enqueue"
+    )
+    assert ResumeQueue.__dict__["enqueue"] is original_enqueue, (
+        "ResumeQueue.enqueue is still the injected stub: every later test in "
+        "this process now runs with a dropped resume enqueue, including tests "
+        "that assert security properties"
+    )
+    if reconciler_was_set:
+        assert os.environ.get("RESUME_RECONCILER_ENABLED") == original_reconciler
+    else:
+        assert "RESUME_RECONCILER_ENABLED" not in os.environ, (
+            "the fault left RESUME_RECONCILER_ENABLED set in a process that started without it"
+        )
+
+
+def test_inject_fault_restores_a_wrapped_resolve_client(harness: InteractionHarness) -> None:
+    """``resolve_transport_error`` must put back the client attributes it broke.
+
+    ``wrap_resolve_client`` overwrites ``client._client.get``/``.post`` IN PLACE.
+    Nothing leaks today only because ``act`` and ``resolve`` happen to build a
+    fresh client per call -- an incidental property of the callers, not a
+    guarantee of the fault. This asserts the guarantee directly, on a client the
+    test owns, so a reused client can never inherit a permanently broken
+    transport from a fault that has been "reverted".
+    """
+
+    import httpx
+    from curie_test_support.interaction.faults import arm_fault, wrap_resolve_client
+
+    class _Transport:
+        def get(self, *args: Any, **kwargs: Any) -> str:
+            return "real-get"
+
+        def post(self, *args: Any, **kwargs: Any) -> str:
+            return "real-post"
+
+    class _Client:
+        def __init__(self) -> None:
+            self._client = _Transport()
+
+    client = _Client()
+    transport = client._client
+    original_get = transport.get
+    assert "get" not in transport.__dict__, "the fixture must start unshadowed"
+
+    armed = arm_fault("resolve_transport_error")
+    try:
+        wrap_resolve_client(client, {"resolve_transport_error": armed})
+        assert transport.get is not original_get, "the wrap bent nothing"
+        with pytest.raises(httpx.HTTPError):
+            transport.post()
+    finally:
+        armed.revert()
+
+    assert transport.get() == "real-get"
+    assert transport.post() == "real-post"
+    assert "get" not in transport.__dict__ and "post" not in transport.__dict__, (
+        "revert left a shadowing instance attribute where the class method was"
+    )
+
+
+def test_disarming_an_option_only_fault_mutates_no_production_object(
+    harness: InteractionHarness,
+) -> None:
+    """``private_metadata_unusable`` must remain option-only, arm and revert.
+
+    It is consumed where the harness reads the modal's metadata, so it patches
+    nothing -- and this pins that. If it ever grows an in-place mutation it must
+    also grow a restore, and the ``_patches`` assertion is what fails first.
+    """
+
+    from curie_test_support.interaction.faults import arm_fault
+
+    before = dict(os.environ)
+    armed = arm_fault("private_metadata_unusable")
+    try:
+        assert armed._patches == [], "private_metadata_unusable grew a patch without a revert test"
+        assert dict(os.environ) == before
+    finally:
+        armed.revert()
+    assert dict(os.environ) == before
+    assert armed._patches == []
+
+
+def test_inject_fault_rejects_an_unknown_fault_name(harness: InteractionHarness) -> None:
+    """An unknown name must fail loudly, naming the supported set.
+
+    The dangerous alternative is a silent no-op: a test that arms
+    ``"principle_expired"`` (one typo) would arm nothing, drive the happy path,
+    and pass while claiming to cover the expired-principal case. That is a
+    falsely claimed proof, so the typo has to be fatal.
+    """
+
+    with pytest.raises(ValueError) as raised:
+        with harness.inject_fault("principle_expired"):  # deliberate typo
+            pytest.fail("an unknown fault name must not enter the body")
+
+    message = str(raised.value)
+    assert "principle_expired" in message
+    for name in SUPPORTED_FAULTS:
+        assert name in message, (
+            "the error must list the supported faults, so a caller fixes the "
+            f"typo from the message alone; {name!r} was missing"
+        )
+
+
+def test_the_supported_fault_set_is_exactly_the_three_driven_faults() -> None:
+    """The fault vocabulary is closed, and pinned here.
+
+    Pinned as an exact set rather than a subset check: ``inject_fault`` is the
+    only way a test can bend the system away from the happy path, so a name
+    added without a test is a capability nobody is watching, and a name removed
+    silently turns its D3 case into a no-op. Every name here is driven by at
+    least one test: ``resume_enqueue_lost`` and ``resolve_transport_error`` by
+    D3 cases 3 and 7, ``private_metadata_unusable`` by the ``act`` test below.
+    The forged-principal faults are deliberately absent -- stage 2 already owns
+    that coverage in ``test_approval_journey_dev.py``
+    (``test_ac6_the_real_verifier_refuses_a_forged_principal``), and a second
+    implementation of the minting here would be unwatched surface.
+    """
+
+    assert set(SUPPORTED_FAULTS) == {
+        "resume_enqueue_lost",
+        "resolve_transport_error",
+        "private_metadata_unusable",
+    }
+
+
+def test_inject_fault_makes_act_submit_unusable_private_metadata(
+    harness: InteractionHarness,
+) -> None:
+    """``private_metadata_unusable`` is DRIVEN, not merely declared.
+
+    A fault name in ``SUPPORTED_FAULTS`` that no test arms is advertised surface
+    nobody watches, so this is the case that exercises it end to end: the note
+    modal really opens, the metadata the dispatcher really stamped is tampered
+    with on its way back, and the submission must move nothing.
+
+    The second half is what makes the first half mean anything: after the fault
+    reverts, the SAME captured action resolves the approval. Without that, an
+    ``act`` that silently drove nothing at all would pass the pending assertion.
+    """
+
+    from curie_dispatcher.approval_actions import APPROVE_NOTE_ACTION_ID
+
+    harness.send("scale the payments deployment to 10 replicas")
+    harness.await_outcome(
+        predicate=lambda snapshot: any(m.actions for m in snapshot.messages),
+        deadline_s=30.0,
+    )
+    card = next(m for m in harness.messages().messages if m.actions)
+    note_action = next((a for a in card.actions if a.action_id == APPROVE_NOTE_ACTION_ID), None)
+    assert note_action is not None, (
+        "the approval card carried no approve-with-note button, so the note "
+        f"modal this fault bends is unreachable: {[a.action_id for a in card.actions]}"
+    )
+
+    with harness.inject_fault("private_metadata_unusable"):
+        harness.act(
+            message=card.message_id, action=note_action, actor="U0EXAMPLE1", deadline_s=60.0
+        )
+        assert harness.approval(str(card.approval_id)).status == "pending", (
+            "a submission carrying metadata the dispatcher cannot trust must resolve nothing"
+        )
+
+    recovered = harness.act(
+        message=card.message_id, action=note_action, actor="U0EXAMPLE1", deadline_s=60.0
+    )
+    assert recovered.accepted is True, recovered.to_dict()
+    assert harness.approval(str(card.approval_id)).status == "approved"
+
+
+# --- reset() ------------------------------------------------------------------
+
+
+def test_reset_empties_the_runs_stream_namespace(harness: InteractionHarness) -> None:
+    """After ``reset`` the run's stream is empty, asserted against real Valkey.
+
+    Against the store, not against a counter the harness keeps: a harness that
+    zeroes its own bookkeeping and leaves the entries in Valkey passes every
+    in-memory assertion and then makes the NEXT test's "exactly one stream
+    entry" read two.
+    """
+
+    harness.send("scale the payments deployment to 10 replicas")
+    harness.await_outcome(
+        predicate=lambda snapshot: snapshot.stream_entries > 0,
+        deadline_s=30.0,
+    )
+
+    result = harness.reset()
+
+    assert result.entries_remaining == 0
+    assert harness.redis.exists(harness.stream) == 0, (
+        "reset reported an empty namespace but the stream key still exists in "
+        "Valkey; the reported number is bookkeeping, not the store"
+    )
+
+
+def test_reset_is_idempotent(harness: InteractionHarness) -> None:
+    """Calling ``reset`` on an already-clean harness must not raise.
+
+    An agent scripting the harness resets defensively between steps and has no
+    cheap way to know whether anything happened since the last one. A reset that
+    raises on an absent key turns that defensive call into a scripted failure.
+    """
+
+    first = harness.reset()
+    second = harness.reset()
+
+    assert first.entries_remaining == 0
+    assert second.entries_remaining == 0
+    assert second.stream == first.stream
+
+
+def test_reset_keeps_the_harness_usable(harness: InteractionHarness) -> None:
+    """``reset`` clears state; it does not tear the harness down.
+
+    The distinction matters because the cheap implementation of ``reset`` --
+    dispose of everything and rebuild -- would pass both tests above and then
+    strand every identifier an agent captured before the call.
+    """
+
+    harness.reset()
+    result = harness.send("a turn after the reset")
+
+    assert isinstance(result, SendResult)
+    assert result.run_id == harness.run_id
+
+
+# --- The `python -m` CLI ------------------------------------------------------
+
+
+def _run_cli(script: str) -> subprocess.CompletedProcess[str]:
+    """Drive the CLI exactly as an agent would: a real subprocess over stdin.
+
+    A subprocess, not an in-process ``main([...])`` call, because the contract
+    being tested is the process contract -- exit status, stdout framing and
+    stderr -- and every one of those is faked by an in-process call.
+    """
+
+    return subprocess.run(
+        [sys.executable, "-m", "curie_test_support.interaction"],
+        input=script,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+
+
+def test_the_cli_emits_one_json_object_per_verb_and_exits_zero() -> None:
+    """NDJSON in, NDJSON out, one line per verb, in order.
+
+    Line-per-verb rather than one document at the end: an agent streaming the
+    harness needs the result of step 1 before it writes step 2, and a buffered
+    single document is unusable for that. The ordering assertion is what pins
+    it.
+    """
+
+    script = "\n".join(
+        [
+            json.dumps({"verb": "send", "text": "scale the payments deployment"}),
+            json.dumps({"verb": "messages"}),
+            json.dumps({"verb": "reset"}),
+        ]
+    )
+
+    completed = _run_cli(script + "\n")
+
+    assert completed.returncode == 0, (
+        f"the CLI exited {completed.returncode}; stderr was:\n{completed.stderr}"
+    )
+    lines = [line for line in completed.stdout.splitlines() if line.strip()]
+    assert len(lines) == 3, f"expected one JSON object per verb, got {lines!r}"
+    parsed = [json.loads(line) for line in lines]
+    assert [entry["verb"] for entry in parsed] == ["send", "messages", "reset"]
+    for entry in parsed:
+        assert entry["ok"] is True
+        assert isinstance(entry["result"], dict)
+
+
+def test_the_cli_rejects_an_unknown_verb_without_claiming_success() -> None:
+    """A bad verb exits non-zero, says so on stderr, and emits no success line.
+
+    The third clause is the one worth having. A CLI that printed
+    ``{"ok": true}`` for the verbs it managed before the bad one, and only THEN
+    exited non-zero, would be read by an agent as partial success -- and an
+    agent that believes an approval was sent when it was not is exactly the
+    class of false proof this whole stage exists to prevent. So no line may
+    claim success for the failing verb, and the failing verb must be named.
+    """
+
+    script = json.dumps({"verb": "approve_everything"}) + "\n"
+
+    completed = _run_cli(script)
+
+    assert completed.returncode != 0, "an unknown verb must not exit 0"
+    assert "approve_everything" in completed.stderr, (
+        "stderr must name the verb it rejected, or a script author cannot tell "
+        "which line of their NDJSON was wrong"
+    )
+    for line in completed.stdout.splitlines():
+        if not line.strip():
+            continue
+        entry = json.loads(line)
+        assert entry.get("verb") != "approve_everything" or entry.get("ok") is not True, (
+            "the CLI emitted a success object for the verb it rejected"
+        )
+
+
+def test_the_cli_reports_a_harness_timeout_as_structured_failure() -> None:
+    """A timeout inside the CLI is a reported failure, not a hang or a traceback.
+
+    Same reasoning as the in-process bounded-wait tests, at the process
+    boundary: an agent scripting the harness needs the timeout to arrive as a
+    parseable object naming the verb, not as a killed process with a Python
+    traceback on stderr that it has to regex.
+    """
+
+    script = json.dumps(
+        {"verb": "await_outcome", "predicate": "never", "deadline_s": _NEVER_DEADLINE_S}
+    )
+
+    completed = _run_cli(script + "\n")
+
+    assert completed.returncode != 0
+    lines = [line for line in completed.stdout.splitlines() if line.strip()]
+    assert lines, "the CLI must still report the failed verb on stdout"
+    entry = json.loads(lines[-1])
+    assert entry["ok"] is False
+    assert entry["verb"] == "await_outcome"
+    assert entry["error"]["type"] == "HarnessTimeout"
+    assert entry["error"]["deadline_s"] == pytest.approx(_NEVER_DEADLINE_S)
+
+
+# --- The bounded wait, with the HTTP path genuinely in it ----------------------
+
+
+@contextlib.contextmanager
+def _black_hole_api() -> Iterator[str]:
+    """A loopback server that ACCEPTS and never answers.
+
+    The shape that makes an unclipped timeout visible: a refused connection
+    fails instantly and proves nothing, while an accepted connection with no
+    response parks the reader for its full read timeout. Nothing is read off the
+    socket, so the accepted connections simply sit there until close.
+    """
+
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(16)
+    accepted: list[socket.socket] = []
+    stop = threading.Event()
+
+    def _accept() -> None:
+        listener.settimeout(0.1)
+        while not stop.is_set():
+            try:
+                conn, _ = listener.accept()
+            except OSError:
+                continue
+            accepted.append(conn)
+
+    thread = threading.Thread(target=_accept, name="black-hole-api", daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{listener.getsockname()[1]}"
+    finally:
+        stop.set()
+        thread.join(timeout=5.0)
+        for conn in accepted:
+            with contextlib.suppress(OSError):
+                conn.close()
+        listener.close()
+
+
+def test_await_outcome_stays_bounded_when_the_approval_read_hangs(
+    harness: InteractionHarness,
+) -> None:
+    """The bound must hold when the predicate's own read is the thing that hangs.
+
+    The other bounded-wait test above cannot catch this: it never creates an
+    approval, so ``snapshot()`` short-circuits and no HTTP request is ever
+    issued. With an approval in play every poll reads the row over the composed
+    API, and that read carries its own timeout -- one that is many times the
+    deadline this verb was given. So the read is pointed at a server that
+    accepts and never answers, which is what a wedged API looks like from here,
+    and the verb must still return inside its own bound rather than inside
+    httpx's.
+    """
+
+    created = harness.create_approval()
+    assert harness.approval_id == created.approval_id, (
+        "the harness must be tracking the approval, or the HTTP read this test "
+        "exists to bound is never taken"
+    )
+
+    real = harness.api
+    with _black_hole_api() as base_url:
+        harness._api = ComposedApi(base_url=base_url, port=real.port, app=real.app)  # noqa: SLF001
+        try:
+            started = time.monotonic()
+            with pytest.raises(HarnessTimeout) as raised:
+                harness.await_outcome(
+                    predicate=lambda snapshot: False, deadline_s=_NEVER_DEADLINE_S
+                )
+            elapsed = time.monotonic() - started
+        finally:
+            harness._api = real  # noqa: SLF001
+
+    assert elapsed < _NEVER_DEADLINE_S * _BOUND_SLACK, (
+        f"await_outcome overran its {_NEVER_DEADLINE_S}s deadline by more than "
+        f"{_BOUND_SLACK}x ({elapsed:.2f}s): the approval read inside the "
+        "predicate is not clipped to the remaining budget"
+    )
+    assert raised.value.verb == "await_outcome"
+
+
+# --- Provenance is the OBJECT, not its fields ---------------------------------
+
+
+def test_act_refuses_a_hand_built_captured_action_with_the_real_triple(
+    harness: InteractionHarness,
+) -> None:
+    """A fabricated ``CapturedAction`` is refused even with every field correct.
+
+    The fields are reconstructible without ever rendering a card: the action id
+    is an importable constant, the message id follows the harness's own
+    numbering, and the value is the approval id. So a content match is a door
+    straight past the card -- the render, the ownership probe, the block
+    structure -- which is the one thing ``act`` exists to refuse. Provenance has
+    to be the object that came out of ``messages()``.
+    """
+
+    harness.send("scale the payments deployment to 10 replicas")
+    harness.await_outcome(
+        predicate=lambda snapshot: any(m.actions for m in snapshot.messages),
+        deadline_s=30.0,
+    )
+    card = next(m for m in harness.messages().messages if m.actions)
+    real_action = card.actions[0]
+
+    forged = CapturedAction(
+        action_id=real_action.action_id,
+        message_id=real_action.message_id,
+        value=real_action.value,
+        text=real_action.text,
+        # The handle too. It is the pipe's provenance token and it is meant to
+        # be unguessable, but in process it must buy the forgery NOTHING: the
+        # in-process rule is object identity, and copying every field including
+        # the handle is the sharpest form of this test.
+        handle=real_action.handle,
+    )
+    assert forged == real_action, (
+        "the forgery must be field-identical, or this test would pass against "
+        "a content match too and prove nothing"
+    )
+    assert forged is not real_action
+
+    with pytest.raises(UncapturedAction) as raised:
+        harness.act(message=card.message_id, action=forged, actor="U0EXAMPLE1")
+
+    assert real_action.action_id in str(raised.value)
+
+
+def test_act_accepts_an_action_held_across_two_messages_snapshots(
+    harness: InteractionHarness,
+) -> None:
+    """A REAL captured action stays acceptable after a later ``messages()``.
+
+    The other half of the rule, and the reason the refusal above has to be
+    identity against the STORED objects rather than identity against one
+    snapshot: an agent captures an action, calls ``messages()`` again while it
+    waits, and then acts. That must work, or the provenance rule is a trap.
+    """
+
+    harness.send("scale the payments deployment to 10 replicas")
+    harness.await_outcome(
+        predicate=lambda snapshot: any(m.actions for m in snapshot.messages),
+        deadline_s=30.0,
+    )
+    held = next(m for m in harness.messages().messages if m.actions).actions[0]
+    later = harness.messages()
+    assert later.messages, "the second snapshot captured nothing"
+
+    result = harness.act(message=held.message_id, action=held, actor="U0EXAMPLE1")
+
+    assert result.action_id == held.action_id
+
+
+# --- The CLI can arm a fault --------------------------------------------------
+
+
+def test_the_cli_can_arm_and_disarm_a_fault() -> None:
+    """``inject_fault``'s pipe equivalent, or half the harness is unreachable.
+
+    A context manager cannot span two NDJSON lines, so without an arming verb an
+    agent on the pipe can drive only the happy path -- every failure case the
+    fault set names would be in-process-only while the CLI still claimed the
+    whole surface.
+    """
+
+    script = "\n".join(
+        [
+            json.dumps({"verb": "arm_fault", "fault": "resolve_transport_error"}),
+            json.dumps({"verb": "disarm_fault", "fault": "resolve_transport_error"}),
+        ]
+    )
+
+    completed = _run_cli(script + "\n")
+
+    assert completed.returncode == 0, (
+        f"the CLI exited {completed.returncode}; stderr was:\n{completed.stderr}"
+    )
+    lines = [json.loads(line) for line in completed.stdout.splitlines() if line.strip()]
+    assert [entry["verb"] for entry in lines] == ["arm_fault", "disarm_fault"]
+    assert lines[0]["result"]["armed"] is True
+    assert lines[0]["result"]["armed_faults"] == ["resolve_transport_error"]
+    assert lines[1]["result"]["armed"] is False
+    assert lines[1]["result"]["armed_faults"] == []
+
+
+def test_the_cli_rejects_an_unknown_fault_name_without_claiming_success() -> None:
+    """A typo in an armed fault must fail the run, not silently arm nothing."""
+
+    script = json.dumps({"verb": "arm_fault", "fault": "principle_expired"}) + "\n"
+
+    completed = _run_cli(script)
+
+    assert completed.returncode != 0
+    lines = [json.loads(line) for line in completed.stdout.splitlines() if line.strip()]
+    assert lines, "the CLI must report the failed verb on stdout"
+    assert lines[-1]["ok"] is False
+    assert "principle_expired" in lines[-1]["error"]["message"]
+
+
+# --- AC5: the verbs really do run against the real runner ---------------------
+
+
+def test_send_drives_the_real_runner_behind_the_kernel(
+    harness: InteractionHarness,
+) -> None:
+    """``send`` is a real-runner proof, not only the one bespoke journey test.
+
+    The kernel dials the REAL ``curie_runner`` (``build_runner(...,
+    fake_model=True)`` -> ``create_app``), so the only stand-in left in the turn
+    loop is the model. The fake MODEL session's recorded queries are what makes
+    that assertable: a scripted test double behind the kernel would satisfy
+    every other assertion in this module and record nothing here.
+    """
+
+    text = "scale the payments deployment to 10 replicas"
+    harness.send(text)
+
+    session = harness.runner._session  # noqa: SLF001 - the model seam IS the assertion
+    assert session.queries, (
+        "the real runner's model session saw no query: the kernel is dialling "
+        "something other than the runner this harness booted"
+    )
+    assert any(text in query for query in session.queries), (
+        f"the turn text never reached the runner's model session: {session.queries!r}"
+    )
+    assert any(m.actions for m in harness.messages().messages), (
+        "the real runner's turn produced no approval card, so the approval the "
+        "verbs drive did not come out of the production request_approval path"
+    )
+
+
+# --- AC3 over the pipe: the CLI's provenance is a handle, not a guess ---------
+
+
+_CLI_SETUP_LINES = (
+    json.dumps({"verb": "send", "text": "scale the payments deployment"}),
+    json.dumps({"verb": "await_outcome", "predicate": "any_action", "deadline_s": 60.0}),
+)
+
+
+def _cli_entries(completed_stdout: str) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in completed_stdout.splitlines() if line.strip()]
+
+
+def test_the_cli_refuses_an_act_named_only_by_a_guessable_action_id() -> None:
+    """The pipe must be exactly as unforgeable as the in-process identity rule.
+
+    In process ``act`` matches on object identity, so a hand-built
+    ``CapturedAction`` is refused however correct its fields. The CLI has no
+    objects and must look the stored action up from the request -- and if it
+    looks it up by ``action_id`` / ``message`` / ``value``, the identity check
+    is handed the REAL stored object and cannot fail, while every one of those
+    fields is reconstructible without the card ever rendering. This test
+    reconstructs them exactly that way: the action id is imported from the
+    production renderer's own constants, and the message id is the harness's
+    ``1700.%04d`` scheme. ``messages`` is deliberately never called, so the
+    script is a caller who has seen no card at all -- and the click must be
+    refused.
+    """
+
+    from curie_dispatcher.approval_actions import APPROVE_NOTE_ACTION_ID
+
+    script = (
+        "\n".join(
+            [
+                *_CLI_SETUP_LINES,
+                json.dumps(
+                    {
+                        "verb": "act",
+                        "message": "1700.0000",
+                        "action_id": APPROVE_NOTE_ACTION_ID,
+                        "actor": "U0EXAMPLE1",
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+
+    completed = _run_cli(script)
+
+    assert completed.returncode != 0, (
+        "the CLI accepted an act named only by its action id and message id -- "
+        "both reconstructible without ever calling messages(), so AC3 is "
+        "forgeable over the pipe"
+    )
+    failed = _cli_entries(completed.stdout)[-1]
+    assert failed["verb"] == "act"
+    assert failed["ok"] is False
+    assert failed["error"]["type"] == "UncapturedAction"
+    assert "handle" in failed["error"]["message"]
+
+
+def test_the_cli_refuses_an_act_with_a_fabricated_handle() -> None:
+    """A handle no capture minted names nothing, however well-formed.
+
+    The companion to the test above: refusing a request with no handle buys
+    nothing if any string in the handle slot is accepted. A fabricated handle is
+    also what a STALE one looks like -- handles are minted per captured action
+    inside one harness process, so one carried over from an earlier run has
+    nothing to name in this one.
+    """
+
+    script = (
+        "\n".join(
+            [
+                *_CLI_SETUP_LINES,
+                json.dumps(
+                    {
+                        "verb": "act",
+                        "message": "1700.0000",
+                        "handle": "not-a-handle-that-was-ever-minted",
+                        "actor": "U0EXAMPLE1",
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+
+    completed = _run_cli(script)
+
+    assert completed.returncode != 0, "the CLI accepted a handle it never minted"
+    failed = _cli_entries(completed.stdout)[-1]
+    assert failed["verb"] == "act"
+    assert failed["ok"] is False
+    assert failed["error"]["type"] == "UncapturedAction"
+    assert "not-a-handle-that-was-ever-minted" in failed["error"]["message"]
+
+
+def test_the_cli_accepts_an_act_carrying_a_handle_from_a_real_messages_call() -> None:
+    """The positive control: the handle route must actually work, in one process.
+
+    Without this the two refusals above are satisfied by a CLI that refuses
+    every ``act``, which is an unusable surface rather than a provenance rule.
+
+    It is driven over a LIVE pipe rather than a pre-written script, and that is
+    the point rather than test mechanics: a handle is minted per captured action
+    inside one harness process, so the only way to hold one is to read the
+    ``messages`` answer from the same process before writing the ``act`` line.
+    A caller that could not do that would have no honest route to ``act`` at
+    all -- which is the pressure that pushes a provenance rule back into a
+    guessable one. So this also pins that the CLI answers line by line, and that
+    ``messages`` publishes the handle.
+    """
+
+    process = subprocess.Popen(
+        [sys.executable, "-m", "curie_test_support.interaction"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    assert process.stdin is not None and process.stdout is not None
+    try:
+        for line in (*_CLI_SETUP_LINES, json.dumps({"verb": "messages"})):
+            process.stdin.write(line + "\n")
+        process.stdin.flush()
+
+        answers = [json.loads(process.stdout.readline()) for _ in range(3)]
+        assert [entry["verb"] for entry in answers] == ["send", "await_outcome", "messages"]
+        card = next(message for message in answers[-1]["result"]["messages"] if message["actions"])
+        handle = card["actions"][0]["handle"]
+        assert handle, "messages() published no handle, so the CLI's act is unreachable"
+
+        process.stdin.write(
+            json.dumps(
+                {
+                    "verb": "act",
+                    "message": card["message_id"],
+                    "handle": handle,
+                    "actor": "U0EXAMPLE1",
+                }
+            )
+            + "\n"
+        )
+        process.stdin.flush()
+        acted = json.loads(process.stdout.readline())
+        process.stdin.close()
+        status = process.wait(timeout=180)
+        assert status == 0, f"the CLI exited {status} after a valid act"
+    finally:
+        process.kill()
+
+    assert acted["verb"] == "act"
+    assert acted["ok"] is True, f"the CLI refused an act carrying a real handle: {acted!r}"
+    assert acted["result"]["action_id"] == card["actions"][0]["action_id"]
+
+
+# --- The bounded wait, with VALKEY as the thing that hangs --------------------
+
+
+def test_await_outcome_stays_bounded_when_valkey_hangs(
+    harness: InteractionHarness,
+) -> None:
+    """The mirror of the black-hole HTTP test, against the other blocking edge.
+
+    ``snapshot()`` -- the thing ``await_outcome`` polls -- reads the stream
+    length out of Valkey before it reads the approval status over HTTP, and
+    ``resume_turns`` xranges the same stream. The client those go through comes
+    from ``connect_or_skip``, which sets ``socket_connect_timeout`` and
+    deliberately NO ``socket_timeout``, so a Valkey that accepts and never
+    answers parks the command inside a C-level socket read. ``_Deadline.wait``
+    polls a predicate and cannot interrupt that, so the verb's headline bound is
+    broken by the first thing the predicate touches. The existing HTTP test
+    cannot see this: it reaches the status read only after the Valkey read has
+    already returned.
+
+    So the harness's client is pointed at a black hole -- the same accept-and-
+    never-answer server, which is what a wedged Valkey looks like from here --
+    and the verb must still return inside its own bound.
+    """
+
+    import redis
+
+    real = harness.redis
+    with _black_hole_api() as base_url:
+        host, port = base_url.removeprefix("http://").split(":")
+        wedged = redis.Redis(
+            host=host,
+            port=int(port),
+            decode_responses=True,
+            socket_connect_timeout=2.0,
+        )
+        harness._redis = wedged  # noqa: SLF001
+        try:
+            started = time.monotonic()
+            with pytest.raises(HarnessTimeout) as raised:
+                harness.await_outcome(predicate=lambda snapshot: True, deadline_s=_NEVER_DEADLINE_S)
+            elapsed = time.monotonic() - started
+        finally:
+            harness._redis = real  # noqa: SLF001
+            wedged.close()
+
+    assert elapsed < _NEVER_DEADLINE_S * _BOUND_SLACK, (
+        f"await_outcome overran its {_NEVER_DEADLINE_S}s deadline by more than "
+        f"{_BOUND_SLACK}x ({elapsed:.2f}s): the Valkey read inside snapshot() is "
+        "not clipped to the remaining budget"
+    )
+    assert raised.value.verb == "await_outcome"
+
+
+def test_reset_stays_bounded_when_valkey_hangs(harness: InteractionHarness) -> None:
+    """``reset`` is one of the six verbs and took no ``deadline_s`` at all.
+
+    Two Valkey commands are fast until Valkey is the wedged thing, and an agent
+    is told to reset defensively between steps -- so the unbounded one was the
+    verb most likely to be called into a hang, with no verb name on the result.
+    """
+
+    import redis
+
+    real = harness.redis
+    with _black_hole_api() as base_url:
+        host, port = base_url.removeprefix("http://").split(":")
+        wedged = redis.Redis(
+            host=host,
+            port=int(port),
+            decode_responses=True,
+            socket_connect_timeout=2.0,
+        )
+        harness._redis = wedged  # noqa: SLF001
+        try:
+            started = time.monotonic()
+            with pytest.raises(HarnessTimeout) as raised:
+                harness.reset(deadline_s=_NEVER_DEADLINE_S)
+            elapsed = time.monotonic() - started
+        finally:
+            harness._redis = real  # noqa: SLF001
+            wedged.close()
+
+    assert elapsed < _NEVER_DEADLINE_S * _BOUND_SLACK, (
+        f"reset overran its {_NEVER_DEADLINE_S}s deadline by more than "
+        f"{_BOUND_SLACK}x ({elapsed:.2f}s)"
+    )
+    assert raised.value.verb == "reset"


### PR DESCRIPTION
Stage 3 of the three-PR approval pilot (`.projects/local-readiness/2026-09-10-interface-test-plan/review.md`, item 3). Stacked on #2623, which is stacked on #2616. **Do not merge this PR on its own** — per the maintainer decision of 2026-09-11 the three PRs are reviewed and decided as one stack.

## What this adds

**A reusable, agent-facing interaction harness** (`packages/test-support/src/curie_test_support/interaction/`) exposing `send`, `messages`, `act`, `await_outcome`, `reset` and `inject_fault`, each returning a frozen JSON-serialisable result, plus a `python -m curie_test_support.interaction` NDJSON CLI. Every blocking call is bounded by an explicit deadline and raises `HarnessTimeout` naming the verb and the segment — including nested HTTP reads and every Valkey command. `act` accepts only an action captured off a rendered card, and over the CLI only via an unforgeable per-action handle minted at capture.

**The real runner with a fake model.** The harness builds `create_app(build_runner(..., fake_model=True))` and passes it through the existing `kernel_harness(runner_app=)` seam, so the runner state machine is genuinely in the path for the harness verbs, not only in one test.

**The failure half stage 2 deferred:** rejected terminal outcome; expiry driven by invoking the production sweeper once; a lost resume-enqueue healed by the production reconciler; modal cancel; tampered `private_metadata` refused rather than declined; and a failed resolve transport surfaced with no phantom resume.

**Production-exclusion proof** for the whole capability: an instruction-level Dockerfile posture check across six production recipes, the dependency closure each image installs, the single dev-group declaration, the release compose, the sealed chart render, and a prod-mode probe that must be refused and must leave approval state unchanged.

## A stage 2 defect this fixes

`test_approval_journey_dev.py` pinned `TEST_VALKEY_PORT` to the literal `36379` — stage 2's own private stack — so the module failed on CI and on every machine but the one that wrote it. The guard now asserts the property it wanted (frozen Valkey constant agrees with the environment, `VALKEY_URL` absent, `CI_REQUIRE_VALKEY_TESTS` set, run namespace unique and empty), with two tests proving the guard can still fail.

## Known gap, stated rather than claimed

**There is no server-side note validation in the product.** The modal's `max_length=2000` is client-side only, `resolve_note_submission` neither validates nor truncates, and `ApprovalResolve.note` is unconstrained. The plan's "note-modal validation failure" case is therefore carried as a *characterisation* test of current behaviour plus an `UNMET PROOF` note, not as a covered case. Closing it is a production change this stage does not own.

## Tier classification (assembled diff `9e3d8b62` → this head)

No production `src/` file is changed; the diff is test, dev-test-package and CI-assertion code only. All six tiers not applicable: **skill** — no skill surface or bundle; **local** — no compose service, image or `curie` verb behaviour (the compose edit is an added assertion); **local-release** — no released-binary surface and deliberately no new `curie` verb; **cluster** — no chart template, the chart edits are `ci/*.sh` render assertions; **live-provider** — `fake_model=True`, no provider credential or model call; **external-integration** — Slack stays faked at the edge.

Deliberately no `curie` subcommand: a CLI surface would pull the local and local-release tiers into a stage whose diff otherwise bears no runtime behaviour. Stage 1 recorded the same decision for the same reason.

## Review

Four independent adversarial reviews via `agent-router` (reviewer: grok; primary claude excluded), three rounds of fixes. Findings files are under `.projects/plans/`. Notable catches, all fixed: the bounded-wait claim was false (a predicate's 10s HTTP read outran a 1s deadline); `act`'s provenance rule accepted a hand-built action, and later accepted a guessable one over the CLI; `send` double-produced one turn; the expiry/reconciler "production object" assertions were import tautologies; the new chart script was not wired into helm-ci while `chart_check.rs` requires a 1:1 match, so that gate was red; and four separate ways to get the harness into a shipped `/app/.venv` that every exclusion control passed.

## CI

**This PR reports no checks.** `ci.yaml` triggers only on `pull_request: branches: [main, next]`, and this PR targets `task/interface-pilot-2-approval`. That is structural, not a bypass or a failure. Do not read the absence of red as green — the local assembled baseline in the handoff is the evidence for this stage.
